### PR TITLE
fix(cli): require --all to stop every agent (foot-gun fix)

### DIFF
--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -2,10 +2,28 @@ import { Command } from 'commander';
 import { IPCClient } from '../daemon/ipc-server.js';
 
 export const stopCommand = new Command('stop')
-  .argument('[agent]', 'Specific agent to stop (stops all if omitted)')
+  .argument('[agent]', 'Agent name to stop. Omit and pass --all to stop every running agent.')
   .option('--instance <id>', 'Instance ID', 'default')
-  .description('Stop the daemon or a specific agent')
-  .action(async (agent: string | undefined, options: { instance: string }) => {
+  .option('--all', 'Stop every running agent (required when no agent name is given)')
+  .description('Stop a running agent. Use --all to stop every agent. Does NOT stop the daemon process itself — use `pm2 stop cortextos-daemon` for that.')
+  .action(async (agent: string | undefined, options: { instance: string; all?: boolean }) => {
+    // Safety: refuse to stop the entire fleet unless the user explicitly opted in.
+    if (!agent && !options.all) {
+      console.error('Refusing to stop all agents without an explicit target.');
+      console.error('');
+      console.error('  To stop one agent:    cortextos stop <agent>');
+      console.error('  To stop every agent:  cortextos stop --all');
+      console.error('  To stop the daemon:   pm2 stop cortextos-daemon');
+      console.error('');
+      console.error('(Previously `cortextos stop` with no argument silently stopped every running agent. That behavior was a foot-gun and now requires --all.)');
+      process.exit(2);
+    }
+
+    if (agent && options.all) {
+      console.error('Error: pass either an agent name or --all, not both.');
+      process.exit(2);
+    }
+
     const ipc = new IPCClient(options.instance);
     const daemonRunning = await ipc.isDaemonRunning();
 
@@ -21,17 +39,26 @@ export const stopCommand = new Command('stop')
         console.log(`  ${response.data}`);
       } else {
         console.error(`  Error: ${response.error}`);
+        process.exit(1);
       }
-    } else {
-      console.log('Stopping all agents...');
-      const listResponse = await ipc.send({ type: 'list-agents' });
-      if (listResponse.success) {
-        const agents = listResponse.data as string[];
-        for (const a of agents) {
-          const response = await ipc.send({ type: 'stop-agent', agent: a });
-          console.log(`  ${a}: ${response.success ? 'stopped' : response.error}`);
-        }
-      }
-      console.log('\nTo stop the daemon entirely: pm2 stop cortextos-daemon');
+      return;
     }
+
+    // options.all === true
+    console.log('Stopping all agents...');
+    const listResponse = await ipc.send({ type: 'list-agents' });
+    if (!listResponse.success) {
+      console.error(`  Error listing agents: ${listResponse.error}`);
+      process.exit(1);
+    }
+    const agents = listResponse.data as string[];
+    if (agents.length === 0) {
+      console.log('  No agents are running.');
+      return;
+    }
+    for (const a of agents) {
+      const response = await ipc.send({ type: 'stop-agent', agent: a });
+      console.log(`  ${a}: ${response.success ? 'stopped' : response.error}`);
+    }
+    console.log('\nAll agents stopped. The daemon is still running. To stop it: pm2 stop cortextos-daemon');
   });


### PR DESCRIPTION
## Summary

`cortextos stop` with no arguments silently iterated `list-agents` and stopped every running agent in sequence, taking down the entire fleet. The command's description claimed it would "stop the daemon," which is doubly wrong: it did not stop the daemon, and it did stop every agent. This caused a real cascade in production: an autonomous orchestrator agent ran `cortextos stop` expecting to stop the daemon process and instead killed all six running agents within seconds.

This PR makes the dangerous behavior require an explicit `--all` flag and rewrites the help text to be accurate.

## Behavior before

```
$ cortextos stop
Stopping all agents...
  alice: stopped
  bob: stopped
  carol: stopped
  ...
```

The entire fleet went down. The daemon kept running. Description said "Stop the daemon or a specific agent."

## Behavior after

```
$ cortextos stop
Refusing to stop all agents without an explicit target.

  To stop one agent:    cortextos stop <agent>
  To stop every agent:  cortextos stop --all
  To stop the daemon:   pm2 stop cortextos-daemon

(Previously `cortextos stop` with no argument silently stopped every running agent. That behavior was a foot-gun and now requires --all.)
$ echo $?
2
```

- `cortextos stop <agent>` — unchanged, still stops one agent.
- `cortextos stop --all` — new, explicit opt-in to fleet-wide stop.
- `cortextos stop` — now a hard error with a helpful message; exits 2; performs no IPC.
- `cortextos stop <agent> --all` — rejected as ambiguous; exits 2.
- Description and `[agent]` help text rewritten to accurately describe behavior and explicitly disclaim that this command does not stop the daemon process.

## Test plan

No existing tests cover `src/cli/*.ts`, so this PR follows the project precedent of manual verification:

- [ ] `cortextos stop` (no args) prints the safety error and exits 2; no agent is stopped.
- [ ] `cortextos stop --all` stops every running agent and exits 0; daemon still running.
- [ ] `cortextos stop <agent>` still stops the named agent and exits 0.
- [ ] `cortextos stop <agent> --all` errors out with the mutual-exclusion message and exits 2.
- [ ] `cortextos stop --help` shows the `--all` flag and the `pm2 stop cortextos-daemon` guidance.

## Out of scope

- Cleaning up the corrupt `enabled-agents.json` entry (separate task).
- Adding source logging to the IPC server's `stop-agent` handler (separate task).
- Touching v1 LaunchAgents (separate task).
- Symmetric changes to `cortextos start` (start does not have a cascade risk).
- Renaming the command, telemetry, or backfilling tests for the existing `stop <agent>` path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)