### PR TITLE
fix(daemon): poll isAlive() before pty.kill() to prevent SIGHUP (BUG-032)

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -188,10 +188,17 @@ export class AgentProcess {
       } catch {
         // Ignore write errors during shutdown
       }
-      try {
-        pty.kill();
-      } catch {
-        // PTY may have already exited — ignore
+      // BUG-032 follow-up: only kill the PTY if the process is still alive.
+      // After /exit + 5s wait, the child has usually exited cleanly. Calling
+      // pty.kill() on an already-exited PTY tears down the file descriptor,
+      // which can send SIGHUP (exit code 129) to a process that was in the
+      // middle of flushing. Polling first eliminates the remaining SIGHUP risk.
+      if (pty.isAlive()) {
+        try {
+          pty.kill();
+        } catch {
+          // PTY may have exited between the check and the kill — ignore
+        }
       }
 
       // BUG-011 fix: AWAIT the exit handler before resolving stop().

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -8,6 +8,7 @@ const mockPty = {
   kill: vi.fn(),
   write: vi.fn(),
   getPid: vi.fn().mockReturnValue(12345),
+  isAlive: vi.fn().mockReturnValue(true),
   onExit: vi.fn().mockImplementation((cb: (exitCode: number, signal?: number) => void) => {
     capturedOnExit = cb;
   }),
@@ -68,6 +69,8 @@ beforeEach(() => {
   mockPty.spawn.mockClear();
   mockPty.kill.mockClear();
   mockPty.write.mockClear();
+  mockPty.isAlive.mockClear();
+  mockPty.isAlive.mockReturnValue(true);
   mockPty.onExit.mockClear();
 });
 


### PR DESCRIPTION
## Summary
- Replaces the unconditional `pty.kill()` in `AgentProcess.stop()` with an `isAlive()` check
- After sending `/exit` + 5s wait, the child process has usually exited cleanly; calling `kill()` on an already-exited PTY sends SIGHUP (exit code 129)
- Adds `isAlive` to the AgentPTY mock in tests

## Root Cause
The existing BUG-032 defensive fix (CRLF + 5s wait) addressed the most common trigger, but `pty.kill()` at line 192 still fired unconditionally. When the process had already exited during the 5s wait, tearing down the PTY file descriptor delivered SIGHUP to any still-flushing child.

## Test plan
- [x] Build passes (`npm run build`)
- [x] All 4 agent-process tests pass (including BUG-011 regression tests)
- [x] Full suite: 419/423 pass (4 pre-existing failures in agents.test.ts unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)