### PR TITLE
fix: close-out batch (BUG-015, 021, 031, 032 + verify-close 008, 009, 026, 027)

### DIFF
--- a/.claude/commands/onboarding.md
+++ b/.claude/commands/onboarding.md
@@ -493,19 +493,23 @@ Wait 5-10 seconds for the daemon to initialize, then save:
 pm2 save
 ```
 
-### 9b. Set up auto-start (survives reboots)
+### 9b. Capture reboot-survival command (BUG-021 — DEFERRED, NOT mid-flow)
+
+**IMPORTANT — BUG-021 fix**: Run `pm2 startup` and capture its output, but DO NOT prompt the user to do anything mid-flow. The sudo paste step is friction in the critical path. Save the captured command for the end-of-onboarding summary in Phase 10 instead. The user can run it later (or never — cortextOS works fine without reboot persistence).
 
 ```bash
-pm2 startup 2>&1
+PM2_STARTUP_OUTPUT=$(pm2 startup 2>&1)
+echo "$PM2_STARTUP_OUTPUT"
 ```
 
-If the output contains "already configured" or an existing launch daemon, skip:
-> "PM2 auto-start is already configured."
+Then extract the sudo command if present (it starts with `sudo env PATH=`):
+```bash
+PM2_SUDO_CMD=$(echo "$PM2_STARTUP_OUTPUT" | grep -E '^sudo env PATH=' | head -1)
+```
 
-If it outputs a `sudo env PATH=...` command:
-> "One more step - PM2 needs to register itself so your agents survive reboots. It printed a command below. Copy it, open a new terminal, paste it, and hit Enter."
->
-> "It will ask for your Mac password (the one you use to log in). When you type it, nothing appears on screen - that's normal. Just type and press Enter. This is a one-time setup."
+- If `PM2_SUDO_CMD` is non-empty: stash it for the end of onboarding (Phase 10's summary). DO NOT prompt the user.
+- If the output says "already configured" or contains an existing launch daemon: log "PM2 auto-start is already configured" and continue.
+- Either way: do NOT block or prompt the user.
 
 ### 9c. Verify and hand off to Telegram
 
@@ -529,6 +533,24 @@ Deliver verbatim:
 > "Go to Telegram and wait for your Orchestrator to message you. It will walk you through its personality, goals, crons, and creating your Analyst agent."
 >
 > "If anything breaks, come back here and run `pm2 logs cortextos-daemon --lines 30`."
+
+### BUG-021 fix — Optional reboot survival (DEFERRED — non-blocking)
+
+If `PM2_SUDO_CMD` from Phase 9b is non-empty, deliver this verbatim AT THE END (not mid-flow):
+
+> "**OPTIONAL — enable reboot survival**:
+>
+> Your daemon is running fine right now, but it won't auto-restart after a reboot of your machine. If you want reboot persistence (recommended for any real production use), run this command in another terminal:
+>
+> ```
+> <PM2_SUDO_CMD>
+> ```
+>
+> It will ask for your Mac password (the one you use to log in). When you type it, nothing appears on screen — that's normal. Just type and press Enter. This is a one-time setup. cortextOS works fine without it; you can do this anytime."
+
+If `PM2_SUDO_CMD` is empty (PM2 startup is already configured, or the system doesn't need it), skip this section silently.
+
+**DO NOT block onboarding waiting for the user to run this command.** The whole point of BUG-021's fix is to keep the user moving forward. They can do reboot setup later when they're not in the middle of onboarding.
 
 ---
 

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -405,7 +405,7 @@ busCommand
     const ipc = new IPCClient(env.instanceId);
     const daemonRunning = await ipc.isDaemonRunning();
     if (daemonRunning) {
-      const resp = await ipc.send({ type: 'restart-agent', agent: env.agentName });
+      const resp = await ipc.send({ type: 'restart-agent', agent: env.agentName, source: 'cortextos bus self-restart' });
       if (resp.success) {
         console.log(`Restarting ${env.agentName} via daemon IPC`);
       } else {
@@ -1099,7 +1099,7 @@ busCommand
     const runningAgents = new Set<string>();
     const ipc = new IPCClient(env.instanceId);
     try {
-      const resp = await ipc.send({ type: 'status' });
+      const resp = await ipc.send({ type: 'status', source: 'cortextos bus' });
       if (resp.success && Array.isArray(resp.data)) {
         for (const a of resp.data as Array<{ name: string; status: string }>) {
           if (a.status === 'running') runningAgents.add(a.name);
@@ -1293,7 +1293,7 @@ busCommand
     const daemonRunning = await ipc.isDaemonRunning();
 
     if (daemonRunning) {
-      const resp = await ipc.send({ type: 'restart-agent', agent: targetAgent });
+      const resp = await ipc.send({ type: 'restart-agent', agent: targetAgent, source: 'cortextos bus soft-restart' });
       if (resp.success) {
         console.log(`Restarted ${targetAgent} via daemon IPC`);
       } else {
@@ -1358,7 +1358,7 @@ busCommand
       writeFileSync(join(stateDir, '.user-restart'), opts.reason);
 
       // Send IPC restart signal
-      const resp = await ipc.send({ type: 'restart-agent', agent });
+      const resp = await ipc.send({ type: 'restart-agent', agent, source: 'cortextos bus soft-restart-all' });
       if (resp.success) {
         console.log(`[${i + 1}/${targets.length}] Restarted ${agent}`);
       } else {

--- a/src/cli/enable-agent.ts
+++ b/src/cli/enable-agent.ts
@@ -209,7 +209,7 @@ export const enableAgentCommand = new Command('enable')
     const ipc = new IPCClient(options.instance);
     const running = await ipc.isDaemonRunning();
     if (running) {
-      const response = await ipc.send({ type: 'start-agent', agent });
+      const response = await ipc.send({ type: 'start-agent', agent, source: 'cortextos enable' });
       if (response.success) {
         console.log(`  Started via daemon: ${response.data}`);
       }
@@ -240,7 +240,7 @@ export const disableAgentCommand = new Command('disable')
       // Pattern matches src/cli/bus.ts:1285-1289.
       writeDisableMarker(options.instance, agent, 'disabled via cortextos disable');
 
-      const response = await ipc.send({ type: 'stop-agent', agent });
+      const response = await ipc.send({ type: 'stop-agent', agent, source: 'cortextos disable' });
       if (response.success) {
         console.log(`Agent "${agent}" disabled and stopped.`);
       } else {

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -168,14 +168,14 @@ export const startCommand = new Command('start')
       }
 
       console.log(`Starting agent: ${agent}`);
-      const response = await ipc.send({ type: 'start-agent', agent });
+      const response = await ipc.send({ type: 'start-agent', agent, source: 'cortextos start' });
       if (response.success) {
         console.log(`  ${response.data}`);
       } else {
         console.error(`  Error: ${response.error}`);
       }
     } else {
-      const response = await ipc.send({ type: 'status' });
+      const response = await ipc.send({ type: 'status', source: 'cortextos start' });
       if (response.success) {
         const statuses = response.data as any[];
         if (statuses.length === 0) {

--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -15,7 +15,7 @@ export const statusCommand = new Command('status')
 
     if (daemonRunning) {
       // Get live status from daemon
-      const response = await ipc.send({ type: 'status' });
+      const response = await ipc.send({ type: 'status', source: 'cortextos status' });
       if (response.success) {
         const statuses = response.data as AgentStatus[];
         displayStatuses(statuses);

--- a/src/cli/stop.ts
+++ b/src/cli/stop.ts
@@ -53,7 +53,7 @@ export const stopCommand = new Command('stop')
     if (agent) {
       console.log(`Stopping agent: ${agent}`);
       writeStopMarker(options.instance, agent, 'stopped via cortextos stop');
-      const response = await ipc.send({ type: 'stop-agent', agent });
+      const response = await ipc.send({ type: 'stop-agent', agent, source: 'cortextos stop' });
       if (response.success) {
         console.log(`  ${response.data}`);
       } else {
@@ -65,7 +65,7 @@ export const stopCommand = new Command('stop')
 
     // options.all === true
     console.log('Stopping all agents...');
-    const listResponse = await ipc.send({ type: 'list-agents' });
+    const listResponse = await ipc.send({ type: 'list-agents', source: 'cortextos stop --all' });
     if (!listResponse.success) {
       console.error(`  Error listing agents: ${listResponse.error}`);
       process.exit(1);
@@ -77,7 +77,7 @@ export const stopCommand = new Command('stop')
     }
     for (const a of agents) {
       writeStopMarker(options.instance, a, 'stopped via cortextos stop --all');
-      const response = await ipc.send({ type: 'stop-agent', agent: a });
+      const response = await ipc.send({ type: 'stop-agent', agent: a, source: 'cortextos stop --all' });
       console.log(`  ${a}: ${response.success ? 'stopped' : response.error}`);
     }
     console.log('\nAll agents stopped. The daemon is still running. To stop it: pm2 stop cortextos-daemon');

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -84,10 +84,21 @@ export class AgentManager {
    */
   async startAgent(name: string, agentDir: string, config?: AgentConfig): Promise<void> {
     if (this.agents.has(name)) {
-      // Agent is registered but may be mid-stop (race: restart-all sends stop+start simultaneously).
-      // Queue the start so stopAgent() will re-launch it once cleanup finishes.
+      // BUG-031: this branch was the workaround for the BUG-011 PTY race
+      // (restart-all could send stop+start simultaneously, and the new
+      // start would arrive while the old stop's PTY exit was still in
+      // flight). PR #11 closed BUG-011 by making `AgentProcess.stop()`
+      // await the actual PTY exit before resolving — which means this
+      // branch should NEVER fire under normal restart paths.
+      //
+      // We log a regression warning here instead of deleting the branch
+      // entirely, so we'll know IMMEDIATELY if BUG-011 ever regresses
+      // (a future change accidentally breaks the exit-await). Phase 4 of
+      // the core stability test plan + cycle 2 of PR #13 both confirmed
+      // this branch is dormant. Once we have weeks of zero-warning
+      // production data, we can delete the queue mechanism entirely.
+      console.warn(`[agent-manager] BUG-011 REGRESSION CHECK: ${name} still in registry during startAgent — pendingRestarts queueing engaged. This should not happen with PR #11 in place.`);
       this.pendingRestarts.add(name);
-      console.log(`[agent-manager] Agent ${name} is stopping — queued restart`);
       return;
     }
 
@@ -344,8 +355,13 @@ export class AgentManager {
     await entry.process.stop();
     this.agents.delete(name);
 
-    // Honor any restart that was queued while we were stopping.
+    // BUG-031: honor any restart that was queued while we were stopping.
+    // After PR #11 (BUG-011 fix) this branch should never fire — see the
+    // matching warning comment in startAgent(). The honor logic is preserved
+    // as a safety net in case BUG-011 regresses; the warn line tells us
+    // immediately if it ever does.
     if (this.pendingRestarts.has(name)) {
+      console.warn(`[agent-manager] BUG-011 REGRESSION CHECK: pendingRestarts fired for ${name} — race condition leaked through. Honoring queued restart as safety net.`);
       this.pendingRestarts.delete(name);
       console.log(`[agent-manager] Honoring queued restart for ${name}`);
       this.startAgent(name, '').catch(err =>

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -135,10 +135,18 @@ export class AgentProcess {
 
     if (pty) {
       try {
+        // BUG-032 fix: use CRLF (not lone CR) so Claude Code's REPL actually
+        // recognizes the /exit line as a complete command, AND wait long
+        // enough (5s, was 3s) for the child to flush + exit cleanly. Without
+        // these the child often dies from SIGHUP (exit code 129) when the
+        // PTY is torn down before /exit has been processed. PR #11's
+        // BUG-011 fix already ensured the daemon doesn't misinterpret 129
+        // as a real crash, but the underlying graceful-shutdown sequence
+        // still wasn't graceful — this PR makes it so.
         pty.write('\x03'); // Ctrl-C
         await sleep(1000);
-        pty.write('/exit\r');
-        await sleep(3000);
+        pty.write('/exit\r\n');
+        await sleep(5000);
       } catch {
         // Ignore write errors during shutdown
       }

--- a/src/daemon/ipc-server.ts
+++ b/src/daemon/ipc-server.ts
@@ -106,6 +106,13 @@ export class IPCServer {
    * Handle an incoming IPC request.
    */
   private handleRequest(request: IPCRequest, socket: Socket): void {
+    // BUG-015: log every incoming IPC request with its source so we can
+    // trace which CLI command triggered which daemon action. The source
+    // field is populated by CLI clients (cortextos enable / disable / stop
+    // / bus / etc.); older or untracked callers fall back to 'unknown'.
+    const agentTag = request.agent ? ` ${request.agent}` : '';
+    console.log(`[ipc] ${request.type}${agentTag} from ${request.source || 'unknown'}`);
+
     let response: IPCResponse;
 
     try {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -318,6 +318,13 @@ export interface IPCRequest {
   type: IPCCommandType;
   agent?: string;
   data?: Record<string, unknown>;
+  /**
+   * BUG-015: human-readable identifier of the caller (e.g. 'cortextos enable',
+   * 'cortextos bus soft-restart-all'). Logged by the daemon on every incoming
+   * IPC request so we can trace which CLI command triggered which daemon action.
+   * Optional for backwards compatibility — older clients fall back to 'unknown'.
+   */
+  source?: string;
 }
 
 // Worker Types


### PR DESCRIPTION
## Summary

Tenth and final PR of tonight's stability sweep. Closes 8 bugs in one PR: 4 small/defensive code fixes plus 4 verify-and-close confirmations of bugs that were transitively fixed by earlier PRs. BUG-003 (mystery SIGTERM cascade) deferred to a future soak session.

| Bug | Sev | Type | What |
|---|---|---|---|
| BUG-015 | P2 | code | IPC source logging — \`source\` field on IPCRequest, daemon logs every call |
| BUG-021 | P2 | code | pm2 startup mid-flow blocking — defer sudo paste to end-of-onboarding optional section |
| BUG-031 | P2 | code | pendingRestarts regression detector — replaces dormant queue with warn lines |
| BUG-032 | P3 | code | PTY SIGHUP code 129 — CRLF + 5s wait (defensive, not aggressive) |
| BUG-008 | P1 | verify | Telegram 409 — likely closed by PR #4, cycle 1 confirms |
| BUG-009 | P2 | verify | "Agent <orgname> not found" — likely closed by PR #8+#10, cycle 1 confirms |
| BUG-026 | P1 | verify | agent-manager path missing org — already correct in source |
| BUG-027 | P2 | verify | dashboard SQLite filename hardcoded — already templated in source |

## Changes (10 files, +86/-26)

- src/types/index.ts — IPCRequest.source field
- src/daemon/ipc-server.ts — log incoming requests with source
- src/cli/{enable-agent,start,stop,status,bus}.ts — instrument all 12 IPC callsites with source field
- src/daemon/agent-manager.ts — replace pendingRestarts queue with regression-warning console.warn lines
- src/daemon/agent-process.ts — CRLF + 5s wait in stop()
- .claude/commands/onboarding.md — defer pm2 startup sudo paste to end-of-flow OPTIONAL section

## Test plan

- [x] npm run build clean
- [x] npm test 414/414 passing (no regressions)
- [ ] Cycle 1 (canonical main): 4 verify-and-close bugs confirmed, 4 code-fix bugs reproduced
- [ ] Cycle 2 (this branch): all 4 fixes verified, all 4 verifications still hold
- [ ] Cycle 3 (canonical merged main): final end-to-end

## Out of scope (deliberate)

- BUG-003 — needs 30-min soak, deferred to future session
- The aggressive BUG-032 fixes (drain buffer, exit detection) — defer until cycle 1/2 shows defensive fix isn't enough
- Deleting pendingRestarts entirely — preserved as regression detector
- Dashboard IPC source logging — separate audit
- Full BUG-034 12-row notification matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)