### PR TITLE
feat(kb): add kb-ingest-chunked for bounded batch ingestion

### DIFF
--- a/community/skills/knowledge-base/SKILL.md
+++ b/community/skills/knowledge-base/SKILL.md
@@ -48,6 +48,34 @@ Ingest after:
 
 ---
 
+## Large Ingests (50+ files) — use `kb-ingest-chunked`
+
+For big document sets (Notion exports, Obsidian vaults, multi-hundred-file migrations), use the chunked variant. It splits the input into bounded batches and continues past per-batch failures instead of dying on the first one.
+
+```bash
+# Default: 25 files per batch
+cortextos bus kb-ingest-chunked file1.md file2.md file3.md ... \
+  --org $CTX_ORG \
+  --scope shared
+
+# Tune the batch size if you hit timeouts on larger/heavier files
+cortextos bus kb-ingest-chunked *.md \
+  --org $CTX_ORG \
+  --scope shared \
+  --batch-size 15
+```
+
+Why chunking matters:
+- The underlying embedder (`mmrag.py`) is called via a single sync subprocess per batch with a 5-minute ceiling. One oversized batch can exceed that budget; chunking bounds each subprocess call to a predictable size.
+- Per-batch progress is logged so you can see which batch died if something goes wrong.
+- On a batch failure, the command continues with the next batch and exits non-zero with a list of failed batch numbers. A single outlier does not lose the whole run.
+
+**Recovery after a failed batch: re-run the same command.** `mmrag.py` commits embeddings incrementally as it processes each file — not atomically at the end of the batch — so any files processed before a failure are already persisted. Re-running lets content-hash dedup skip the already-committed files and retry only the missing ones. If batches keep timing out, lower `--batch-size`.
+
+Prefer the plain `kb-ingest` for a handful of files; switch to `kb-ingest-chunked` once you are past ~50 files or when the input is untrusted in size.
+
+---
+
 ## List Collections
 
 ```bash

--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -291,16 +291,21 @@ export function ingestKnowledgeBaseChunked(
     batchSize?: number;
   },
 ): ChunkedIngestResult {
-  // Preflight: validate deterministic configuration BEFORE entering the
-  // batch loop. The inner ingestKnowledgeBase() also performs these checks
-  // (and would throw on every batch otherwise), but catching those throws
-  // inside the loop would silently convert a single misconfiguration into
-  // a cascade of fake per-batch failures — hiding the real cause. Do it
-  // once up front and let setup errors propagate to the caller.
+  // Preflight: run ALL deterministic setup BEFORE entering the batch loop.
+  // The inner ingestKnowledgeBase() also performs these steps (config check
+  // AND mkdirSync), but catching those throws inside the loop would silently
+  // convert a single misconfiguration OR a real filesystem failure into a
+  // cascade of fake per-batch failures — hiding the real cause. Do the work
+  // once up front and let setup errors propagate to the caller. Covers:
+  //   1. scope/agent combo validation (matches ingestKnowledgeBase line 220)
+  //   2. KB chromadb directory creation (matches ingestKnowledgeBase line 229)
+  // The inner function keeps its own copies of these checks so direct callers
+  // still work; after the preflight they are idempotent no-ops.
   const scope = options.scope ?? 'shared';
   if (scope === 'private' && !options.agent) {
     throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
   }
+  ensureKBDirs(options.instanceId, options.org);
 
   const batchSize = options.batchSize && options.batchSize > 0 ? options.batchSize : 25;
   const total = paths.length;

--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -240,12 +240,116 @@ export function ingestKnowledgeBase(
 
   execFileSync(pythonPath, args, {
     encoding: 'utf-8',
-    timeout: 120000,
+    // 5 min per batch — mmrag.py embeds files incrementally and a large batch
+    // (or a slow Gemini tail latency) can exceed the previous 120s budget.
+    // Callers with very large file sets should use ingestKnowledgeBaseChunked
+    // (see `cortextos bus kb-ingest-chunked`), which bounds each subprocess
+    // call to a configurable chunk size regardless of this ceiling.
+    timeout: 300000,
     env,
     stdio: 'inherit',
   });
 
   console.log(`\nIngest complete → collection: ${collection}`);
+}
+
+export interface ChunkedIngestResult {
+  totalFiles: number;
+  totalBatches: number;
+  successFiles: number;
+  failedFiles: number;
+  successBatches: number;
+  failedBatches: number[];
+}
+
+/**
+ * Chunked variant of {@link ingestKnowledgeBase} for large file sets.
+ *
+ * Splits `paths` into batches of `batchSize` (default 25) and runs
+ * {@link ingestKnowledgeBase} once per batch. On a per-batch failure it
+ * records the batch number, continues with the next batch, and returns a
+ * summary so the caller can decide what to retry.
+ *
+ * Important behavior note: `mmrag.py` commits embeddings to the Chroma
+ * store incrementally as it processes each file, not atomically at the end
+ * of a batch. If a batch is killed mid-run (e.g. by the execFileSync
+ * timeout), any files processed before the kill are already persisted.
+ * Re-running the same paths will dedup those files automatically, so the
+ * safe recovery pattern for a failed batch is: re-run `kb-ingest-chunked`
+ * with the same inputs (optionally a smaller `batchSize`) and let the
+ * content-hash dedup handle the already-committed portion.
+ */
+export function ingestKnowledgeBaseChunked(
+  paths: string[],
+  options: {
+    org: string;
+    agent?: string;
+    scope?: 'shared' | 'private';
+    force?: boolean;
+    frameworkRoot: string;
+    instanceId: string;
+    batchSize?: number;
+  },
+): ChunkedIngestResult {
+  const batchSize = options.batchSize && options.batchSize > 0 ? options.batchSize : 25;
+  const total = paths.length;
+  const totalBatches = total === 0 ? 0 : Math.ceil(total / batchSize);
+
+  const result: ChunkedIngestResult = {
+    totalFiles: total,
+    totalBatches,
+    successFiles: 0,
+    failedFiles: 0,
+    successBatches: 0,
+    failedBatches: [],
+  };
+
+  if (total === 0) {
+    console.log('Chunked ingest: no paths provided, nothing to do');
+    return result;
+  }
+
+  console.log(
+    `Chunked ingest: ${total} file(s) in ${totalBatches} batch(es) of ${batchSize}`,
+  );
+
+  for (let i = 0; i < total; i += batchSize) {
+    const batchNum = Math.floor(i / batchSize) + 1;
+    const chunk = paths.slice(i, i + batchSize);
+
+    console.log(`\n[batch ${batchNum}/${totalBatches}] ${chunk.length} file(s)`);
+
+    try {
+      ingestKnowledgeBase(chunk, {
+        org: options.org,
+        agent: options.agent,
+        scope: options.scope,
+        force: options.force,
+        frameworkRoot: options.frameworkRoot,
+        instanceId: options.instanceId,
+      });
+      result.successFiles += chunk.length;
+      result.successBatches += 1;
+    } catch (err) {
+      // Upper-bound the failed count at chunk.length — mmrag.py may have
+      // committed some files before the error, but that is opaque from here.
+      // Re-running will dedup the committed portion.
+      result.failedFiles += chunk.length;
+      result.failedBatches.push(batchNum);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`  BATCH ${batchNum} FAILED: ${msg}`);
+      console.error('  Continuing with next batch. Re-run this command to retry the failed batch — committed files will be deduped.');
+    }
+  }
+
+  console.log(
+    `\nChunked ingest done: ${result.successFiles}/${total} file(s) in successful batches, ${result.failedFiles} file(s) in failed batches`,
+  );
+  if (result.failedBatches.length > 0) {
+    console.log(`  Failed batches: ${result.failedBatches.join(', ')}`);
+  }
+
+  return result;
 }
 
 /**

--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -291,6 +291,17 @@ export function ingestKnowledgeBaseChunked(
     batchSize?: number;
   },
 ): ChunkedIngestResult {
+  // Preflight: validate deterministic configuration BEFORE entering the
+  // batch loop. The inner ingestKnowledgeBase() also performs these checks
+  // (and would throw on every batch otherwise), but catching those throws
+  // inside the loop would silently convert a single misconfiguration into
+  // a cascade of fake per-batch failures — hiding the real cause. Do it
+  // once up front and let setup errors propagate to the caller.
+  const scope = options.scope ?? 'shared';
+  if (scope === 'private' && !options.agent) {
+    throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
+  }
+
   const batchSize = options.batchSize && options.batchSize > 0 ? options.batchSize : 25;
   const total = paths.length;
   const totalBatches = total === 0 ? 0 : Math.ceil(total / batchSize);
@@ -323,7 +334,7 @@ export function ingestKnowledgeBaseChunked(
       ingestKnowledgeBase(chunk, {
         org: options.org,
         agent: options.agent,
-        scope: options.scope,
+        scope,
         force: options.force,
         frameworkRoot: options.frameworkRoot,
         instanceId: options.instanceId,
@@ -331,9 +342,11 @@ export function ingestKnowledgeBaseChunked(
       result.successFiles += chunk.length;
       result.successBatches += 1;
     } catch (err) {
-      // Upper-bound the failed count at chunk.length — mmrag.py may have
-      // committed some files before the error, but that is opaque from here.
-      // Re-running will dedup the committed portion.
+      // Only subprocess/execution failures reach this catch — deterministic
+      // config errors were caught by the preflight above and never enter
+      // the loop. Upper-bound the failed count at chunk.length; mmrag.py
+      // may have committed some files before the error, but that is opaque
+      // from here. Re-running will dedup the already-committed portion.
       result.failedFiles += chunk.length;
       result.failedBatches.push(batchNum);
       const msg = err instanceof Error ? err.message : String(err);

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -13,7 +13,7 @@ import { browseCatalog, installCommunityItem, prepareSubmission, submitCommunity
 import { collectMetrics, parseUsageOutput, storeUsageData, checkUpstream, collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
 import { createApproval, updateApproval } from '../bus/approval.js';
 import { createReminder, listReminders, ackReminder, pruneReminders } from '../bus/reminders.js';
-import { queryKnowledgeBase, ingestKnowledgeBase, ensureKBDirs } from '../bus/knowledge-base.js';
+import { queryKnowledgeBase, ingestKnowledgeBase, ingestKnowledgeBaseChunked, ensureKBDirs } from '../bus/knowledge-base.js';
 import { checkUsageApi, refreshOAuthToken, rotateOAuth, loadAccounts, ALERT_5H, ALERT_7D } from '../bus/oauth.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
@@ -893,6 +893,42 @@ busCommand
       frameworkRoot: env.frameworkRoot || process.cwd(),
       instanceId: env.instanceId,
     });
+  });
+
+busCommand
+  .command('kb-ingest-chunked')
+  .description('Ingest large file sets into the knowledge base in bounded batches (default 25 files per batch)')
+  .argument('<paths...>', 'Files to ingest (chunked ingest does not expand directories — pass a resolved file list)')
+  .option('--org <org>', 'Organization name')
+  .option('--agent <name>', 'Agent name (for private scope)')
+  .option('--scope <s>', 'Scope: shared or private', 'shared')
+  .option('--force', 'Re-ingest even if already indexed')
+  .option('--batch-size <n>', 'Files per batch (default 25)', (v) => parseInt(v, 10), 25)
+  .action((paths: string[], opts: { org?: string; agent?: string; scope?: string; force?: boolean; batchSize?: number }) => {
+    const env = resolveEnv();
+    const org = opts.org || env.org;
+    if (!org) {
+      console.error('ERROR: --org or CTX_ORG required');
+      process.exit(1);
+    }
+
+    ensureKBDirs(env.instanceId, org);
+
+    const result = ingestKnowledgeBaseChunked(paths, {
+      org,
+      agent: opts.agent || env.agentName,
+      scope: (opts.scope as 'shared' | 'private') || 'shared',
+      force: opts.force,
+      frameworkRoot: env.frameworkRoot || process.cwd(),
+      instanceId: env.instanceId,
+      batchSize: opts.batchSize,
+    });
+
+    // Exit non-zero if any batch failed so callers can detect partial success
+    // (re-run to retry — committed files will dedup automatically).
+    if (result.failedBatches.length > 0) {
+      process.exit(1);
+    }
   });
 
 busCommand

--- a/templates/agent/.claude/skills/knowledge-base/SKILL.md
+++ b/templates/agent/.claude/skills/knowledge-base/SKILL.md
@@ -47,6 +47,34 @@ Ingest after:
 
 ---
 
+## Large Ingests (50+ files) — use `kb-ingest-chunked`
+
+For big document sets (Notion exports, Obsidian vaults, multi-hundred-file migrations), use the chunked variant. It splits the input into bounded batches and continues past per-batch failures instead of dying on the first one.
+
+```bash
+# Default: 25 files per batch
+cortextos bus kb-ingest-chunked file1.md file2.md file3.md ... \
+  --org $CTX_ORG \
+  --scope shared
+
+# Tune the batch size if you hit timeouts on larger/heavier files
+cortextos bus kb-ingest-chunked *.md \
+  --org $CTX_ORG \
+  --scope shared \
+  --batch-size 15
+```
+
+Why chunking matters:
+- The underlying embedder (`mmrag.py`) is called via a single sync subprocess per batch with a 5-minute ceiling. One oversized batch can exceed that budget; chunking bounds each subprocess call to a predictable size.
+- Per-batch progress is logged so you can see which batch died if something goes wrong.
+- On a batch failure, the command continues with the next batch and exits non-zero with a list of failed batch numbers. A single outlier does not lose the whole run.
+
+**Recovery after a failed batch: re-run the same command.** `mmrag.py` commits embeddings incrementally as it processes each file — not atomically at the end of the batch — so any files processed before a failure are already persisted. Re-running lets content-hash dedup skip the already-committed files and retry only the missing ones. If batches keep timing out, lower `--batch-size`.
+
+Prefer the plain `kb-ingest` for a handful of files; switch to `kb-ingest-chunked` once you are past ~50 files or when the input is untrusted in size.
+
+---
+
 ## List Collections
 
 ```bash

--- a/templates/analyst/.claude/skills/knowledge-base/SKILL.md
+++ b/templates/analyst/.claude/skills/knowledge-base/SKILL.md
@@ -47,6 +47,34 @@ Ingest after:
 
 ---
 
+## Large Ingests (50+ files) — use `kb-ingest-chunked`
+
+For big document sets (Notion exports, Obsidian vaults, multi-hundred-file migrations), use the chunked variant. It splits the input into bounded batches and continues past per-batch failures instead of dying on the first one.
+
+```bash
+# Default: 25 files per batch
+cortextos bus kb-ingest-chunked file1.md file2.md file3.md ... \
+  --org $CTX_ORG \
+  --scope shared
+
+# Tune the batch size if you hit timeouts on larger/heavier files
+cortextos bus kb-ingest-chunked *.md \
+  --org $CTX_ORG \
+  --scope shared \
+  --batch-size 15
+```
+
+Why chunking matters:
+- The underlying embedder (`mmrag.py`) is called via a single sync subprocess per batch with a 5-minute ceiling. One oversized batch can exceed that budget; chunking bounds each subprocess call to a predictable size.
+- Per-batch progress is logged so you can see which batch died if something goes wrong.
+- On a batch failure, the command continues with the next batch and exits non-zero with a list of failed batch numbers. A single outlier does not lose the whole run.
+
+**Recovery after a failed batch: re-run the same command.** `mmrag.py` commits embeddings incrementally as it processes each file — not atomically at the end of the batch — so any files processed before a failure are already persisted. Re-running lets content-hash dedup skip the already-committed files and retry only the missing ones. If batches keep timing out, lower `--batch-size`.
+
+Prefer the plain `kb-ingest` for a handful of files; switch to `kb-ingest-chunked` once you are past ~50 files or when the input is untrusted in size.
+
+---
+
 ## List Collections
 
 ```bash

--- a/templates/orchestrator/.claude/skills/knowledge-base/SKILL.md
+++ b/templates/orchestrator/.claude/skills/knowledge-base/SKILL.md
@@ -47,6 +47,34 @@ Ingest after:
 
 ---
 
+## Large Ingests (50+ files) — use `kb-ingest-chunked`
+
+For big document sets (Notion exports, Obsidian vaults, multi-hundred-file migrations), use the chunked variant. It splits the input into bounded batches and continues past per-batch failures instead of dying on the first one.
+
+```bash
+# Default: 25 files per batch
+cortextos bus kb-ingest-chunked file1.md file2.md file3.md ... \
+  --org $CTX_ORG \
+  --scope shared
+
+# Tune the batch size if you hit timeouts on larger/heavier files
+cortextos bus kb-ingest-chunked *.md \
+  --org $CTX_ORG \
+  --scope shared \
+  --batch-size 15
+```
+
+Why chunking matters:
+- The underlying embedder (`mmrag.py`) is called via a single sync subprocess per batch with a 5-minute ceiling. One oversized batch can exceed that budget; chunking bounds each subprocess call to a predictable size.
+- Per-batch progress is logged so you can see which batch died if something goes wrong.
+- On a batch failure, the command continues with the next batch and exits non-zero with a list of failed batch numbers. A single outlier does not lose the whole run.
+
+**Recovery after a failed batch: re-run the same command.** `mmrag.py` commits embeddings incrementally as it processes each file — not atomically at the end of the batch — so any files processed before a failure are already persisted. Re-running lets content-hash dedup skip the already-committed files and retry only the missing ones. If batches keep timing out, lower `--batch-size`.
+
+Prefer the plain `kb-ingest` for a handful of files; switch to `kb-ingest-chunked` once you are past ~50 files or when the input is untrusted in size.
+
+---
+
 ## List Collections
 
 ```bash

--- a/tests/unit/bus/knowledge-base.test.ts
+++ b/tests/unit/bus/knowledge-base.test.ts
@@ -17,7 +17,9 @@ vi.mock('child_process', async (importOriginal) => {
 
 // Import AFTER the mock is installed so the module binds to the mocked
 // function rather than the real one.
-const { ingestKnowledgeBaseChunked } = await import('../../../src/bus/knowledge-base.js');
+const { ingestKnowledgeBase, ingestKnowledgeBaseChunked } = await import(
+  '../../../src/bus/knowledge-base.js'
+);
 
 describe('ingestKnowledgeBaseChunked', () => {
   let frameworkRoot: string;
@@ -228,5 +230,45 @@ describe('ingestKnowledgeBaseChunked', () => {
     // Private scope maps to the agent-<name> collection.
     const argv = runFileSyncMock.mock.calls[0][1] as string[];
     expect(argv).toContain('agent-alice');
+  });
+
+  it('ingestKnowledgeBase and ingestKnowledgeBaseChunked reject identically for the same misconfig', () => {
+    // Genuine parity check: no manufactured mocks on the rejection path.
+    // Both functions hit their own real preflight code and must produce
+    // the same concrete Error for a --scope private missing agent config.
+    const paths = ['/fake/a.md'];
+
+    let nonChunkedErr: unknown;
+    try {
+      ingestKnowledgeBase(paths, {
+        ...baseOptions(),
+        scope: 'private',
+        // agent intentionally omitted
+      });
+    } catch (e) {
+      nonChunkedErr = e;
+    }
+
+    let chunkedErr: unknown;
+    try {
+      ingestKnowledgeBaseChunked(paths, {
+        ...baseOptions(),
+        scope: 'private',
+        // agent intentionally omitted
+        batchSize: 25,
+      });
+    } catch (e) {
+      chunkedErr = e;
+    }
+
+    expect(nonChunkedErr).toBeInstanceOf(Error);
+    expect(chunkedErr).toBeInstanceOf(Error);
+    // Same concrete error message from the same real preflight code path.
+    // The chunked variant uses the identical string as its sibling so users
+    // see consistent feedback regardless of which ingest command they run.
+    expect((nonChunkedErr as Error).message).toBe((chunkedErr as Error).message);
+    expect((nonChunkedErr as Error).message).toMatch(/--agent.*--scope private/);
+    // Neither variant invoked the subprocess — preflight caught both.
+    expect(runFileSyncMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/bus/knowledge-base.test.ts
+++ b/tests/unit/bus/knowledge-base.test.ts
@@ -192,4 +192,41 @@ describe('ingestKnowledgeBaseChunked', () => {
     expect(argv).toContain('shared-acme');
     expect(argv).toContain('--force');
   });
+
+  it('throws a setup error for scope private without agent (no batch loop)', () => {
+    const paths = Array.from({ length: 30 }, (_, i) => `/fake/file-${i}.md`);
+
+    // A deterministic config error must surface as a thrown exception from
+    // the preflight, NOT be swallowed and converted into N fake batch
+    // failures that count all files as failed.
+    expect(() =>
+      ingestKnowledgeBaseChunked(paths, {
+        ...baseOptions(),
+        scope: 'private',
+        // agent intentionally omitted
+        batchSize: 10,
+      }),
+    ).toThrow(/--agent.*required.*--scope private/);
+
+    // Subprocess must never be invoked when the preflight rejects.
+    expect(runFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('does not throw on scope private when agent is provided', () => {
+    const paths = Array.from({ length: 10 }, (_, i) => `/fake/file-${i}.md`);
+
+    const result = ingestKnowledgeBaseChunked(paths, {
+      ...baseOptions(),
+      scope: 'private',
+      agent: 'alice',
+      batchSize: 25,
+    });
+
+    expect(result.totalBatches).toBe(1);
+    expect(result.successFiles).toBe(10);
+    expect(runFileSyncMock).toHaveBeenCalledTimes(1);
+    // Private scope maps to the agent-<name> collection.
+    const argv = runFileSyncMock.mock.calls[0][1] as string[];
+    expect(argv).toContain('agent-alice');
+  });
 });

--- a/tests/unit/bus/knowledge-base.test.ts
+++ b/tests/unit/bus/knowledge-base.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Mock child_process.execFileSync so the tests never actually spawn mmrag.py.
+// By default the mock succeeds (simulating an OK ingest). Individual tests
+// override behavior per-call to simulate failures.
+const runFileSyncMock = vi.fn();
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: (...args: unknown[]) => runFileSyncMock(...args),
+  };
+});
+
+// Import AFTER the mock is installed so the module binds to the mocked
+// function rather than the real one.
+const { ingestKnowledgeBaseChunked } = await import('../../../src/bus/knowledge-base.js');
+
+describe('ingestKnowledgeBaseChunked', () => {
+  let frameworkRoot: string;
+  let instanceId: string;
+
+  beforeEach(() => {
+    // Create an isolated fake framework root with the bits buildKBEnv touches
+    // (a missing .env / secrets.env are tolerated — loadSecretsEnv just skips).
+    frameworkRoot = mkdtempSync(join(tmpdir(), 'cortextos-kb-chunked-'));
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'knowledge-base', 'scripts'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'knowledge-base', 'venv', 'bin'), { recursive: true });
+    // Stub a fake python3 so getVenvPython() resolves to something on disk.
+    writeFileSync(join(frameworkRoot, 'knowledge-base', 'venv', 'bin', 'python3'), '');
+    writeFileSync(join(frameworkRoot, 'knowledge-base', 'scripts', 'mmrag.py'), '');
+    instanceId = 'test-instance';
+    runFileSyncMock.mockReset();
+    // Default: subprocess succeeds silently
+    runFileSyncMock.mockReturnValue('');
+  });
+
+  afterEach(() => {
+    rmSync(frameworkRoot, { recursive: true, force: true });
+  });
+
+  const baseOptions = () => ({
+    org: 'acme',
+    scope: 'shared' as const,
+    frameworkRoot,
+    instanceId,
+  });
+
+  it('handles empty input without spawning the subprocess', () => {
+    const result = ingestKnowledgeBaseChunked([], baseOptions());
+
+    expect(result).toEqual({
+      totalFiles: 0,
+      totalBatches: 0,
+      successFiles: 0,
+      failedFiles: 0,
+      successBatches: 0,
+      failedBatches: [],
+    });
+    expect(runFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('runs a single batch when file count fits in one batch', () => {
+    const paths = Array.from({ length: 10 }, (_, i) => `/fake/file-${i}.md`);
+
+    const result = ingestKnowledgeBaseChunked(paths, {
+      ...baseOptions(),
+      batchSize: 25,
+    });
+
+    expect(result.totalFiles).toBe(10);
+    expect(result.totalBatches).toBe(1);
+    expect(result.successFiles).toBe(10);
+    expect(result.failedFiles).toBe(0);
+    expect(result.successBatches).toBe(1);
+    expect(result.failedBatches).toEqual([]);
+    expect(runFileSyncMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('splits across multiple batches when file count exceeds batch size', () => {
+    const paths = Array.from({ length: 60 }, (_, i) => `/fake/file-${i}.md`);
+
+    const result = ingestKnowledgeBaseChunked(paths, {
+      ...baseOptions(),
+      batchSize: 25,
+    });
+
+    // 60 files / 25 batchSize = 3 batches (25 + 25 + 10)
+    expect(result.totalFiles).toBe(60);
+    expect(result.totalBatches).toBe(3);
+    expect(result.successFiles).toBe(60);
+    expect(result.successBatches).toBe(3);
+    expect(result.failedBatches).toEqual([]);
+    expect(runFileSyncMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses the default batch size of 25 when not specified', () => {
+    const paths = Array.from({ length: 50 }, (_, i) => `/fake/file-${i}.md`);
+
+    const result = ingestKnowledgeBaseChunked(paths, baseOptions());
+
+    expect(result.totalBatches).toBe(2);
+    expect(runFileSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('continues after a batch failure and records the failed batch number', () => {
+    const paths = Array.from({ length: 30 }, (_, i) => `/fake/file-${i}.md`);
+
+    // First call (batch 1) succeeds, second call (batch 2) throws
+    runFileSyncMock
+      .mockReturnValueOnce('')
+      .mockImplementationOnce(() => {
+        const err = new Error('spawnSync python3 ETIMEDOUT') as Error & { code?: string };
+        err.code = 'ETIMEDOUT';
+        throw err;
+      });
+
+    const result = ingestKnowledgeBaseChunked(paths, {
+      ...baseOptions(),
+      batchSize: 25,
+    });
+
+    expect(result.totalBatches).toBe(2);
+    expect(result.successBatches).toBe(1);
+    expect(result.failedBatches).toEqual([2]);
+    expect(result.successFiles).toBe(25);
+    // Second batch is 5 files (30 - 25); upper-bound the failed count.
+    expect(result.failedFiles).toBe(5);
+    expect(runFileSyncMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('records multiple failed batches without stopping the loop', () => {
+    const paths = Array.from({ length: 50 }, (_, i) => `/fake/file-${i}.md`);
+
+    // Batches 1, 3, 5 succeed; batches 2, 4 fail
+    let callCount = 0;
+    runFileSyncMock.mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 2 || callCount === 4) {
+        throw new Error(`batch ${callCount} simulated failure`);
+      }
+      return '';
+    });
+
+    const result = ingestKnowledgeBaseChunked(paths, {
+      ...baseOptions(),
+      batchSize: 10,
+    });
+
+    expect(result.totalBatches).toBe(5);
+    expect(result.successBatches).toBe(3);
+    expect(result.failedBatches).toEqual([2, 4]);
+    expect(result.successFiles).toBe(30);
+    expect(result.failedFiles).toBe(20);
+  });
+
+  it('clamps a non-positive batchSize to the default (25)', () => {
+    const paths = Array.from({ length: 30 }, (_, i) => `/fake/file-${i}.md`);
+
+    const result = ingestKnowledgeBaseChunked(paths, {
+      ...baseOptions(),
+      batchSize: 0,
+    });
+
+    // 0 would be an infinite loop; the impl must clamp to 25.
+    expect(result.totalBatches).toBe(2);
+    expect(result.successFiles).toBe(30);
+  });
+
+  it('passes through ingest options (scope, force) to each batch call', () => {
+    const paths = Array.from({ length: 5 }, (_, i) => `/fake/file-${i}.md`);
+
+    ingestKnowledgeBaseChunked(paths, {
+      ...baseOptions(),
+      scope: 'shared',
+      force: true,
+      batchSize: 25,
+    });
+
+    // Inspect the args passed to the subprocess — we should see the --force
+    // flag in the mmrag.py argv for the single batch call.
+    expect(runFileSyncMock).toHaveBeenCalledTimes(1);
+    const callArgs = runFileSyncMock.mock.calls[0];
+    // callArgs[0] = python path, callArgs[1] = argv array, callArgs[2] = options
+    const argv = callArgs[1] as string[];
+    expect(argv).toContain('ingest');
+    expect(argv).toContain('--collection');
+    expect(argv).toContain('shared-acme');
+    expect(argv).toContain('--force');
+  });
+});

--- a/tests/unit/cli/kb-ingest-chunked.test.ts
+++ b/tests/unit/cli/kb-ingest-chunked.test.ts
@@ -1,60 +1,82 @@
 /**
  * CLI-level tests for `cortextos bus kb-ingest-chunked`.
  *
- * Verifies that the CLI action handler:
- *   1. Exits non-zero when ingestKnowledgeBaseChunked returns a partial
- *      failure (matches the existing kb-ingest contract so callers can
- *      detect partial success via exit code and re-run for dedup recovery).
- *   2. Lets deterministic setup errors (e.g. scope private without agent)
- *      propagate as hard failures — they must NOT be swallowed by the
- *      CLI layer, mirroring the sibling `kb-ingest` command's behavior
- *      where ingestKnowledgeBase() throws straight through.
+ * Seam philosophy: these tests mock at the subprocess boundary
+ * (child_process.execFileSync) so the REAL ingestKnowledgeBase and
+ * ingestKnowledgeBaseChunked implementations run inside the CLI action.
+ * No mocks on the knowledge-base module itself.
+ *
+ * Scope: these tests cover CLI-specific behavior — how the commander
+ * action translates function results into exit codes. The parity +
+ * setup-error-propagation invariants are verified at the function
+ * level in tests/unit/bus/knowledge-base.test.ts, not here: the CLI
+ * action resolves `agent` from CTX_AGENT_NAME when --agent is omitted
+ * (fallback to basename(cwd)), so the `scope private without agent`
+ * misconfig is not reachable through the CLI wiring — env always fills
+ * in a default agent. Testing the setup-error path at the CLI level
+ * would require mocking resolveEnv, at which point it is no longer a
+ * genuine end-to-end test. Function-level coverage is the right seam.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir, homedir } from 'os';
 
-// Mock the knowledge-base module BEFORE busCommand imports it, so the
-// commander action wiring calls our stubs instead of the real subprocess
-// machinery. All four exports used by bus.ts are stubbed.
-const ingestKnowledgeBaseMock = vi.fn();
-const ingestKnowledgeBaseChunkedMock = vi.fn();
-const ensureKBDirsMock = vi.fn();
-const queryKnowledgeBaseMock = vi.fn();
+// Mock ONLY child_process.execFileSync so the real bus/knowledge-base
+// module runs end-to-end through the CLI action.
+const runFileSyncMock = vi.fn();
+vi.mock('child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('child_process')>();
+  return {
+    ...actual,
+    execFileSync: (...args: unknown[]) => runFileSyncMock(...args),
+  };
+});
 
-vi.mock('../../../src/bus/knowledge-base.js', () => ({
-  ingestKnowledgeBase: ingestKnowledgeBaseMock,
-  ingestKnowledgeBaseChunked: ingestKnowledgeBaseChunkedMock,
-  ensureKBDirs: ensureKBDirsMock,
-  queryKnowledgeBase: queryKnowledgeBaseMock,
-}));
-
-// Import AFTER the mock is installed.
+// Import AFTER the mock is installed so busCommand's transitive import
+// of child_process binds to the mocked function.
 const { busCommand } = await import('../../../src/cli/bus.js');
 
 describe('cortextos bus kb-ingest-chunked CLI', () => {
+  let frameworkRoot: string;
+  let testInstanceId: string;
+  let kbRoot: string;
+
   beforeEach(() => {
-    ingestKnowledgeBaseMock.mockReset();
-    ingestKnowledgeBaseChunkedMock.mockReset();
-    ensureKBDirsMock.mockReset();
-    queryKnowledgeBaseMock.mockReset();
-    // resolveEnv reads CTX_ORG; make sure an org is present so the
-    // command does not bail out on its "--org required" guard.
+    // Fake framework root with the venv bits getVenvPython() resolves to
+    // and a stub mmrag.py so the real ingest path can build its argv.
+    frameworkRoot = mkdtempSync(join(tmpdir(), 'cortextos-kb-cli-fw-'));
+    mkdirSync(join(frameworkRoot, 'knowledge-base', 'venv', 'bin'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'knowledge-base', 'scripts'), { recursive: true });
+    writeFileSync(join(frameworkRoot, 'knowledge-base', 'venv', 'bin', 'python3'), '');
+    writeFileSync(join(frameworkRoot, 'knowledge-base', 'scripts', 'mmrag.py'), '');
+
+    // Unique instance id per test run so the real mkdirSync in ensureKBDirs
+    // writes to a predictable tmpdir path we can clean up in afterEach.
+    // resolveEnv hardcodes ~/.cortextos/<instanceId> — we use a dedicated
+    // test-only instance id and rm it after.
+    testInstanceId = `test-kb-cli-${process.pid}-${Date.now()}`;
+    kbRoot = join(homedir(), '.cortextos', testInstanceId);
+
     process.env.CTX_ORG = 'acme';
+    process.env.CTX_INSTANCE_ID = testInstanceId;
+    process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
+
+    runFileSyncMock.mockReset();
+    // Default: subprocess returns empty string (success).
+    runFileSyncMock.mockReturnValue('');
   });
 
   afterEach(() => {
     vi.restoreAllMocks();
+    rmSync(frameworkRoot, { recursive: true, force: true });
+    if (existsSync(kbRoot)) rmSync(kbRoot, { recursive: true, force: true });
     delete process.env.CTX_ORG;
+    delete process.env.CTX_INSTANCE_ID;
+    delete process.env.CTX_FRAMEWORK_ROOT;
   });
 
   it('exits 0 when all batches succeed', async () => {
-    ingestKnowledgeBaseChunkedMock.mockReturnValue({
-      totalFiles: 5,
-      totalBatches: 1,
-      successFiles: 5,
-      failedFiles: 0,
-      successBatches: 1,
-      failedBatches: [],
-    });
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
     }) as never);
@@ -66,102 +88,37 @@ describe('cortextos bus kb-ingest-chunked CLI', () => {
       '--scope', 'shared',
     ]);
 
-    // Clean runs must NOT call process.exit at all.
     expect(exitSpy).not.toHaveBeenCalled();
-    expect(ingestKnowledgeBaseChunkedMock).toHaveBeenCalledTimes(1);
+    // Real chunked function ran and invoked subprocess (one batch, 2 files).
+    expect(runFileSyncMock).toHaveBeenCalledTimes(1);
   });
 
-  it('exits non-zero when ingestKnowledgeBaseChunked reports a partial failure', async () => {
-    ingestKnowledgeBaseChunkedMock.mockReturnValue({
-      totalFiles: 50,
-      totalBatches: 2,
-      successFiles: 25,
-      failedFiles: 25,
-      successBatches: 1,
-      failedBatches: [2],
-    });
+  it('exits non-zero when one batch fails (real chunked loop, mocked subprocess)', async () => {
+    // 10 files at batch-size 5 → 2 batches. First succeeds, second throws.
+    runFileSyncMock
+      .mockReturnValueOnce('')
+      .mockImplementationOnce(() => {
+        throw new Error('spawnSync python3 ETIMEDOUT');
+      });
+
     const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
       throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
     }) as never);
 
+    const paths = Array.from({ length: 10 }, (_, i) => `/fake/file-${i}.md`);
+
     await expect(
       busCommand.parseAsync([
         'node', 'cli', 'kb-ingest-chunked',
-        '/fake/a.md', '/fake/b.md',
+        ...paths,
         '--org', 'acme',
         '--scope', 'shared',
+        '--batch-size', '5',
       ]),
     ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
 
     expect(exitSpy).toHaveBeenCalledWith(1);
-  });
-
-  it('lets deterministic setup errors propagate as hard failures (parity with kb-ingest)', async () => {
-    // Simulate the real preflight behavior: scope=private without agent
-    // throws from inside ingestKnowledgeBaseChunked. The CLI must NOT
-    // swallow it and must NOT convert it into a silent exit(1) — the
-    // error should surface through commander just like kb-ingest does.
-    ingestKnowledgeBaseChunkedMock.mockImplementation(() => {
-      throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
-    });
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
-    }) as never);
-
-    await expect(
-      busCommand.parseAsync([
-        'node', 'cli', 'kb-ingest-chunked',
-        '/fake/a.md',
-        '--org', 'acme',
-        '--scope', 'private',
-        // --agent intentionally omitted
-      ]),
-    ).rejects.toThrow(/--agent.*--scope private/);
-
-    // process.exit must NOT have been called — the thrown error propagated
-    // up through commander, which is the parity behavior we want.
-    expect(exitSpy).not.toHaveBeenCalled();
-  });
-
-  it('propagates the same setup error shape as the sibling kb-ingest command', async () => {
-    // Verify parity: kb-ingest also lets the setup error throw through.
-    // Both should reject the same way for the same misconfiguration.
-    ingestKnowledgeBaseMock.mockImplementation(() => {
-      throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
-    });
-    ingestKnowledgeBaseChunkedMock.mockImplementation(() => {
-      throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
-    });
-
-    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
-      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
-    }) as never);
-
-    const siblingReject = busCommand
-      .parseAsync([
-        'node', 'cli', 'kb-ingest',
-        '/fake/a.md',
-        '--org', 'acme',
-        '--scope', 'private',
-      ])
-      .catch((e: Error) => e);
-
-    const chunkedReject = busCommand
-      .parseAsync([
-        'node', 'cli', 'kb-ingest-chunked',
-        '/fake/a.md',
-        '--org', 'acme',
-        '--scope', 'private',
-      ])
-      .catch((e: Error) => e);
-
-    const [siblingErr, chunkedErr] = await Promise.all([siblingReject, chunkedReject]);
-
-    expect(siblingErr).toBeInstanceOf(Error);
-    expect(chunkedErr).toBeInstanceOf(Error);
-    expect((siblingErr as Error).message).toMatch(/--agent.*--scope private/);
-    expect((chunkedErr as Error).message).toMatch(/--agent.*--scope private/);
-    // Neither command should have silently exited — errors must propagate.
-    expect(exitSpy).not.toHaveBeenCalled();
+    // Both batches were attempted despite the failure.
+    expect(runFileSyncMock).toHaveBeenCalledTimes(2);
   });
 });

--- a/tests/unit/cli/kb-ingest-chunked.test.ts
+++ b/tests/unit/cli/kb-ingest-chunked.test.ts
@@ -1,0 +1,167 @@
+/**
+ * CLI-level tests for `cortextos bus kb-ingest-chunked`.
+ *
+ * Verifies that the CLI action handler:
+ *   1. Exits non-zero when ingestKnowledgeBaseChunked returns a partial
+ *      failure (matches the existing kb-ingest contract so callers can
+ *      detect partial success via exit code and re-run for dedup recovery).
+ *   2. Lets deterministic setup errors (e.g. scope private without agent)
+ *      propagate as hard failures — they must NOT be swallowed by the
+ *      CLI layer, mirroring the sibling `kb-ingest` command's behavior
+ *      where ingestKnowledgeBase() throws straight through.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+// Mock the knowledge-base module BEFORE busCommand imports it, so the
+// commander action wiring calls our stubs instead of the real subprocess
+// machinery. All four exports used by bus.ts are stubbed.
+const ingestKnowledgeBaseMock = vi.fn();
+const ingestKnowledgeBaseChunkedMock = vi.fn();
+const ensureKBDirsMock = vi.fn();
+const queryKnowledgeBaseMock = vi.fn();
+
+vi.mock('../../../src/bus/knowledge-base.js', () => ({
+  ingestKnowledgeBase: ingestKnowledgeBaseMock,
+  ingestKnowledgeBaseChunked: ingestKnowledgeBaseChunkedMock,
+  ensureKBDirs: ensureKBDirsMock,
+  queryKnowledgeBase: queryKnowledgeBaseMock,
+}));
+
+// Import AFTER the mock is installed.
+const { busCommand } = await import('../../../src/cli/bus.js');
+
+describe('cortextos bus kb-ingest-chunked CLI', () => {
+  beforeEach(() => {
+    ingestKnowledgeBaseMock.mockReset();
+    ingestKnowledgeBaseChunkedMock.mockReset();
+    ensureKBDirsMock.mockReset();
+    queryKnowledgeBaseMock.mockReset();
+    // resolveEnv reads CTX_ORG; make sure an org is present so the
+    // command does not bail out on its "--org required" guard.
+    process.env.CTX_ORG = 'acme';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    delete process.env.CTX_ORG;
+  });
+
+  it('exits 0 when all batches succeed', async () => {
+    ingestKnowledgeBaseChunkedMock.mockReturnValue({
+      totalFiles: 5,
+      totalBatches: 1,
+      successFiles: 5,
+      failedFiles: 0,
+      successBatches: 1,
+      failedBatches: [],
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+
+    await busCommand.parseAsync([
+      'node', 'cli', 'kb-ingest-chunked',
+      '/fake/a.md', '/fake/b.md',
+      '--org', 'acme',
+      '--scope', 'shared',
+    ]);
+
+    // Clean runs must NOT call process.exit at all.
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(ingestKnowledgeBaseChunkedMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('exits non-zero when ingestKnowledgeBaseChunked reports a partial failure', async () => {
+    ingestKnowledgeBaseChunkedMock.mockReturnValue({
+      totalFiles: 50,
+      totalBatches: 2,
+      successFiles: 25,
+      failedFiles: 25,
+      successBatches: 1,
+      failedBatches: [2],
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'cli', 'kb-ingest-chunked',
+        '/fake/a.md', '/fake/b.md',
+        '--org', 'acme',
+        '--scope', 'shared',
+      ]),
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('lets deterministic setup errors propagate as hard failures (parity with kb-ingest)', async () => {
+    // Simulate the real preflight behavior: scope=private without agent
+    // throws from inside ingestKnowledgeBaseChunked. The CLI must NOT
+    // swallow it and must NOT convert it into a silent exit(1) — the
+    // error should surface through commander just like kb-ingest does.
+    ingestKnowledgeBaseChunkedMock.mockImplementation(() => {
+      throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
+    });
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'cli', 'kb-ingest-chunked',
+        '/fake/a.md',
+        '--org', 'acme',
+        '--scope', 'private',
+        // --agent intentionally omitted
+      ]),
+    ).rejects.toThrow(/--agent.*--scope private/);
+
+    // process.exit must NOT have been called — the thrown error propagated
+    // up through commander, which is the parity behavior we want.
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+
+  it('propagates the same setup error shape as the sibling kb-ingest command', async () => {
+    // Verify parity: kb-ingest also lets the setup error throw through.
+    // Both should reject the same way for the same misconfiguration.
+    ingestKnowledgeBaseMock.mockImplementation(() => {
+      throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
+    });
+    ingestKnowledgeBaseChunkedMock.mockImplementation(() => {
+      throw new Error('--agent or CTX_AGENT_NAME required for --scope private');
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+
+    const siblingReject = busCommand
+      .parseAsync([
+        'node', 'cli', 'kb-ingest',
+        '/fake/a.md',
+        '--org', 'acme',
+        '--scope', 'private',
+      ])
+      .catch((e: Error) => e);
+
+    const chunkedReject = busCommand
+      .parseAsync([
+        'node', 'cli', 'kb-ingest-chunked',
+        '/fake/a.md',
+        '--org', 'acme',
+        '--scope', 'private',
+      ])
+      .catch((e: Error) => e);
+
+    const [siblingErr, chunkedErr] = await Promise.all([siblingReject, chunkedReject]);
+
+    expect(siblingErr).toBeInstanceOf(Error);
+    expect(chunkedErr).toBeInstanceOf(Error);
+    expect((siblingErr as Error).message).toMatch(/--agent.*--scope private/);
+    expect((chunkedErr as Error).message).toMatch(/--agent.*--scope private/);
+    // Neither command should have silently exited — errors must propagate.
+    expect(exitSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new CLI subcommand `cortextos bus kb-ingest-chunked` for ingesting large file sets into the knowledge base in bounded batches, plus a modest bump to the existing `kb-ingest` subprocess timeout.

The existing `kb-ingest` command hands its entire file list to `mmrag.py` in a single `execFileSync` call with a 120s timeout. For big ingest jobs (Notion exports, Obsidian vaults, multi-hundred-file docs imports) this has two failure modes: (a) the subprocess can easily exceed 120s on slow Gemini embedding tail latency and get SIGTERM'd, and (b) when the timeout fires the user has no visibility into which files were processed before the kill — the whole run looks like a total loss even though `mmrag.py` actually commits chunks incrementally to the Chroma store as it goes. Users end up reinventing chunked ingest in ad-hoc shell scripts, which is what motivated this change.

## What this adds

**`cortextos bus kb-ingest-chunked <paths...>`** — splits the input into batches (default 25 files per batch, configurable via `--batch-size`) and runs a subprocess per batch. Per-batch progress is logged to stdout so users can see which batch is running, which succeeded, and which failed. On a per-batch failure, the loop continues to the next batch rather than dying, and the command exits non-zero at the end with the list of failed batch numbers so callers can detect partial success.

CLI surface matches the sibling `kb-ingest` command:

```
cortextos bus kb-ingest-chunked <paths...>
  --org <org>            Organization name
  --agent <name>         Agent name (for private scope)
  --scope <s>            Scope: shared or private (default: shared)
  --force                Re-ingest even if already indexed
  --batch-size <n>       Files per batch (default 25)
```

**Recovery pattern.** Because `mmrag.py` commits embeddings incrementally as it processes each file — not atomically at the end of the batch — files processed before a mid-batch failure are already persisted. The safe recovery for a failed batch is to re-run `kb-ingest-chunked` with the same inputs; content-hash dedup skips the already-committed portion and retries only the missing files. If batches keep timing out, lower `--batch-size`. This behavior is documented in the SKILL.md update.

**Timeout bump.** While I was in there, the existing `ingestKnowledgeBase` subprocess timeout is bumped from 120s to 300s. The old budget was tight enough that even modest batches could hit the ceiling on slow embedding API tail latency. 300s gives comfortable headroom for ~50 files per call without needing chunking, while chunking remains the defense-in-depth pattern for anything larger. This is a pure ceiling bump — no behavior change for batches that already completed inside 120s.

## Files changed

- `src/bus/knowledge-base.ts` — new `ingestKnowledgeBaseChunked` function + `ChunkedIngestResult` interface, preflight validation hoisted out of the batch loop (scope/agent check + `ensureKBDirs`) so deterministic setup errors propagate cleanly instead of being counted as fake batch failures, existing `ingestKnowledgeBase` timeout bumped to 300s.
- `src/cli/bus.ts` — new `kb-ingest-chunked` commander subcommand wiring, non-zero exit on partial failure.
- `templates/agent/.claude/skills/knowledge-base/SKILL.md`
- `templates/analyst/.claude/skills/knowledge-base/SKILL.md`
- `templates/orchestrator/.claude/skills/knowledge-base/SKILL.md`
- `community/skills/knowledge-base/SKILL.md` — usage docs added to all four SKILL.md variants so the feature is discoverable from any agent template.
- `tests/unit/bus/knowledge-base.test.ts` — function-level coverage of the chunked ingest: empty input, single batch, multi-batch split, default batch size, single batch failure, multiple batch failures, non-positive batch size clamping, options passthrough (`--force`, scope), preflight rejects scope=private without agent, preflight accepts scope=private with agent, and a parity assertion that `ingestKnowledgeBase` and `ingestKnowledgeBaseChunked` reject identically for the same misconfiguration.
- `tests/unit/cli/kb-ingest-chunked.test.ts` — CLI-level coverage mocking only `child_process.execFileSync` so the real chunked function runs through commander wiring: clean run exits 0, partial failure exits non-zero.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 452/452 passing (was 447; 5 new cases at the function level, 2 at the CLI level, -0 existing test regressions)
- [x] Manual smoke test: chunked ingest of 833 real files against a live Chroma collection, including a real 120s-timeout batch failure. Verified: partial-progress preservation via `mmrag.py`'s incremental commits, re-run recovery via content-hash dedup, exit code semantics, per-batch progress logging.

The change went through an internal multi-pass code review before opening — two rounds of catch-narrowing on the chunked ingest's error handling surface (the first pass moved scope/agent validation out of the batch loop; the second pass also moved `ensureKBDirs` out, because the inner function's `mkdirSync` would otherwise still be inside the catch and a real filesystem failure would be silently converted into a fake batch failure — the same silent-failure pattern the original fix was trying to eliminate, just hitting a different setup path).