### PR TITLE
fix(daemon): queue pending restarts when stop+start race on restart-all

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -19,6 +19,9 @@ import { processMediaMessage } from '../telegram/media.js';
 export class AgentManager {
   private agents: Map<string, { process: AgentProcess; checker: FastChecker; poller?: TelegramPoller }> = new Map();
   private workers: Map<string, WorkerProcess> = new Map();
+  // Tracks agents that received a start request while still stopping.
+  // stopAgent() honors these after cleanup completes so restart-all is race-free.
+  private pendingRestarts: Set<string> = new Set();
   private instanceId: string;
   private ctxRoot: string;
   private frameworkRoot: string;
@@ -50,7 +53,10 @@ export class AgentManager {
    */
   async startAgent(name: string, agentDir: string, config?: AgentConfig): Promise<void> {
     if (this.agents.has(name)) {
-      console.log(`[agent-manager] Agent ${name} already running`);
+      // Agent is registered but may be mid-stop (race: restart-all sends stop+start simultaneously).
+      // Queue the start so stopAgent() will re-launch it once cleanup finishes.
+      this.pendingRestarts.add(name);
+      console.log(`[agent-manager] Agent ${name} is stopping — queued restart`);
       return;
     }
 
@@ -306,6 +312,15 @@ export class AgentManager {
     entry.checker.stop();
     await entry.process.stop();
     this.agents.delete(name);
+
+    // Honor any restart that was queued while we were stopping.
+    if (this.pendingRestarts.has(name)) {
+      this.pendingRestarts.delete(name);
+      console.log(`[agent-manager] Honoring queued restart for ${name}`);
+      this.startAgent(name, '').catch(err =>
+        console.error(`[agent-manager] Queued restart failed for ${name}:`, err),
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

When a restart-all fires (e.g. from the dashboard or CLI), the daemon calls `stopAgent()` and `startAgent()` near-simultaneously for each agent. `startAgent()` checks `this.agents.has(name)` — but the agent is still in the registry while `stop()` is in progress. So `startAgent()` bails with \"Agent X already running\". When `stopAgent()` finishes and removes the agent from the map, nobody restarts it. All agents end up stopped.

Reproduced live: James did a restart-all and all 6 agents went dark.

## Root cause

```
stopAgent(paul2) starts  → agent still in this.agents map
startAgent(paul2) fires  → sees 'already running', returns early  ← BUG
stopAgent(paul2) finishes → removes from map
// Nobody restarts paul2
```

## Fix

Add a `pendingRestarts: Set<string>` to `AgentManager`.

- `startAgent()`: if agent is in map (mid-stop), queue name to `pendingRestarts` instead of bailing
- `stopAgent()`: after removing from map, check `pendingRestarts` and re-launch

```
stopAgent(paul2) starts  → agent still in map
startAgent(paul2) fires  → pendingRestarts.add('paul2'), logs "queued restart"
stopAgent(paul2) finishes → removes from map, sees pendingRestarts has paul2
                          → calls startAgent('paul2', '') → auto-discovers dir → starts ✓
```

## Test

Restart all agents simultaneously — all should come back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)