### PR TITLE
fix(install): chmod 600 the instance .env file

### DIFF
--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -258,6 +258,7 @@ export const installCommand = new Command('install')
         `CTX_ROOT=${ctxRoot}`,
         '',
       ].join('\n'), 'utf-8');
+      try { chmodSync(envPath, 0o600); } catch { /* ignore on Windows */ }
       console.log('  Created .env');
     }
 


### PR DESCRIPTION
## Summary

The instance `.env` file written by `cortextos install` (at `~/.cortextos/<instance>/.env`) is being created with the default mode (644 — world-readable). The parent directory is 700 so cross-user access is blocked, but `.env` files conventionally hold secrets, and any future feature writing a token or credential there would silently expose it to any local process running as the same user.

## Repro (on plain `main`)

```bash
curl -fsSL https://raw.githubusercontent.com/grandamenium/cortextos/main/install.mjs | node
stat -f '%Mp%Lp' ~/.cortextos/default/.env
# → 0644 (current behavior)
```

## Fix

One-line addition mirroring the existing pattern at `src/cli/install.ts:269` (`bus-signing-key`) and `:306` (`dashboard.env`):

```ts
try { chmodSync(envPath, 0o600); } catch { /* ignore on Windows */ }
```

`chmodSync` was already imported at the top of the file. The chmod is inside the `if (!existsSync(envPath))` block so existing `.env` files are unaffected — only new installs get the fix.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 382/382 passed
- [ ] Reproduce bug on plain main: `curl ... main ... | node && stat -f '%Mp%Lp' ~/.cortextos/default/.env` → expect `0644`
- [ ] Apply fix, reinstall, verify: `stat -f '%Mp%Lp' ~/.cortextos/default/.env` → expect `0600`

## Context

Found during a fresh-install audit on a clean macOS install. Filed internally as `BUG-001`. First in a series of small upstream fixes coming out of a comprehensive cortextOS production-readiness sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)