### PR TITLE
fix(daemon): close PTY race in AgentProcess.stop() (BUG-011)

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -26,6 +26,12 @@ export class AgentProcess {
   private sessionStart: Date | null = null;
   private status: AgentStatus['status'] = 'stopped';
   private stopping: boolean = false;
+  // BUG-011 fix: stop() awaits this promise (resolved by the onExit handler in start())
+  // to guarantee the PTY exit has fired before stopping=false is reset. Without
+  // this, the exit handler can fire after stopping=false and trigger spurious
+  // crash recovery for an agent we just stopped intentionally.
+  private exitPromise: Promise<void> | null = null;
+  private resolveExit: (() => void) | null = null;
   private dedup: MessageDedup;
   private log: LogFn;
   private onStatusChange: ((status: AgentStatus) => void) | null = null;
@@ -77,10 +83,20 @@ export class AgentProcess {
     this.log(`Log path: ${logPath}`);
     this.pty = new AgentPTY(this.env, this.config, logPath);
 
+    // BUG-011 fix: create a fresh exit signal for this run. resolveExit is
+    // called from the onExit handler below; stop() awaits exitPromise to
+    // guarantee the exit handler has fired before clearing stopping.
+    this.exitPromise = new Promise<void>((resolve) => {
+      this.resolveExit = resolve;
+    });
+
     // Handle exit
     this.pty.onExit((exitCode, signal) => {
       this.log(`Exited with code ${exitCode} signal ${signal}`);
       this.handleExit(exitCode);
+      // Signal anyone awaiting this PTY's exit (e.g. stop() — BUG-011 fix)
+      this.resolveExit?.();
+      this.resolveExit = null;
     });
 
     try {
@@ -113,6 +129,9 @@ export class AgentProcess {
     // shutdown doesn't race with us and trigger crash recovery or a double-kill.
     const pty = this.pty;
     this.pty = null;
+    // Capture the exit promise before any awaits — we'll wait on this AFTER
+    // pty.kill() to guarantee the exit handler has run before stopping=false.
+    const exitPromise = this.exitPromise;
 
     if (pty) {
       try {
@@ -128,6 +147,15 @@ export class AgentProcess {
       } catch {
         // PTY may have already exited — ignore
       }
+
+      // BUG-011 fix: AWAIT the exit handler before resolving stop().
+      // Without this, stop() returns while the PTY exit is still in flight,
+      // and the exit handler may fire AFTER stopping=false (set below),
+      // triggering spurious crash recovery for an agent we just stopped.
+      // 5-second timeout guards against a hung PTY.
+      if (exitPromise) {
+        await Promise.race([exitPromise, sleep(5000)]);
+      }
     }
 
     this.stopping = false;
@@ -138,45 +166,18 @@ export class AgentProcess {
 
   /**
    * Restart with --continue (session refresh).
+   *
+   * Delegates to stop() + start() so it inherits the BUG-011 race fix
+   * automatically. This also eliminates a separate bug in the previous
+   * inline implementation where the OLD pty's exit handler could fire
+   * AFTER the NEW pty was set up, nulling out the wrong reference.
+   * `start()` will pick up `continue` mode automatically because the
+   * conversation directory still has .jsonl files (shouldContinue() is true).
    */
   async sessionRefresh(): Promise<void> {
     this.log('Session refresh (--continue restart)');
-    this.stopping = true;
-    this.clearSessionTimer();
-
-    // Capture and null out pty before awaits (same race-condition guard as stop()).
-    const pty = this.pty;
-    this.pty = null;
-
-    if (pty) {
-      try {
-        pty.write('\x03'); // Ctrl-C
-        await sleep(1000);
-        pty.write('/exit\r');
-        await sleep(3000);
-      } catch {
-        // Ignore
-      }
-      try {
-        pty.kill();
-      } catch {
-        // PTY may have already exited — ignore
-      }
-    }
-
-    this.stopping = false;
-
-    // Relaunch with continue mode
-    const logPath = join(this.env.ctxRoot, 'logs', this.name, 'stdout.log');
-    this.pty = new AgentPTY(this.env, this.config, logPath);
-
-    this.pty.onExit((exitCode) => {
-      this.handleExit(exitCode);
-    });
-
-    const prompt = this.buildContinuePrompt();
-    await this.pty.spawn('continue', prompt);
-    this.startSessionTimer();
+    await this.stop();
+    await this.start();
     this.log('Session refreshed');
   }
 

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Capture the PTY exit handler so tests can simulate exits at controlled times
+let capturedOnExit: ((exitCode: number, signal?: number) => void) | null = null;
+
+const mockPty = {
+  spawn: vi.fn().mockResolvedValue(undefined),
+  kill: vi.fn(),
+  write: vi.fn(),
+  getPid: vi.fn().mockReturnValue(12345),
+  onExit: vi.fn().mockImplementation((cb: (exitCode: number, signal?: number) => void) => {
+    capturedOnExit = cb;
+  }),
+};
+
+vi.mock('../../../src/pty/agent-pty.js', () => ({
+  AgentPTY: function AgentPTY() { return mockPty; },
+}));
+
+vi.mock('../../../src/pty/inject.js', () => ({
+  injectMessage: vi.fn(),
+  MessageDedup: class { isDuplicate() { return false; } },
+}));
+
+vi.mock('../../../src/utils/atomic.js', () => ({
+  ensureDir: vi.fn(),
+  atomicWriteSync: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/env.js', () => ({
+  writeCortextosEnv: vi.fn(),
+  resolveEnv: vi.fn().mockReturnValue({ instanceId: 'test', ctxRoot: '/tmp/test' }),
+}));
+
+vi.mock('../../../src/bus/reminders.js', () => ({
+  getOverdueReminders: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../../../src/utils/paths.js', () => ({
+  resolvePaths: vi.fn().mockReturnValue({}),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    mkdirSync: vi.fn(),
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+  };
+});
+
+const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+
+const mockEnv = {
+  instanceId: 'test',
+  ctxRoot: '/tmp/test-ctx',
+  frameworkRoot: '/tmp/fw',
+  agentName: 'alice',
+  agentDir: '/tmp/fw/orgs/acme/agents/alice',
+  org: 'acme',
+  projectRoot: '/tmp/fw',
+};
+
+beforeEach(() => {
+  capturedOnExit = null;
+  mockPty.spawn.mockClear();
+  mockPty.kill.mockClear();
+  mockPty.write.mockClear();
+  mockPty.onExit.mockClear();
+});
+
+describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
+  it('stop() awaits the PTY exit handler before resolving', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+    expect(capturedOnExit).not.toBeNull();
+    expect(ap.getStatus().status).toBe('running');
+
+    let stopResolved = false;
+    const stopPromise = ap.stop().then(() => { stopResolved = true; });
+
+    // Give stop() a moment to enter its kill phase. The 4s of internal sleeps
+    // (1s after Ctrl-C + 3s after /exit) plus the awaitExit will keep stop()
+    // in flight. After 100ms, it should NOT have resolved.
+    await new Promise(r => setTimeout(r, 100));
+    expect(stopResolved).toBe(false);
+
+    // Now simulate the PTY exit firing
+    capturedOnExit!(0, 0);
+
+    // After the exit fires, stop() should be able to resolve
+    // (after its internal sleeps finish — wait long enough)
+    await stopPromise;
+    expect(stopResolved).toBe(true);
+    expect(ap.getStatus().status).toBe('stopped');
+  }, 10000);
+
+  it('stop() does NOT trigger crash recovery on intentional stop (the BUG-011 regression)', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    // Stop and have the exit fire DURING the await window
+    const stopPromise = ap.stop();
+    await new Promise(r => setTimeout(r, 100));
+    capturedOnExit!(0, 0);
+    await stopPromise;
+
+    // The agent should be 'stopped', NOT 'crashed'.
+    // Before the fix, the exit handler could fire after stopping=false and
+    // call into the crash recovery branch, leaving status='crashed'.
+    expect(ap.getStatus().status).toBe('stopped');
+  }, 10000);
+
+  it('handleExit DOES trigger crash recovery on UNINTENTIONAL exit (regression check)', async () => {
+    // Make sure we didn't accidentally break the real crash recovery path
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+    expect(ap.getStatus().status).toBe('running');
+
+    // Fire the exit handler WITHOUT calling stop() first — simulates a real crash
+    capturedOnExit!(1, 0);
+
+    // The agent should be in 'crashed' state (crash recovery scheduled)
+    expect(ap.getStatus().status).toBe('crashed');
+  });
+
+  it('sessionRefresh() delegates to stop() then start() (in order)', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    // Spy on stop and start so we can verify the delegation
+    const stopSpy = vi.spyOn(ap, 'stop').mockResolvedValue();
+    const startSpy = vi.spyOn(ap, 'start').mockResolvedValue();
+
+    await ap.sessionRefresh();
+
+    expect(stopSpy).toHaveBeenCalled();
+    expect(startSpy).toHaveBeenCalled();
+    // Verify call order: stop must complete before start
+    const stopOrder = stopSpy.mock.invocationCallOrder[0];
+    const startOrder = startSpy.mock.invocationCallOrder[0];
+    expect(stopOrder).toBeLessThan(startOrder);
+  });
+});


### PR DESCRIPTION
## Summary

`AgentProcess.stop()` had a race window where the PTY's exit handler could fire AFTER `stopping=false` was set, falling into the crash recovery branch and resurrecting an agent we just intentionally stopped. This PR closes the window by making `stop()` await the actual PTY exit before resolving, and also delegates `sessionRefresh()` to `stop() + start()` (eliminating an additional duplicate-pty bug).

## The race (verified in source)

`src/daemon/agent-process.ts:106-137` (before this PR):

```ts
async stop(): Promise<void> {
  if (this.stopping) return;
  this.stopping = true;          // race window opens
  // ... write Ctrl-C, /exit, sleep, kill ...
  this.stopping = false;          // race window closes — but exit may not have fired yet
  this.status = 'stopped';
  // ...
}
```

The PTY's `kill()` is asynchronous on macOS. The exit callback (set in `start()` at line 81) fires whenever the underlying process actually dies — could be before, during, or AFTER `stop()` returns. The exit handler at line 250-256 has a guard:

```ts
private handleExit(exitCode: number): void {
  this.pty = null;
  this.clearSessionTimer();
  if (this.stopping) return;    // ← this check is the race
  // ... crash recovery: increment crashCount, status='crashed', schedule restart ...
}
```

If the exit fires AFTER `stop()` set `stopping=false`, the guard fails and the function falls through to crash recovery. Result: an agent we *intentionally* stopped gets resurrected ~5-10 seconds later under the wrong assumption that it crashed.

## Empirical evidence

PR #4's cycle 2 daemon log captured the AgentManager-level `pendingRestarts` race protection firing TWICE during a single restart sequence:

```
[agent-manager] Restarting testbot
[testbot] Stopping...
[testbot] Exited with code 0 signal 0
[testbot] Stopped
[agent-manager] Honoring queued restart for testbot          ← race window 1
[testbot] Starting in continue mode
[testbot] Running (pid: ...)
[agent-manager] Agent testbot is stopping — queued restart   ← race window 2
[agent-manager] Restart complete for testbot
```

Two `startAgent` calls effectively raced through the same restart. The end state was correct that time, but the underlying race is real and non-deterministic. The `pendingRestarts` mechanism in AgentManager was a workaround for the underlying race fixed in this PR.

## Fix

### Change 1 — `stop()` awaits the PTY exit before resolving

Add `exitPromise` and `resolveExit` fields. `start()` creates a fresh promise; the existing `onExit` handler resolves it AFTER calling `handleExit`. `stop()` awaits the promise (with a 5-second safety timeout for hung PTYs) AFTER `pty.kill()` and BEFORE `stopping=false`.

```ts
async start(): Promise<void> {
  // ... existing setup ...
  this.exitPromise = new Promise<void>((resolve) => {
    this.resolveExit = resolve;
  });
  this.pty.onExit((exitCode, signal) => {
    this.log(`Exited with code ${exitCode} signal ${signal}`);
    this.handleExit(exitCode);
    this.resolveExit?.();        // signal anyone awaiting the exit
    this.resolveExit = null;
  });
}

async stop(): Promise<void> {
  if (this.stopping) return;
  this.stopping = true;
  // ... clearSessionTimer, capture pty, write Ctrl-C, kill ...
  if (exitPromise) {
    await Promise.race([exitPromise, sleep(5000)]);  // BUG-011 fix
  }
  this.stopping = false;
  // ...
}
```

By the time `stopping=false` runs, the exit handler has already fired and seen `stopping=true`, so it skipped crash recovery. Race closed.

### Change 2 — `sessionRefresh()` delegates to `stop() + start()`

The previous inline implementation duplicated the stop logic AND had a separate bug where the OLD pty's exit handler could fire AFTER the NEW pty was set up, nulling out the wrong reference. The cleanest fix is the same lesson PR #4 applied to `restartAgent`:

```ts
async sessionRefresh(): Promise<void> {
  this.log('Session refresh (--continue restart)');
  await this.stop();
  await this.start();  // shouldContinue() returns true → continue mode
  this.log('Session refreshed');
}
```

Inherits the BUG-011 fix automatically AND eliminates the duplicate-pty bug for free.

## Tests

- [x] `npm test`: **395/395 passing** (391 baseline + 4 new in `tests/unit/daemon/agent-process.test.ts`)
- [x] New tests:
  - `stop() awaits the PTY exit handler before resolving`
  - `stop() does NOT trigger crash recovery on intentional stop` ← regression test for the bug
  - `handleExit DOES trigger crash recovery on UNINTENTIONAL exit` ← regression check, make sure real crash recovery still works
  - `sessionRefresh() delegates to stop() then start()` ← pins the new delegation
- [ ] Manual: 3-cycle test (reset → main without fix → reset → branch with fix → reset → main with merge), follow up in comments

## What this PR does NOT change

- The `stopping` flag's existence or its semantics — the only change is WHEN it gets reset (after the exit fires, not before)
- The `handleExit` function — left untouched, just gets `resolveExit` called AFTER it
- The crash recovery branch — left untouched, regression test pins it in place
- The AgentManager-level `pendingRestarts` logic — separate concern. With BUG-011 fixed, we can revisit whether `pendingRestarts` is still needed (or just dead code paying the price for the absent BUG-011 fix). Will track as BUG-031 if it doesn't go away.

## Refs

- BUG-011 in our internal tracker (the PTY race itself)
- Likely also closes BUG-010 (boris2 SIGHUP code 129 on restart) — that was the symptom of spurious crash recovery firing on an intentional stop, then `start()` running into a half-cleaned-up PTY state
- Sixth PR in tonight's stability sweep (#7, #8, #9, #10, #4, #5, this one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)