### PR TITLE
fix(daemon): make AgentManager multi-org aware (BUG-043)

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -47,7 +47,7 @@ export class AgentManager {
     // re-discover and re-start any agent dir on disk regardless of user intent.
     const instanceEnabled = this.readInstanceEnableList();
 
-    for (const { name, dir, config } of agentDirs) {
+    for (const { name, dir, org, config } of agentDirs) {
       // Per-agent config.json `enabled: false` (existing behavior, unchanged)
       if (config.enabled === false) {
         console.log(`[agent-manager] Skipping disabled agent: ${name} (per-agent config.json)`);
@@ -59,7 +59,9 @@ export class AgentManager {
         console.log(`[agent-manager] Skipping disabled agent: ${name} (enabled-agents.json)`);
         continue;
       }
-      await this.startAgent(name, dir, config);
+      // BUG-043 fix: pass the per-agent org so startAgent can use it instead
+      // of falling back to `this.org` (the daemon's startup org).
+      await this.startAgent(name, dir, config, org);
     }
   }
 
@@ -80,9 +82,62 @@ export class AgentManager {
   }
 
   /**
-   * Start a specific agent.
+   * BUG-043 fix: resolve the canonical org for a given agent without
+   * defaulting to the daemon's startup `this.org`.
+   *
+   * Resolution order:
+   *   1. Explicit `org` argument (e.g. from `discoverAgents()` which knows
+   *      which org a dir lives under)
+   *   2. `enabled-agents.json[name].org` — set by `cortextos enable`/`add-agent`
+   *   3. Filesystem scan: walk `frameworkRoot/orgs/*` looking for a dir
+   *      named `name` — handles legacy enabled-agents.json entries that
+   *      were written before the `org` field was added
+   *   4. Legacy fallback: `this.org` (preserves single-org install behavior)
+   *
+   * Before this fix, all six `this.org` sites in `agent-manager.ts` would
+   * short-circuit to the daemon's startup `CTX_ORG`, which silently broke
+   * multi-org installs — agents in `lifeos` or `cointally` were invisible
+   * to a daemon started with `CTX_ORG=testorg`.
    */
-  async startAgent(name: string, agentDir: string, config?: AgentConfig): Promise<void> {
+  private resolveAgentOrg(name: string, explicitOrg?: string): string {
+    if (explicitOrg) return explicitOrg;
+
+    const enabledAgents = this.readInstanceEnableList();
+    const entry = enabledAgents[name];
+    if (entry?.org) return entry.org;
+
+    // Legacy fallback: scan all orgs on disk for a dir named `name`.
+    // Handles enabled-agents.json entries missing the `org` field, or
+    // agents that were created via raw filesystem operations.
+    const orgsBase = join(this.frameworkRoot, 'orgs');
+    if (existsSync(orgsBase)) {
+      try {
+        const orgs = readdirSync(orgsBase, { withFileTypes: true })
+          .filter(d => d.isDirectory())
+          .map(d => d.name);
+        for (const org of orgs) {
+          if (existsSync(join(orgsBase, org, 'agents', name))) {
+            return org;
+          }
+        }
+      } catch { /* ignore read errors */ }
+    }
+
+    // Ultimate fallback: daemon's startup org (single-org install behavior)
+    return this.org;
+  }
+
+  /**
+   * Start a specific agent.
+   *
+   * BUG-043 fix: accepts an optional `org` parameter and uses
+   * `resolveAgentOrg()` to find the correct org for path/env lookups
+   * instead of falling back to `this.org`. This makes the daemon
+   * multi-org aware — an install with lifeos + cointally + testorg will
+   * spawn each agent in its correct org dir regardless of what
+   * `CTX_ORG` the daemon was started with.
+   */
+  async startAgent(name: string, agentDir: string, config?: AgentConfig, org?: string): Promise<void> {
     if (this.agents.has(name)) {
       // BUG-031: this branch was the workaround for the BUG-011 PTY race
       // (restart-all could send stop+start simultaneously, and the new
@@ -102,9 +157,12 @@ export class AgentManager {
       return;
     }
 
+    // BUG-043 fix: resolve the agent's true org instead of using `this.org`.
+    const resolvedOrg = this.resolveAgentOrg(name, org);
+
     // Auto-discover agent directory if not provided (e.g. when started via IPC)
     if (!agentDir || !existsSync(agentDir)) {
-      const discovered = join(this.frameworkRoot, 'orgs', this.org, 'agents', name);
+      const discovered = join(this.frameworkRoot, 'orgs', resolvedOrg, 'agents', name);
       if (existsSync(discovered)) {
         agentDir = discovered;
       } else {
@@ -123,11 +181,11 @@ export class AgentManager {
       frameworkRoot: this.frameworkRoot,
       agentName: name,
       agentDir,
-      org: this.org,
+      org: resolvedOrg,
       projectRoot: this.frameworkRoot,
     };
 
-    const paths = resolvePaths(name, this.instanceId, this.org);
+    const paths = resolvePaths(name, this.instanceId, resolvedOrg);
 
     const log = (msg: string) => {
       console.log(`[${name}] ${msg}`);
@@ -544,26 +602,50 @@ export class AgentManager {
 
   /**
    * Discover agents from the organization directory structure.
+   *
+   * BUG-043 fix: iterate over EVERY org under `frameworkRoot/orgs/*`,
+   * not just `this.org`. Before this fix, a daemon started with
+   * `CTX_ORG=testorg` would only discover agents in `orgs/testorg/agents/`
+   * — agents in `orgs/lifeos/agents/` and `orgs/cointally/agents/` were
+   * effectively invisible to the daemon and could never be auto-spawned
+   * from a cold start. Multi-org installs silently half-worked.
+   *
+   * The returned tuple now includes an `org` field so `discoverAndStart()`
+   * can pass the correct org to `startAgent()` and downstream path
+   * lookups via `resolveAgentOrg()`.
    */
-  private discoverAgents(): Array<{ name: string; dir: string; config: AgentConfig }> {
-    const agents: Array<{ name: string; dir: string; config: AgentConfig }> = [];
+  private discoverAgents(): Array<{ name: string; dir: string; org: string; config: AgentConfig }> {
+    const agents: Array<{ name: string; dir: string; org: string; config: AgentConfig }> = [];
 
-    // Look for agents in orgs/{org}/agents/
-    const agentsBase = join(this.frameworkRoot, 'orgs', this.org, 'agents');
-    if (!existsSync(agentsBase)) return agents;
+    const orgsBase = join(this.frameworkRoot, 'orgs');
+    if (!existsSync(orgsBase)) return agents;
 
+    let orgNames: string[] = [];
     try {
-      const dirs = readdirSync(agentsBase, { withFileTypes: true })
+      orgNames = readdirSync(orgsBase, { withFileTypes: true })
         .filter(d => d.isDirectory())
         .map(d => d.name);
-
-      for (const name of dirs) {
-        const dir = join(agentsBase, name);
-        const config = this.loadAgentConfig(dir);
-        agents.push({ name, dir, config });
-      }
     } catch {
-      // Ignore read errors
+      return agents; // unreadable orgs dir — treat as empty
+    }
+
+    for (const org of orgNames) {
+      const agentsBase = join(orgsBase, org, 'agents');
+      if (!existsSync(agentsBase)) continue;
+
+      try {
+        const dirs = readdirSync(agentsBase, { withFileTypes: true })
+          .filter(d => d.isDirectory())
+          .map(d => d.name);
+
+        for (const name of dirs) {
+          const dir = join(agentsBase, name);
+          const config = this.loadAgentConfig(dir);
+          agents.push({ name, dir, org, config });
+        }
+      } catch {
+        // Ignore read errors for this org — continue scanning others
+      }
     }
 
     return agents;

--- a/tests/unit/daemon/agent-manager.test.ts
+++ b/tests/unit/daemon/agent-manager.test.ts
@@ -77,7 +77,8 @@ describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
 
     // alice should be skipped (disabled in instance file), bob should be started
     expect(startSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).toHaveBeenCalledWith('bob', expect.any(String), expect.any(Object));
+    // BUG-043: startAgent now accepts a 4th `org` argument
+    expect(startSpy).toHaveBeenCalledWith('bob', expect.any(String), expect.any(Object), 'acme');
   });
 
   it('starts all discovered agents when enabled-agents.json is missing', async () => {
@@ -117,7 +118,8 @@ describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
     await am.discoverAndStart();
 
     expect(startSpy).toHaveBeenCalledTimes(1);
-    expect(startSpy).toHaveBeenCalledWith('bob', expect.any(String), expect.any(Object));
+    // BUG-043: startAgent now accepts a 4th `org` argument
+    expect(startSpy).toHaveBeenCalledWith('bob', expect.any(String), expect.any(Object), 'acme');
   });
 
   it('handles corrupt enabled-agents.json by defaulting to enabled-all', async () => {
@@ -133,6 +135,99 @@ describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
 
     // Corrupt file is treated as missing — all discovered agents start
     expect(startSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('AgentManager.discoverAndStart - BUG-043 fix (multi-org support)', () => {
+  let testDir: string;
+  let ctxRoot: string;
+  let frameworkRoot: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-am-multiorg-'));
+    ctxRoot = join(testDir, 'instance');
+    frameworkRoot = join(testDir, 'framework');
+    mkdirSync(join(ctxRoot, 'config'), { recursive: true });
+    // Two orgs with agents in each — simulates a multi-org install
+    // (e.g. James's lifeos + cointally + testorg setup)
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'bob'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'widgetco', 'agents', 'carol'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'widgetco', 'agents', 'dave'), { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('discovers agents from ALL orgs, not just the daemon startup org', async () => {
+    // BUG-043: before the fix, an AgentManager constructed with org='acme'
+    // would only discover agents in orgs/acme/. Agents in orgs/widgetco/
+    // were silently invisible. This test pins the multi-org scan in place.
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    expect(startSpy).toHaveBeenCalledTimes(4);
+    const namesStarted = startSpy.mock.calls.map(call => call[0]).sort();
+    expect(namesStarted).toEqual(['alice', 'bob', 'carol', 'dave']);
+  });
+
+  it('passes the correct per-agent org as the 4th argument to startAgent', async () => {
+    // BUG-043: startAgent must know which org the agent lives under
+    // so it can build the right filesystem path. discoverAgents now
+    // attaches org per discovered entry, and discoverAndStart threads
+    // it through.
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    const callsByName = new Map<string, readonly unknown[]>();
+    for (const call of startSpy.mock.calls) {
+      callsByName.set(call[0] as string, call);
+    }
+    expect(callsByName.get('alice')?.[3]).toBe('acme');
+    expect(callsByName.get('bob')?.[3]).toBe('acme');
+    expect(callsByName.get('carol')?.[3]).toBe('widgetco');
+    expect(callsByName.get('dave')?.[3]).toBe('widgetco');
+  });
+
+  it('respects enabled-agents.json disable-flags across multiple orgs', async () => {
+    // alice in acme and dave in widgetco are both disabled. The fix must
+    // still honor per-agent enable/disable regardless of which org the
+    // agent is in.
+    writeFileSync(
+      join(ctxRoot, 'config', 'enabled-agents.json'),
+      JSON.stringify({
+        alice: { enabled: false, org: 'acme' },
+        dave: { enabled: false, org: 'widgetco' },
+      }),
+    );
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+    await am.discoverAndStart();
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    const namesStarted = startSpy.mock.calls.map(call => call[0]).sort();
+    expect(namesStarted).toEqual(['bob', 'carol']);
+  });
+
+  it('returns empty list when orgs/ does not exist (backward compat)', async () => {
+    const emptyDir = mkdtempSync(join(tmpdir(), 'cortextos-am-empty-'));
+    try {
+      // No orgs/ dir at all — daemon should not error, just discover nothing
+      const am = new AgentManager('test-instance', ctxRoot, emptyDir, 'acme');
+      const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+
+      await am.discoverAndStart();
+
+      expect(startSpy).not.toHaveBeenCalled();
+    } finally {
+      rmSync(emptyDir, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
## Summary

BUG-043 (P0) fixes multi-org support in the daemon. Before this fix, the AgentManager had a singleton \`this.org\` field from daemon startup env and used it everywhere, which meant a daemon started with \`CTX_ORG=testorg\` could never discover, find, or operate agents in other orgs.

## The bug

Discovered live during the 8-agent migration: agent \`donna\` was created at \`~/cortextos/orgs/lifeos/agents/donna\` (correctly), registered in enabled-agents.json with \`org: 'lifeos'\` (correctly), but running \`cortextos enable donna\` logged:

\`\`\`
[agent-manager] Agent directory not found for donna: tried /Users/cortextos/cortextos/orgs/testorg/agents/donna
\`\`\`

Wrong org — daemon used its startup \`testorg\` instead of donna's actual \`lifeos\`.

## Root cause

Six sites in \`src/daemon/agent-manager.ts\` used \`this.org\` where they should have used a per-agent org lookup:

- L107: auto-discovery \`join(frameworkRoot, 'orgs', this.org, 'agents', name)\`
- L126: env.org passed to AgentProcess
- L130: resolvePaths() for messaging paths
- L489: env.org for worker spawning (intentionally kept — workers are ephemeral)
- L552: discoverAgents scans only \`orgs/{this.org}/agents/\`

Plus the structural bug in \`discoverAgents()\`: iterated one org directory instead of walking all orgs, so agents in other orgs were invisible on daemon startup.

## Fix

1. **\`discoverAgents()\` walks all orgs**: iterates \`orgs/*/agents/*\` instead of \`orgs/{this.org}/agents/*\`. Return type gains an \`org\` field so downstream code knows where each agent lives.

2. **New \`resolveAgentOrg(name, explicitOrg?)\` helper**: four-tier resolution (explicit → enabled-agents.json → filesystem scan → \`this.org\` legacy fallback).

3. **\`startAgent()\` accepts optional \`org\` parameter**: uses resolveAgentOrg internally so IPC callers (who only have the agent name) still work.

4. **\`discoverAndStart()\` threads \`org\` to \`startAgent()\`**: no more fallback to \`this.org\` for agents discovered on startup.

5. **Worker spawning keeps \`this.org\`** — workers are ephemeral, don't have enabled-agents.json entries, and inherit org from their parent agent's context.

6. **Backward compatibility preserved** via the legacy \`this.org\` fallback in resolveAgentOrg. Single-org installs (most new users) see no change.

## Test plan

- [x] \`npm run build\` clean
- [x] \`npm test\` 423/423 passing (419 baseline + 4 new multi-org tests)
- [ ] **Cycle 2**: manual dist deploy + pm2 restart daemon → verify donna (lifeos) + commander/cortext-designer (testorg) all spawn correctly in a multi-org install
- [ ] **Cycle 3**: merged main verification (second pm2 restart) — same behavior
- [ ] bugs.md → BUG-043 verified

## Fast-loop note (daemon restart required)

Unlike CLI-only fixes, this is daemon code — pm2 restart is required for the new code to take effect. I'm running as a daemon-managed agent (cortext-designer); the restart will kill my PTY and the daemon will respawn me via \`claude --continue\`, which forks this conversation's session JSONL cleanly. Proven pattern from PR #15 (BUG-040) and PR #16 (BUG-041). I'll do the restart myself and verify post-respawn.

## Out of scope

- \`src/cli/start.ts\` still passes first-agent-org as \`CTX_ORG\` — harmless legacy, separate hygiene PR if desired
- \`src/daemon/index.ts\` startup still takes \`CTX_ORG\` — kept for backward compat

🤖 Generated with [Claude Code](https://claude.com/claude-code)