### PR TITLE
feat(daemon): add 50-min heartbeat watchdog to fast-checker

### DIFF
--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -1,4 +1,5 @@
 import { readdirSync, readFileSync, existsSync, writeFileSync, unlinkSync } from 'fs';
+import { exec } from 'child_process';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
@@ -41,6 +42,9 @@ export class FastChecker {
 
   // SIGUSR1 wake: resolve to immediately wake from sleep
   private wakeResolve: (() => void) | null = null;
+
+  // Idle-session heartbeat watchdog
+  private heartbeatTimer: NodeJS.Timeout | null = null;
 
   constructor(
     agent: AgentProcess,
@@ -85,6 +89,16 @@ export class FastChecker {
     await this.waitForBootstrap();
     this.log('Bootstrap complete. Beginning poll loop.');
 
+    // Idle-session heartbeat watchdog: fires every 50 min regardless of REPL state
+    const HEARTBEAT_INTERVAL_MS = 50 * 60 * 1000;
+    const agentName = this.agent.name;
+    this.heartbeatTimer = setInterval(() => {
+      const ts = new Date().toISOString();
+      exec(`cortextos bus update-heartbeat "[watchdog] ${agentName} alive — idle session ${ts}"`, (err) => {
+        if (err) this.log(`Heartbeat watchdog error: ${err.message}`);
+      });
+    }, HEARTBEAT_INTERVAL_MS);
+
     while (this.running) {
       try {
         // Check for urgent signal file
@@ -106,6 +120,10 @@ export class FastChecker {
    */
   stop(): void {
     this.running = false;
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer);
+      this.heartbeatTimer = null;
+    }
   }
 
   /**

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -1,4 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('child_process', () => ({ exec: vi.fn() }));
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -553,6 +555,55 @@ describe('FastChecker', () => {
       const result = FastChecker.formatTelegramVoiceMessage('Bob', '123', '/tmp/voice.ogg', undefined);
 
       expect(result).toContain('duration: unknowns');
+    });
+  });
+
+  describe('heartbeat watchdog', () => {
+    beforeEach(() => { vi.useFakeTimers(); });
+    afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
+
+    it('fires exec after bootstrap at 50-min interval', async () => {
+      const { exec } = await import('child_process');
+      const agent = createMockAgent('my-agent');
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      checker.start();
+      await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
+      expect(exec).toHaveBeenCalledWith(
+        expect.stringContaining('[watchdog] my-agent alive — idle session'),
+        expect.any(Function),
+      );
+      checker.stop();
+      checker.wake();
+    });
+
+    it('clears timer on stop — no further exec calls after stop', async () => {
+      const { exec } = await import('child_process');
+      const execMock = exec as ReturnType<typeof vi.fn>;
+      const agent = createMockAgent('my-agent');
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      checker.start();
+      await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
+      const callsBefore = execMock.mock.calls.length;
+      expect(callsBefore).toBeGreaterThan(0);
+      checker.stop();
+      checker.wake();
+      await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
+      expect(execMock.mock.calls.length).toBe(callsBefore);
+    });
+
+    it('does not fire before bootstrap completes', async () => {
+      const { exec } = await import('child_process');
+      const agent = createMockAgent('my-agent');
+      agent.isBootstrapped.mockReturnValue(false);
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      checker.start();
+      await vi.advanceTimersByTimeAsync(20 * 1000);
+      expect(exec).not.toHaveBeenCalledWith(
+        expect.stringContaining('[watchdog]'),
+        expect.any(Function),
+      );
+      checker.stop();
+      checker.wake();
     });
   });
 


### PR DESCRIPTION
## Summary

- Adds `setInterval` (50 min) inside `FastChecker.start()` that fires `cortextos bus update-heartbeat` after bootstrap completes
- Clears the timer in `stop()` to prevent leaks
- Covers idle sessions where REPL-bound cron jobs miss the theta wave window

## Test plan

- [x] `fires exec after bootstrap at 50-min interval`
- [x] `clears timer on stop — no further exec calls after stop`
- [x] `does not fire before bootstrap completes`
- [x] Full suite: 430/430 tests pass
- [x] `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)