### PR TITLE
feat(memory): agentmemory MCP + session-restore hook (replaces claude-mem)

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1546,6 +1546,16 @@ busCommand
   .description('Stop hook: writes last_idle.flag timestamp so fast-checker knows agent finished its turn')
   .action(() => runHook('hook-idle-flag'));
 
+busCommand
+  .command('hook-extract-facts')
+  .description('PreCompact hook: extracts and stores session summary as structured fact entry for cross-session memory')
+  .action(() => runHook('hook-extract-facts'));
+
+busCommand
+  .command('hook-session-restore')
+  .description('SessionStart hook: injects the most recent compaction snapshot as additionalContext to restore working state')
+  .action(() => runHook('hook-session-restore'));
+
 // --- OAuth token rotation commands ---
 
 busCommand

--- a/src/hooks/hook-session-restore.ts
+++ b/src/hooks/hook-session-restore.ts
@@ -1,0 +1,117 @@
+/**
+ * hook-session-restore.ts — SessionStart hook.
+ *
+ * Injects the most recent compaction snapshot into the new session as
+ * `additionalContext`. This restores working state automatically after a
+ * context compaction without requiring the agent to explicitly call
+ * `recall-facts` — the context arrives before the agent's first turn.
+ *
+ * Design:
+ * - Reads the last N fact entries written by hook-extract-facts (PreCompact).
+ * - Formats the most recent summary as a compact context block.
+ * - Returns `{"additionalContext": "..."}` so Claude Code injects it.
+ * - Silent on any error — never blocks session start.
+ *
+ * Registered in settings.json under "SessionStart".
+ * Compatible with agentmemory MCP: this hook handles short-term compaction
+ * restore; agentmemory provides long-term semantic search across many sessions.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { loadEnv, readStdin } from './index.js';
+
+interface FactEntry {
+  ts: string;
+  session_id: string;
+  agent: string;
+  org: string;
+  source: string;
+  summary: string;
+  keywords: string[];
+}
+
+interface SessionStartPayload {
+  session_id?: string;
+  source?: string; // 'startup' | 'resume' | 'compact'
+}
+
+const MAX_SUMMARY_CHARS = 3000;
+const MAX_AGE_HOURS = 6;
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let payload: SessionStartPayload = {};
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      // Non-JSON input — proceed with defaults
+    }
+
+    // On fresh startup (not a resume/compact), no restore needed
+    if (payload.source === 'startup') {
+      process.exit(0);
+    }
+
+    const env = loadEnv();
+    const factsDir = join(env.ctxRoot, 'state', env.agentName, 'memory', 'facts');
+
+    const entries: FactEntry[] = [];
+    for (let d = 0; d < 2; d++) {
+      const date = new Date(Date.now() - d * 24 * 60 * 60 * 1000);
+      const dateStr = date.toISOString().slice(0, 10);
+      const factsFile = join(factsDir, `${dateStr}.jsonl`);
+      if (!existsSync(factsFile)) continue;
+      try {
+        const lines = readFileSync(factsFile, 'utf-8').split('\n').filter(l => l.trim());
+        for (const line of lines) {
+          try {
+            const entry = JSON.parse(line) as FactEntry;
+            if (entry.source === 'precompact' && entry.summary) {
+              entries.push(entry);
+            }
+          } catch { /* skip corrupt lines */ }
+        }
+      } catch { /* skip unreadable files */ }
+    }
+
+    if (entries.length === 0) {
+      process.exit(0);
+    }
+
+    // Use the most recent entry
+    const latest = entries[entries.length - 1];
+
+    // Skip if the snapshot is too old (agent probably had a clean restart)
+    const ageMs = Date.now() - new Date(latest.ts).getTime();
+    if (ageMs > MAX_AGE_HOURS * 60 * 60 * 1000) {
+      process.exit(0);
+    }
+
+    const ts = latest.ts.replace('T', ' ').replace('Z', ' UTC').slice(0, 16);
+    const summary = latest.summary.slice(0, MAX_SUMMARY_CHARS);
+    const keywordsLine = latest.keywords.length > 0
+      ? `\nKey topics: ${latest.keywords.slice(0, 8).join(', ')}`
+      : '';
+
+    const additionalContext = [
+      `## Context from Previous Session`,
+      ``,
+      `_Snapshot taken at ${ts} (before context compaction)_`,
+      keywordsLine,
+      ``,
+      summary,
+    ].filter(line => line !== null).join('\n');
+
+    const output = { additionalContext };
+    process.stdout.write(JSON.stringify(output) + '\n');
+    process.exit(0);
+
+  } catch {
+    // Never fail — session start must not be blocked
+    process.exit(0);
+  }
+}
+
+main().catch(() => process.exit(0));

--- a/src/hooks/hook-session-restore.ts
+++ b/src/hooks/hook-session-restore.ts
@@ -7,9 +7,12 @@
  * `recall-facts` — the context arrives before the agent's first turn.
  *
  * Design:
- * - Reads the last N fact entries written by hook-extract-facts (PreCompact).
+ * - Only fires when source === 'compact'. Skips startup, resume, and clear.
+ * - Reads the last N fact entries written by hook-extract-facts (PreCompact),
+ *   sorted by timestamp (most recent last) across up to two days of files.
  * - Formats the most recent summary as a compact context block.
- * - Returns `{"additionalContext": "..."}` so Claude Code injects it.
+ * - Returns Claude Code's SessionStart hookSpecificOutput shape so the
+ *   additionalContext is injected before the agent's first turn.
  * - Silent on any error — never blocks session start.
  *
  * Registered in settings.json under "SessionStart".
@@ -33,7 +36,7 @@ interface FactEntry {
 
 interface SessionStartPayload {
   session_id?: string;
-  source?: string; // 'startup' | 'resume' | 'compact'
+  source?: string; // 'startup' | 'resume' | 'compact' | 'clear'
 }
 
 const MAX_SUMMARY_CHARS = 3000;
@@ -49,8 +52,9 @@ async function main(): Promise<void> {
       // Non-JSON input — proceed with defaults
     }
 
-    // On fresh startup (not a resume/compact), no restore needed
-    if (payload.source === 'startup') {
+    // Only restore on compaction. Skip startup, resume (user --continue), and
+    // /clear (user explicitly cleared context — respect that intent).
+    if (payload.source !== 'compact') {
       process.exit(0);
     }
 
@@ -80,7 +84,10 @@ async function main(): Promise<void> {
       process.exit(0);
     }
 
-    // Use the most recent entry
+    // Sort all entries by timestamp and take the most recent.
+    // This is correct even across the day boundary where d=0 (today) and
+    // d=1 (yesterday) entries are interleaved in the array.
+    entries.sort((a, b) => a.ts.localeCompare(b.ts));
     const latest = entries[entries.length - 1];
 
     // Skip if the snapshot is too old (agent probably had a clean restart)
@@ -102,9 +109,15 @@ async function main(): Promise<void> {
       keywordsLine,
       ``,
       summary,
-    ].filter(line => line !== null).join('\n');
+    ].join('\n');
 
-    const output = { additionalContext };
+    // Claude Code SessionStart hook output shape
+    const output = {
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext,
+      },
+    };
     process.stdout.write(JSON.stringify(output) + '\n');
     process.exit(0);
 

--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -43,6 +43,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-session-restore",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/templates/agent/.mcp.json
+++ b/templates/agent/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["-y", "agentmemory-mcp"],
+      "env": {
+        "TOKEN_BUDGET": "2000",
+        "AGENTMEMORY_TOOLS": "core"
+      }
+    }
+  }
+}

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -43,6 +43,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-session-restore",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/templates/analyst/.mcp.json
+++ b/templates/analyst/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["-y", "agentmemory-mcp"],
+      "env": {
+        "TOKEN_BUDGET": "2000",
+        "AGENTMEMORY_TOOLS": "core"
+      }
+    }
+  }
+}

--- a/templates/orchestrator/.claude/settings.json
+++ b/templates/orchestrator/.claude/settings.json
@@ -43,6 +43,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-session-restore",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/templates/orchestrator/.mcp.json
+++ b/templates/orchestrator/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["-y", "agentmemory-mcp"],
+      "env": {
+        "TOKEN_BUDGET": "2000",
+        "AGENTMEMORY_TOOLS": "core"
+      }
+    }
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     'hooks/hook-compact-telegram': 'src/hooks/hook-compact-telegram.ts',
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
+    'hooks/hook-session-restore': 'src/hooks/hook-session-restore.ts',
   },
   format: ['cjs'],
   target: 'node20',


### PR DESCRIPTION
## Summary

- Adds `.mcp.json` to all three agent templates (agent, orchestrator, analyst) with `agentmemory-mcp` configured as the default semantic memory server — replaces claude-mem (operators should remove any user-level claude-mem plugin install)
- Adds `src/hooks/hook-session-restore.ts` — a new SessionStart hook that reads the last PreCompact snapshot from `memory/facts/` and injects it as `additionalContext`, so agents automatically recover working state after a context compaction without an explicit `recall-facts` call
- Registers `hook-extract-facts` and `hook-session-restore` as `cortextos bus` commands (hook-extract-facts was previously wired in settings.json but missing from bus.ts)
- Adds `hook-session-restore` entry to `tsup.config.ts`
- Wires `SessionStart` hook in all three template `settings.json` files

**agentmemory** is local-only (SQLite + BM25 + all-MiniLM-L6-v2 embeddings via @xenova/transformers — no external API). Core mode exposes 7 tools: `memory_recall`, `memory_save`, `memory_smart_search`, `memory_file_history`, `memory_sessions`, `memory_profile`, `memory_export`.

**hook-session-restore** only fires on `source === 'compact'` (not startup, resume, or /clear). Guards against stale snapshots older than 6 hours. Output shape uses Claude Code's `hookSpecificOutput.additionalContext` contract.

Codex review performed before filing — three issues found and fixed: wrong hookSpecificOutput shape, day-boundary sort bug, incorrect source guard.

## Test plan

- [x] `npm run build` passes cleanly
- [x] `npm test` — 30 files, 439 tests pass
- [x] `npm run typecheck` passes
- [x] `.mcp.json` format validated against Claude Code schema
- [x] Codex review signed off after fixes
- [ ] End-to-end: add agent, trigger a compaction, verify context restored on next session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)