### PR TITLE
feat(install): add CORTEXTOS_BRANCH env var for testing pre-merge fixes

### DIFF
--- a/install.mjs
+++ b/install.mjs
@@ -14,6 +14,18 @@ import { homedir, platform } from 'os';
 
 const REPO_URL = process.env.CORTEXTOS_REPO || 'https://github.com/grandamenium/cortextos.git';
 const INSTALL_DIR = process.env.CORTEXTOS_DIR || join(homedir(), 'cortextos');
+
+// CORTEXTOS_BRANCH lets you install a specific branch instead of `main`. Useful
+// for testing fixes before they merge:
+//   CORTEXTOS_BRANCH=fix/foo curl -fsSL .../fix/foo/install.mjs | node
+// Branch name is restricted to standard git ref characters to avoid shell injection.
+const REPO_BRANCH_RAW = process.env.CORTEXTOS_BRANCH || 'main';
+if (!/^[a-zA-Z0-9._/-]+$/.test(REPO_BRANCH_RAW)) {
+  console.error(`Invalid CORTEXTOS_BRANCH value: ${REPO_BRANCH_RAW}`);
+  console.error('Branch names may only contain letters, digits, dot, underscore, slash, or dash.');
+  process.exit(1);
+}
+const REPO_BRANCH = REPO_BRANCH_RAW;
 const IS_WINDOWS = platform() === 'win32';
 const IS_MAC = platform() === 'darwin';
 const IS_LINUX = platform() === 'linux';
@@ -389,8 +401,8 @@ if (existsSync(INSTALL_DIR)) {
     fail(`${INSTALL_DIR} exists but is not a git repo. Remove it or set CORTEXTOS_DIR to a different path.`);
   }
 } else {
-  log(`Cloning cortextOS to ${INSTALL_DIR}...`);
-  runVisible(`git clone ${REPO_URL} ${JSON.stringify(INSTALL_DIR)}`);
+  log(`Cloning cortextOS (branch: ${REPO_BRANCH}) to ${INSTALL_DIR}...`);
+  runVisible(`git clone --branch ${REPO_BRANCH} ${REPO_URL} ${JSON.stringify(INSTALL_DIR)}`);
   ok('Cloned');
 
   // Rename origin → upstream so check-upstream and upstream-sync work out of the box


### PR DESCRIPTION
## Summary

Add a `CORTEXTOS_BRANCH` env var to `install.mjs` so we can test pre-merge fixes via the canonical curl install path. ~10 lines, fully backward compatible.

## Why

The canonical install command is:
```bash
curl -fsSL https://raw.githubusercontent.com/grandamenium/cortextos/main/install.mjs | node
```

The curl URL fetches `install.mjs` from a specific branch, but `install.mjs` itself unconditionally clones `main` (line 392 today). So if you want to test a fix in `fix/some-branch` via curl:

- Option A — clone `main`, get the unfixed code, defeats the purpose
- Option B — manually `git clone --branch fix/some-branch && node ~/cortextos/install.mjs`, which works but isn't the "real user experience" the curl command represents
- Option C — wait until your fix is merged to test via curl, which means publishing unverified fixes

This PR adds option D:

```bash
CORTEXTOS_BRANCH=fix/some-branch \
  curl -fsSL https://raw.githubusercontent.com/grandamenium/cortextos/fix/some-branch/install.mjs | node
```

Both URL components point at the same branch — `install.mjs` is fetched FROM that branch (containing this fix) and then clones FROM that branch via `git clone --branch ${REPO_BRANCH}`. Self-bootstrapping.

## Change

Mirrors the existing pattern for `CORTEXTOS_REPO` and `CORTEXTOS_DIR` (lines 15-16):

```js
// CORTEXTOS_BRANCH lets you install a specific branch instead of `main`. Useful
// for testing fixes before they merge:
//   CORTEXTOS_BRANCH=fix/foo curl -fsSL .../fix/foo/install.mjs | node
// Branch name is restricted to standard git ref characters to avoid shell injection.
const REPO_BRANCH_RAW = process.env.CORTEXTOS_BRANCH || 'main';
if (!/^[a-zA-Z0-9._/-]+$/.test(REPO_BRANCH_RAW)) {
  console.error(`Invalid CORTEXTOS_BRANCH value: ${REPO_BRANCH_RAW}`);
  console.error('Branch names may only contain letters, digits, dot, underscore, slash, or dash.');
  process.exit(1);
}
const REPO_BRANCH = REPO_BRANCH_RAW;
```

And one line in the clone block:
```js
runVisible(`git clone --branch ${REPO_BRANCH} ${REPO_URL} ${JSON.stringify(INSTALL_DIR)}`);
```

## Backward compatibility

- `CORTEXTOS_BRANCH` unset → defaults to `main` → identical behavior to today
- `CORTEXTOS_BRANCH=main` → explicitly clones main → identical behavior
- Branch name validation: shell-injection-safe regex (matches git's own ref naming rules conservatively)
- The existing-install path (`git pull upstream main --ff-only`) is intentionally NOT touched in this PR — it still pulls from `main`. If you want to switch an existing install to a branch, manually delete `~/cortextos` first, then re-run with `CORTEXTOS_BRANCH=foo`.

## Test plan

- [x] `npm test` — 389/389 passing (install.mjs has no unit tests; this just confirms nothing else broke)
- [ ] Manual: `./reset.sh && CORTEXTOS_BRANCH=fix/install-branch-flag curl -fsSL https://raw.githubusercontent.com/grandamenium/cortextos/fix/install-branch-flag/install.mjs | node` → verify install lands on commit 5a043b1
- [ ] Sanity: `./reset.sh && curl -fsSL https://raw.githubusercontent.com/grandamenium/cortextos/main/install.mjs | node` (canonical, unchanged) → still works

Will follow up with proof comments after testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)