### PR TITLE
fix(daemon): close PTY exit/stop timing race (BUG-040, closes BUG-038)

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -26,6 +26,22 @@ export class AgentProcess {
   private sessionStart: Date | null = null;
   private status: AgentStatus['status'] = 'stopped';
   private stopping: boolean = false;
+  // BUG-040 fix: persists across stop() return until handleExit clears it.
+  // Required because BUG-032's CRLF + 5s wait can cause graceful shutdown to
+  // exceed the 5s Promise.race timeout in stop(), which would otherwise reset
+  // `stopping=false` BEFORE the PTY actually exits, then handleExit would fire
+  // with stopping=false and trigger spurious crash recovery (a partial regression
+  // of BUG-011). stopRequested survives the timeout and is only cleared either
+  // by handleExit when an intentional exit fires, or by start() at the beginning
+  // of a new lifecycle.
+  private stopRequested: boolean = false;
+  // BUG-040 fix: monotonic generation counter incremented on each successful
+  // start(). Each PTY's onExit closure captures the generation at spawn time
+  // and bails out if the generation doesn't match — i.e. a NEW PTY has been
+  // spawned since this old one was created. Without this guard, a late exit
+  // from an old PTY can race past stopRequested and trigger crash recovery on
+  // the new agent.
+  private lifecycleGeneration: number = 0;
   // BUG-011 fix: stop() awaits this promise (resolved by the onExit handler in start())
   // to guarantee the PTY exit has fired before stopping=false is reset. Without
   // this, the exit handler can fire after stopping=false and trigger spurious
@@ -77,6 +93,16 @@ export class AgentProcess {
     this.log(`Starting in ${mode} mode`);
     this.status = 'starting';
 
+    // BUG-040 fix: clear any stale stop request from a previous lifecycle
+    // (e.g. if the previous stop() timed out before the PTY actually exited).
+    // We're starting fresh — the new PTY has no pending stop.
+    this.stopRequested = false;
+    // BUG-040 fix: bump generation. The onExit closure below captures THIS
+    // value and uses it to detect "I'm an old PTY whose exit fired after a
+    // new lifecycle began" — in which case it bails out without touching
+    // handleExit, preventing spurious crash recovery on the new agent.
+    const myGeneration = ++this.lifecycleGeneration;
+
     // Create PTY
     const logPath = join(this.env.ctxRoot, 'logs', this.name, 'stdout.log');
     ensureDir(join(this.env.ctxRoot, 'logs', this.name));
@@ -92,6 +118,14 @@ export class AgentProcess {
 
     // Handle exit
     this.pty.onExit((exitCode, signal) => {
+      // BUG-040 fix: if the lifecycle has moved on (a new start() incremented
+      // the generation since this PTY was spawned), this is an old PTY's late
+      // exit. Ignore it entirely — we don't want it to trigger handleExit on
+      // the current PTY's state.
+      if (myGeneration !== this.lifecycleGeneration) {
+        this.log(`Ignoring late exit from previous lifecycle gen ${myGeneration} (current: ${this.lifecycleGeneration})`);
+        return;
+      }
       this.log(`Exited with code ${exitCode} signal ${signal}`);
       this.handleExit(exitCode);
       // Signal anyone awaiting this PTY's exit (e.g. stop() — BUG-011 fix)
@@ -122,6 +156,10 @@ export class AgentProcess {
   async stop(): Promise<void> {
     if (this.stopping) return;
     this.stopping = true;
+    // BUG-040 fix: stopRequested persists ACROSS stop()'s return until
+    // handleExit clears it. This is the safety net for the case where the
+    // PTY exits later than the Promise.race timeout below.
+    this.stopRequested = true;
     this.log('Stopping...');
     this.clearSessionTimer();
 
@@ -157,16 +195,20 @@ export class AgentProcess {
       }
 
       // BUG-011 fix: AWAIT the exit handler before resolving stop().
-      // Without this, stop() returns while the PTY exit is still in flight,
-      // and the exit handler may fire AFTER stopping=false (set below),
-      // triggering spurious crash recovery for an agent we just stopped.
-      // 5-second timeout guards against a hung PTY.
+      // BUG-040 fix: bumped timeout from 5s to 15s to give the PTY plenty of
+      // time to exit cleanly even when BUG-032's slow graceful shutdown stacks
+      // on top of pty.kill() lag. The functional correctness no longer depends
+      // on this timeout (stopRequested handles late exits), but a generous
+      // timeout reduces "Ignoring late exit from previous lifecycle" log noise.
       if (exitPromise) {
-        await Promise.race([exitPromise, sleep(5000)]);
+        await Promise.race([exitPromise, sleep(15000)]);
       }
     }
 
     this.stopping = false;
+    // NOTE: this.stopRequested is intentionally NOT cleared here. It is
+    // cleared by handleExit when the intentional exit fires (or by start()
+    // when a new lifecycle begins). See BUG-040 fix in handleExit().
     this.status = 'stopped';
     this.notifyStatusChange();
     this.log('Stopped');
@@ -260,8 +302,22 @@ export class AgentProcess {
     this.pty = null;
     this.clearSessionTimer();
 
-    // If stop() is in progress, this exit was intentional — skip crash recovery.
-    if (this.stopping) return;
+    // BUG-040 fix: check stopRequested instead of (only) stopping. The
+    // stopping flag is cleared inside stop() after a 15s timeout window —
+    // which means a slow PTY shutdown can fire handleExit AFTER stopping is
+    // already false, leading to spurious crash recovery. stopRequested is
+    // set by stop() at the START of the shutdown sequence and persists across
+    // stop()'s return until handleExit clears it (right here). This guarantees
+    // that the FIRST exit after a stop() call is treated as intentional, no
+    // matter how delayed it is.
+    //
+    // Also keep the legacy `stopping` check for in-progress detection during
+    // the (most common) case where the exit fires while stop() is still
+    // awaiting. Either flag short-circuits crash recovery.
+    if (this.stopRequested || this.stopping) {
+      this.stopRequested = false;
+      return;
+    }
 
     // Check crash limit
     this.crashCount++;


### PR DESCRIPTION
## Summary

Closes BUG-040 (P0) — the actual root cause of BUG-038 (the pendingRestarts regression detector firing under restart-all).

## The bug

PR #11 (BUG-011) introduced \`exitPromise\` so \`stop()\` would await the PTY exit before clearing the \`stopping\` flag. This worked great until PR #14 (BUG-032) bumped the post-/exit wait from 3s to 5s. With the longer wait, total elapsed time before \`pty.kill()\` is ~6s, then the PTY can take additional time to actually exit. If that delayed exit fires AFTER stop()'s 5-second \`Promise.race\` timeout, \`stopping\` is already cleared and \`handleExit\` triggers spurious crash recovery — exactly what PR #11 was supposed to prevent.

**Surfaced live in this session's fastloop test**: a single \`pm2 restart cortextos-daemon\` produced a crash recovery cascade with two crash counts incrementing during what should have been a clean shutdown.

## Fix

1. **\`stopRequested\` flag** that persists across \`stop()\`'s return until \`handleExit\` clears it. Survives the timeout. Cleared either by handleExit consuming an intentional exit, or by \`start()\` beginning a new lifecycle.

2. **\`lifecycleGeneration\` counter** incremented on each \`start()\`. Each PTY's onExit closure captures the generation at spawn time and bails out if it doesn't match — prevents an old PTY's late exit from polluting a new lifecycle.

3. **Bumped Promise.race timeout from 5s to 15s** for less log noise (functional correctness no longer depends on it).

4. **\`handleExit\` now checks \`stopRequested || stopping\`** — either flag short-circuits crash recovery.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 414/414 passing (no regressions)
- [x] **Live verification via fastloop** (no full reinstall needed):
  - Daemon SIGTERM (\`pm2 restart cortextos-daemon\`): clean shutdown, zero crash recovery
  - 5× \`cortextos bus soft-restart-all\`: 0 \"Crash recovery\", 0 \"REGRESSION CHECK\", 0 \"Ignoring late exit\", 5× \"Restart complete\"
  - **Telegram screenshot evidence**: 5× correct \"🔄 commander restarted by user\" at 14:23, zero false 🚨 CRASH alarms
- [x] BUG-038 (the symptom) closes as a side effect — pendingRestarts regression detector stays silent

## Closes

- BUG-040 (root cause)
- BUG-038 (symptom — closed as side effect)

## Note on BUG-032

BUG-032 (PTY exits with SIGHUP code 129) is still present — agents still exit with 129 instead of 0 after the graceful shutdown sequence. But with BUG-040 fixed, the daemon correctly recognizes 129 as intentional and does NOT fire crash recovery. BUG-032 is now purely cosmetic log noise and can be addressed in a separate aggressive-fix follow-up if desired.

## Methodology note

This is the **first PR to use the new fast-loop iteration cycle** (\`helper-fastloop.sh\` instead of \`helper-install-and-onboard.sh\`). The bug was identified, the fix written, deployed, and verified in ~15 minutes total — vs the ~30 min cycle a full reinstall would have required. The fix doesn't touch any install-pipeline files (install.mjs, onboarding.md, ecosystem.ts, init.ts), so the fast-loop is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)