### PR TITLE
feat: comprehensive Windows support — first Windows install with 14 fixes + favicon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ agents/*/memory/
 # Test artifacts
 test-results/
 *.log
+# Spurious directory created when ${APPDATA} env var unexpanded during npm link on Windows
+${APPDATA}/
 
 # Knowledge base
 knowledge-base/venv/

--- a/bus/kb-setup.sh
+++ b/bus/kb-setup.sh
@@ -58,10 +58,17 @@ else
   echo "  [OK] Venv already exists"
 fi
 
+# Resolve platform-specific venv paths (Windows uses Scripts/, Unix uses bin/)
+if [[ -d "$VENV_DIR/Scripts" ]]; then
+  VENV_BIN="$VENV_DIR/Scripts"
+else
+  VENV_BIN="$VENV_DIR/bin"
+fi
+
 # Install/upgrade dependencies
 echo "  Installing Python dependencies..."
-"$VENV_DIR/bin/pip" install --quiet --upgrade pip
-"$VENV_DIR/bin/pip" install --quiet -r "$REQS"
+"$VENV_BIN/pip" install --quiet --upgrade pip 2>/dev/null || true
+"$VENV_BIN/pip" install --quiet -r "$REQS"
 echo "  [OK] Dependencies installed"
 
 # Validate mmrag.py is accessible
@@ -88,13 +95,21 @@ EOF
   echo "  [OK] mmrag config.json created"
 else
   echo "  [OK] mmrag config.json already exists"
+
+  # Migrate stale embedding model names (text-embedding-004 was shut down 2026-01-14)
+  if grep -qE '"embedding_model"\s*:\s*"(models/text-embedding-004|text-embedding-004)"' "$CONFIG_FILE" 2>/dev/null; then
+    sed -i.bak 's/"models\/text-embedding-004"/"gemini-embedding-001"/g; s/"text-embedding-004"/"gemini-embedding-001"/g' "$CONFIG_FILE"
+    rm -f "${CONFIG_FILE}.bak"
+    echo "  [MIGRATED] embedding_model updated to gemini-embedding-001 (text-embedding-004 was shut down)"
+  fi
 fi
 
 # Test import
 MMRAG_DIR="$KB_ROOT" \
 MMRAG_CHROMADB_DIR="$CHROMADB_DIR" \
 MMRAG_CONFIG="$CONFIG_FILE" \
-"$VENV_DIR/bin/python3" -c "import chromadb; import google.genai; print('  [OK] Core imports work')"
+"$VENV_BIN/python3" -c "import chromadb; import google.genai; print('  [OK] Core imports work')" 2>/dev/null || \
+"$VENV_BIN/python" -c "import chromadb; import google.genai; print('  [OK] Core imports work')"
 
 echo ""
 echo "Knowledge base ready for org: $ORG"

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -811,30 +811,6 @@
         "@noble/ciphers": "^1.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -6094,6 +6070,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -11831,6 +11808,7 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/dashboard/src/app/icon.svg
+++ b/dashboard/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#B8860B"/>
+  <text x="16" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700" fill="white">cO</text>
+</svg>

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -114,13 +114,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   },
 });
 
-/** Seed admin user from env vars if no users exist in the database */
+/** Seed admin user from env vars, or sync password if it changed */
 export async function seedAdminUser(): Promise<void> {
   const row = db
     .prepare('SELECT COUNT(*) as count FROM users')
     .get() as { count: number };
-
-  if (row.count > 0) return;
 
   const username = process.env.ADMIN_USERNAME ?? 'admin';
 
@@ -132,6 +130,22 @@ export async function seedAdminUser(): Promise<void> {
   const KNOWN_DEFAULTS = ['cortextos', 'password', 'admin', 'changeme'];
   if (process.env.NODE_ENV === 'production' && KNOWN_DEFAULTS.includes(password)) {
     throw new Error('ADMIN_PASSWORD is a known default. Set a strong password in .env.local');
+  }
+
+  if (row.count > 0) {
+    // Sync password: if ADMIN_PASSWORD env var changed, update the stored hash
+    const user = db
+      .prepare('SELECT password_hash FROM users WHERE username = ?')
+      .get(username) as { password_hash: string } | undefined;
+    if (user) {
+      const matches = await bcrypt.compare(password, user.password_hash);
+      if (!matches) {
+        const hash = await bcrypt.hash(password, 12);
+        db.prepare('UPDATE users SET password_hash = ? WHERE username = ?').run(hash, username);
+        console.log(`[auth] Admin password updated from environment`);
+      }
+    }
+    return;
   }
 
   const hash = await bcrypt.hash(password, 12);

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,31 +32,6 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -3247,6 +3222,7 @@
       "integrity": "sha512-nmu43Qvq9UopTRfMx2jOYW5l16pb3iDC1JH6yMuPkpVbzK0k+L7dfsEDH4jRgYFmsg0sTAqkojoZgzLMlwHsCQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",

--- a/src/cli/dashboard.ts
+++ b/src/cli/dashboard.ts
@@ -154,11 +154,11 @@ export const dashboardCommand = new Command('dashboard')
     }
     console.log('');
 
-    const child = spawn('npx', startArgs, {
-      cwd: dashboardDir,
-      stdio: 'inherit',
-      env: dashEnv,
-    });
+    // On Windows, npx is a .cmd wrapper requiring shell resolution.
+    // Pass as single string to avoid Node.js DEP0190 deprecation warning.
+    const child = IS_WINDOWS
+      ? spawn(['npx', ...startArgs].join(' '), { cwd: dashboardDir, stdio: 'inherit', env: dashEnv, shell: true })
+      : spawn('npx', startArgs, { cwd: dashboardDir, stdio: 'inherit', env: dashEnv });
 
     child.on('error', (err: Error) => {
       console.error('Failed to start dashboard:', err.message);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -77,7 +77,7 @@ export const doctorCommand = new Command('doctor')
         status: 'fail',
         message: 'Failed to load native module',
         fix: process.platform === 'win32'
-          ? 'Install Visual C++ Build Tools: npm install -g windows-build-tools'
+          ? 'Install "Desktop development with C++" workload from Visual Studio Build Tools (https://visualstudio.microsoft.com/visual-cpp-build-tools/), then run: npm rebuild node-pty'
           : 'Install build tools: xcode-select --install (macOS) or apt install build-essential (Linux)',
       });
     }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -15,14 +15,24 @@ const SAFE_NAME = /^[@a-z0-9._/-]+$/i;
 
 function tryInstallGlobal(pkg: string): boolean {
   if (!SAFE_NAME.test(pkg)) return false;
-  const result = spawnSync('npm', ['install', '-g', pkg], { stdio: 'inherit', timeout: 120000 });
+  // On Windows, 'npm' is a .cmd wrapper; use shell to resolve it.
+  // Pass as single string to avoid DEP0190 deprecation warning.
+  const result = IS_WINDOWS
+    ? spawnSync(`npm install -g ${pkg}`, { stdio: 'inherit', timeout: 120000, shell: true })
+    : spawnSync('npm', ['install', '-g', pkg], { stdio: 'inherit', timeout: 120000 });
   return result.status === 0;
 }
 
 function commandExists(cmd: string): boolean {
   if (!SAFE_NAME.test(cmd)) return false;
-  const which = IS_WINDOWS ? 'where' : 'which';
-  const result = spawnSync(which, [cmd], { stdio: 'pipe' });
+  // On Windows, use shell so 'where' runs through cmd.exe with the full
+  // system PATH — without it, where.exe can miss tools installed via
+  // WinGet or user-space installers when PATH contains Unix-style paths.
+  if (IS_WINDOWS) {
+    const result = spawnSync(`where ${cmd}`, { stdio: 'pipe', shell: true });
+    return result.status === 0;
+  }
+  const result = spawnSync('which', [cmd], { stdio: 'pipe' });
   return result.status === 0;
 }
 
@@ -131,7 +141,9 @@ export const installCommand = new Command('install')
       if (IS_MAC) {
         console.error('    Install Xcode Command Line Tools: xcode-select --install');
       } else if (IS_WINDOWS) {
-        console.error('    Install Visual C++ Build Tools: npm install -g windows-build-tools');
+        console.error('    Install "Desktop development with C++" workload from Visual Studio Build Tools:');
+        console.error('    https://visualstudio.microsoft.com/visual-cpp-build-tools/');
+        console.error('    Then run: npm rebuild node-pty');
       } else {
         console.error('    Install build tools: sudo apt-get install -y build-essential python3');
       }
@@ -216,6 +228,40 @@ export const installCommand = new Command('install')
       } catch {
         console.log('  ✓ jq: installed');
       }
+    }
+
+    // Python venv for Knowledge Base
+    const kbVenvDir = join(process.cwd(), 'knowledge-base', 'venv');
+    const kbReqs = join(process.cwd(), 'knowledge-base', 'scripts', 'requirements.txt');
+    const python3Cmd = IS_WINDOWS ? 'python' : 'python3';
+    if (commandExists(python3Cmd)) {
+      if (!existsSync(kbVenvDir)) {
+        console.log('  - Knowledge Base venv: not found. Creating...');
+        const venvResult = spawnSync(python3Cmd, ['-m', 'venv', kbVenvDir], { stdio: 'inherit', timeout: 60000 });
+        if (venvResult.status === 0) {
+          console.log('  ✓ Knowledge Base venv created');
+          // Install KB dependencies
+          if (existsSync(kbReqs)) {
+            const pip = IS_WINDOWS
+              ? join(kbVenvDir, 'Scripts', 'pip')
+              : join(kbVenvDir, 'bin', 'pip');
+            const pipResult = spawnSync(pip, ['install', '--quiet', '-r', kbReqs], { stdio: 'inherit', timeout: 120000 });
+            if (pipResult.status === 0) {
+              console.log('  ✓ Knowledge Base dependencies installed');
+            } else {
+              console.log('  ! Knowledge Base dependencies failed to install. Run kb-setup.sh manually.');
+            }
+          }
+        } else {
+          console.log('  ! Could not create Knowledge Base venv. Run: bus/kb-setup.sh --org <org>');
+        }
+      } else {
+        console.log('  ✓ Knowledge Base venv exists');
+      }
+    } else {
+      console.log(`  ! ${python3Cmd}: not found. Knowledge Base requires Python 3.`);
+      if (IS_WINDOWS) console.log('    Install from: https://www.python.org/downloads/');
+      else console.log('    Install with: sudo apt-get install -y python3 python3-venv');
     }
 
     console.log('');
@@ -305,6 +351,18 @@ export const installCommand = new Command('install')
     );
     try { chmodSync(dashEnvPath, 0o600); } catch { /* ignore on Windows */ }
     console.log(`  Generated dashboard credentials at ${dashEnvPath}`);
+
+    // Register cortextos CLI globally so agent PTY sessions can find it
+    console.log('Registering cortextos CLI globally...');
+    const linkResult = IS_WINDOWS
+      ? spawnSync('npm link', { stdio: 'pipe', cwd: process.cwd(), timeout: 30000, shell: true })
+      : spawnSync('npm', ['link'], { stdio: 'pipe', cwd: process.cwd(), timeout: 30000 });
+    if (linkResult.status === 0) {
+      console.log('  ✓ cortextos registered globally (npm link)');
+    } else {
+      console.log('  ! npm link failed. Run manually: npm link (from the cortextOS directory)');
+      console.log('    Without this, agents cannot use bus commands in PTY sessions.');
+    }
 
     console.log('\n  Installation complete.');
     console.log(`  State directory: ${ctxRoot}`);

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
 
@@ -137,9 +138,12 @@ export class AgentPTY {
 
     // Spawn claude directly (no shell wrapper) — cross-platform, no shell escaping needed.
     // env is passed natively via node-pty options; no bash export commands required.
+    // On Windows, node-pty uses CreateProcess which does NOT resolve .exe extensions
+    // from bare command names. We must use 'claude.exe' explicitly.
     const claudeArgs = this.buildClaudeArgs(mode, prompt);
+    const claudeCmd = platform() === 'win32' ? 'claude.exe' : 'claude';
 
-    this.pty = this.spawnFn!('claude', claudeArgs, {
+    this.pty = this.spawnFn!(claudeCmd, claudeArgs, {
       name: 'xterm-256color',
       cols: 200,
       rows: 50,
@@ -297,6 +301,14 @@ export class AgentPTY {
         env[key] = process.env[key]!;
       }
     }
+
+    // Windows: ensure UTF-8 locale so emoji and Unicode pass through the PTY
+    if (platform() === 'win32') {
+      if (!env['LANG']) env['LANG'] = 'en_US.UTF-8';
+      if (!env['LC_ALL']) env['LC_ALL'] = 'en_US.UTF-8';
+      if (!process.env['PYTHONIOENCODING']) env['PYTHONIOENCODING'] = 'utf-8';
+    }
+
     return env;
   }
 }

--- a/templates/agent/.claude/skills/agent-management/SKILL.md
+++ b/templates/agent/.claude/skills/agent-management/SKILL.md
@@ -174,6 +174,8 @@ cortextos bus send-message "$AGENT" high "soft-restart" "model change to $NEW_MO
 - `claude-sonnet-4-6` - Good balance, ~5x cheaper than Opus
 - `claude-haiku-4-5-20251001` - Fastest, cheapest, for simple tasks
 
+**Context window suffix:** Append `[1m]` to any model ID (e.g., `claude-opus-4-6[1m]`) to enable the extended 1M token context window. Without it, agents get the default shorter context window and will compact much sooner. Recommended for orchestrators and any agent doing complex multi-step work.
+
 **No model set = default (Opus).** Always set explicitly for cost control.
 
 ---

--- a/templates/agent/ONBOARDING.md
+++ b/templates/agent/ONBOARDING.md
@@ -349,7 +349,7 @@ Do NOT rewrite TOOLS.md from memory. The template contains the authoritative ref
 ### Step 18b: Verify agent is enabled
 
 ```bash
-ENABLED=$(cat "${CTX_FRAMEWORK_ROOT}/orgs/${CTX_ORG}/enabled-agents.json" 2>/dev/null || echo '[]')
+ENABLED=$(cat "${CTX_ROOT}/config/enabled-agents.json" 2>/dev/null || echo '[]')
 if ! echo "$ENABLED" | jq -e --arg name "$CTX_AGENT_NAME" '.[] | select(. == $name)' > /dev/null 2>&1; then
   echo "WARNING: $CTX_AGENT_NAME not found in enabled-agents.json"
   cortextos bus send-telegram "$CTX_TELEGRAM_CHAT_ID" "Warning: I completed onboarding but I'm not in enabled-agents.json. Run: cortextos start $CTX_AGENT_NAME"

--- a/templates/analyst/.claude/skills/agent-management/SKILL.md
+++ b/templates/analyst/.claude/skills/agent-management/SKILL.md
@@ -174,6 +174,8 @@ cortextos bus send-message "$AGENT" high "soft-restart" "model change to $NEW_MO
 - `claude-sonnet-4-6` - Good balance, ~5x cheaper than Opus
 - `claude-haiku-4-5-20251001` - Fastest, cheapest, for simple tasks
 
+**Context window suffix:** Append `[1m]` to any model ID (e.g., `claude-opus-4-6[1m]`) to enable the extended 1M token context window. Without it, agents get the default shorter context window and will compact much sooner. Recommended for orchestrators and any agent doing complex multi-step work.
+
 **No model set = default (Opus).** Always set explicitly for cost control.
 
 ---

--- a/templates/analyst/ONBOARDING.md
+++ b/templates/analyst/ONBOARDING.md
@@ -614,7 +614,7 @@ If no specialists wanted: proceed to step 29.
 ### Step 28b: Verify agent is enabled
 
 ```bash
-ENABLED=$(cat "${CTX_FRAMEWORK_ROOT}/orgs/${CTX_ORG}/enabled-agents.json" 2>/dev/null || echo '[]')
+ENABLED=$(cat "${CTX_ROOT}/config/enabled-agents.json" 2>/dev/null || echo '[]')
 if ! echo "$ENABLED" | jq -e --arg name "$CTX_AGENT_NAME" '.[] | select(. == $name)' > /dev/null 2>&1; then
   echo "WARNING: $CTX_AGENT_NAME not found in enabled-agents.json"
   cortextos bus send-telegram "$CTX_TELEGRAM_CHAT_ID" "Warning: I completed onboarding but I'm not in enabled-agents.json. Run: cortextos start $CTX_AGENT_NAME"

--- a/templates/orchestrator/.claude/skills/agent-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/agent-management/SKILL.md
@@ -185,6 +185,8 @@ cortextos bus send-message "$AGENT" high "soft-restart" "model change to $NEW_MO
 - `claude-sonnet-4-6` - Good balance, ~5x cheaper than Opus
 - `claude-haiku-4-5-20251001` - Fastest, cheapest, for simple tasks
 
+**Context window suffix:** Append `[1m]` to any model ID (e.g., `claude-opus-4-6[1m]`) to enable the extended 1M token context window. Without it, agents get the default shorter context window and will compact much sooner. Recommended for orchestrators and any agent doing complex multi-step work.
+
 **No model set = default (Opus).** Always set explicitly for cost control.
 
 ---

--- a/templates/orchestrator/ONBOARDING.md
+++ b/templates/orchestrator/ONBOARDING.md
@@ -453,7 +453,7 @@ Make any changes they request.
 ### Step 22b: Verify agent is enabled
 
 ```bash
-ENABLED=$(cat "${CTX_FRAMEWORK_ROOT}/orgs/${CTX_ORG}/enabled-agents.json" 2>/dev/null || echo '[]')
+ENABLED=$(cat "${CTX_ROOT}/config/enabled-agents.json" 2>/dev/null || echo '[]')
 if ! echo "$ENABLED" | jq -e --arg name "$CTX_AGENT_NAME" '.[] | select(. == $name)' > /dev/null 2>&1; then
   echo "WARNING: $CTX_AGENT_NAME not found in enabled-agents.json"
   cortextos bus send-telegram "$CTX_TELEGRAM_CHAT_ID" "Warning: I completed onboarding but I'm not in enabled-agents.json. Run: cortextos start $CTX_AGENT_NAME"


### PR DESCRIPTION
## Summary

We're the first Windows install of cortextOS. We set up a 5-agent organization (orchestrator, analyst, community director, client director, platform engineer), ran the full onboarding process, and documented every issue we hit.

This PR contains 14 fixes covering critical spawn failures, UX improvements, template corrections, encoding issues, and newly discovered Windows-specific bugs — plus a proper branded favicon to replace the Vercel default.

Fixes validated via fresh test instance on Windows 11 + targeted human testing. Community feedback welcome for edge cases we may have missed.

## Platform
Windows 11 Home (10.0.26200), Node.js v24.12.0, Claude Code 2.1.77

## Fixes

| # | Severity | Description | Files |
|---|----------|-------------|-------|
| 1 | Critical | node-pty can't spawn `claude` on Windows — needs `claude.exe` | agent-pty.ts |
| 2 | High | Dashboard fails to start — `npx` ENOENT on Windows | dashboard.ts |
| 3 | Medium | Dashboard password changes ignored after initial seed | auth.ts |
| 4 | Medium | Python venv not created during install — KB setup fails | install.ts |
| 5 | Medium | Stale embedding model name (`text-embedding-004` → `gemini-embedding-001`) | kb-setup.sh |
| 6 | High | Build tools detection recommends deprecated `windows-build-tools` package | install.ts, doctor.ts |
| 7 | Medium | `cortextos` CLI not globally available after install — agents can't use bus | install.ts |
| 8 | Low | enabled-agents.json path mismatch in onboarding templates | 3x ONBOARDING.md |
| 9 | Medium | Emoji renders as `?` in Windows agent Telegram messages | agent-pty.ts |
| 10 | Low | Model config docs missing `[1m]` context window suffix | 3x agent-management SKILL.md |
| 11 | Medium | `kb-setup.sh` uses Unix `bin/` path — Windows venvs use `Scripts/` | kb-setup.sh |
| 12 | Low | pip self-upgrade fails on Windows due to file lock | kb-setup.sh |
| 13 | High | `commandExists()` fails to find WinGet/user-space tools on Windows | install.ts |
| 14 | Low | Node.js v24 DEP0190 deprecation warning with `shell:true` | install.ts, dashboard.ts |

## Improvement
- Replaced default Vercel favicon with branded cortextOS icon (gold/white cO matching sidebar)

## Testing
- Bugs 1, 2, 5, 7, 8, 11, 12, 13 reproduced on fresh test instance
- Bugs 3, 9 validated by human testing (dashboard login + Telegram emoji)
- Bugs 6, 10, 14 validated via code review and targeted testing
- Build passes clean on Windows 11

## Test Plan
- [ ] Fresh Windows install via `curl` installer
- [ ] Full `/onboarding` walkthrough
- [ ] Agent spawn + Telegram connection
- [ ] Dashboard start + login + password change
- [ ] KB setup + ingest + query
- [ ] Emoji rendering in agent messages