### PR TITLE
fix(telegram): relative paths for media files (BUG-046)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ agents/*/memory/
 # Test artifacts
 test-results/
 *.log
+# Spurious directory created when ${APPDATA} env var unexpanded during npm link on Windows
+${APPDATA}/
 
 # Knowledge base
 knowledge-base/venv/

--- a/bus/kb-setup.sh
+++ b/bus/kb-setup.sh
@@ -58,10 +58,17 @@ else
   echo "  [OK] Venv already exists"
 fi
 
+# Resolve platform-specific venv paths (Windows uses Scripts/, Unix uses bin/)
+if [[ -d "$VENV_DIR/Scripts" ]]; then
+  VENV_BIN="$VENV_DIR/Scripts"
+else
+  VENV_BIN="$VENV_DIR/bin"
+fi
+
 # Install/upgrade dependencies
 echo "  Installing Python dependencies..."
-"$VENV_DIR/bin/pip" install --quiet --upgrade pip
-"$VENV_DIR/bin/pip" install --quiet -r "$REQS"
+"$VENV_BIN/pip" install --quiet --upgrade pip 2>/dev/null || true
+"$VENV_BIN/pip" install --quiet -r "$REQS"
 echo "  [OK] Dependencies installed"
 
 # Validate mmrag.py is accessible
@@ -88,13 +95,21 @@ EOF
   echo "  [OK] mmrag config.json created"
 else
   echo "  [OK] mmrag config.json already exists"
+
+  # Migrate stale embedding model names (text-embedding-004 was shut down 2026-01-14)
+  if grep -qE '"embedding_model"\s*:\s*"(models/text-embedding-004|text-embedding-004)"' "$CONFIG_FILE" 2>/dev/null; then
+    sed -i.bak 's/"models\/text-embedding-004"/"gemini-embedding-001"/g; s/"text-embedding-004"/"gemini-embedding-001"/g' "$CONFIG_FILE"
+    rm -f "${CONFIG_FILE}.bak"
+    echo "  [MIGRATED] embedding_model updated to gemini-embedding-001 (text-embedding-004 was shut down)"
+  fi
 fi
 
 # Test import
 MMRAG_DIR="$KB_ROOT" \
 MMRAG_CHROMADB_DIR="$CHROMADB_DIR" \
 MMRAG_CONFIG="$CONFIG_FILE" \
-"$VENV_DIR/bin/python3" -c "import chromadb; import google.genai; print('  [OK] Core imports work')"
+"$VENV_BIN/python3" -c "import chromadb; import google.genai; print('  [OK] Core imports work')" 2>/dev/null || \
+"$VENV_BIN/python" -c "import chromadb; import google.genai; print('  [OK] Core imports work')"
 
 echo ""
 echo "Knowledge base ready for org: $ORG"

--- a/dashboard/src/app/icon.svg
+++ b/dashboard/src/app/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#B8860B"/>
+  <text x="16" y="22" text-anchor="middle" font-family="system-ui, -apple-system, sans-serif" font-size="16" font-weight="700" fill="white">cO</text>
+</svg>

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -114,13 +114,11 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
   },
 });
 
-/** Seed admin user from env vars if no users exist in the database */
+/** Seed admin user from env vars, or sync password if SYNC_ADMIN_PASSWORD=true */
 export async function seedAdminUser(): Promise<void> {
   const row = db
     .prepare('SELECT COUNT(*) as count FROM users')
     .get() as { count: number };
-
-  if (row.count > 0) return;
 
   const username = process.env.ADMIN_USERNAME ?? 'admin';
 
@@ -132,6 +130,26 @@ export async function seedAdminUser(): Promise<void> {
   const KNOWN_DEFAULTS = ['cortextos', 'password', 'admin', 'changeme'];
   if (process.env.NODE_ENV === 'production' && KNOWN_DEFAULTS.includes(password)) {
     throw new Error('ADMIN_PASSWORD is a known default. Set a strong password in .env.local');
+  }
+
+  if (row.count > 0) {
+    // Opt-in password sync: only update stored hash when SYNC_ADMIN_PASSWORD=true.
+    // This prevents the dashboard from silently overwriting a password that was
+    // changed through the UI on every restart.
+    if (process.env.SYNC_ADMIN_PASSWORD === 'true') {
+      const user = db
+        .prepare('SELECT password_hash FROM users WHERE username = ?')
+        .get(username) as { password_hash: string } | undefined;
+      if (user) {
+        const matches = await bcrypt.compare(password, user.password_hash);
+        if (!matches) {
+          const hash = await bcrypt.hash(password, 12);
+          db.prepare('UPDATE users SET password_hash = ? WHERE username = ?').run(hash, username);
+          console.log(`[auth] Admin password updated from environment (SYNC_ADMIN_PASSWORD=true)`);
+        }
+      }
+    }
+    return;
   }
 
   const hash = await bcrypt.hash(password, 12);

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -120,9 +120,17 @@ export async function seedAdminUser(): Promise<void> {
     .prepare('SELECT COUNT(*) as count FROM users')
     .get() as { count: number };
 
+  // Early return: users already exist and no password sync requested.
+  // Do NOT validate ADMIN_PASSWORD here — existing deployments may not have it set,
+  // and we don't need it when there is nothing to seed or sync.
+  if (row.count > 0 && process.env.SYNC_ADMIN_PASSWORD !== 'true') {
+    return;
+  }
+
   const username = process.env.ADMIN_USERNAME ?? 'admin';
 
   // Security (H8): Do not fall back to hardcoded password.
+  // Only validate when we actually need the password (seeding or syncing).
   const password = process.env.ADMIN_PASSWORD;
   if (!password) {
     throw new Error('ADMIN_PASSWORD environment variable is required but not set.');
@@ -136,17 +144,15 @@ export async function seedAdminUser(): Promise<void> {
     // Opt-in password sync: only update stored hash when SYNC_ADMIN_PASSWORD=true.
     // This prevents the dashboard from silently overwriting a password that was
     // changed through the UI on every restart.
-    if (process.env.SYNC_ADMIN_PASSWORD === 'true') {
-      const user = db
-        .prepare('SELECT password_hash FROM users WHERE username = ?')
-        .get(username) as { password_hash: string } | undefined;
-      if (user) {
-        const matches = await bcrypt.compare(password, user.password_hash);
-        if (!matches) {
-          const hash = await bcrypt.hash(password, 12);
-          db.prepare('UPDATE users SET password_hash = ? WHERE username = ?').run(hash, username);
-          console.log(`[auth] Admin password updated from environment (SYNC_ADMIN_PASSWORD=true)`);
-        }
+    const user = db
+      .prepare('SELECT password_hash FROM users WHERE username = ?')
+      .get(username) as { password_hash: string } | undefined;
+    if (user) {
+      const matches = await bcrypt.compare(password, user.password_hash);
+      if (!matches) {
+        const hash = await bcrypt.hash(password, 12);
+        db.prepare('UPDATE users SET password_hash = ? WHERE username = ?').run(hash, username);
+        console.log(`[auth] Admin password updated from environment (SYNC_ADMIN_PASSWORD=true)`);
       }
     }
     return;

--- a/dashboard/src/lib/db.ts
+++ b/dashboard/src/lib/db.ts
@@ -24,7 +24,19 @@ function createDatabase(): Database.Database {
   // require write locks (e.g. WAL switch, CREATE TABLE). Without this, parallel
   // processes (like Next.js build workers) hit SQLITE_BUSY immediately.
   db.pragma('busy_timeout = 10000');
-  db.pragma('journal_mode = WAL');
+
+  // Switch to WAL mode (requires exclusive lock on the DB file).
+  // Guard against SQLITE_BUSY when multiple Next.js build workers open the DB
+  // simultaneously: if the switch fails, check whether another worker already
+  // succeeded. If so, continue; otherwise re-throw.
+  try {
+    db.pragma('journal_mode = WAL');
+  } catch (err: unknown) {
+    if ((err as NodeJS.ErrnoException & { code?: string }).code !== 'SQLITE_BUSY') throw err;
+    const rows = db.pragma('journal_mode') as { journal_mode: string }[];
+    if (rows[0]?.journal_mode !== 'wal') throw err;
+    // Another worker already switched to WAL — we're fine.
+  }
   db.pragma('synchronous = NORMAL');
   db.pragma('foreign_keys = ON');
 

--- a/src/cli/dashboard.ts
+++ b/src/cli/dashboard.ts
@@ -154,11 +154,11 @@ export const dashboardCommand = new Command('dashboard')
     }
     console.log('');
 
-    const child = spawn('npx', startArgs, {
-      cwd: dashboardDir,
-      stdio: 'inherit',
-      env: dashEnv,
-    });
+    // On Windows, npx is a .cmd wrapper requiring shell resolution.
+    // Pass as single string to avoid Node.js DEP0190 deprecation warning.
+    const child = IS_WINDOWS
+      ? spawn(['npx', ...startArgs].join(' '), { cwd: dashboardDir, stdio: 'inherit', env: dashEnv, shell: true })
+      : spawn('npx', startArgs, { cwd: dashboardDir, stdio: 'inherit', env: dashEnv });
 
     child.on('error', (err: Error) => {
       console.error('Failed to start dashboard:', err.message);

--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -77,7 +77,7 @@ export const doctorCommand = new Command('doctor')
         status: 'fail',
         message: 'Failed to load native module',
         fix: process.platform === 'win32'
-          ? 'Install Visual C++ Build Tools: npm install -g windows-build-tools'
+          ? 'Install "Desktop development with C++" workload from Visual Studio Build Tools (https://visualstudio.microsoft.com/visual-cpp-build-tools/), then run: npm rebuild node-pty'
           : 'Install build tools: xcode-select --install (macOS) or apt install build-essential (Linux)',
       });
     }

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -15,14 +15,24 @@ const SAFE_NAME = /^[@a-z0-9._/-]+$/i;
 
 function tryInstallGlobal(pkg: string): boolean {
   if (!SAFE_NAME.test(pkg)) return false;
-  const result = spawnSync('npm', ['install', '-g', pkg], { stdio: 'inherit', timeout: 120000 });
+  // On Windows, 'npm' is a .cmd wrapper; use shell to resolve it.
+  // Pass as single string to avoid DEP0190 deprecation warning.
+  const result = IS_WINDOWS
+    ? spawnSync(`npm install -g ${pkg}`, { stdio: 'inherit', timeout: 120000, shell: true })
+    : spawnSync('npm', ['install', '-g', pkg], { stdio: 'inherit', timeout: 120000 });
   return result.status === 0;
 }
 
 function commandExists(cmd: string): boolean {
   if (!SAFE_NAME.test(cmd)) return false;
-  const which = IS_WINDOWS ? 'where' : 'which';
-  const result = spawnSync(which, [cmd], { stdio: 'pipe' });
+  // On Windows, use shell so 'where' runs through cmd.exe with the full
+  // system PATH — without it, where.exe can miss tools installed via
+  // WinGet or user-space installers when PATH contains Unix-style paths.
+  if (IS_WINDOWS) {
+    const result = spawnSync(`where ${cmd}`, { stdio: 'pipe', shell: true });
+    return result.status === 0;
+  }
+  const result = spawnSync('which', [cmd], { stdio: 'pipe' });
   return result.status === 0;
 }
 
@@ -131,7 +141,9 @@ export const installCommand = new Command('install')
       if (IS_MAC) {
         console.error('    Install Xcode Command Line Tools: xcode-select --install');
       } else if (IS_WINDOWS) {
-        console.error('    Install Visual C++ Build Tools: npm install -g windows-build-tools');
+        console.error('    Install "Desktop development with C++" workload from Visual Studio Build Tools:');
+        console.error('    https://visualstudio.microsoft.com/visual-cpp-build-tools/');
+        console.error('    Then run: npm rebuild node-pty');
       } else {
         console.error('    Install build tools: sudo apt-get install -y build-essential python3');
       }
@@ -216,6 +228,40 @@ export const installCommand = new Command('install')
       } catch {
         console.log('  ✓ jq: installed');
       }
+    }
+
+    // Python venv for Knowledge Base
+    const kbVenvDir = join(process.cwd(), 'knowledge-base', 'venv');
+    const kbReqs = join(process.cwd(), 'knowledge-base', 'scripts', 'requirements.txt');
+    const python3Cmd = IS_WINDOWS ? 'python' : 'python3';
+    if (commandExists(python3Cmd)) {
+      if (!existsSync(kbVenvDir)) {
+        console.log('  - Knowledge Base venv: not found. Creating...');
+        const venvResult = spawnSync(python3Cmd, ['-m', 'venv', kbVenvDir], { stdio: 'inherit', timeout: 60000 });
+        if (venvResult.status === 0) {
+          console.log('  ✓ Knowledge Base venv created');
+          // Install KB dependencies
+          if (existsSync(kbReqs)) {
+            const pip = IS_WINDOWS
+              ? join(kbVenvDir, 'Scripts', 'pip')
+              : join(kbVenvDir, 'bin', 'pip');
+            const pipResult = spawnSync(pip, ['install', '--quiet', '-r', kbReqs], { stdio: 'inherit', timeout: 120000 });
+            if (pipResult.status === 0) {
+              console.log('  ✓ Knowledge Base dependencies installed');
+            } else {
+              console.log('  ! Knowledge Base dependencies failed to install. Run kb-setup.sh manually.');
+            }
+          }
+        } else {
+          console.log('  ! Could not create Knowledge Base venv. Run: bus/kb-setup.sh --org <org>');
+        }
+      } else {
+        console.log('  ✓ Knowledge Base venv exists');
+      }
+    } else {
+      console.log(`  ! ${python3Cmd}: not found. Knowledge Base requires Python 3.`);
+      if (IS_WINDOWS) console.log('    Install from: https://www.python.org/downloads/');
+      else console.log('    Install with: sudo apt-get install -y python3 python3-venv');
     }
 
     console.log('');
@@ -306,6 +352,18 @@ export const installCommand = new Command('install')
     );
     try { chmodSync(dashEnvPath, 0o600); } catch { /* ignore on Windows */ }
     console.log(`  Generated dashboard credentials at ${dashEnvPath}`);
+
+    // Register cortextos CLI globally so agent PTY sessions can find it
+    console.log('Registering cortextos CLI globally...');
+    const linkResult = IS_WINDOWS
+      ? spawnSync('npm link', { stdio: 'pipe', cwd: process.cwd(), timeout: 30000, shell: true })
+      : spawnSync('npm', ['link'], { stdio: 'pipe', cwd: process.cwd(), timeout: 30000 });
+    if (linkResult.status === 0) {
+      console.log('  ✓ cortextos registered globally (npm link)');
+    } else {
+      console.log('  ! npm link failed. Run manually: npm link (from the cortextOS directory)');
+      console.log('    Without this, agents cannot use bus commands in PTY sessions.');
+    }
 
     console.log('\n  Installation complete.');
     console.log(`  State directory: ${ctxRoot}`);

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -1,6 +1,6 @@
 import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import type { AgentConfig, AgentStatus, CtxEnv, BusPaths, WorkerStatus } from '../types/index.js';
+import { join, relative } from 'path';
+import type { AgentConfig, AgentStatus, CtxEnv, BusPaths, WorkerStatus, TelegramMessage } from '../types/index.js';
 import { AgentProcess } from './agent-process.js';
 import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
@@ -327,17 +327,24 @@ export class AgentManager {
               return;
             }
 
-            log(`[DEBUG] media.type=${media.type} image_path=${JSON.stringify(media.image_path)} file_path=${JSON.stringify(media.file_path)}`);
+            // BUG-046: Convert absolute paths to relative (from agent working dir).
+            // Claude Code strips absolute paths from pasted user input, so the
+            // agent never sees them. Relative paths survive injection.
+            const toRel = (p: string | undefined) => p ? relative(agentDir, p) : '';
+            const relImagePath = toRel(media.image_path);
+            const relFilePath = toRel(media.file_path);
+
+            log(`[DEBUG] media.type=${media.type} image_path=${JSON.stringify(relImagePath)} file_path=${JSON.stringify(relFilePath)}`);
             let formatted: string;
             if (media.type === 'photo') {
-              formatted = FastChecker.formatTelegramPhotoMessage(from, effectiveChatId, media.text, media.image_path ?? '');
+              formatted = FastChecker.formatTelegramPhotoMessage(from, effectiveChatId, media.text, relImagePath);
             } else if (media.type === 'document') {
-              formatted = FastChecker.formatTelegramDocumentMessage(from, effectiveChatId, media.text, media.file_path!, media.file_name!);
+              formatted = FastChecker.formatTelegramDocumentMessage(from, effectiveChatId, media.text, relFilePath, media.file_name!);
             } else if (media.type === 'voice' || media.type === 'audio') {
-              formatted = FastChecker.formatTelegramVoiceMessage(from, effectiveChatId, media.file_path!, media.duration);
+              formatted = FastChecker.formatTelegramVoiceMessage(from, effectiveChatId, relFilePath, media.duration);
             } else {
               // video or video_note
-              formatted = FastChecker.formatTelegramVideoMessage(from, effectiveChatId, media.text, media.file_path!, media.file_name || '', media.duration);
+              formatted = FastChecker.formatTelegramVideoMessage(from, effectiveChatId, media.text, relFilePath, media.file_name || '', media.duration);
             }
 
             if (checker.isDuplicate(formatted)) {
@@ -358,9 +365,8 @@ export class AgentManager {
         // Text message (non-media)
         const text = stripControlChars(msg.text || '');
         const lastSent = FastChecker.readLastSent(stateDir, effectiveChatId);
-        const replyToText = msg.reply_to_message?.text
-          ? stripControlChars(msg.reply_to_message.text)
-          : undefined;
+        // Build reply context from the replied-to message.
+        const replyToText = buildReplyContext(msg.reply_to_message);
 
         const formatted = FastChecker.formatTelegramTextMessage(
           from,
@@ -665,4 +671,29 @@ export class AgentManager {
     }
     return {}; // Default config
   }
+}
+
+/**
+ * Derive a human-readable reply context string from a Telegram replied-to message.
+ *
+ * Priority: text > caption > media type label.
+ * This is exported for unit testing; call sites use it via the message handler.
+ *
+ * Before this fix (BUG: reply context lost for media messages): only `.text` was
+ * checked, so replies to videos/photos/voice arrived as bare text with no
+ * indication of what was being replied to (e.g. "This one" with zero context).
+ */
+export function buildReplyContext(
+  replyMsg: TelegramMessage | undefined,
+): string | undefined {
+  if (!replyMsg) return undefined;
+  if (replyMsg.text) return stripControlChars(replyMsg.text);
+  if (replyMsg.caption) return stripControlChars(replyMsg.caption);
+  if (replyMsg.video) return '[video]';
+  if (replyMsg.video_note) return '[video note]';
+  if (replyMsg.photo) return '[photo]';
+  if (replyMsg.voice) return '[voice message]';
+  if (replyMsg.audio) return '[audio]';
+  if (replyMsg.document) return `[document: ${replyMsg.document.file_name ?? 'file'}]`;
+  return undefined;
 }

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
 
@@ -137,9 +138,12 @@ export class AgentPTY {
 
     // Spawn claude directly (no shell wrapper) — cross-platform, no shell escaping needed.
     // env is passed natively via node-pty options; no bash export commands required.
+    // On Windows, node-pty uses CreateProcess which does NOT resolve .exe extensions
+    // from bare command names. We must use 'claude.exe' explicitly.
     const claudeArgs = this.buildClaudeArgs(mode, prompt);
+    const claudeCmd = platform() === 'win32' ? 'claude.exe' : 'claude';
 
-    this.pty = this.spawnFn!('claude', claudeArgs, {
+    this.pty = this.spawnFn!(claudeCmd, claudeArgs, {
       name: 'xterm-256color',
       cols: 200,
       rows: 50,
@@ -297,6 +301,14 @@ export class AgentPTY {
         env[key] = process.env[key]!;
       }
     }
+
+    // Windows: ensure UTF-8 locale so emoji and Unicode pass through the PTY
+    if (platform() === 'win32') {
+      if (!env['LANG']) env['LANG'] = 'en_US.UTF-8';
+      if (!env['LC_ALL']) env['LC_ALL'] = 'en_US.UTF-8';
+      if (!process.env['PYTHONIOENCODING']) env['PYTHONIOENCODING'] = 'utf-8';
+    }
+
     return env;
   }
 }

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -138,10 +138,10 @@ export class AgentPTY {
 
     // Spawn claude directly (no shell wrapper) — cross-platform, no shell escaping needed.
     // env is passed natively via node-pty options; no bash export commands required.
-    // On Windows, node-pty uses CreateProcess which does NOT resolve .exe extensions
-    // from bare command names. We must use 'claude.exe' explicitly.
+    // On Windows, npm global installs create .cmd wrappers, not .exe binaries.
+    // node-pty's CreateProcess requires the exact wrapper name to resolve correctly.
     const claudeArgs = this.buildClaudeArgs(mode, prompt);
-    const claudeCmd = platform() === 'win32' ? 'claude.exe' : 'claude';
+    const claudeCmd = platform() === 'win32' ? 'claude.cmd' : 'claude';
 
     this.pty = this.spawnFn!(claudeCmd, claudeArgs, {
       name: 'xterm-256color',

--- a/templates/agent/.claude/skills/agent-management/SKILL.md
+++ b/templates/agent/.claude/skills/agent-management/SKILL.md
@@ -174,6 +174,8 @@ cortextos bus send-message "$AGENT" high "soft-restart" "model change to $NEW_MO
 - `claude-sonnet-4-6` - Good balance, ~5x cheaper than Opus
 - `claude-haiku-4-5-20251001` - Fastest, cheapest, for simple tasks
 
+**Context window suffix:** Append `[1m]` to any model ID (e.g., `claude-opus-4-6[1m]`) to enable the extended 1M token context window. Without it, agents get the default shorter context window and will compact much sooner. Recommended for orchestrators and any agent doing complex multi-step work.
+
 **No model set = default (Opus).** Always set explicitly for cost control.
 
 ---

--- a/templates/agent/ONBOARDING.md
+++ b/templates/agent/ONBOARDING.md
@@ -349,7 +349,7 @@ Do NOT rewrite TOOLS.md from memory. The template contains the authoritative ref
 ### Step 18b: Verify agent is enabled
 
 ```bash
-ENABLED=$(cat "${CTX_FRAMEWORK_ROOT}/orgs/${CTX_ORG}/enabled-agents.json" 2>/dev/null || echo '[]')
+ENABLED=$(cat "${CTX_ROOT}/config/enabled-agents.json" 2>/dev/null || echo '[]')
 if ! echo "$ENABLED" | jq -e --arg name "$CTX_AGENT_NAME" '.[] | select(. == $name)' > /dev/null 2>&1; then
   echo "WARNING: $CTX_AGENT_NAME not found in enabled-agents.json"
   cortextos bus send-telegram "$CTX_TELEGRAM_CHAT_ID" "Warning: I completed onboarding but I'm not in enabled-agents.json. Run: cortextos start $CTX_AGENT_NAME"

--- a/templates/analyst/.claude/skills/agent-management/SKILL.md
+++ b/templates/analyst/.claude/skills/agent-management/SKILL.md
@@ -174,6 +174,8 @@ cortextos bus send-message "$AGENT" high "soft-restart" "model change to $NEW_MO
 - `claude-sonnet-4-6` - Good balance, ~5x cheaper than Opus
 - `claude-haiku-4-5-20251001` - Fastest, cheapest, for simple tasks
 
+**Context window suffix:** Append `[1m]` to any model ID (e.g., `claude-opus-4-6[1m]`) to enable the extended 1M token context window. Without it, agents get the default shorter context window and will compact much sooner. Recommended for orchestrators and any agent doing complex multi-step work.
+
 **No model set = default (Opus).** Always set explicitly for cost control.
 
 ---

--- a/templates/analyst/ONBOARDING.md
+++ b/templates/analyst/ONBOARDING.md
@@ -614,7 +614,7 @@ If no specialists wanted: proceed to step 29.
 ### Step 28b: Verify agent is enabled
 
 ```bash
-ENABLED=$(cat "${CTX_FRAMEWORK_ROOT}/orgs/${CTX_ORG}/enabled-agents.json" 2>/dev/null || echo '[]')
+ENABLED=$(cat "${CTX_ROOT}/config/enabled-agents.json" 2>/dev/null || echo '[]')
 if ! echo "$ENABLED" | jq -e --arg name "$CTX_AGENT_NAME" '.[] | select(. == $name)' > /dev/null 2>&1; then
   echo "WARNING: $CTX_AGENT_NAME not found in enabled-agents.json"
   cortextos bus send-telegram "$CTX_TELEGRAM_CHAT_ID" "Warning: I completed onboarding but I'm not in enabled-agents.json. Run: cortextos start $CTX_AGENT_NAME"

--- a/templates/orchestrator/.claude/skills/agent-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/agent-management/SKILL.md
@@ -185,6 +185,8 @@ cortextos bus send-message "$AGENT" high "soft-restart" "model change to $NEW_MO
 - `claude-sonnet-4-6` - Good balance, ~5x cheaper than Opus
 - `claude-haiku-4-5-20251001` - Fastest, cheapest, for simple tasks
 
+**Context window suffix:** Append `[1m]` to any model ID (e.g., `claude-opus-4-6[1m]`) to enable the extended 1M token context window. Without it, agents get the default shorter context window and will compact much sooner. Recommended for orchestrators and any agent doing complex multi-step work.
+
 **No model set = default (Opus).** Always set explicitly for cost control.
 
 ---

--- a/templates/orchestrator/ONBOARDING.md
+++ b/templates/orchestrator/ONBOARDING.md
@@ -453,7 +453,7 @@ Make any changes they request.
 ### Step 22b: Verify agent is enabled
 
 ```bash
-ENABLED=$(cat "${CTX_FRAMEWORK_ROOT}/orgs/${CTX_ORG}/enabled-agents.json" 2>/dev/null || echo '[]')
+ENABLED=$(cat "${CTX_ROOT}/config/enabled-agents.json" 2>/dev/null || echo '[]')
 if ! echo "$ENABLED" | jq -e --arg name "$CTX_AGENT_NAME" '.[] | select(. == $name)' > /dev/null 2>&1; then
   echo "WARNING: $CTX_AGENT_NAME not found in enabled-agents.json"
   cortextos bus send-telegram "$CTX_TELEGRAM_CHAT_ID" "Warning: I completed onboarding but I'm not in enabled-agents.json. Run: cortextos start $CTX_AGENT_NAME"

--- a/tests/unit/daemon/agent-manager.test.ts
+++ b/tests/unit/daemon/agent-manager.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { buildReplyContext } from '../../../src/daemon/agent-manager.js';
 
 // Mock the PTY layer so we don't load native bindings or spawn real processes.
 // AgentManager → AgentProcess → AgentPTY → node-pty. We mock at AgentProcess.
@@ -283,5 +284,67 @@ describe('AgentManager.restartAgent - BUG-007 fix (rebuild Telegram poller)', ()
 
     expect(stopSpy).not.toHaveBeenCalled();
     expect(startSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('buildReplyContext - Telegram reply context (BUG fix: media replies lost)', () => {
+  it('returns undefined when no reply message', () => {
+    expect(buildReplyContext(undefined)).toBeUndefined();
+  });
+
+  it('returns text content for plain text replies', () => {
+    const msg = { message_id: 1, chat: { id: 1 }, text: 'Hello world' };
+    expect(buildReplyContext(msg)).toBe('Hello world');
+  });
+
+  it('returns caption for media messages with captions', () => {
+    const msg = { message_id: 2, chat: { id: 1 }, photo: [{ file_id: 'x', width: 100, height: 100, file_size: 1 }], caption: 'Check this out' };
+    expect(buildReplyContext(msg)).toBe('Check this out');
+  });
+
+  it('returns [video] for video messages without caption', () => {
+    const msg = { message_id: 3, chat: { id: 1 }, video: { file_id: 'v1', width: 1920, height: 1080, duration: 30 } };
+    expect(buildReplyContext(msg)).toBe('[video]');
+  });
+
+  it('returns [photo] for photo messages without caption', () => {
+    const msg = { message_id: 4, chat: { id: 1 }, photo: [{ file_id: 'p1', width: 100, height: 100, file_size: 1 }] };
+    expect(buildReplyContext(msg)).toBe('[photo]');
+  });
+
+  it('returns [voice message] for voice messages', () => {
+    const msg = { message_id: 5, chat: { id: 1 }, voice: { file_id: 'vc1', duration: 5 } };
+    expect(buildReplyContext(msg)).toBe('[voice message]');
+  });
+
+  it('returns [video note] for video note messages', () => {
+    const msg = { message_id: 6, chat: { id: 1 }, video_note: { file_id: 'vn1', length: 240, duration: 10 } };
+    expect(buildReplyContext(msg)).toBe('[video note]');
+  });
+
+  it('returns [audio] for audio messages', () => {
+    const msg = { message_id: 7, chat: { id: 1 }, audio: { file_id: 'a1', duration: 120 } };
+    expect(buildReplyContext(msg)).toBe('[audio]');
+  });
+
+  it('returns document name for document messages', () => {
+    const msg = { message_id: 8, chat: { id: 1 }, document: { file_id: 'd1', file_name: 'report.pdf' } };
+    expect(buildReplyContext(msg)).toBe('[document: report.pdf]');
+  });
+
+  it('returns [document: file] when document has no file_name', () => {
+    const msg = { message_id: 9, chat: { id: 1 }, document: { file_id: 'd2' } };
+    expect(buildReplyContext(msg)).toBe('[document: file]');
+  });
+
+  it('prefers text over caption when both present', () => {
+    const msg = { message_id: 10, chat: { id: 1 }, text: 'Text content', caption: 'Caption content' };
+    expect(buildReplyContext(msg)).toBe('Text content');
+  });
+
+  it('strips control characters from text', () => {
+    const msg = { message_id: 11, chat: { id: 1 }, text: 'Hello\x00world' };
+    const result = buildReplyContext(msg);
+    expect(result).not.toContain('\x00');
   });
 });


### PR DESCRIPTION
## Summary
- **BUG-046**: Claude Code strips absolute file paths from pasted user input. Telegram photos/documents/voice/video download correctly but agents receive empty `local_file:` fields. Fix converts absolute paths to relative (from agent working dir) before PTY injection.
- Adds `buildReplyContext()` for proper reply context on media messages — previously replies to photos/videos arrived with no context.

## Root cause
The daemon's `processMediaMessage()` returns absolute paths like `/Users/.../telegram-images/file.jpg`. These are injected via bracketed paste into the agent's PTY. Claude Code sanitizes pasted input and strips absolute file paths, so agents see `local_file:` with nothing after it.

## Fix
In `agent-manager.ts`, convert `media.image_path` and `media.file_path` to relative paths using `path.relative(agentDir, ...)` before passing to format functions. Result: `telegram-images/file.jpg` instead of `/Users/.../telegram-images/file.jpg`.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` — 423 tests passing
- [ ] Deploy to daemon, send test photo via Telegram, verify `local_file:` shows relative path
- [ ] Verify agent can Read the file at the relative path

🤖 Generated with [Claude Code](https://claude.com/claude-code)