### PR TITLE
fix(dashboard): SparkLine dimensions + Brand Voice markdown

### DIFF
--- a/dashboard/src/components/charts/spark-line.tsx
+++ b/dashboard/src/components/charts/spark-line.tsx
@@ -28,7 +28,7 @@ export function SparkLine({
   const chartData = data.map((value, i) => ({ i, v: value }));
 
   return (
-    <span className={className} style={{ display: 'inline-block', width, height }}>
+    <div className={className} style={{ display: 'inline-block', width, height, minWidth: 1, minHeight: 1 }}>
       <ResponsiveContainer width="100%" height="100%">
         <LineChart data={chartData}>
           <Line
@@ -41,6 +41,6 @@ export function SparkLine({
           />
         </LineChart>
       </ResponsiveContainer>
-    </span>
+    </div>
   );
 }

--- a/dashboard/src/components/knowledge-base/kb-view.tsx
+++ b/dashboard/src/components/knowledge-base/kb-view.tsx
@@ -3,112 +3,12 @@
 import { useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { renderMarkdown } from '@/lib/render-markdown';
 
 interface KnowledgeBaseViewProps {
   content: string;
   org: string;
   filePath: string;
-}
-
-// Lightweight markdown renderer for knowledge.md files.
-// Handles: headings, bold, italic, inline code, code blocks, bullets, numbered lists, links, hr.
-function renderMarkdown(text: string): React.ReactNode[] {
-  const lines = text.split('\n');
-  const nodes: React.ReactNode[] = [];
-  let i = 0;
-  let keyCounter = 0;
-  const key = () => keyCounter++;
-
-  const renderInline = (line: string): React.ReactNode => {
-    // Split by bold, italic, inline code, links
-    const parts: React.ReactNode[] = [];
-    const re = /(\*\*(.+?)\*\*|\*(.+?)\*|`([^`]+)`|\[([^\]]+)\]\(([^)]+)\))/g;
-    let last = 0;
-    let m;
-    while ((m = re.exec(line)) !== null) {
-      if (m.index > last) parts.push(line.slice(last, m.index));
-      if (m[2]) parts.push(<strong key={key()}>{m[2]}</strong>);
-      else if (m[3]) parts.push(<em key={key()}>{m[3]}</em>);
-      else if (m[4]) parts.push(<code key={key()} className="bg-muted px-1 py-0.5 rounded text-xs font-mono">{m[4]}</code>);
-      else if (m[5]) parts.push(<a key={key()} href={m[6]} className="text-primary underline" target="_blank" rel="noopener noreferrer">{m[5]}</a>);
-      last = m.index + m[0].length;
-    }
-    if (last < line.length) parts.push(line.slice(last));
-    return parts.length === 1 ? parts[0] : <>{parts}</>;
-  };
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    // Code block
-    if (line.startsWith('```')) {
-      const lang = line.slice(3).trim();
-      const codeLines: string[] = [];
-      i++;
-      while (i < lines.length && !lines[i].startsWith('```')) {
-        codeLines.push(lines[i]);
-        i++;
-      }
-      nodes.push(
-        <pre key={key()} className="bg-muted rounded-md p-3 text-xs font-mono overflow-x-auto my-2 whitespace-pre-wrap">
-          {lang && <span className="text-muted-foreground text-[10px] block mb-1">{lang}</span>}
-          {codeLines.join('\n')}
-        </pre>
-      );
-      i++;
-      continue;
-    }
-
-    // HR
-    if (/^---+$/.test(line.trim())) {
-      nodes.push(<hr key={key()} className="border-muted my-3" />);
-      i++;
-      continue;
-    }
-
-    // Headings
-    const h3 = line.match(/^### (.+)/);
-    if (h3) { nodes.push(<h3 key={key()} className="text-sm font-semibold mt-4 mb-1">{renderInline(h3[1])}</h3>); i++; continue; }
-    const h2 = line.match(/^## (.+)/);
-    if (h2) { nodes.push(<h2 key={key()} className="text-base font-semibold mt-5 mb-2 pb-1 border-b">{renderInline(h2[1])}</h2>); i++; continue; }
-    const h1 = line.match(/^# (.+)/);
-    if (h1) { nodes.push(<h1 key={key()} className="text-lg font-bold mt-4 mb-2">{renderInline(h1[1])}</h1>); i++; continue; }
-
-    // Bullet list — collect consecutive bullets
-    if (/^[-*] /.test(line)) {
-      const items: React.ReactNode[] = [];
-      while (i < lines.length && /^[-*] /.test(lines[i])) {
-        items.push(<li key={key()} className="ml-4 text-sm">{renderInline(lines[i].replace(/^[-*] /, ''))}</li>);
-        i++;
-      }
-      nodes.push(<ul key={key()} className="list-disc list-inside space-y-0.5 my-1">{items}</ul>);
-      continue;
-    }
-
-    // Numbered list
-    if (/^\d+\. /.test(line)) {
-      const items: React.ReactNode[] = [];
-      while (i < lines.length && /^\d+\. /.test(lines[i])) {
-        items.push(<li key={key()} className="ml-4 text-sm">{renderInline(lines[i].replace(/^\d+\. /, ''))}</li>);
-        i++;
-      }
-      nodes.push(<ol key={key()} className="list-decimal list-inside space-y-0.5 my-1">{items}</ol>);
-      continue;
-    }
-
-    // Blank line
-    if (line.trim() === '') {
-      nodes.push(<div key={key()} className="h-2" />);
-      i++;
-      continue;
-    }
-
-    // Paragraph
-    nodes.push(<p key={key()} className="text-sm leading-relaxed">{renderInline(line)}</p>);
-    i++;
-  }
-
-  return nodes;
 }
 
 export function KnowledgeBaseView({ content, org, filePath }: KnowledgeBaseViewProps) {

--- a/dashboard/src/components/settings/organization-tab.tsx
+++ b/dashboard/src/components/settings/organization-tab.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { fetchOrgMetadata } from '@/lib/actions/settings';
+import { renderMarkdown } from '@/lib/render-markdown';
 
 interface OrgData {
   context: {
@@ -222,10 +223,8 @@ export function OrganizationTab() {
           <CardHeader>
             <CardTitle>Brand Voice</CardTitle>
           </CardHeader>
-          <CardContent>
-            <pre className="text-sm whitespace-pre-wrap font-sans text-muted-foreground">
-              {data.brandVoice}
-            </pre>
+          <CardContent className="text-muted-foreground">
+            {renderMarkdown(data.brandVoice)}
           </CardContent>
         </Card>
       )}

--- a/dashboard/src/lib/render-markdown.tsx
+++ b/dashboard/src/lib/render-markdown.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+
+/**
+ * Lightweight markdown renderer for dashboard content.
+ * Handles: headings, bold, italic, inline code, code blocks, bullets,
+ * numbered lists, links, horizontal rules.
+ *
+ * Extracted from kb-view.tsx for reuse across settings, experiments, etc.
+ */
+export function renderMarkdown(text: string): React.ReactNode[] {
+  const lines = text.split('\n');
+  const nodes: React.ReactNode[] = [];
+  let i = 0;
+  let keyCounter = 0;
+  const key = () => keyCounter++;
+
+  const renderInline = (line: string): React.ReactNode => {
+    const parts: React.ReactNode[] = [];
+    const re = /(\*\*(.+?)\*\*|\*(.+?)\*|`([^`]+)`|\[([^\]]+)\]\(([^)]+)\))/g;
+    let last = 0;
+    let m;
+    while ((m = re.exec(line)) !== null) {
+      if (m.index > last) parts.push(line.slice(last, m.index));
+      if (m[2]) parts.push(<strong key={key()}>{m[2]}</strong>);
+      else if (m[3]) parts.push(<em key={key()}>{m[3]}</em>);
+      else if (m[4]) parts.push(<code key={key()} className="bg-muted px-1 py-0.5 rounded text-xs font-mono">{m[4]}</code>);
+      else if (m[5]) parts.push(<a key={key()} href={m[6]} className="text-primary underline" target="_blank" rel="noopener noreferrer">{m[5]}</a>);
+      last = m.index + m[0].length;
+    }
+    if (last < line.length) parts.push(line.slice(last));
+    return parts.length === 1 ? parts[0] : <>{parts}</>;
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    // Code block
+    if (line.startsWith('```')) {
+      const lang = line.slice(3).trim();
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      nodes.push(
+        <pre key={key()} className="bg-muted rounded-md p-3 text-xs font-mono overflow-x-auto my-2 whitespace-pre-wrap">
+          {lang && <span className="text-muted-foreground text-[10px] block mb-1">{lang}</span>}
+          {codeLines.join('\n')}
+        </pre>
+      );
+      i++;
+      continue;
+    }
+
+    // HR
+    if (/^---+$/.test(line.trim())) {
+      nodes.push(<hr key={key()} className="border-muted my-3" />);
+      i++;
+      continue;
+    }
+
+    // Headings
+    const h3 = line.match(/^### (.+)/);
+    if (h3) { nodes.push(<h3 key={key()} className="text-sm font-semibold mt-4 mb-1">{renderInline(h3[1])}</h3>); i++; continue; }
+    const h2 = line.match(/^## (.+)/);
+    if (h2) { nodes.push(<h2 key={key()} className="text-base font-semibold mt-5 mb-2 pb-1 border-b">{renderInline(h2[1])}</h2>); i++; continue; }
+    const h1 = line.match(/^# (.+)/);
+    if (h1) { nodes.push(<h1 key={key()} className="text-lg font-bold mt-4 mb-2">{renderInline(h1[1])}</h1>); i++; continue; }
+
+    // Bullet list
+    if (/^[-*] /.test(line)) {
+      const items: React.ReactNode[] = [];
+      while (i < lines.length && /^[-*] /.test(lines[i])) {
+        items.push(<li key={key()} className="ml-4 text-sm">{renderInline(lines[i].replace(/^[-*] /, ''))}</li>);
+        i++;
+      }
+      nodes.push(<ul key={key()} className="list-disc list-inside space-y-0.5 my-1">{items}</ul>);
+      continue;
+    }
+
+    // Numbered list
+    if (/^\d+\. /.test(line)) {
+      const items: React.ReactNode[] = [];
+      while (i < lines.length && /^\d+\. /.test(lines[i])) {
+        items.push(<li key={key()} className="ml-4 text-sm">{renderInline(lines[i].replace(/^\d+\. /, ''))}</li>);
+        i++;
+      }
+      nodes.push(<ol key={key()} className="list-decimal list-inside space-y-0.5 my-1">{items}</ol>);
+      continue;
+    }
+
+    // Blank line
+    if (line.trim() === '') {
+      nodes.push(<div key={key()} className="h-2" />);
+      i++;
+      continue;
+    }
+
+    // Paragraph
+    nodes.push(<p key={key()} className="text-sm leading-relaxed">{renderInline(line)}</p>);
+    i++;
+  }
+
+  return nodes;
+}


### PR DESCRIPTION
## Summary
- Fix Recharts negative container dimensions: change SparkLine wrapper from `<span>` to `<div>` with `minWidth`/`minHeight` constraints
- Fix Settings Brand Voice raw markdown: replace `<pre>` with the existing `renderMarkdown()` renderer
- Extract `renderMarkdown()` to shared `lib/render-markdown.tsx` (was inline in kb-view.tsx)
- Tasks page filters and "new task" button already exist (false alarm from audit)

## Test plan
- [x] Dashboard builds (`next build`)
- [x] Core tests pass (423/423)
- [x] TypeScript compiles cleanly
- [ ] Visual: verify SparkLine renders without console warnings
- [ ] Visual: verify Brand Voice renders markdown formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)