### PR TITLE
fix(cli): validate agent name in add-agent to match resolveEnv (BUG-041)

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -3,6 +3,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, copyFi
 import { join, resolve } from 'path';
 import { homedir } from 'os';
 import { OrgContext } from '../types';
+import { validateAgentName } from '../utils/validate';
 
 export const addAgentCommand = new Command('add-agent')
   .argument('<name>', 'Agent name')
@@ -11,6 +12,24 @@ export const addAgentCommand = new Command('add-agent')
   .option('--instance <id>', 'Instance ID', 'default')
   .description('Add a new agent to the organization')
   .action(async (name: string, options: { template: string; org?: string; instance: string }) => {
+    // BUG-041 fix: validate the agent name BEFORE creating anything on disk.
+    // Without this, mixed-case names like 'CortextDesigner' pass through
+    // add-agent, get written to disk, and THEN fail every `cortextos bus *`
+    // command at runtime because `src/utils/env.ts:resolveEnv()` strictly
+    // validates CTX_AGENT_NAME via the same `validateAgentName()` function.
+    // The mismatch made affected agents half-functional — daemon-managed
+    // fine but unable to use any bus command (including send-telegram).
+    // Canonical rule lives in `src/utils/validate.ts`:
+    //   AGENT_NAME_REGEX = /^[a-z0-9_-]+$/
+    try {
+      validateAgentName(name);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      console.error(`Agent names must match /^[a-z0-9_-]+$/ (lowercase letters, numbers, underscores, hyphens).`);
+      console.error(`Examples of valid names: paul, sentinel, cortext-designer, m2c1-worker, agent_1`);
+      process.exit(1);
+    }
+
     const projectRoot = process.env.CTX_FRAMEWORK_ROOT || process.env.CTX_PROJECT_ROOT || process.cwd();
 
     // Auto-detect org if not specified

--- a/tests/unit/cli/add-agent-validation.test.ts
+++ b/tests/unit/cli/add-agent-validation.test.ts
@@ -1,0 +1,95 @@
+/**
+ * BUG-041 regression test: `cortextos add-agent` must reject invalid agent
+ * names (mixed-case, spaces, path traversal, etc.) BEFORE creating any
+ * filesystem artifacts.
+ *
+ * Before the fix, `cortextos add-agent CortextDesigner --template agent --org testorg`
+ * succeeded at the CLI level, wrote the agent dir to disk, registered the
+ * agent in `enabled-agents.json`, and THEN failed every `cortextos bus *`
+ * command at runtime because `resolveEnv()` rejected the same name that
+ * add-agent had accepted. Affected agents were half-functional — daemon-
+ * managed fine but unable to reply to Telegram, create tasks, check inbox,
+ * or do anything via the bus.
+ *
+ * The fix centralizes validation by calling `validateAgentName()` at the
+ * entry of the add-agent action, so bad names are rejected upfront and
+ * the caller gets a clear error before any filesystem state is touched.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { addAgentCommand } from '../../../src/cli/add-agent';
+
+describe('BUG-041: add-agent agent name validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects CortextDesigner (PascalCase) before any filesystem write', async () => {
+    // Commander calls process.exit(1) on validation failure. We intercept
+    // it by throwing, which we catch via expect().rejects. This avoids the
+    // test runner itself exiting on process.exit().
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'CortextDesigner', '--template', 'agent', '--org', 'testorg']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    // The error message must tell the user exactly what was wrong
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join(' ');
+    expect(errorOutput).toContain("Invalid agent name 'CortextDesigner'");
+    // And it must show the validation rule so the user knows how to fix it
+    expect(errorOutput).toContain('/^[a-z0-9_-]+$/');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects a simpler single-uppercase name (Agent)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'Agent', '--template', 'agent', '--org', 'testorg']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects names with spaces', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'my agent', '--template', 'agent', '--org', 'testorg']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects path traversal attempts', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', '../evil', '--template', 'agent', '--org', 'testorg']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/utils/validate.test.ts
+++ b/tests/unit/utils/validate.test.ts
@@ -44,6 +44,19 @@ describe('validateAgentName', () => {
     expect(() => validateAgentName('../traversal')).toThrow(); // path traversal
     expect(() => validateAgentName('agent/path')).toThrow(); // slash
   });
+
+  it('rejects mixed-case / PascalCase / CamelCase (BUG-041 regression)', () => {
+    // BUG-041: these names passed through `cortextos add-agent` before the fix,
+    // got written to disk, and then failed every `cortextos bus *` command at
+    // runtime because `resolveEnv()` validates with the same regex. Lock in
+    // the rejection at the validator level so add-agent can rely on it.
+    expect(() => validateAgentName('CortextDesigner')).toThrow();
+    expect(() => validateAgentName('MyAgent')).toThrow();
+    expect(() => validateAgentName('camelCase')).toThrow();
+    expect(() => validateAgentName('Agent1')).toThrow();
+    expect(() => validateAgentName('tally-Bot')).toThrow();
+    expect(() => validateAgentName('snake_Case')).toThrow();
+  });
 });
 
 describe('validatePriority', () => {


### PR DESCRIPTION
## Summary

BUG-041 (P0) validation mismatch: `cortextos add-agent` accepted any string as an agent name, but `resolveEnv()` in `src/utils/env.ts` strictly validates via `validateAgentName()` at runtime. Result: mixed-case names like \`CortextDesigner\` got written to disk, the daemon spawned them, then every `cortextos bus *` command failed. Affected agents were half-functional — daemon-managed fine, Telegram receiving worked, but sending, inbox reading, task creation, approvals, and every other bus call were broken.

## Discovery

Hit live this session: an ephemeral worker agent 'CortextDesigner' was created (mixed-case) and spawned successfully, but couldn't reply to user messages on Telegram because the bus command rejected its own name. Workaround was calling the Telegram API directly via curl using BOT_TOKEN from .env — not sustainable.

## Fix

Call \`validateAgentName()\` at the start of the add-agent action, BEFORE any filesystem operations. Same function that resolveEnv uses, so add-agent and resolveEnv now agree.

## Changes

- \`src/cli/add-agent.ts\` — import + call \`validateAgentName(name)\` at action entry, with clear error + valid name examples
- \`tests/unit/utils/validate.test.ts\` — new regression test for mixed-case / PascalCase names
- \`tests/unit/cli/add-agent-validation.test.ts\` (NEW) — 4 integration tests using Commander parseAsync + process.exit spy

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 419/419 passing (414 baseline + 5 new)
- [x] **Live verification via manual dist copy** (no pm2 restart needed — CLI-only fix):
  - \`cortextos add-agent TestMixedCase --template agent --org testorg\` → rejected with clear error, exit 1, no directory created ✓
  - \`cortextos add-agent test-valid-name --template agent --org testorg\` → succeeds, normal flow works ✓
  - \`CTX_AGENT_NAME=test-valid-name cortextos bus list-agents\` → succeeds, proves fix makes add-agent and resolveEnv consistent ✓
  - \`CTX_AGENT_NAME=CortextDesigner cortextos bus list-agents\` → still fails (expected — fix prevents NEW bad agents, existing stay broken until recreated) ✓

## Why this was a good fast-loop PR

- Single source file change + 2 test files
- CLI-only fix → deploys via manual \`cp -r dist\` with no pm2 restart
- No install pipeline changes
- Deterministic repro (anyone can type a mixed-case name to trigger)
- Security-positive: closes validation gap
- Immediately user-visible: affected agents can now be recreated with valid names and actually work

## Out of scope (follow-ups)

- Inline regex duplicates in \`src/cli/setup.ts\`, \`src/cli/goals.ts\`, \`src/bus/agents.ts\`, \`src/bus/system.ts\` — hygiene cleanup, separate PR
- Existing CortextDesigner agent — stays broken, will be manually recreated as valid name
- Rename-agent CLI command — doesn't exist, would be nice, separate feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)