### PR TITLE
fix(daemon): rebuild Telegram poller on restartAgent

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -356,21 +356,24 @@ export class AgentManager {
 
   /**
    * Restart a specific agent.
+   *
+   * Delegates to stopAgent + startAgent to guarantee a full teardown and
+   * rebuild of every per-agent resource: AgentProcess, FastChecker, TelegramAPI,
+   * TelegramPoller, crash callback, and slash-command registration. Fresh
+   * credentials are re-read from {agentDir}/.env on each restart.
+   *
+   * agentDir is auto-discovered by startAgent() from frameworkRoot/orgs/{org}/agents/{name}.
+   * Participates in the pendingRestarts race protection used by restart-all.
    */
   async restartAgent(name: string): Promise<void> {
-    const entry = this.agents.get(name);
-    if (!entry) return;
-
-    entry.checker.stop();
-    try {
-      await entry.process.stop();
-    } catch (err) {
-      console.error(`[agent-manager] Error stopping ${name} during restart:`, err);
+    if (!this.agents.has(name)) {
+      console.log(`[agent-manager] Agent ${name} not found — cannot restart`);
+      return;
     }
-    await entry.process.start();
-    entry.checker.start().catch((err) => {
-      console.error(`[agent-manager] Fast checker error for ${name}:`, err);
-    });
+    console.log(`[agent-manager] Restarting ${name}`);
+    await this.stopAgent(name);
+    await this.startAgent(name, '');
+    console.log(`[agent-manager] Restart complete for ${name}`);
   }
 
   /**

--- a/tests/unit/daemon/agent-manager.test.ts
+++ b/tests/unit/daemon/agent-manager.test.ts
@@ -135,3 +135,58 @@ describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
     expect(startSpy).toHaveBeenCalledTimes(2);
   });
 });
+
+describe('AgentManager.restartAgent - BUG-007 fix (rebuild Telegram poller)', () => {
+  let testDir: string;
+  let ctxRoot: string;
+  let frameworkRoot: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-am-restart-test-'));
+    ctxRoot = join(testDir, 'instance');
+    frameworkRoot = join(testDir, 'framework');
+    mkdirSync(join(ctxRoot, 'config'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('delegates to stopAgent then startAgent (in order)', async () => {
+    // BUG-007: previously restartAgent only stopped/started the AgentProcess and
+    // FastChecker inline, leaving the TelegramPoller from the previous incarnation
+    // running. The fix delegates to stopAgent (which DOES clean up the poller) and
+    // startAgent (which builds a fresh poller from the agent's .env). This test
+    // pins that delegation in place so a future regression to inline cleanup
+    // would fail loudly.
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    // Inject a fake agent so restartAgent's existence check passes without
+    // actually running the full startAgent flow
+    (am as any).agents.set('alice', { process: {}, checker: {}, poller: { stop() {} } });
+
+    const stopSpy = vi.spyOn(am, 'stopAgent').mockResolvedValue();
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.restartAgent('alice');
+
+    expect(stopSpy).toHaveBeenCalledWith('alice');
+    expect(startSpy).toHaveBeenCalledWith('alice', '');
+    // Verify call order: stop must complete before start, so the old poller
+    // is fully torn down before the new one is constructed
+    const stopOrder = stopSpy.mock.invocationCallOrder[0];
+    const startOrder = startSpy.mock.invocationCallOrder[0];
+    expect(stopOrder).toBeLessThan(startOrder);
+  });
+
+  it('is a no-op when the agent does not exist', async () => {
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const stopSpy = vi.spyOn(am, 'stopAgent').mockResolvedValue();
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.restartAgent('nonexistent');
+
+    expect(stopSpy).not.toHaveBeenCalled();
+    expect(startSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
`restartAgent()` in `src/daemon/agent-manager.ts` stopped and restarted the agent process and fast checker, but never touched the `TelegramPoller`. After every IPC `restart-agent` call the old poller kept running in stale state forever and no new poller was ever created — agents silently stopped receiving Telegram messages until the daemon itself restarted.

## Fix
Delegate to `stopAgent` + `startAgent('')` so every per-agent resource is rebuilt from fresh `.env` credentials on restart:
- `AgentProcess`
- `FastChecker` (incidentally picks up any credential changes)
- `TelegramAPI` and `TelegramPoller`
- `AgentProcess.onStatusChanged` crash-notification callback
- Slash-command registration

`agentDir` is auto-discovered by `startAgent` from `frameworkRoot/orgs/{org}/agents/{name}`, which is the same path used for queued restarts in `stopAgent` (line 320). The new implementation participates in the `pendingRestarts` race protection added in #1 for free.

## Scope
Single-method rewrite. No helpers, no new tests, no signature changes, no telemetry beyond two log lines.

## Explicitly out of scope
- `FastChecker` credential staleness (incidentally fixed, not expanded)
- SIGUSR1 double-registration window in `FastChecker.stop`/`start` (sidestepped by instance replacement)
- `TelegramPoller.getUpdates` AbortController (separate known issue)
- Dashboard passing `mode` to restart-agent IPC (ignored, separate issue)

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean
- [x] `npm test` — all existing tests pass
- [ ] End-to-end: fresh-boot a live agent, send it a Telegram message (baseline), `cortextos bus restart <agent>`, send a second Telegram message — agent must reply. This is executed by the orchestrator after review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)