### PR TITLE
fix(daemon): guard auto-start behind require.main to prevent accidental spawn

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -113,9 +113,15 @@ class Daemon {
   }
 }
 
-// Start daemon
-const daemon = new Daemon();
-daemon.start().catch(err => {
-  console.error('[daemon] Fatal error:', err);
-  process.exit(1);
-});
+// Only auto-start when run directly (e.g. `node dist/daemon.js` or via PM2).
+// Guarding with require.main prevents accidental daemon spawn when the module
+// is require()'d for testing or class imports — which would start a full daemon
+// with TelegramPollers, IPC server, and Claude PTY processes as a side effect.
+// See: https://github.com/grandamenium/cortextos/issues/44
+if (require.main === module) {
+  const daemon = new Daemon();
+  daemon.start().catch(err => {
+    console.error('[daemon] Fatal error:', err);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Summary

- `dist/daemon.js` previously ran `new Daemon(); daemon.start()` unconditionally on load — any `require('./dist/daemon.js')` started a full live daemon as a side effect
- Wraps the startup block with `if (require.main === module)` so importing/requiring the module is safe
- Preserves all existing launch paths: `node dist/daemon.js`, PM2, `cortextos ecosystem && pm2 start`

## Root cause incident

On 2026-04-12, a test one-liner `node -e "require('./dist/daemon.js')"` during BUG-050 verification spawned a rogue daemon that ran for 31+ minutes alongside the main daemon. The rogue daemon created duplicate TelegramPollers for all 6 Telegram-enabled agents, causing persistent `Conflict: terminated by other getUpdates request` errors (~9/sec) and double responses to James's messages.

## Test plan

- [ ] `node -e "require('./dist/daemon.js'); console.log('ok')"` — should print `ok` and exit cleanly without starting a daemon
- [ ] `npm run build && npm test` — 451 tests pass
- [ ] `node dist/daemon.js` (with CTX_FRAMEWORK_ROOT set) — daemon starts normally

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)