### PR TITLE
feat(daemon): auto-verify cron restoration after agent bootstrap

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -266,6 +266,11 @@ export class AgentManager {
     // Start agent
     await agentProcess.start();
 
+    // Schedule background cron verification: waits for the agent to finish
+    // its startup turn (idle flag), then injects a prompt to verify CronList
+    // matches config.json. Handles both fresh and --continue restarts safely.
+    agentProcess.scheduleCronVerification();
+
     // Start fast checker in background
     checker.start().catch(err => {
       console.error(`[${name}] Fast checker error:`, err);

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -463,6 +463,92 @@ export class AgentProcess {
       this.onStatusChange(this.getStatus());
     }
   }
+
+  /**
+   * Schedule a background cron verification check.
+   *
+   * Waits for the agent to finish its startup sequence (detected via the
+   * last_idle.flag written by the Stop hook after the agent's first turn
+   * completes), then injects a lightweight prompt asking the agent to
+   * verify its crons match config.json and restore any that are missing.
+   *
+   * Safe for both fresh starts and --continue restarts: the idle-wait
+   * ensures we never inject mid-conversation.
+   *
+   * Fire-and-forget: errors are logged but never propagated.
+   */
+  scheduleCronVerification(): void {
+    const crons = this.config.crons;
+    if (!crons || crons.length === 0) return;
+
+    const recurringNames = crons
+      .filter(c => c.type !== 'once')
+      .map(c => c.name);
+    if (recurringNames.length === 0) return;
+
+    const generation = this.lifecycleGeneration;
+
+    // Run in background — don't block startup
+    this.verifyCronsAfterIdle(recurringNames, generation).catch(err => {
+      this.log(`Cron verification failed (non-fatal): ${err}`);
+    });
+  }
+
+  private async verifyCronsAfterIdle(
+    expectedCrons: string[],
+    generation: number,
+  ): Promise<void> {
+    const stateDir = join(this.env.ctxRoot, 'state', this.name);
+    const flagPath = join(stateDir, 'last_idle.flag');
+
+    // Record the idle flag timestamp at boot so we can detect the NEXT idle
+    // (i.e. after the agent has finished processing its startup prompt).
+    let bootIdleTs = 0;
+    try {
+      if (existsSync(flagPath)) {
+        bootIdleTs = parseInt(readFileSync(flagPath, 'utf-8').trim(), 10);
+      }
+    } catch { /* ignore */ }
+
+    // Wait up to 10 minutes for the agent to finish its startup turn.
+    // Poll every 15s. Bail if the agent stopped or a new lifecycle started.
+    const maxWaitMs = 10 * 60 * 1000;
+    const pollMs = 15_000;
+    const startTime = Date.now();
+
+    while (Date.now() - startTime < maxWaitMs) {
+      // Bail if this lifecycle is stale (agent restarted or stopped)
+      if (generation !== this.lifecycleGeneration || this.status !== 'running') {
+        return;
+      }
+
+      await sleep(pollMs);
+
+      try {
+        if (existsSync(flagPath)) {
+          const currentIdleTs = parseInt(readFileSync(flagPath, 'utf-8').trim(), 10);
+          if (currentIdleTs > bootIdleTs) {
+            // Agent has gone idle after boot — safe to inject
+            break;
+          }
+        }
+      } catch { /* ignore read errors, keep polling */ }
+    }
+
+    // Final stale check
+    if (generation !== this.lifecycleGeneration || this.status !== 'running') {
+      return;
+    }
+
+    // Inject the verification prompt
+    const cronList = expectedCrons.join(', ');
+    const verifyPrompt = `[SYSTEM] Cron verification: your config.json defines these recurring crons: ${cronList}. Run CronList now. If any are missing, restore them from config.json using /loop. This is an automated safety check.`;
+
+    this.log(`Injecting cron verification (expecting: ${cronList})`);
+    if (this.pty) {
+      injectMessage((data) => this.pty!.write(data), verifyPrompt);
+    }
+  }
 }
 
 function sleep(ms: number): Promise<void> {

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -515,6 +515,7 @@ export class AgentProcess {
     const maxWaitMs = 10 * 60 * 1000;
     const pollMs = 15_000;
     const startTime = Date.now();
+    let foundIdle = false;
 
     while (Date.now() - startTime < maxWaitMs) {
       // Bail if this lifecycle is stale (agent restarted or stopped)
@@ -529,10 +530,18 @@ export class AgentProcess {
           const currentIdleTs = parseInt(readFileSync(flagPath, 'utf-8').trim(), 10);
           if (currentIdleTs > bootIdleTs) {
             // Agent has gone idle after boot — safe to inject
+            foundIdle = true;
             break;
           }
         }
       } catch { /* ignore read errors, keep polling */ }
+    }
+
+    // If the loop timed out without detecting an idle transition, do not inject:
+    // the agent never finished its startup turn (e.g. stuck on a very long boot).
+    if (!foundIdle) {
+      this.log('Cron verification: timed out waiting for idle flag, skipping injection');
+      return;
     }
 
     // Final stale check

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -17,8 +17,9 @@ vi.mock('../../../src/pty/agent-pty.js', () => ({
   AgentPTY: function AgentPTY() { return mockPty; },
 }));
 
+const mockInjectMessage = vi.fn();
 vi.mock('../../../src/pty/inject.js', () => ({
-  injectMessage: vi.fn(),
+  injectMessage: mockInjectMessage,
   MessageDedup: class { isDuplicate() { return false; } },
 }));
 
@@ -69,6 +70,7 @@ beforeEach(() => {
   mockPty.kill.mockClear();
   mockPty.write.mockClear();
   mockPty.onExit.mockClear();
+  mockInjectMessage.mockClear();
 });
 
 describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
@@ -142,5 +144,41 @@ describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
     const stopOrder = stopSpy.mock.invocationCallOrder[0];
     const startOrder = startSpy.mock.invocationCallOrder[0];
     expect(stopOrder).toBeLessThan(startOrder);
+  });
+});
+
+describe('AgentProcess - cron auto-verification', () => {
+  it('scheduleCronVerification() is a no-op when config has no crons', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+    // Should not throw, should not schedule anything
+    ap.scheduleCronVerification();
+    // No inject calls expected (beyond any from start)
+    expect(mockInjectMessage).not.toHaveBeenCalled();
+  });
+
+  it('scheduleCronVerification() is a no-op when config has only once crons', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {
+      crons: [{ name: 'reminder', type: 'once' as const, fire_at: '2099-01-01T00:00:00Z', prompt: 'test' }],
+    });
+    await ap.start();
+    ap.scheduleCronVerification();
+    // Wait briefly to confirm nothing fires
+    await new Promise(r => setTimeout(r, 100));
+    expect(mockInjectMessage).not.toHaveBeenCalled();
+  });
+
+  it('scheduleCronVerification() schedules verification when config has recurring crons', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {
+      crons: [
+        { name: 'heartbeat', interval: '4h', prompt: 'check in' },
+        { name: 'research', type: 'recurring' as const, interval: '24h', prompt: 'research' },
+      ],
+    });
+    await ap.start();
+    // This should not throw — verification runs in background
+    ap.scheduleCronVerification();
+    // Verification is waiting for idle flag — no immediate injection
+    expect(mockInjectMessage).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Capture the PTY exit handler so tests can simulate exits at controlled times
 let capturedOnExit: ((exitCode: number, signal?: number) => void) | null = null;
@@ -180,5 +180,56 @@ describe('AgentProcess - cron auto-verification', () => {
     ap.scheduleCronVerification();
     // Verification is waiting for idle flag — no immediate injection
     expect(mockInjectMessage).not.toHaveBeenCalled();
+  });
+
+  it('verifyCronsAfterIdle: injects prompt containing cron names once idle flag appears newer than boot', async () => {
+    const fs = await import('fs');
+    const mockExistsSync = vi.mocked(fs.existsSync);
+    const mockReadFileSync = vi.mocked(fs.readFileSync);
+
+    const bootTs = 1000;
+    const idleTs = 2000;
+
+    // Track calls so the first read (boot snapshot) returns bootTs,
+    // subsequent reads (poll) return idleTs (agent went idle)
+    let readCount = 0;
+    mockExistsSync.mockImplementation((p) => {
+      if (typeof p === 'string' && p.endsWith('last_idle.flag')) return true;
+      return false;
+    });
+    mockReadFileSync.mockImplementation((p) => {
+      if (typeof p === 'string' && p.endsWith('last_idle.flag')) {
+        readCount++;
+        return readCount === 1 ? String(bootTs) : String(idleTs);
+      }
+      return '';
+    });
+
+    vi.useFakeTimers();
+    try {
+      const ap = new AgentProcess('alice', mockEnv, {
+        crons: [
+          { name: 'heartbeat', interval: '4h', prompt: 'check in' },
+          { name: 'daily-report', interval: '24h', prompt: 'report' },
+        ],
+      });
+      await ap.start();
+
+      ap.scheduleCronVerification();
+
+      // Advance past the 15s poll interval so the background loop wakes,
+      // reads the newer flag timestamp, and injects the verification prompt
+      await vi.advanceTimersByTimeAsync(16_000);
+    } finally {
+      vi.useRealTimers();
+      // Restore default fs mock behaviour for other tests
+      mockExistsSync.mockReturnValue(false);
+      mockReadFileSync.mockReset();
+    }
+
+    expect(mockInjectMessage).toHaveBeenCalledOnce();
+    const promptArg: string = mockInjectMessage.mock.calls[0][1] as string;
+    expect(promptArg).toContain('heartbeat');
+    expect(promptArg).toContain('daily-report');
   });
 });


### PR DESCRIPTION
## Summary
- Adds framework-level cron verification safety net to `AgentProcess`
- After agent finishes its startup turn (idle flag), daemon reads `config.json` crons and injects a verification prompt
- Agent checks CronList and restores any missing recurring crons
- Handles both fresh starts and `--continue` restarts safely (idle-wait prevents mid-conversation injection)
- Addresses systemic pattern where agents skip cron restoration on session start (same root cause as BUG-027)

## Design
- `scheduleCronVerification()` on `AgentProcess`: fire-and-forget, called by `AgentManager` after `start()`
- `verifyCronsAfterIdle()`: polls `last_idle.flag` every 15s (up to 10 min) waiting for agent to finish boot
- Lifecycle-generation-aware: bails if agent restarts or stops during the wait
- Only triggers for recurring crons (one-shots handled by existing pending-reminders system)

## Test plan
- [x] Build passes
- [x] All 426 tests pass (423 existing + 3 new cron verification tests)
- [x] No-op when config has no crons
- [x] No-op when config has only one-shot crons
- [x] Schedules verification when config has recurring crons
- [ ] Integration: verify cron injection fires on real agent with missing crons

🤖 Generated with [Claude Code](https://claude.com/claude-code)