### PR TITLE
fix(daemon): respect enabled-agents.json in discoverAndStart + listAgents

### DIFF
--- a/src/bus/agents.ts
+++ b/src/bus/agents.ts
@@ -6,50 +6,44 @@ import { sendMessage } from './message.js';
 
 /**
  * List all agents in the system.
- * Scans enabled-agents.json and org agent directories.
- * Mirrors bash list-agents.sh behavior.
+ *
+ * Merges two sources of truth:
+ *   1. The framework directory scan (`${CTX_FRAMEWORK_ROOT}/orgs/<org>/agents/`)
+ *      — this is what the daemon discovers and runs.
+ *   2. `enabled-agents.json` — explicit user-set enable/disable state from
+ *      `cortextos enable`/`disable` and the dashboard.
+ *
+ * BUG-028: previously this function treated `enabled-agents.json` as
+ * authoritative — if the file existed, the directory scan was skipped, causing
+ * `cortextos list-agents` to miss agents that the daemon was actually running.
+ * Now both sources are always merged, with the file providing the explicit
+ * enabled flag and the directory scan providing the canonical existence check.
  */
 export function listAgents(ctxRoot: string, org?: string): AgentInfo[] {
   const agents: AgentInfo[] = [];
   const seen = new Set<string>();
 
-  // 1. Read enabled-agents.json for configured agents
+  // 1. Read enabled-agents.json for explicit enable/disable state.
+  // This is treated as metadata, not as the list of agents to display.
   const enabledFile = join(ctxRoot, 'config', 'enabled-agents.json');
   let enabledAgents: Record<string, { org?: string; enabled?: boolean }> = {};
-
   if (existsSync(enabledFile)) {
     try {
       enabledAgents = JSON.parse(readFileSync(enabledFile, 'utf-8'));
     } catch {
-      // Skip corrupt file
+      // Skip corrupt file — fall through to directory scan only.
     }
   }
 
-  for (const [name, cfg] of Object.entries(enabledAgents)) {
-    if (!/^[a-z0-9_-]+$/.test(name)) continue;
-    const agentOrg = cfg.org || '';
-
-    // Filter by org if specified
-    if (org && agentOrg !== org) continue;
-
-    seen.add(name);
-    agents.push(buildAgentInfo(name, agentOrg, cfg.enabled !== false, ctxRoot));
-  }
-
-  // 2. Scan project directories for agents not in enabled list.
-  // If enabled-agents.json exists it's authoritative — skip directory scan.
-  // Without CTX_FRAMEWORK_ROOT set, skip scan to avoid cross-environment bleed.
-  if (existsSync(enabledFile) || !process.env.CTX_FRAMEWORK_ROOT) {
-    return agents;
-  }
-
+  // 2. ALWAYS scan org agent directories (BUG-028 fix).
+  // The directory scan is now the primary source for "what agents exist".
+  // The enabled-agents.json entries are merged in as metadata.
   const cliProjectRoot = process.env.CTX_FRAMEWORK_ROOT;
   const scanRoots: string[] = [];
-
-  if (existsSync(join(cliProjectRoot, 'orgs'))) {
+  if (cliProjectRoot && existsSync(join(cliProjectRoot, 'orgs'))) {
     scanRoots.push(cliProjectRoot);
   }
-  // Also try cwd as fallback (only if no other roots found)
+  // Fallback: cwd, but only if no framework root is set
   if (scanRoots.length === 0) {
     const cwd = process.cwd();
     if (existsSync(join(cwd, 'orgs'))) {
@@ -85,13 +79,29 @@ export function listAgents(ctxRoot: string, org?: string): AgentInfo[] {
         if (!/^[a-z0-9_-]+$/.test(agentName)) continue;
         if (seen.has(agentName)) continue;
 
-        const agentDir = join(agentsDir, orgName, 'agents', agentName);
-        if (!existsSync(join(agentsDir, agentName))) continue;
-
         seen.add(agentName);
-        agents.push(buildAgentInfo(agentName, orgName, false, ctxRoot));
+
+        // Determine enabled state: explicit from enabled-agents.json if present,
+        // otherwise default to enabled (matches the daemon's discoverAndStart
+        // default-on behavior).
+        const explicitEntry = enabledAgents[agentName];
+        const isEnabled = explicitEntry ? explicitEntry.enabled !== false : true;
+
+        agents.push(buildAgentInfo(agentName, orgName, isEnabled, ctxRoot));
       }
     }
+  }
+
+  // 3. Append any entries from enabled-agents.json that don't have a corresponding
+  // directory on disk (stale registrations — file has them but the dir was deleted
+  // or never existed). These are surfaced so users can clean them up.
+  for (const [name, cfg] of Object.entries(enabledAgents)) {
+    if (!/^[a-z0-9_-]+$/.test(name)) continue;
+    if (seen.has(name)) continue;
+    const agentOrg = cfg.org || '';
+    if (org && agentOrg !== org) continue;
+    seen.add(name);
+    agents.push(buildAgentInfo(name, agentOrg, cfg.enabled !== false, ctxRoot));
   }
 
   return agents;

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -39,12 +39,43 @@ export class AgentManager {
    */
   async discoverAndStart(): Promise<void> {
     const agentDirs = this.discoverAgents();
+
+    // BUG-028: read instance-level enabled-agents.json so the daemon respects
+    // the user's explicit enable/disable choices written by the CLI
+    // (`cortextos enable`/`disable`) and the dashboard. Without this read, those
+    // commands have no effect across daemon restarts — the daemon would
+    // re-discover and re-start any agent dir on disk regardless of user intent.
+    const instanceEnabled = this.readInstanceEnableList();
+
     for (const { name, dir, config } of agentDirs) {
+      // Per-agent config.json `enabled: false` (existing behavior, unchanged)
       if (config.enabled === false) {
-        console.log(`[agent-manager] Skipping disabled agent: ${name}`);
+        console.log(`[agent-manager] Skipping disabled agent: ${name} (per-agent config.json)`);
+        continue;
+      }
+      // Instance-level enabled-agents.json `enabled: false` (BUG-028 fix)
+      const entry = instanceEnabled[name];
+      if (entry && entry.enabled === false) {
+        console.log(`[agent-manager] Skipping disabled agent: ${name} (enabled-agents.json)`);
         continue;
       }
       await this.startAgent(name, dir, config);
+    }
+  }
+
+  /**
+   * Read the instance-level enabled-agents.json registry.
+   * Returns an empty object if the file is missing or unreadable —
+   * agents not present in the file default to enabled, matching the existing
+   * default-on behavior of `discoverAndStart`.
+   */
+  private readInstanceEnableList(): Record<string, { enabled?: boolean; org?: string; status?: string }> {
+    const enabledFile = join(this.ctxRoot, 'config', 'enabled-agents.json');
+    if (!existsSync(enabledFile)) return {};
+    try {
+      return JSON.parse(readFileSync(enabledFile, 'utf-8'));
+    } catch {
+      return {}; // corrupt or unreadable — fall through to default-enabled
     }
   }
 

--- a/tests/unit/bus/agents.test.ts
+++ b/tests/unit/bus/agents.test.ts
@@ -129,6 +129,49 @@ describe('Agent Discovery', () => {
       expect(agents.length).toBe(1);
       expect(agents[0].name).toBe('boris');
     });
+
+    // BUG-028: daemon and CLI must agree on what's enabled.
+    // Previously, listAgents short-circuited on enabled-agents.json existence,
+    // hiding agents the daemon was actually running from `cortextos list-agents`.
+    it('shows agents from dir scan even when enabled-agents.json exists', () => {
+      // Set up: enabled-agents.json with one agent (alice), but TWO dirs on disk
+      // (alice and bob). Previously listAgents would only return alice. After
+      // the fix, both should be returned.
+      const configDir = join(ctxRoot, 'config');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(
+        join(configDir, 'enabled-agents.json'),
+        JSON.stringify({ alice: { org: 'acme', enabled: true } }),
+      );
+
+      const frameworkRoot = join(testDir, 'framework');
+      process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
+      mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice'), { recursive: true });
+      mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'bob'), { recursive: true });
+
+      const agents = listAgents(ctxRoot);
+      expect(agents.map(a => a.name).sort()).toEqual(['alice', 'bob']);
+    });
+
+    it('respects enabled: false from enabled-agents.json for agents found in dir scan', () => {
+      // Set up: dir for alice + entry in enabled-agents.json saying enabled: false.
+      // listAgents should return alice with enabled: false (not skip her entirely).
+      const configDir = join(ctxRoot, 'config');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(
+        join(configDir, 'enabled-agents.json'),
+        JSON.stringify({ alice: { org: 'acme', enabled: false } }),
+      );
+
+      const frameworkRoot = join(testDir, 'framework');
+      process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
+      mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice'), { recursive: true });
+
+      const agents = listAgents(ctxRoot);
+      expect(agents.length).toBe(1);
+      expect(agents[0].name).toBe('alice');
+      expect(agents[0].enabled).toBe(false);
+    });
   });
 
   describe('notifyAgent', () => {

--- a/tests/unit/daemon/agent-manager.test.ts
+++ b/tests/unit/daemon/agent-manager.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock the PTY layer so we don't load native bindings or spawn real processes.
+// AgentManager → AgentProcess → AgentPTY → node-pty. We mock at AgentProcess.
+vi.mock('../../../src/daemon/agent-process.js', () => ({
+  AgentProcess: class {
+    name: string;
+    dir: string;
+    constructor(name: string, dir: string) {
+      this.name = name;
+      this.dir = dir;
+    }
+    async start() { /* no-op */ }
+    async stop() { /* no-op */ }
+    getStatus() { return { name: this.name, status: 'stopped' }; }
+    onExit() { /* no-op */ }
+  },
+}));
+
+// Mock FastChecker so it doesn't try to spawn anything either.
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class {
+    start() { /* no-op */ }
+    stop() { /* no-op */ }
+    wake() { /* no-op */ }
+  },
+}));
+
+// Mock Telegram so we don't try to make HTTP calls.
+vi.mock('../../../src/telegram/api.js', () => ({
+  TelegramAPI: class {
+    constructor() { /* no-op */ }
+  },
+}));
+
+vi.mock('../../../src/telegram/poller.js', () => ({
+  TelegramPoller: class {
+    start() { /* no-op */ }
+    stop() { /* no-op */ }
+  },
+}));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+
+describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
+  let testDir: string;
+  let ctxRoot: string;
+  let frameworkRoot: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-am-test-'));
+    ctxRoot = join(testDir, 'instance');
+    frameworkRoot = join(testDir, 'framework');
+    mkdirSync(join(ctxRoot, 'config'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'bob'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('skips agents marked enabled: false in enabled-agents.json', async () => {
+    // Mark alice as disabled at the instance level (the file the CLI writes to)
+    writeFileSync(
+      join(ctxRoot, 'config', 'enabled-agents.json'),
+      JSON.stringify({ alice: { enabled: false, org: 'acme' } }),
+    );
+
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    // alice should be skipped (disabled in instance file), bob should be started
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledWith('bob', expect.any(String), expect.any(Object));
+  });
+
+  it('starts all discovered agents when enabled-agents.json is missing', async () => {
+    // No enabled-agents.json on disk — daemon defaults to enabled-on-discovery
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    const namesStarted = startSpy.mock.calls.map(call => call[0]).sort();
+    expect(namesStarted).toEqual(['alice', 'bob']);
+  });
+
+  it('starts all discovered agents when enabled-agents.json is empty {}', async () => {
+    writeFileSync(join(ctxRoot, 'config', 'enabled-agents.json'), '{}');
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    // Empty object means no overrides — all discovered agents start
+    expect(startSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('still respects per-agent config.json enabled: false (existing behavior)', async () => {
+    // Per-agent config.json takes precedence — this is the legacy behavior we
+    // explicitly preserved in the BUG-028 fix
+    writeFileSync(
+      join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice', 'config.json'),
+      JSON.stringify({ enabled: false }),
+    );
+
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    expect(startSpy).toHaveBeenCalledTimes(1);
+    expect(startSpy).toHaveBeenCalledWith('bob', expect.any(String), expect.any(Object));
+  });
+
+  it('handles corrupt enabled-agents.json by defaulting to enabled-all', async () => {
+    writeFileSync(
+      join(ctxRoot, 'config', 'enabled-agents.json'),
+      'this is not valid json',
+    );
+
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    // Corrupt file is treated as missing — all discovered agents start
+    expect(startSpy).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

The daemon's agent discovery loop and the CLI's `list-agents` command were reading from completely different sources of truth, so user-initiated `enable`/`disable` operations had no effect across daemon restarts and `cortextos list-agents` could show a fictional view that didn't match what the daemon was actually running.

This PR aligns both sides on the same logical model with two surgical changes (~70 lines net).

## Root cause

There were TWO parallel "agent enabled" registries that didn't talk to each other:

1. **Per-agent `config.json`** at `${frameworkRoot}/orgs/${org}/agents/${name}/config.json` with `enabled` field — the daemon respects this (`agent-manager.ts:43`)
2. **Instance-level `enabled-agents.json`** at `${ctxRoot}/config/enabled-agents.json` — the CLI's `enable`/`disable` commands, the dashboard's lifecycle API, `list-agents`, `metrics`, and various bus subcommands all read/write this file

The daemon completely ignored `enabled-agents.json` (verified: `grep -rn "enabled-agents" src/daemon/` returns ONLY references to its own internal `discoverAgents` function).

Symmetrically, `bus/agents.ts:listAgents` treated `enabled-agents.json` as authoritative — if the file existed, the directory scan was skipped entirely. This caused `cortextos list-agents` to miss any agent that the daemon had discovered but that wasn't in the file.

## Repro on plain `main` (`6421635`)

```bash
curl -fsSL https://raw.githubusercontent.com/grandamenium/cortextos/main/install.mjs | node
# ... add an agent dir to ~/cortextos/orgs/<org>/agents/<name> ...
cortextos start
# verify the daemon discovers and runs the agent
cortextos disable <name>
# the file is updated, IPC stop sent
pm2 restart cortextos-daemon
# the agent is RUNNING AGAIN — daemon ignored the disable
```

## Fix

### Change 1 — `src/daemon/agent-manager.ts`

`discoverAndStart` now also reads `${ctxRoot}/config/enabled-agents.json` and respects `enabled: false` entries. The existing per-agent `config.enabled === false` check is preserved unchanged. A new private helper `readInstanceEnableList()` encapsulates the file read with safe fallback on missing/corrupt file.

### Change 2 — `src/bus/agents.ts:listAgents`

Always scans the framework `orgs/` directory. The "skip dir scan if enabled-agents.json exists" branch is removed. The file is still read and used to override the default enabled state on each discovered agent. Stale file entries (have an entry but no matching dir on disk) are appended at the end so users can see them and clean them up.

## What this PR does NOT change

- `cortextos enable`/`disable` — keep writing to `enabled-agents.json` (now actually respected by the daemon)
- `cortextos install` — keeps creating an empty `enabled-agents.json`
- `cortextos add-agent` — keeps writing to the file
- Dashboard — keeps writing via existing API routes
- All IPC handlers in `src/daemon/ipc-server.ts` — unchanged
- Schema of `enabled-agents.json` — unchanged
- All other CLI subcommands, metrics, bus catalog/restart-all — unchanged

**Backward compatible. No migration. No schema changes.**

## Tests

- [x] `npm run build` — clean (TypeScript compile in 29ms)
- [x] `npm test` — **389/389 passing** (382 baseline + 7 new)
- [x] New `tests/unit/daemon/agent-manager.test.ts` — 5 cases covering enable/disable interaction, missing file, empty file, per-agent config precedence, corrupt file fallback
- [x] Extended `tests/unit/bus/agents.test.ts` — 2 new cases covering dir-scan-with-existing-file and dir-scan-with-disabled-entry
- [ ] Manual: reproduce on plain main, apply fix, re-test (will follow in comments)

## Refs

- BUG-028 in internal tracker. Structural root cause of BUG-024 (split-brain), BUG-025 (daemon ignores user intent), and possibly BUG-009 ("Agent <orgname> not found").
- Second PR in the cortextOS production-readiness sweep, following #7 (BUG-001).

🤖 Generated with [Claude Code](https://claude.com/claude-code)