### PR TITLE
fix(telegram): only advance poller offset after handlers succeed

### DIFF
--- a/src/telegram/poller.ts
+++ b/src/telegram/poller.ts
@@ -66,14 +66,21 @@ export class TelegramPoller {
 
   /**
    * Perform a single poll cycle.
+   *
+   * Offset-after-handler semantics: the offset only advances after every
+   * registered handler for an update returns successfully. If any handler
+   * throws, the update is left un-acknowledged (Telegram will re-deliver it
+   * on the next `getUpdates` call) and the remainder of the batch is deferred
+   * to preserve ordering. The offset is persisted after each successful
+   * update so a crash mid-batch does not drop confirmed state.
    */
   async pollOnce(): Promise<void> {
     const result = await this.api.getUpdates(this.offset, 1);
     if (!result?.result?.length) return;
 
     for (const update of result.result as TelegramUpdate[]) {
-      // Update offset to acknowledge this update
-      this.offset = update.update_id + 1;
+      const nextOffset = update.update_id + 1;
+      let handlerFailed = false;
 
       if (update.message) {
         for (const handler of this.messageHandlers) {
@@ -81,23 +88,33 @@ export class TelegramPoller {
             handler(update.message);
           } catch (err) {
             console.error('[telegram-poller] Message handler error:', err);
+            handlerFailed = true;
+            break;
           }
         }
       }
 
-      if (update.callback_query) {
+      if (!handlerFailed && update.callback_query) {
         for (const handler of this.callbackHandlers) {
           try {
             handler(update.callback_query);
           } catch (err) {
             console.error('[telegram-poller] Callback handler error:', err);
+            handlerFailed = true;
+            break;
           }
         }
       }
-    }
 
-    // Persist offset for crash recovery
-    this.saveOffset();
+      if (handlerFailed) {
+        // Do not advance offset — the update will be redelivered.
+        // Stop processing the rest of this batch to preserve ordering.
+        return;
+      }
+
+      this.offset = nextOffset;
+      this.saveOffset();
+    }
   }
 
   /**

--- a/tests/unit/telegram/poller.test.ts
+++ b/tests/unit/telegram/poller.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { TelegramPoller } from '../../../src/telegram/poller';
+import type { TelegramAPI } from '../../../src/telegram/api';
+import type { TelegramUpdate } from '../../../src/types/index';
+
+function makeMessageUpdate(updateId: number, text: string): TelegramUpdate {
+  return {
+    update_id: updateId,
+    message: {
+      message_id: updateId,
+      chat: { id: 1, type: 'private' },
+      text,
+    },
+  };
+}
+
+function makeCallbackUpdate(updateId: number, data: string): TelegramUpdate {
+  return {
+    update_id: updateId,
+    callback_query: {
+      id: String(updateId),
+      from: { id: 1, is_bot: false, first_name: 'test' },
+      data,
+    } as any,
+  };
+}
+
+function makeStubApi(updates: TelegramUpdate[]): { api: TelegramAPI; calls: number[] } {
+  const calls: number[] = [];
+  const api = {
+    getUpdates: vi.fn(async (offset: number) => {
+      calls.push(offset);
+      const remaining = updates.filter((u) => u.update_id >= offset);
+      return { result: remaining };
+    }),
+  } as unknown as TelegramAPI;
+  return { api, calls };
+}
+
+describe('TelegramPoller — offset-after-handler', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'cortextos-poller-'));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('advances offset only after message handler succeeds', async () => {
+    const { api } = makeStubApi([makeMessageUpdate(100, 'hello')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    const received: string[] = [];
+    poller.onMessage((msg) => {
+      received.push(msg.text ?? '');
+    });
+
+    await poller.pollOnce();
+
+    expect(received).toEqual(['hello']);
+    const persisted = readFileSync(join(stateDir, '.telegram-offset'), 'utf-8').trim();
+    expect(persisted).toBe('101');
+  });
+
+  it('does NOT advance offset if a message handler throws', async () => {
+    const { api } = makeStubApi([makeMessageUpdate(200, 'boom')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    poller.onMessage(() => {
+      throw new Error('inject failed');
+    });
+
+    // Handler errors are caught internally — pollOnce should not throw.
+    await expect(poller.pollOnce()).resolves.toBeUndefined();
+
+    // Offset file must not exist (or must still be 0) — update should redeliver.
+    const offsetFile = join(stateDir, '.telegram-offset');
+    if (existsSync(offsetFile)) {
+      const persisted = readFileSync(offsetFile, 'utf-8').trim();
+      expect(persisted).toBe('0');
+    }
+  });
+
+  it('halts the batch on failure to preserve ordering', async () => {
+    const { api } = makeStubApi([
+      makeMessageUpdate(10, 'first'),
+      makeMessageUpdate(11, 'second-will-fail'),
+      makeMessageUpdate(12, 'third'),
+    ]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    const received: string[] = [];
+    poller.onMessage((msg) => {
+      received.push(msg.text ?? '');
+      if (msg.text === 'second-will-fail') {
+        throw new Error('inject failed');
+      }
+    });
+
+    await poller.pollOnce();
+
+    // First succeeded, second threw, third MUST NOT have run.
+    expect(received).toEqual(['first', 'second-will-fail']);
+
+    // Offset should be advanced past the first (11) but not past the second.
+    const persisted = readFileSync(join(stateDir, '.telegram-offset'), 'utf-8').trim();
+    expect(persisted).toBe('11');
+  });
+
+  it('persists offset per-update so a mid-batch crash preserves confirmed state', async () => {
+    const { api } = makeStubApi([
+      makeMessageUpdate(50, 'a'),
+      makeMessageUpdate(51, 'b'),
+      makeMessageUpdate(52, 'c'),
+    ]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    const offsetsSeenDuringHandling: string[] = [];
+    poller.onMessage(() => {
+      // Read the persisted file mid-batch to prove per-update persistence.
+      const f = join(stateDir, '.telegram-offset');
+      offsetsSeenDuringHandling.push(existsSync(f) ? readFileSync(f, 'utf-8').trim() : 'none');
+    });
+
+    await poller.pollOnce();
+
+    // Before processing 50, nothing persisted. Before 51, 51 persisted. Before 52, 52 persisted.
+    expect(offsetsSeenDuringHandling).toEqual(['none', '51', '52']);
+
+    const persisted = readFileSync(join(stateDir, '.telegram-offset'), 'utf-8').trim();
+    expect(persisted).toBe('53');
+  });
+
+  it('advances offset only after callback handler succeeds', async () => {
+    const { api } = makeStubApi([makeCallbackUpdate(300, 'approve')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    const received: string[] = [];
+    poller.onCallback((cb) => {
+      received.push(cb.data ?? '');
+    });
+
+    await poller.pollOnce();
+
+    expect(received).toEqual(['approve']);
+    const persisted = readFileSync(join(stateDir, '.telegram-offset'), 'utf-8').trim();
+    expect(persisted).toBe('301');
+  });
+
+  it('does NOT advance offset if a callback handler throws', async () => {
+    const { api } = makeStubApi([makeCallbackUpdate(400, 'deny')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    poller.onCallback(() => {
+      throw new Error('callback broke');
+    });
+
+    await poller.pollOnce();
+
+    const offsetFile = join(stateDir, '.telegram-offset');
+    if (existsSync(offsetFile)) {
+      const persisted = readFileSync(offsetFile, 'utf-8').trim();
+      expect(persisted).toBe('0');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- `TelegramPoller.pollOnce()` previously bumped the offset to `update.update_id + 1` **before** handlers ran, swallowed handler errors silently, and persisted the offset unconditionally at the end of the batch. If a handler threw (e.g. a PTY inject failure) or the process died mid-batch, the update was acknowledged to Telegram but never reached the agent — messages were silently lost.
- The fix: advance the offset only after every registered handler for an update returns successfully, halt the rest of the batch on failure to preserve ordering, and persist per-update so a mid-batch crash keeps confirmed state.
- Adds `tests/unit/telegram/poller.test.ts` with 6 cases covering the success path, message-handler throw, mid-batch failure + ordering preservation, per-update persistence, callback-handler success, and callback-handler throw.

## Why this matters

In a fleet setup where the poller's message handler does real work (injecting into a PTY, writing files, forwarding to another bot), any transient failure silently loses user messages. Telegram's `getUpdates` API is designed so the *client* acknowledges delivery by advancing offset — the previous behavior acknowledged on fetch, not on handle, which is the classic "at-most-once" footgun.

## Behavior change

- **Happy path:** identical — offset advances, handlers run, state persists.
- **Handler throws:** the failing update is *not* acknowledged (Telegram redelivers it on the next `getUpdates` call), the rest of the current batch is deferred to preserve ordering, and `pollOnce()` still resolves normally so the polling loop continues.
- **Mid-batch crash:** every successfully-handled update has already had its offset persisted, so on restart the poller resumes exactly at the first un-handled update.

## Test plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npx vitest run tests/unit/telegram/poller.test.ts` — 6/6 pass
- [x] `npx vitest run` — full suite 445/445 pass, no regressions across 31 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)