### PR TITLE
fix(daemon): signal re-entrancy guard for SIGTERM cascade (BUG-003)

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -81,9 +81,16 @@ class Daemon {
       process.exit(0);
     };
 
-    // Wrap in a synchronous handler that catches unhandled promise rejections
-    // so a shutdown error never leaves the process hanging.
+    // BUG-003 fix: re-entrancy guard. A second SIGTERM arriving while
+    // shutdown() is in flight would start a parallel stopAll(), causing
+    // unpredictable signal cascades across child PTY processes.
+    let shuttingDown = false;
     const handleSignal = () => {
+      if (shuttingDown) {
+        console.log('[daemon] Shutdown already in progress, ignoring signal');
+        return;
+      }
+      shuttingDown = true;
       shutdown().catch((err) => {
         console.error('[daemon] Fatal shutdown error:', err);
         process.exit(1);


### PR DESCRIPTION
## Summary
- Adds a `shuttingDown` boolean guard to the daemon signal handler in `index.ts`
- A second SIGTERM arriving while `shutdown()` is in flight would start a parallel `stopAll()`, causing unpredictable signal cascades across child PTY processes
- Now subsequent signals are logged and ignored

## Root Cause
The `handleSignal` closure had no re-entrancy protection. On rapid SIGTERM delivery (e.g. PM2 restart + manual kill), `shutdown()` could run concurrently, racing on `agentManager.stopAll()` and causing cascading signals to child PTYs.

## Test plan
- [x] Build passes (`npm run build`)
- [x] All tests pass (419/423, 4 pre-existing failures in agents.test.ts unrelated)
- [ ] 30-minute idle soak test with multi-agent daemon (recommended by PR #14)

🤖 Generated with [Claude Code](https://claude.com/claude-code)