### PR TITLE
fix(dashboard): dashboard login over non-localhost (Tailscale/LAN/VPN)

### DIFF
--- a/dashboard/next.config.ts
+++ b/dashboard/next.config.ts
@@ -1,7 +1,24 @@
 import type { NextConfig } from "next";
 
+// Next.js 15.2+ blocks non-localhost origins from /_next/* dev-internal
+// resources by default. When the dashboard is accessed over Tailscale, a LAN
+// IP, or a reverse proxy, the browser receives the SSR HTML but the client
+// bundle cannot finish hydrating because dev-resource requests are rejected —
+// useEffect never fires, the CSRF token is never fetched, and the login form
+// is stuck.
+//
+// Set DASHBOARD_ALLOWED_DEV_ORIGINS to a comma-separated list of hostnames or
+// IPs to whitelist (e.g. "100.64.95.40,mybox.local,dashboard.example.com").
+// Localhost is always allowed. Only reads in development; production builds
+// ignore the setting.
+const allowedDevOrigins = (process.env.DASHBOARD_ALLOWED_DEV_ORIGINS ?? '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
 const nextConfig: NextConfig = {
   serverExternalPackages: ['better-sqlite3'],
+  ...(allowedDevOrigins.length > 0 && { allowedDevOrigins }),
   async headers() {
     return [
       {

--- a/dashboard/src/app/(auth)/login/page.tsx
+++ b/dashboard/src/app/(auth)/login/page.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
-import { signIn } from 'next-auth/react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -33,27 +32,88 @@ export default function LoginPage() {
       .catch(() => {});
   }, [router]);
 
+  // CSRF token strategy: fetch once, hold in a ref, inject on submit.
+  // React state bound with value={csrfToken} and imperative writes via
+  // querySelector both fail — React reconciliation resets uncontrolled
+  // input values between the useEffect completion and the next render, so
+  // the hidden input never carries the real token at submit time. The
+  // hidden input in the JSX below is a placeholder; the real token is put
+  // on the request body in handleSubmit().
+  const csrfTokenRef = useRef<string>('');
+  const [csrfReady, setCsrfReady] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/auth/csrf', { credentials: 'same-origin' });
+        const data = await res.json();
+        if (cancelled) return;
+        const token = data?.csrfToken;
+        if (!token) {
+          console.error('[login] /api/auth/csrf returned no token', data);
+          return;
+        }
+        csrfTokenRef.current = token;
+        setCsrfReady(true);
+      } catch (err) {
+        console.error('[login] csrf fetch failed:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    // POST the credentials callback ourselves with an
+    // application/x-www-form-urlencoded body. NextAuth's CSRF validator
+    // reads the csrfToken field from urlencoded bodies; a multipart/form-data
+    // body (what `new FormData()` produces) fails with MissingCSRF because
+    // the parser doesn't recover the token from the multipart stream.
+    // Bypassing signIn() from next-auth/react lets us control the exact body.
     e.preventDefault();
     setLoading(true);
     setError('');
 
-    const formData = new FormData(e.currentTarget);
-    const result = await signIn('credentials', {
-      username: formData.get('username'),
-      password: formData.get('password'),
-      redirect: false,
-    });
+    const form = e.currentTarget;
+    const usernameInput = form.querySelector('input[name="username"]') as HTMLInputElement | null;
+    const passwordInput = form.querySelector('input[name="password"]') as HTMLInputElement | null;
 
-    if (result?.error) {
-      setError('Invalid username or password');
-      setLoading(false);
-    } else {
-      // Show splash, then navigate with hard redirect (works even if hydration fails)
-      setShowSplash(true);
-      setTimeout(() => {
+    const body = new URLSearchParams();
+    body.set('csrfToken', csrfTokenRef.current || '');
+    body.set('username', usernameInput?.value || '');
+    body.set('password', passwordInput?.value || '');
+
+    try {
+      const res = await fetch(form.action, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        body: body.toString(),
+        credentials: 'same-origin',
+        redirect: 'follow',
+      });
+      if (res.redirected) {
+        const target = new URL(res.url);
+        if (target.pathname.startsWith('/login')) {
+          const code = target.searchParams.get('error') || 'Unknown';
+          setError(`Sign-in failed: ${code}`);
+          setLoading(false);
+          return;
+        }
+        window.location.href = res.url;
+        return;
+      }
+      if (res.ok) {
         window.location.href = '/';
-      }, 800);
+        return;
+      }
+      setError(`Sign-in failed with status ${res.status}`);
+      setLoading(false);
+    } catch (err) {
+      console.error('[login] submit error:', err);
+      setError('Network error. Please try again.');
+      setLoading(false);
     }
   }
 
@@ -87,7 +147,8 @@ export default function LoginPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <form onSubmit={handleSubmit} className="space-y-4">
+            <form onSubmit={handleSubmit} method="POST" action="/api/auth/callback/credentials" className="space-y-4" suppressHydrationWarning>
+              <input type="hidden" name="csrfToken" defaultValue="" suppressHydrationWarning />
               <div className="space-y-1.5">
                 <Label htmlFor="username" className="text-xs">Username</Label>
                 <Input
@@ -97,6 +158,7 @@ export default function LoginPage() {
                   required
                   autoFocus
                   placeholder="admin"
+                  suppressHydrationWarning
                 />
               </div>
               <div className="space-y-1.5">
@@ -107,13 +169,14 @@ export default function LoginPage() {
                   type="password"
                   required
                   placeholder="Enter password"
+                  suppressHydrationWarning
                 />
               </div>
               {error && (
                 <p className="text-xs text-destructive">{error}</p>
               )}
-              <Button type="submit" className="w-full" disabled={loading}>
-                {loading ? 'Signing in...' : 'Sign In'}
+              <Button type="submit" className="w-full" disabled={loading || !csrfReady}>
+                {loading ? 'Signing in...' : csrfReady ? 'Sign In' : 'Loading…'}
               </Button>
             </form>
           </CardContent>


### PR DESCRIPTION
## Summary

Fixes dashboard login hanging forever when accessed via a Tailscale IP, LAN address, or reverse proxy. Login worked on localhost:3001 (used 3001 because port 3000 was taken by OpenWebUI) but never on any other host — the form would load, the user would type credentials, and the Sign In button would do nothing (or spin forever) with no user-visible error.

Root cause was three independent layers, each one invisible until the previous one was fixed. All three have to land together for the form to reach the bcrypt credential check — verified end-to-end in a headless browser.

### 1. `dashboard/next.config.ts` — `allowedDevOrigins`
Next.js 15.2+ rejects `/_next/*` dev-internal requests from non-localhost origins by default. When the dashboard is accessed over Tailscale, the browser gets the SSR HTML but the client bundle never finishes hydrating because the dev-resource fetches are rejected — `useEffect` never fires, `/api/auth/csrf` is never called, and the form is permanently stuck in its initial render.

Instead of hard-coding specific hostnames, the whitelist is now read from a new `DASHBOARD_ALLOWED_DEV_ORIGINS` env var (comma-separated; localhost is always allowed). Each deployment picks its own hosts:

```
DASHBOARD_ALLOWED_DEV_ORIGINS=100.64.95.40,mybox.local,dashboard.example.com
```

If unset, behavior is identical to before this PR.

### 2. `login/page.tsx` — CSRF token lifetime
Previous attempts stored the CSRF token in React state bound with `value={csrfToken}` or set it imperatively on the hidden input via `querySelector`. Both failed: React reconciliation resets uncontrolled input values between the `useEffect` completion and the next render, so the hidden input never carried the real token at submit time. `MissingCSRF` on every submit.

The token is now fetched once, held in a `useRef`, and injected onto the request body at submit time. The hidden input stays in the JSX as a placeholder for form semantics.

### 3. `login/page.tsx` — submit body format
Submit previously used `new FormData()` via `signIn('credentials', ...)`, which sends the body as `multipart/form-data`. NextAuth's CSRF validator does not recover the `csrfToken` field from a multipart stream in this version and fails with `MissingCSRF` even when the field is present.

Submit now bypasses `signIn()` and POSTs the credentials callback directly as `application/x-www-form-urlencoded`, which NextAuth parses correctly. Also handles the 302 redirect manually (`redirect: 'follow'`) and reads error codes from the callback URL.

---

## Test plan

- [x] Root `npm run build` clean (tsup)
- [x] Dashboard `tsc --noEmit` clean
- [x] `npm test` — 419 passing. 4 pre-existing failures in `tests/unit/bus/agents.test.ts` are unrelated (stale test expectations after the multi-org `listAgents` fix in #17 — not touched by this PR).
- [x] Manual e2e via headless browser: localhost login works, Tailscale login works (with `DASHBOARD_ALLOWED_DEV_ORIGINS` set), bad credentials show error, successful login redirects.

## Notes

- `signIn` from `next-auth/react` is no longer imported (removed unused).
- The long inline comments in `login/page.tsx` are intentional — they document the three dead ends and why the current shape exists, so nobody re-introduces them.
- `allowedDevOrigins` only applies in dev mode; production builds ignore it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)