### PR TITLE
fix(onboarding): pass --instance flags + reuse empty default instance

### DIFF
--- a/.claude/commands/onboarding.md
+++ b/.claude/commands/onboarding.md
@@ -146,19 +146,33 @@ cortextos install
 **Do not ask the user about instance names.** Auto-assign one silently:
 
 ```bash
-# Find next available instance name
-INSTANCE_NUM=1
-while [ -d "${HOME}/.cortextos/cortextos${INSTANCE_NUM}" ]; do
-  INSTANCE_NUM=$((INSTANCE_NUM + 1))
-done
-INSTANCE_ID="cortextos${INSTANCE_NUM}"
+# Reuse the 'default' instance dir if it exists and is empty (the typical
+# fresh-install state — `cortextos install` always creates default/ with an
+# empty enabled-agents.json). Otherwise pick the next free `cortextosN` slot.
+if [ -d "${HOME}/.cortextos/default" ] && \
+   [ "$(cat "${HOME}/.cortextos/default/config/enabled-agents.json" 2>/dev/null | tr -d '[:space:]')" = "{}" ]; then
+  INSTANCE_ID="default"
+else
+  INSTANCE_NUM=1
+  while [ -d "${HOME}/.cortextos/cortextos${INSTANCE_NUM}" ]; do
+    INSTANCE_NUM=$((INSTANCE_NUM + 1))
+  done
+  INSTANCE_ID="cortextos${INSTANCE_NUM}"
+fi
 ```
 
-**Note on environment variables:** `CTX_INSTANCE_ID`, `CTX_ROOT`, `CTX_ORG`, and `CTX_AGENT_NAME` are set automatically by the framework based on where commands are run from. You do not need to set these manually - they are referenced in the examples below for clarity.
+**IMPORTANT:** Every `node dist/cli.js <subcommand>` call below MUST include
+`--instance "${INSTANCE_ID}"` (and `--org "${ORG_NAME}"` where the command
+takes one). The CLI subcommands default the instance to literal `'default'` if
+neither the flag nor the `CTX_INSTANCE_ID` env var is set. Forgetting the flag
+silently writes to the wrong instance dir, splitting the agent registration
+across multiple `~/.cortextos/<instance>/` trees. Always pass the flags.
 
-Set variables for the rest of onboarding:
+Also export the env vars so any indirect subprocess (e.g. PM2 reading `ecosystem.config.js`) inherits them:
+
 ```bash
-CTX_ROOT="${HOME}/.cortextos/${INSTANCE_ID}"
+export CTX_INSTANCE_ID="${INSTANCE_ID}"
+export CTX_ROOT="${HOME}/.cortextos/${INSTANCE_ID}"
 ```
 
 ---
@@ -297,7 +311,7 @@ If ORCH_CHAT_ID is empty after 3 retries, tell user to send another message and 
 ### 6b. Create Agent Directory
 
 ```bash
-node dist/cli.js add-agent "${ORCH_NAME}" --template orchestrator --org "${ORG_NAME}"
+node dist/cli.js add-agent "${ORCH_NAME}" --template orchestrator --org "${ORG_NAME}" --instance "${INSTANCE_ID}"
 ```
 
 Write `.env` with credentials:
@@ -330,7 +344,7 @@ jq --arg model "claude-opus-4-6" '.model = $model' "${ORCH_CONFIG}" > "${TMPDIR:
 ### 6d. Enable Orchestrator
 
 ```bash
-node dist/cli.js enable "${ORCH_NAME}" --org "${ORG_NAME}"
+node dist/cli.js enable "${ORCH_NAME}" --org "${ORG_NAME}" --instance "${INSTANCE_ID}"
 ```
 
 Verify:
@@ -467,7 +481,7 @@ Everything is configured. Now start the agents.
 ### 9a. Generate PM2 config and start
 
 ```bash
-node dist/cli.js ecosystem
+node dist/cli.js ecosystem --instance "${INSTANCE_ID}" --org "${ORG_NAME}"
 pm2 start ecosystem.config.js
 ```
 


### PR DESCRIPTION
## Summary

The `/onboarding` skill had two reinforcing bugs that produced split-brain state on every clean install:

1. **BUG-029**: every CLI subcommand defaults `--instance` to literal `'default'` when neither flag nor `CTX_INSTANCE_ID` env var is set. The skill set a local `INSTANCE_ID` shell variable but never exported it, and only passed `--instance` to `init`. The `add-agent`, `enable`, and `ecosystem` calls all silently wrote to `~/.cortextos/default/` even though the user's actual instance was `cortextos1` (or higher).

2. **BUG-017**: the auto-numbering loop unconditionally picked `cortextosN` even though `cortextos install` (called earlier in the same flow) always creates an empty `default/` instance. Result: every install ended with TWO instance dirs — an orphaned `default/` that nothing used, and a `cortextos1/` with the actual state.

Together these caused: orchestrator registered in `default/enabled-agents.json`, daemon running on `cortextos1`, two different `bus-signing-key` files, dashboard SQLite named `cortextos-default.db` despite living under `cortextos1/`.

## Repro on `main` (`81b7b27`)

```bash
curl -fsSL https://raw.githubusercontent.com/grandamenium/cortextos/main/install.mjs | node
claude ~/cortextos
# /onboarding (complete the flow)
# Then:
ls ~/.cortextos/                           # → default/ AND cortextos1/  ← BUG
cat ~/.cortextos/default/config/enabled-agents.json    # → contains orchestrator entry  ← BUG-029
cat ~/.cortextos/cortextos1/config/enabled-agents.json # → {}  ← daemon has no idea
diff <(ls ~/.cortextos/default/config/bus-signing-key) <(ls ~/.cortextos/cortextos1/config/bus-signing-key)  # different keys!
```

Verified during this session — see the audit in `~/cortextos-fresh-install-helper/bugs.md` (BUG-017, BUG-024, BUG-025).

## Fix (4 changes to `.claude/commands/onboarding.md`)

### 1. Auto-numbering now reuses empty `default/`

```bash
if [ -d "${HOME}/.cortextos/default" ] && \
   [ "$(cat "${HOME}/.cortextos/default/config/enabled-agents.json" 2>/dev/null | tr -d '[:space:]')" = "{}" ]; then
  INSTANCE_ID="default"
else
  # ... existing cortextosN fallback ...
fi
```

The check is "default exists AND its enabled-agents.json content is literally `{}`" — the fresh-install state. This is robust to whitespace and corrupt files (corrupt = falls through to cortextosN, which is the safe choice). For users who already have content in `default/` (existing installs), the fallback path picks `cortextos1`/`cortextos2`/etc as before, preserving backward compat.

### 2. Add `--instance` to every CLI subcommand

```diff
- node dist/cli.js add-agent "${ORCH_NAME}" --template orchestrator --org "${ORG_NAME}"
+ node dist/cli.js add-agent "${ORCH_NAME}" --template orchestrator --org "${ORG_NAME}" --instance "${INSTANCE_ID}"

- node dist/cli.js enable "${ORCH_NAME}" --org "${ORG_NAME}"
+ node dist/cli.js enable "${ORCH_NAME}" --org "${ORG_NAME}" --instance "${INSTANCE_ID}"

- node dist/cli.js ecosystem
+ node dist/cli.js ecosystem --instance "${INSTANCE_ID}" --org "${ORG_NAME}"
```

(`init` already had `--instance` — left unchanged.)

### 3. Export `CTX_INSTANCE_ID` and `CTX_ROOT`

```bash
export CTX_INSTANCE_ID="${INSTANCE_ID}"
export CTX_ROOT="${HOME}/.cortextos/${INSTANCE_ID}"
```

Belt-and-suspenders alongside the explicit flags. Indirect subprocesses (PM2 reading `ecosystem.config.js`, the dashboard env loader, bus subcommands) inherit the right instance via env even if they don't read the explicit flag.

### 4. Replaced the misleading "auto-set" note

The previous note said:

> `CTX_INSTANCE_ID`, `CTX_ROOT`, `CTX_ORG`, and `CTX_AGENT_NAME` are set automatically by the framework based on where commands are run from. You do not need to set these manually...

This was simply false — the CLI defaults to literal `'default'` if neither flag nor env is set. Replaced with an explicit IMPORTANT block telling maintainers that every CLI call MUST pass `--instance` and explaining the consequences of forgetting.

## Test plan

- [x] `npm test` → 389/389 passing (skill is markdown, no source changes)
- [x] grep verification: all 4 CLI calls now have `--instance "${INSTANCE_ID}"`
- [ ] Manual end-to-end: reset → install → run `/onboarding` to completion → assert `ls ~/.cortextos/` shows ONE instance dir (not two), and that dir's `enabled-agents.json` contains the orchestrator

Will follow up with manual verification comments.

## Closes

- BUG-017 (orphan `default/` instance dir created on every install)
- BUG-029 (`/onboarding` skill omits `--instance` flags)

Combined into one PR because the two bugs cause the same observable symptom (split-brain state) and the fix touches the same file. Separating them would require two test cycles for one outcome.

🤖 Generated with [Claude Code](https://claude.com/claude-code)