### PR TITLE
feat: add Comms Hub — real-time agent communication center for dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,5 @@ WINDOWS-IMPLEMENTATION-PLAN.md
 WINDOWS-SUPPORT-INVESTIGATION.md
 BRAINDUMP*.md
 AGENTS.md
+dashboard/screenshots/
+dashboard/test-*.py

--- a/dashboard/src/app/(dashboard)/comms/page.tsx
+++ b/dashboard/src/app/(dashboard)/comms/page.tsx
@@ -1,0 +1,314 @@
+'use client';
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { Label } from '@/components/ui/label';
+import { IconMessages, IconUsers, IconSearch, IconRefresh, IconArrowsSort } from '@tabler/icons-react';
+import { MessageFeed } from '@/components/comms/message-feed';
+import { ChannelList } from '@/components/comms/channel-list';
+import { ChannelView } from '@/components/comms/channel-view';
+import { SearchResults } from '@/components/comms/search-results';
+
+interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  priority: string;
+  timestamp: string;
+  text: string;
+  reply_to: string | null;
+}
+
+interface Channel {
+  pair: string;
+  agents: [string, string];
+  last_message: { text: string; timestamp: string; from: string };
+  message_count: number;
+  last_activity: string;
+  archived: boolean;
+}
+
+export default function CommsPage() {
+  const [feedMessages, setFeedMessages] = useState<BusMessage[]>([]);
+  const [channels, setChannels] = useState<Channel[]>([]);
+  const [loading, setLoading] = useState(true);
+  // Separate search state per tab so they do not bleed into each other.
+  const [meetingSearch, setMeetingSearch] = useState('');
+  const [channelSearch, setChannelSearch] = useState('');
+  const [selectedPair, setSelectedPair] = useState<string | null>(null);
+  const [showArchived, setShowArchived] = useState(false);
+  const [activeTab, setActiveTab] = useState('meeting-room');
+  const [debouncedMeetingSearch, setDebouncedMeetingSearch] = useState('');
+  const [knownAgents, setKnownAgents] = useState<Set<string>>(new Set());
+  // Sort order — persisted in localStorage. 'asc' = oldest first, newest
+  // at bottom (Telegram-like). 'desc' = newest first, oldest at bottom.
+  const [sortOrder, setSortOrder] = useState<'asc' | 'desc'>('asc');
+  useEffect(() => {
+    try {
+      const saved = localStorage.getItem('comms-sort-order');
+      if (saved === 'asc' || saved === 'desc') setSortOrder(saved);
+    } catch { /* ignore */ }
+  }, []);
+  function toggleSortOrder() {
+    const next = sortOrder === 'asc' ? 'desc' : 'asc';
+    setSortOrder(next);
+    try { localStorage.setItem('comms-sort-order', next); } catch { /* ignore */ }
+  }
+
+  useEffect(() => {
+    fetch('/api/agents')
+      .then(r => (r.ok ? r.json() : []))
+      .then((data: Array<{ name: string }>) => setKnownAgents(new Set(data.map(a => a.name))))
+      .catch(() => { /* best-effort */ });
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'channels' && !selectedPair && channels.length > 0) {
+      setSelectedPair(channels[0].pair);
+    }
+  }, [activeTab, selectedPair, channels]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedMeetingSearch(meetingSearch), 400);
+    return () => clearTimeout(timer);
+  }, [meetingSearch]);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const searchParam = debouncedMeetingSearch ? `&search=${encodeURIComponent(debouncedMeetingSearch)}` : '';
+      const [feedRes, channelsRes] = await Promise.all([
+        fetch(`/api/comms/feed?limit=200${searchParam}`),
+        fetch(`/api/comms/channels?include_archived=${showArchived}`),
+      ]);
+
+      if (feedRes.ok) setFeedMessages(await feedRes.json());
+      if (channelsRes.ok) setChannels(await channelsRes.json());
+    } catch {
+      // Silently fail
+    } finally {
+      setLoading(false);
+    }
+  }, [debouncedMeetingSearch, showArchived]);
+
+  // Initial fetch + refetch on search/filter changes. Only show the loading
+  // skeleton on the very first mount — subsequent fetches (search, archived
+  // toggle, 30s poll) replace data in-place without flashing the skeleton.
+  const initialFetchDone = useRef(false);
+  useEffect(() => {
+    if (!initialFetchDone.current) {
+      setLoading(true);
+      initialFetchDone.current = true;
+    }
+    fetchData();
+  }, [fetchData]);
+
+  useEffect(() => {
+    const interval = setInterval(fetchData, 30000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  function handleAgentClick(agent: string) {
+    const channel = channels.find(ch => ch.agents.includes(agent));
+    if (channel) {
+      setSelectedPair(channel.pair);
+    }
+  }
+
+  if (loading) {
+    return (
+      <div className="space-y-6">
+        <h1 className="text-2xl font-semibold">Comms</h1>
+        <div className="space-y-4">
+          <div className="h-10 w-48 rounded-lg bg-muted/30 animate-pulse" />
+          <div className="space-y-2">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <div key={i} className="h-12 rounded-lg bg-muted/30 animate-pulse" />
+            ))}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">Comms</h1>
+        <Button variant="ghost" size="sm" onClick={fetchData}>
+          <IconRefresh size={14} className="mr-1" />
+          Refresh
+        </Button>
+      </div>
+
+      <Tabs defaultValue="meeting-room" value={activeTab} onValueChange={setActiveTab}>
+        <TabsList>
+          <TabsTrigger value="meeting-room">
+            <IconMessages size={14} className="mr-1" />
+            Meeting Room
+          </TabsTrigger>
+          <TabsTrigger value="channels">
+            <IconUsers size={14} className="mr-1" />
+            Active Channels
+            {channels.length > 0 && (
+              <span className="ml-1.5 flex h-5 min-w-5 items-center justify-center rounded-full bg-primary px-1.5 text-[10px] font-semibold text-primary-foreground tabular-nums">
+                {channels.length}
+              </span>
+            )}
+          </TabsTrigger>
+        </TabsList>
+
+        {/* Meeting Room — org-wide chronological feed */}
+        <TabsContent value="meeting-room">
+          <div className="space-y-3">
+            <div className="flex items-center pt-1">
+              <span className="text-xs text-muted-foreground">
+                {debouncedMeetingSearch
+                  ? `${feedMessages.length} result${feedMessages.length !== 1 ? 's' : ''}`
+                  : `${feedMessages.length} message${feedMessages.length !== 1 ? 's' : ''}`}
+              </span>
+            </div>
+            {/* Search bar — matches Knowledge Base pattern */}
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <IconSearch size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+                <input
+                  type="text"
+                  placeholder="Search messages..."
+                  value={meetingSearch}
+                  onChange={(e) => setMeetingSearch(e.target.value)}
+                  className="w-full rounded-md border bg-background pl-9 pr-4 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-ring/30"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => setMeetingSearch('')}
+                className={`rounded-md px-4 py-2 text-sm font-medium transition-opacity whitespace-nowrap ${
+                  meetingSearch
+                    ? 'bg-muted text-foreground hover:bg-muted/80'
+                    : 'bg-primary text-primary-foreground hover:bg-primary/90'
+                }`}
+              >
+                {meetingSearch ? 'Clear' : 'Search'}
+              </button>
+            </div>
+
+            {/* Show search results panel when query is active, feed when not */}
+            {debouncedMeetingSearch ? (
+              <SearchResults
+                messages={feedMessages}
+                query={debouncedMeetingSearch}
+                onResultClick={(pair) => {
+                  setMeetingSearch('');
+                  setSelectedPair(pair);
+                  setActiveTab('channels');
+                }}
+              />
+            ) : (
+              <MessageFeed
+                messages={feedMessages}
+                onAgentClick={handleAgentClick}
+                onMessageClick={(pair) => {
+                  setSelectedPair(pair);
+                  setActiveTab('channels');
+                }}
+              />
+            )}
+          </div>
+        </TabsContent>
+
+        {/* Active Channels — per-pair conversation view */}
+        <TabsContent value="channels">
+          <div className="space-y-2">
+            {/* Controls row: archived toggle + channel count + search */}
+            <div className="flex items-center gap-3 pt-1">
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={showArchived}
+                  onCheckedChange={setShowArchived}
+                  id="show-archived"
+                />
+                <Label htmlFor="show-archived" className="text-xs">
+                  Show archived
+                </Label>
+              </div>
+              <span className="text-xs text-muted-foreground">
+                {channels.length} channel{channels.length !== 1 ? 's' : ''}
+              </span>
+            </div>
+            {/* Channel search/filter bar — matches KB pattern */}
+            <div className="flex gap-2">
+              <div className="relative flex-1">
+                <IconSearch size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-muted-foreground pointer-events-none" />
+                <input
+                  type="text"
+                  placeholder="Filter channels..."
+                  value={channelSearch}
+                  onChange={(e) => setChannelSearch(e.target.value)}
+                  className="w-full rounded-md border bg-background pl-9 pr-4 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-ring/30"
+                />
+              </div>
+              <button
+                type="button"
+                onClick={() => setChannelSearch('')}
+                className={`rounded-md px-4 py-2 text-sm font-medium transition-opacity whitespace-nowrap ${
+                  channelSearch
+                    ? 'bg-muted text-foreground hover:bg-muted/80'
+                    : 'bg-primary text-primary-foreground hover:bg-primary/90'
+                }`}
+              >
+                {channelSearch ? 'Clear' : 'Search'}
+              </button>
+            </div>
+
+            {/* Channel grid: sidebar list + conversation view */}
+            <div className="grid grid-cols-1 gap-4 md:grid-cols-[280px_1fr] h-[calc(100vh-280px)]">
+              {/* Channel list with top padding so first card hover does not clip */}
+              <div className="overflow-y-auto px-2 pt-3 pb-2">
+                <ChannelList
+                  channels={channels.filter(ch => {
+                    if (!channelSearch.trim()) return true;
+                    const q = channelSearch.toLowerCase();
+                    return ch.agents.some(a => a.toLowerCase().includes(q));
+                  })}
+                  selectedPair={selectedPair}
+                  onChannelClick={setSelectedPair}
+                />
+              </div>
+              {/* Conversation panel — constrained to viewport height */}
+              <div className="flex flex-col min-h-0 rounded-lg border bg-muted/10 overflow-hidden">
+                {selectedPair ? (
+                  <>
+                    {/* Channel header with sort toggle */}
+                    <div className="flex items-center justify-between gap-2 px-4 py-3 border-b flex-shrink-0">
+                      <span className="text-sm font-medium">
+                        {selectedPair.replace('--', ' \u2194 ')}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={toggleSortOrder}
+                        className="flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-xs text-muted-foreground hover:text-foreground hover:bg-muted transition-colors"
+                        title={sortOrder === 'asc' ? 'Newest at bottom — click to flip' : 'Newest at top — click to flip'}
+                      >
+                        <IconArrowsSort size={13} />
+                        {sortOrder === 'asc' ? 'Newest \u2193' : 'Newest \u2191'}
+                      </button>
+                    </div>
+                    <div className="flex-1 min-h-0 overflow-hidden">
+                      <ChannelView pair={selectedPair} knownAgents={knownAgents} sortOrder={sortOrder} />
+                    </div>
+                  </>
+                ) : (
+                  <div className="flex items-center justify-center h-full text-sm text-muted-foreground">
+                    Select a channel to view conversation
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/dashboard/src/app/api/comms/__tests__/routes.test.ts
+++ b/dashboard/src/app/api/comms/__tests__/routes.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Tests for the Comms Hub API routes.
+ *
+ * Each test spins up a fresh temp CTX_ROOT, seeds it with a minimal set
+ * of agent registry + message history + inbox files, then invokes the
+ * route handler directly and asserts on the Response.
+ *
+ * We set CTX_ROOT + ADMIN_USERNAME before importing the handlers so the
+ * route modules pick them up at evaluation time.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { NextRequest } from 'next/server';
+
+// ---------------------------------------------------------------------------
+// Global setup — one shared tmp root across all tests in this file.
+// Each test isolates itself by writing into its own subpath or clearing files.
+// ---------------------------------------------------------------------------
+const rootTmp = fs.mkdtempSync(path.join(os.tmpdir(), 'comms-routes-'));
+process.env.CTX_ROOT = rootTmp;
+process.env.ADMIN_USERNAME = 'james';
+
+// Dynamic imports AFTER env vars are set.
+type FeedRoute = typeof import('../feed/route');
+type ChannelsRoute = typeof import('../channels/route');
+type ChannelRoute = typeof import('../channel/[pair]/route');
+type UploadRoute = typeof import('../upload/route');
+
+let feed: FeedRoute;
+let channels: ChannelsRoute;
+let channel: ChannelRoute;
+let upload: UploadRoute;
+
+beforeAll(async () => {
+  feed = await import('../feed/route');
+  channels = await import('../channels/route');
+  channel = await import('../channel/[pair]/route');
+  upload = await import('../upload/route');
+});
+
+afterAll(() => {
+  try { fs.rmSync(rootTmp, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+// Wipe and re-seed CTX_ROOT before each test so state does not leak.
+beforeEach(() => {
+  for (const entry of fs.readdirSync(rootTmp)) {
+    fs.rmSync(path.join(rootTmp, entry), { recursive: true, force: true });
+  }
+  // Always seed an empty enabled-agents.json so resolveIdentity has agents.
+  fs.mkdirSync(path.join(rootTmp, 'config'), { recursive: true });
+  fs.writeFileSync(
+    path.join(rootTmp, 'config', 'enabled-agents.json'),
+    JSON.stringify({ boris: {}, nick: {} }),
+  );
+  // Empty inbox base exists so the "no inboxBase" short-circuit doesn't fire.
+  fs.mkdirSync(path.join(rootTmp, 'inbox'), { recursive: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function writeHistory(messages: Array<Record<string, unknown>>) {
+  const logDir = path.join(rootTmp, 'logs');
+  fs.mkdirSync(logDir, { recursive: true });
+  const lines = messages.map(m => JSON.stringify(m)).join('\n') + '\n';
+  fs.writeFileSync(path.join(logDir, 'message-history.jsonl'), lines);
+}
+
+function makeRequest(url: string): NextRequest {
+  return new NextRequest(new URL(url, 'http://localhost'));
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/comms/feed
+// ---------------------------------------------------------------------------
+describe('GET /api/comms/feed', () => {
+  it('returns messages from history log sorted newest-first', async () => {
+    writeHistory([
+      { id: 'm1', from: 'boris', to: 'nick', priority: 'normal', timestamp: '2026-04-15T09:00:00Z', text: 'hello', reply_to: null },
+      { id: 'm2', from: 'nick', to: 'boris', priority: 'normal', timestamp: '2026-04-15T10:00:00Z', text: 'world', reply_to: null },
+    ]);
+
+    const res = await feed.GET(makeRequest('/api/comms/feed'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(Array.isArray(data)).toBe(true);
+    expect(data).toHaveLength(2);
+    expect(data[0].id).toBe('m2'); // newest first
+    expect(data[1].id).toBe('m1');
+  });
+
+  it('returns an empty array when there is no inbox directory', async () => {
+    // Wipe the inbox dir seeded by beforeEach to hit the short-circuit.
+    fs.rmSync(path.join(rootTmp, 'inbox'), { recursive: true, force: true });
+
+    const res = await feed.GET(makeRequest('/api/comms/feed'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual([]);
+  });
+
+  it('applies the search filter to message text', async () => {
+    writeHistory([
+      { id: 'm1', from: 'boris', to: 'nick', priority: 'normal', timestamp: '2026-04-15T09:00:00Z', text: 'hello world', reply_to: null },
+      { id: 'm2', from: 'nick', to: 'boris', priority: 'normal', timestamp: '2026-04-15T10:00:00Z', text: 'unrelated', reply_to: null },
+    ]);
+
+    const res = await feed.GET(makeRequest('/api/comms/feed?search=hello'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].id).toBe('m1');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/comms/channels
+// ---------------------------------------------------------------------------
+describe('GET /api/comms/channels', () => {
+  it('groups messages by pair and reports last-message metadata', async () => {
+    writeHistory([
+      { id: 'm1', from: 'boris', to: 'nick', priority: 'normal', timestamp: '2026-04-15T09:00:00Z', text: 'hi', reply_to: null },
+      { id: 'm2', from: 'nick', to: 'boris', priority: 'normal', timestamp: '2026-04-15T10:00:00Z', text: 'reply', reply_to: null },
+    ]);
+
+    const res = await channels.GET(makeRequest('/api/comms/channels'));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].pair).toBe('boris--nick');
+    expect(data[0].message_count).toBe(2);
+    expect(data[0].last_message.from).toBe('nick');
+    expect(data[0].archived).toBe(false);
+  });
+
+  it('hides channels older than the archive threshold by default', async () => {
+    writeHistory([
+      { id: 'old', from: 'boris', to: 'nick', priority: 'normal', timestamp: '2020-01-01T00:00:00Z', text: 'ancient', reply_to: null },
+    ]);
+
+    const defaultRes = await channels.GET(makeRequest('/api/comms/channels'));
+    expect(await defaultRes.json()).toEqual([]);
+
+    const includeRes = await channels.GET(makeRequest('/api/comms/channels?include_archived=true'));
+    const data = await includeRes.json();
+    expect(data).toHaveLength(1);
+    expect(data[0].archived).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/comms/channel/[pair]
+// ---------------------------------------------------------------------------
+describe('GET /api/comms/channel/[pair]', () => {
+  it('returns only messages matching the pair, oldest-first', async () => {
+    writeHistory([
+      { id: 'm1', from: 'boris', to: 'nick', priority: 'normal', timestamp: '2026-04-15T09:00:00Z', text: 'first', reply_to: null },
+      { id: 'm2', from: 'nick', to: 'boris', priority: 'normal', timestamp: '2026-04-15T10:00:00Z', text: 'second', reply_to: null },
+      { id: 'm3', from: 'boris', to: 'james', priority: 'normal', timestamp: '2026-04-15T11:00:00Z', text: 'other pair', reply_to: null },
+    ]);
+
+    const res = await channel.GET(
+      makeRequest('/api/comms/channel/boris--nick'),
+      { params: Promise.resolve({ pair: 'boris--nick' }) },
+    );
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(2);
+    expect(data[0].id).toBe('m1');
+    expect(data[1].id).toBe('m2');
+  });
+
+  it('rejects malformed pair strings with a 400', async () => {
+    // "only-one-side" has no `--` separator.
+    const res = await channel.GET(
+      makeRequest('/api/comms/channel/only-one-side'),
+      { params: Promise.resolve({ pair: 'only-one-side' }) },
+    );
+    expect(res.status).toBe(400);
+
+    // Uppercase / special chars should also be rejected.
+    const res2 = await channel.GET(
+      makeRequest('/api/comms/channel/Boris--NICK'),
+      { params: Promise.resolve({ pair: 'Boris--NICK' }) },
+    );
+    expect(res2.status).toBe(400);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/comms/upload
+// ---------------------------------------------------------------------------
+describe('POST /api/comms/upload', () => {
+  /** Build a POST request carrying a single-file multipart body. */
+  function uploadRequest(file: File): NextRequest {
+    const form = new FormData();
+    form.append('file', file);
+    return new NextRequest(new URL('http://localhost/api/comms/upload'), {
+      method: 'POST',
+      body: form,
+    });
+  }
+
+  it('writes a PNG into media/dashboard-uploads and returns its URL', async () => {
+    const png = new File([new Uint8Array([0x89, 0x50, 0x4E, 0x47])], 'shot.png', {
+      type: 'image/png',
+    });
+
+    const res = await upload.POST(uploadRequest(png));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.success).toBe(true);
+    expect(data.path.startsWith('media/dashboard-uploads/')).toBe(true);
+    expect(data.url.startsWith('/api/media/media/dashboard-uploads/')).toBe(true);
+    expect(data.filename.endsWith('.png')).toBe(true);
+
+    const absPath = path.join(rootTmp, data.path);
+    expect(fs.existsSync(absPath)).toBe(true);
+  });
+
+  it('rejects unsupported MIME types (including SVG)', async () => {
+    // SVG is now explicitly disallowed because it can carry inline <script>.
+    const svg = new File(['<svg xmlns="http://www.w3.org/2000/svg"/>'], 'evil.svg', {
+      type: 'image/svg+xml',
+    });
+    const svgRes = await upload.POST(uploadRequest(svg));
+    expect(svgRes.status).toBe(400);
+
+    const html = new File(['<html></html>'], 'page.html', { type: 'text/html' });
+    const htmlRes = await upload.POST(uploadRequest(html));
+    expect(htmlRes.status).toBe(400);
+  });
+
+  it('forces the server-chosen extension regardless of the uploaded filename', async () => {
+    // Attacker attempts to smuggle an HTML-looking filename through a png MIME.
+    const png = new File([new Uint8Array([0x89, 0x50, 0x4E, 0x47])], '../../evil.html', {
+      type: 'image/png',
+    });
+    const res = await upload.POST(uploadRequest(png));
+    expect(res.status).toBe(200);
+    const data = await res.json();
+
+    // Extension must be the MIME-derived .png, NOT .html.
+    expect(data.filename.endsWith('.png')).toBe(true);
+    expect(data.filename.includes('..')).toBe(false);
+    expect(data.filename.includes('/')).toBe(false);
+
+    // And the file must live inside the intended upload dir, not above it.
+    const absPath = path.resolve(rootTmp, data.path);
+    const uploadDir = path.resolve(rootTmp, 'media', 'dashboard-uploads');
+    expect(absPath.startsWith(uploadDir + path.sep)).toBe(true);
+  });
+
+  it('rejects files over 10MB', async () => {
+    const big = new File([new Uint8Array(11 * 1024 * 1024)], 'huge.png', {
+      type: 'image/png',
+    });
+    const res = await upload.POST(uploadRequest(big));
+    expect(res.status).toBe(400);
+    const data = await res.json();
+    expect(String(data.error).toLowerCase()).toContain('too large');
+  });
+});

--- a/dashboard/src/app/api/comms/channel/[pair]/route.ts
+++ b/dashboard/src/app/api/comms/channel/[pair]/route.ts
@@ -115,23 +115,15 @@ export async function GET(
 
   // Include Telegram messages for this pair.
   //
-  // Voice transcript dedup — this is the fix for "voice messages render as
-  // [Voice message] placeholder" that surfaced across multiple sessions.
-  // Every incoming voice note writes TWO entries to inbound-messages.jsonl
-  // with the same Telegram message_id:
+  // Voice transcript dedup — Telegram voice notes produce two log entries
+  // with the same message_id: a stub (empty text, written immediately on
+  // delivery) and a transcript (full text + media_type, written after
+  // Whisper/Gemini transcription completes). A naive iteration keeps
+  // whichever entry appears first, which is the empty stub.
   //
-  //   1. Stub at T+0     — text: "", no media_type, written the instant
-  //                         Telegram delivers the raw envelope
-  //   2. Content at T+3s — text: "full transcript...", media_type: voice,
-  //                         file_path: ..., written after Whisper/Gemini
-  //                         finishes transcribing
-  //
-  // A naive top-to-bottom iteration dedupes on msgId and keeps whichever
-  // entry hit first — which is the stub. The transcript entry is silently
-  // skipped and the UI has nothing to render. Two-pass fix: first pass
-  // builds a bestByMsgId map where entries with non-empty text always beat
-  // empty stubs with the same id, second pass pushes the winners to the
-  // messages array. Applies to both inbound and outbound logs.
+  // Two-pass approach: first pass builds a bestByMsgId map where entries
+  // with non-empty text always beat empty stubs sharing the same id.
+  // Second pass emits only the winners. Applies to inbound and outbound.
   const logsBase = path.join(ctxRoot, 'logs');
   if (fs.existsSync(logsBase)) {
     interface RawTelegramEntry {

--- a/dashboard/src/app/api/comms/channel/[pair]/route.ts
+++ b/dashboard/src/app/api/comms/channel/[pair]/route.ts
@@ -1,0 +1,217 @@
+import { NextRequest } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { getCTXRoot } from '@/lib/config';
+import { resolveIdentity, buildPairKey } from '@/lib/comms-identity';
+
+export const dynamic = 'force-dynamic';
+
+interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  priority: string;
+  timestamp: string;
+  text: string;
+  reply_to: string | null;
+  /** Optional origin marker — set when the message came from a Telegram voice
+   *  note so the UI can render a microphone indicator next to the transcript. */
+  media_type?: string;
+}
+
+/**
+ * GET /api/comms/channel/[pair] — Messages for a specific agent pair.
+ * pair = "agent1--agent2" (alphabetically sorted).
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ pair: string }> },
+) {
+  const { pair } = await params;
+  const agents = pair.split('--');
+  if (agents.length !== 2 || !agents.every(a => /^[a-z0-9_-]+$/.test(a))) {
+    return Response.json({ error: 'Invalid pair format. Use agent1--agent2' }, { status: 400 });
+  }
+
+  const { searchParams } = request.nextUrl;
+  const limit = Math.min(Math.max(parseInt(searchParams.get('limit') ?? '100', 10) || 100, 1), 500);
+  const before = searchParams.get('before');
+  const search = searchParams.get('search')?.toLowerCase().trim() || '';
+  let searchRegex: RegExp | null = null;
+  if (search) {
+    try {
+      searchRegex = new RegExp(`\\b${search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
+    } catch { searchRegex = null; }
+  }
+  function matchesSearch(text: string): boolean {
+    if (!search) return true;
+    if (searchRegex) return searchRegex.test(text);
+    return text.toLowerCase().includes(search);
+  }
+
+  const ctxRoot = getCTXRoot();
+  const messages: BusMessage[] = [];
+  const [a1, a2] = agents;
+
+  // Resolve user identity so inbound and outbound Telegram messages
+  // land in the same channel as bus messages for the same conversation.
+  const identity = resolveIdentity(ctxRoot);
+
+  // Primary source: persistent message history log (JSONL)
+  const historyLog = path.join(ctxRoot, 'logs', 'message-history.jsonl');
+  if (fs.existsSync(historyLog)) {
+    try {
+      const lines = fs.readFileSync(historyLog, 'utf-8').trim().split('\n');
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg: BusMessage = JSON.parse(line);
+          if (!msg.id || !msg.from || !msg.to || !msg.timestamp) continue;
+          const msgPair = buildPairKey(msg.from, msg.to, identity);
+          if (msgPair !== pair) continue;
+          if (!matchesSearch(msg.text)) continue;
+          if (before && msg.timestamp >= before) continue;
+          messages.push(msg);
+        } catch { /* skip corrupt lines */ }
+      }
+    } catch { /* fall through to inbox scan */ }
+  }
+
+  // Fallback: scan inbox directories for messages not yet in the history log
+  const seen = new Set<string>(messages.map(m => m.id));
+  const inboxBase = path.join(ctxRoot, 'inbox');
+
+  if (fs.existsSync(inboxBase)) {
+    for (const agent of [a1, a2]) {
+      for (const sub of ['processed', 'inflight', '']) {
+        const dir = sub ? path.join(inboxBase, agent, sub) : path.join(inboxBase, agent);
+        if (!fs.existsSync(dir)) continue;
+
+        let files: string[];
+        try {
+          files = fs.readdirSync(dir).filter(f => f.endsWith('.json') && !f.startsWith('.'));
+        } catch { continue; }
+
+        for (const file of files) {
+          try {
+            const raw = fs.readFileSync(path.join(dir, file), 'utf-8');
+            const msg: BusMessage = JSON.parse(raw);
+            if (!msg.id || !msg.from || !msg.to || !msg.timestamp) continue;
+            if (seen.has(msg.id)) continue;
+
+            const msgPair = buildPairKey(msg.from, msg.to, identity);
+            if (msgPair !== pair) continue;
+
+            if (!matchesSearch(msg.text)) continue;
+            if (before && msg.timestamp >= before) continue;
+
+            seen.add(msg.id);
+            messages.push(msg);
+          } catch { /* skip */ }
+        }
+      }
+    }
+  }
+
+  // Include Telegram messages for this pair.
+  //
+  // Voice transcript dedup — this is the fix for "voice messages render as
+  // [Voice message] placeholder" that surfaced across multiple sessions.
+  // Every incoming voice note writes TWO entries to inbound-messages.jsonl
+  // with the same Telegram message_id:
+  //
+  //   1. Stub at T+0     — text: "", no media_type, written the instant
+  //                         Telegram delivers the raw envelope
+  //   2. Content at T+3s — text: "full transcript...", media_type: voice,
+  //                         file_path: ..., written after Whisper/Gemini
+  //                         finishes transcribing
+  //
+  // A naive top-to-bottom iteration dedupes on msgId and keeps whichever
+  // entry hit first — which is the stub. The transcript entry is silently
+  // skipped and the UI has nothing to render. Two-pass fix: first pass
+  // builds a bestByMsgId map where entries with non-empty text always beat
+  // empty stubs with the same id, second pass pushes the winners to the
+  // messages array. Applies to both inbound and outbound logs.
+  const logsBase = path.join(ctxRoot, 'logs');
+  if (fs.existsSync(logsBase)) {
+    interface RawTelegramEntry {
+      id: string;
+      from: string;
+      to: string;
+      priority: string;
+      timestamp: string;
+      text: string;
+      reply_to: null;
+      media_type?: string;
+    }
+    for (const agent of [a1, a2]) {
+      for (const logFile of ['inbound-messages.jsonl', 'outbound-messages.jsonl']) {
+        const filePath = path.join(logsBase, agent, logFile);
+        if (!fs.existsSync(filePath)) continue;
+        const bestByMsgId = new Map<string, RawTelegramEntry>();
+        try {
+          const lines = fs.readFileSync(filePath, 'utf-8').trim().split('\n');
+          const isInbound = logFile.startsWith('inbound');
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const raw = JSON.parse(line);
+              if (!raw.timestamp) continue;
+              const msgId = `tg-${isInbound ? 'in' : 'out'}-${agent}-${raw.message_id || raw.timestamp}`;
+              if (seen.has(msgId)) continue;
+
+              // Resolve both sides through the identity layer so inbound
+              // (user→agent) and outbound (agent→user) land in the same channel.
+              const fromName = isInbound ? identity.canonicalUser : agent;
+              const toName = isInbound ? agent : identity.canonicalUser;
+              const msgPair = buildPairKey(fromName, toName, identity);
+              if (msgPair !== pair) continue;
+
+              // Build the candidate. Text may be empty here — that is fine
+              // for the dedup map, the second-pass write-out only emits
+              // entries that actually have text.
+              const candidate: RawTelegramEntry = {
+                id: msgId,
+                from: fromName,
+                to: toName,
+                priority: 'normal',
+                timestamp: raw.timestamp,
+                text: raw.text || raw.transcript || '',
+                reply_to: null,
+                ...(raw.media_type ? { media_type: raw.media_type } : {}),
+              };
+
+              const existing = bestByMsgId.get(msgId);
+              if (!existing) {
+                bestByMsgId.set(msgId, candidate);
+              } else if (!existing.text && candidate.text) {
+                // Upgrade: this entry has real text, the previous one was
+                // a stub. Prefer this one. Also carry over media_type if
+                // the upgrade brought it along.
+                bestByMsgId.set(msgId, candidate);
+              }
+              // else: both have text, keep the first one (stable order).
+              //       or both are stubs, no change.
+            } catch { /* skip malformed line */ }
+          }
+        } catch { /* skip unreadable file */ }
+
+        // Second pass: write the winners to the messages array, filtering
+        // out any final entry that still has empty text (pure stubs with
+        // no transcript ever arriving). Search filter applied here.
+        for (const msg of bestByMsgId.values()) {
+          if (!msg.text) continue;
+          if (!matchesSearch(msg.text)) continue;
+          if (before && msg.timestamp >= before) continue;
+          seen.add(msg.id);
+          messages.push(msg);
+        }
+      }
+    }
+  }
+
+  // Sort by timestamp ascending (oldest first for chat view)
+  messages.sort((a, b) => a.timestamp.localeCompare(b.timestamp));
+
+  return Response.json(messages.slice(-limit));
+}

--- a/dashboard/src/app/api/comms/channels/route.ts
+++ b/dashboard/src/app/api/comms/channels/route.ts
@@ -75,11 +75,9 @@ export async function GET(request: NextRequest) {
         .map(d => d.name);
     } catch { agentLogDirs = []; }
 
-    // Voice transcript dedup — see channel/[pair]/route.ts for the full
-    // explanation. Two-pass bestByMsgId map so that transcript-bearing
-    // entries beat empty stubs with the same Telegram message_id. Without
-    // this, the channel list last_message previews show "[Voice message]"
-    // or fall through with empty text.
+    // Voice transcript dedup — two-pass bestByMsgId map so transcript
+    // entries beat empty stubs with the same Telegram message_id.
+    // See channel/[pair]/route.ts for the full explanation.
     for (const agent of agentLogDirs) {
       for (const logFile of ['inbound-messages.jsonl', 'outbound-messages.jsonl']) {
         const filePath = path.join(logsBase, agent, logFile);

--- a/dashboard/src/app/api/comms/channels/route.ts
+++ b/dashboard/src/app/api/comms/channels/route.ts
@@ -1,0 +1,167 @@
+import { NextRequest } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { getCTXRoot } from '@/lib/config';
+import { resolveIdentity, buildPairKey } from '@/lib/comms-identity';
+
+export const dynamic = 'force-dynamic';
+
+interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  priority: string;
+  timestamp: string;
+  text: string;
+  reply_to: string | null;
+}
+
+interface Channel {
+  pair: string; // "agent1--agent2" (alphabetically sorted)
+  agents: [string, string];
+  last_message: { text: string; timestamp: string; from: string };
+  message_count: number;
+  last_activity: string;
+  archived: boolean;
+}
+
+const ARCHIVE_THRESHOLD_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+
+/**
+ * GET /api/comms/channels — List active agent-pair channels.
+ *
+ * Groups bus messages by sender-recipient pair.
+ *
+ * Query params:
+ *   include_archived — show archived channels (default false)
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const includeArchived = searchParams.get('include_archived') === 'true';
+
+  const ctxRoot = getCTXRoot();
+  const identity = resolveIdentity(ctxRoot);
+  const inboxBase = path.join(ctxRoot, 'inbox');
+
+  if (!fs.existsSync(inboxBase)) {
+    return Response.json([]);
+  }
+
+  // Primary source: persistent message history log (JSONL)
+  const allMessages: BusMessage[] = [];
+  const historyLog = path.join(ctxRoot, 'logs', 'message-history.jsonl');
+  if (fs.existsSync(historyLog)) {
+    try {
+      const lines = fs.readFileSync(historyLog, 'utf-8').trim().split('\n');
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg: BusMessage = JSON.parse(line);
+          if (msg.id && msg.from && msg.to && msg.timestamp) {
+            allMessages.push(msg);
+          }
+        } catch { /* skip */ }
+      }
+    } catch { /* empty */ }
+  }
+
+  // Include Telegram messages
+  const logsBase = path.join(ctxRoot, 'logs');
+  if (fs.existsSync(logsBase)) {
+    let agentLogDirs: string[];
+    try {
+      agentLogDirs = fs.readdirSync(logsBase, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
+    } catch { agentLogDirs = []; }
+
+    // Voice transcript dedup — see channel/[pair]/route.ts for the full
+    // explanation. Two-pass bestByMsgId map so that transcript-bearing
+    // entries beat empty stubs with the same Telegram message_id. Without
+    // this, the channel list last_message previews show "[Voice message]"
+    // or fall through with empty text.
+    for (const agent of agentLogDirs) {
+      for (const logFile of ['inbound-messages.jsonl', 'outbound-messages.jsonl']) {
+        const filePath = path.join(logsBase, agent, logFile);
+        if (!fs.existsSync(filePath)) continue;
+        const bestByMsgId = new Map<string, BusMessage>();
+        try {
+          const lines = fs.readFileSync(filePath, 'utf-8').trim().split('\n');
+          const isInbound = logFile.startsWith('inbound');
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const raw = JSON.parse(line);
+              if (!raw.timestamp) continue;
+              const msgId = `tg-${isInbound ? 'in' : 'out'}-${agent}-${raw.message_id || raw.timestamp}`;
+              const fromName = isInbound ? identity.canonicalUser : agent;
+              const toName = isInbound ? agent : identity.canonicalUser;
+              const candidate: BusMessage = {
+                id: msgId,
+                from: fromName,
+                to: toName,
+                priority: 'normal',
+                timestamp: raw.timestamp,
+                text: raw.text || raw.transcript || '',
+                reply_to: null,
+              };
+              const existing = bestByMsgId.get(msgId);
+              if (!existing) {
+                bestByMsgId.set(msgId, candidate);
+              } else if (!existing.text && candidate.text) {
+                bestByMsgId.set(msgId, candidate);
+              }
+            } catch { /* skip malformed line */ }
+          }
+        } catch { /* skip unreadable file */ }
+        for (const msg of bestByMsgId.values()) {
+          if (!msg.text) continue;
+          allMessages.push(msg);
+        }
+      }
+    }
+  }
+
+  // Deduplicate
+  const seen = new Set<string>();
+  const unique = allMessages.filter(m => {
+    if (seen.has(m.id)) return false;
+    seen.add(m.id);
+    return true;
+  });
+
+  // Group by agent pair
+  const channelMap = new Map<string, BusMessage[]>();
+  for (const msg of unique) {
+    const pair = buildPairKey(msg.from, msg.to, identity);
+    if (!channelMap.has(pair)) channelMap.set(pair, []);
+    channelMap.get(pair)!.push(msg);
+  }
+
+  const now = Date.now();
+  const channels: Channel[] = [];
+
+  for (const [pair, msgs] of channelMap) {
+    msgs.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+    const latest = msgs[0];
+    const lastActivity = new Date(latest.timestamp).getTime();
+    const archived = (now - lastActivity) > ARCHIVE_THRESHOLD_MS;
+
+    if (!includeArchived && archived) continue;
+
+    const agents = pair.split('--') as [string, string];
+    channels.push({
+      pair,
+      agents,
+      last_message: { text: latest.text, timestamp: latest.timestamp, from: latest.from },
+      message_count: msgs.length,
+      last_activity: latest.timestamp,
+      archived,
+    });
+  }
+
+  // Sort by last activity descending
+  channels.sort((a, b) => b.last_activity.localeCompare(a.last_activity));
+
+  return Response.json(channels);
+}

--- a/dashboard/src/app/api/comms/feed/route.ts
+++ b/dashboard/src/app/api/comms/feed/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import { getCTXRoot, getOrgs, getAgentsForOrg } from '@/lib/config';
+import { getCTXRoot } from '@/lib/config';
 import { resolveIdentity } from '@/lib/comms-identity';
 
 export const dynamic = 'force-dynamic';
@@ -31,7 +31,9 @@ interface BusMessage {
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = request.nextUrl;
-  const orgFilter = searchParams.get('org') || '';
+  // `org` param is accepted but not yet applied — agents for different orgs
+  // are already isolated at the filesystem level under the configured
+  // CTX_ROOT, so the feed naturally scopes to the active org.
   const agentFilter = searchParams.get('agent') || '';
   const defaultLimit = 200;
   const maxLimit = 500;

--- a/dashboard/src/app/api/comms/feed/route.ts
+++ b/dashboard/src/app/api/comms/feed/route.ts
@@ -1,0 +1,186 @@
+import { NextRequest } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { getCTXRoot, getOrgs, getAgentsForOrg } from '@/lib/config';
+import { resolveIdentity } from '@/lib/comms-identity';
+
+export const dynamic = 'force-dynamic';
+
+interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  priority: string;
+  timestamp: string;
+  text: string;
+  reply_to: string | null;
+}
+
+/**
+ * GET /api/comms/feed — Org-wide chronological feed of bus messages.
+ *
+ * Scans all agents' inbox directories (processed, inflight, pending)
+ * for JSON message files. Returns newest first.
+ *
+ * Query params:
+ *   org    — filter by org (required for agent discovery)
+ *   agent  — filter by sender OR recipient
+ *   limit  — max messages (default 100, max 500)
+ *   before — ISO cursor for pagination
+ *   search — text search in message body
+ */
+export async function GET(request: NextRequest) {
+  const { searchParams } = request.nextUrl;
+  const orgFilter = searchParams.get('org') || '';
+  const agentFilter = searchParams.get('agent') || '';
+  const defaultLimit = 200;
+  const maxLimit = 500;
+  const rawLimit = parseInt(searchParams.get('limit') ?? String(defaultLimit), 10) || defaultLimit;
+  const before = searchParams.get('before');
+  const search = searchParams.get('search')?.toLowerCase().trim() || '';
+  // When searching, scan all messages (capped at maxLimit). When not
+  // searching, use the requested limit (default 200) for the recent view.
+  const limit = search ? maxLimit : Math.min(Math.max(rawLimit, 1), maxLimit);
+  // Word-boundary search: build a regex so "help" matches "help" and
+  // "helpful" but not "chelp". Falls back to substring if the search
+  // term contains characters that break regex construction.
+  let searchRegex: RegExp | null = null;
+  if (search) {
+    try {
+      searchRegex = new RegExp(`\\b${search.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}`, 'i');
+    } catch {
+      searchRegex = null; // fall back to includes
+    }
+  }
+  function matchesSearch(text: string): boolean {
+    if (!search) return true;
+    if (searchRegex) return searchRegex.test(text);
+    return text.toLowerCase().includes(search);
+  }
+
+  const ctxRoot = getCTXRoot();
+  const identity = resolveIdentity(ctxRoot);
+  const inboxBase = path.join(ctxRoot, 'inbox');
+
+  if (!fs.existsSync(inboxBase)) {
+    return Response.json([]);
+  }
+
+  const messages: BusMessage[] = [];
+
+  // Primary source: persistent message history log (JSONL)
+  const historyLog = path.join(ctxRoot, 'logs', 'message-history.jsonl');
+  if (fs.existsSync(historyLog)) {
+    try {
+      const lines = fs.readFileSync(historyLog, 'utf-8').trim().split('\n');
+      for (const line of lines) {
+        if (!line.trim()) continue;
+        try {
+          const msg: BusMessage = JSON.parse(line);
+          if (!msg.id || !msg.from || !msg.to || !msg.timestamp) continue;
+          if (agentFilter && msg.from !== agentFilter && msg.to !== agentFilter) continue;
+          if (!matchesSearch(msg.text)) continue;
+          if (before && msg.timestamp >= before) continue;
+          messages.push(msg);
+        } catch { /* skip corrupt lines */ }
+      }
+    } catch { /* fall through to inbox scan */ }
+  }
+
+  // Fallback: scan inbox + processed directories for messages not in the history log.
+  // Processed messages (ACK'd via check-inbox) are moved to ctxRoot/processed/{agent}/
+  // and are invisible without this scan when the history log is empty or absent.
+  const seen = new Set<string>(messages.map(m => m.id));
+  const processedBase = path.join(ctxRoot, 'processed');
+
+  for (const [base, subs] of [[inboxBase, ['inflight', '']], [processedBase, ['']]] as const) {
+    if (!fs.existsSync(base)) continue;
+    let agentDirs: string[];
+    try {
+      agentDirs = fs.readdirSync(base, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
+    } catch {
+      agentDirs = [];
+    }
+
+    for (const agent of agentDirs) {
+      for (const sub of subs) {
+        const dir = sub ? path.join(base, agent, sub) : path.join(base, agent);
+        if (!fs.existsSync(dir)) continue;
+        let files: string[];
+        try {
+          files = fs.readdirSync(dir).filter(f => f.endsWith('.json') && !f.startsWith('.'));
+        } catch { continue; }
+
+        for (const file of files) {
+          try {
+            const raw = fs.readFileSync(path.join(dir, file), 'utf-8');
+            const msg: BusMessage = JSON.parse(raw);
+            if (!msg.id || !msg.from || !msg.to || !msg.timestamp) continue;
+            if (seen.has(msg.id)) continue;
+            if (agentFilter && msg.from !== agentFilter && msg.to !== agentFilter) continue;
+            if (!matchesSearch(msg.text)) continue;
+            if (before && msg.timestamp >= before) continue;
+            seen.add(msg.id);
+            messages.push(msg);
+          } catch { /* skip */ }
+        }
+      }
+    }
+  }
+
+  // Include Telegram messages (inbound from user + outbound from agents)
+  const logsBase = path.join(ctxRoot, 'logs');
+  if (fs.existsSync(logsBase)) {
+    let agentLogDirs: string[];
+    try {
+      agentLogDirs = fs.readdirSync(logsBase, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
+    } catch { agentLogDirs = []; }
+
+    for (const agent of agentLogDirs) {
+      for (const logFile of ['inbound-messages.jsonl', 'outbound-messages.jsonl']) {
+        const filePath = path.join(logsBase, agent, logFile);
+        if (!fs.existsSync(filePath)) continue;
+        try {
+          const lines = fs.readFileSync(filePath, 'utf-8').trim().split('\n');
+          const isInbound = logFile.startsWith('inbound');
+          for (const line of lines) {
+            if (!line.trim()) continue;
+            try {
+              const raw = JSON.parse(line);
+              const msgId = `tg-${isInbound ? 'in' : 'out'}-${agent}-${raw.message_id || raw.timestamp}`;
+              if (seen.has(msgId)) continue;
+              if (!raw.text || !raw.timestamp) continue;
+
+              const fromName = isInbound ? identity.canonicalUser : agent;
+              const toName = isInbound ? agent : identity.canonicalUser;
+
+              if (agentFilter && fromName !== agentFilter && toName !== agentFilter) continue;
+              if (!matchesSearch(raw.text)) continue;
+              if (before && raw.timestamp >= before) continue;
+
+              seen.add(msgId);
+              messages.push({
+                id: msgId,
+                from: fromName,
+                to: toName,
+                priority: 'normal',
+                timestamp: raw.timestamp,
+                text: raw.text,
+                reply_to: null,
+              });
+            } catch { /* skip */ }
+          }
+        } catch { /* skip */ }
+      }
+    }
+  }
+
+  // Sort by timestamp descending (newest first)
+  messages.sort((a, b) => b.timestamp.localeCompare(a.timestamp));
+
+  return Response.json(messages.slice(0, limit));
+}

--- a/dashboard/src/app/api/comms/upload/route.ts
+++ b/dashboard/src/app/api/comms/upload/route.ts
@@ -6,13 +6,27 @@ import { getCTXRoot } from '@/lib/config';
 export const dynamic = 'force-dynamic';
 
 const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+
+// Whitelist by MIME type AND by extension. SVG is intentionally excluded:
+// SVGs can carry inline <script> and embedded event handlers, which turns
+// any "view the image" link into an XSS vector when served from the same
+// origin as the dashboard.
 const ALLOWED_TYPES = new Set([
   'image/jpeg',
   'image/png',
   'image/gif',
   'image/webp',
-  'image/svg+xml',
 ]);
+
+// Canonical extension per MIME type. The server IGNORES the user-supplied
+// filename's extension and chooses the extension from the validated MIME
+// type, so an attacker cannot upload `evil.html` with `image/png` content-type.
+const EXT_FOR_TYPE: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+};
 
 /**
  * POST /api/comms/upload — Upload an image for the chat interface.
@@ -39,7 +53,7 @@ export async function POST(request: NextRequest) {
 
   if (!ALLOWED_TYPES.has(file.type)) {
     return Response.json(
-      { error: `Unsupported file type: ${file.type}. Allowed: JPEG, PNG, GIF, WebP, SVG` },
+      { error: `Unsupported file type: ${file.type}. Allowed: JPEG, PNG, GIF, WebP` },
       { status: 400 },
     );
   }
@@ -56,17 +70,35 @@ export async function POST(request: NextRequest) {
       fs.mkdirSync(uploadDir, { recursive: true });
     }
 
-    // Sanitize filename: keep extension, replace unsafe chars. Clipboard paste
-    // delivers an anonymous File with name "image.png" most of the time, so
-    // the timestamp prefix is what makes entries unique.
-    const ext = path.extname(file.name || 'upload.png').toLowerCase();
-    const baseName = path
-      .basename(file.name || 'upload', ext)
+    // Sanitize filename. We keep only the basename of the client-supplied
+    // name, strip any extension/path separators, and then append a
+    // server-chosen extension derived from the validated MIME type.
+    // This prevents attackers from smuggling `evil.html.png` or
+    // `../../etc/passwd` through the upload endpoint.
+    const rawName = file.name || 'upload';
+    const rawBase = path.basename(rawName);
+    const baseNoExt = rawBase.replace(/\.[^.]*$/, '');
+    const baseName = baseNoExt
       .replace(/[^a-zA-Z0-9_-]/g, '_')
-      .slice(0, 50);
+      .slice(0, 50) || 'upload';
+    const ext = EXT_FOR_TYPE[file.type];
+    if (!ext) {
+      // Defense-in-depth: ALLOWED_TYPES already gated this, but if someone
+      // widens the set without updating EXT_FOR_TYPE we refuse rather than
+      // fall through to an empty extension.
+      return Response.json({ error: 'Unsupported file type' }, { status: 400 });
+    }
     const timestamp = Date.now();
     const filename = `${timestamp}-${baseName}${ext}`;
     const filePath = path.join(uploadDir, filename);
+
+    // Defense-in-depth: ensure the resolved path is still inside uploadDir.
+    // The sanitizer above should already guarantee this, but we verify.
+    const resolvedUploadDir = path.resolve(uploadDir);
+    const resolvedFilePath = path.resolve(filePath);
+    if (!resolvedFilePath.startsWith(resolvedUploadDir + path.sep)) {
+      return Response.json({ error: 'Invalid filename' }, { status: 400 });
+    }
 
     const buffer = Buffer.from(await file.arrayBuffer());
     const tmpPath = filePath + '.tmp';

--- a/dashboard/src/app/api/comms/upload/route.ts
+++ b/dashboard/src/app/api/comms/upload/route.ts
@@ -1,0 +1,91 @@
+import { NextRequest } from 'next/server';
+import fs from 'fs';
+import path from 'path';
+import { getCTXRoot } from '@/lib/config';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_SIZE = 10 * 1024 * 1024; // 10 MB
+const ALLOWED_TYPES = new Set([
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'image/svg+xml',
+]);
+
+/**
+ * POST /api/comms/upload — Upload an image for the chat interface.
+ *
+ * Accepts multipart/form-data with a single "file" field.
+ * Saves to {CTX_ROOT}/media/dashboard-uploads/{timestamp}-{sanitized-name}
+ * Returns { path: "media/dashboard-uploads/...", url: "/api/media/media/dashboard-uploads/..." }
+ *
+ * Used by the chat bar image attach button AND the clipboard paste handler —
+ * both feed into the same endpoint so the media layout is consistent.
+ */
+export async function POST(request: NextRequest) {
+  let formData: FormData;
+  try {
+    formData = await request.formData();
+  } catch {
+    return Response.json({ error: 'Invalid form data' }, { status: 400 });
+  }
+
+  const file = formData.get('file');
+  if (!file || !(file instanceof File)) {
+    return Response.json({ error: 'No file provided' }, { status: 400 });
+  }
+
+  if (!ALLOWED_TYPES.has(file.type)) {
+    return Response.json(
+      { error: `Unsupported file type: ${file.type}. Allowed: JPEG, PNG, GIF, WebP, SVG` },
+      { status: 400 },
+    );
+  }
+
+  if (file.size > MAX_SIZE) {
+    return Response.json({ error: 'File too large (max 10 MB)' }, { status: 400 });
+  }
+
+  const ctxRoot = getCTXRoot();
+  const uploadDir = path.join(ctxRoot, 'media', 'dashboard-uploads');
+
+  try {
+    if (!fs.existsSync(uploadDir)) {
+      fs.mkdirSync(uploadDir, { recursive: true });
+    }
+
+    // Sanitize filename: keep extension, replace unsafe chars. Clipboard paste
+    // delivers an anonymous File with name "image.png" most of the time, so
+    // the timestamp prefix is what makes entries unique.
+    const ext = path.extname(file.name || 'upload.png').toLowerCase();
+    const baseName = path
+      .basename(file.name || 'upload', ext)
+      .replace(/[^a-zA-Z0-9_-]/g, '_')
+      .slice(0, 50);
+    const timestamp = Date.now();
+    const filename = `${timestamp}-${baseName}${ext}`;
+    const filePath = path.join(uploadDir, filename);
+
+    const buffer = Buffer.from(await file.arrayBuffer());
+    const tmpPath = filePath + '.tmp';
+    fs.writeFileSync(tmpPath, buffer);
+    fs.renameSync(tmpPath, filePath);
+
+    const relativePath = `media/dashboard-uploads/${filename}`;
+    const mediaUrl = `/api/media/${relativePath}`;
+
+    return Response.json({
+      success: true,
+      path: relativePath,
+      url: mediaUrl,
+      filename,
+      size: file.size,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[api/comms/upload] Error:', message);
+    return Response.json({ error: 'Upload failed' }, { status: 500 });
+  }
+}

--- a/dashboard/src/app/api/messages/send/route.ts
+++ b/dashboard/src/app/api/messages/send/route.ts
@@ -48,10 +48,11 @@ export async function POST(request: NextRequest) {
 
   const ctxRoot = getCTXRoot();
 
-  // Generate unique message ID and filename (same format as bus/send-message.sh)
+  // Sender identity: use the dashboard admin username so chat bar messages
+  // land in the same channel as Telegram messages for the same user.
   const epochMs = Date.now();
   const rand = Math.random().toString(36).slice(2, 7);
-  const from = 'mobile-user';
+  const from = (process.env.ADMIN_USERNAME ?? 'user').toLowerCase();
   const messageId = `${epochMs}-${from}-${rand}`;
 
   // Priority 2 = normal (matches bus/send-message.sh mapping)
@@ -108,7 +109,8 @@ export async function POST(request: NextRequest) {
       direction: 'inbound',
       type: type || 'text',
       text,
-      source: 'mobile',
+      from_name: from,
+      source: 'dashboard',
     });
     fs.appendFileSync(logFile, logEntry + '\n');
 

--- a/dashboard/src/app/api/messages/upload/route.ts
+++ b/dashboard/src/app/api/messages/upload/route.ts
@@ -73,7 +73,7 @@ export async function POST(request: NextRequest) {
   // Write to agent inbox as a media message
   const epochMs = Date.now();
   const rand = Math.random().toString(36).slice(2, 7);
-  const from = 'mobile-user';
+  const from = (process.env.ADMIN_USERNAME ?? 'user').toLowerCase();
   const messageId = `${epochMs}-${from}-${rand}`;
   const inboxFilename = `2-${epochMs}-from-${from}-${rand}.json`;
 

--- a/dashboard/src/components/comms/channel-list.tsx
+++ b/dashboard/src/components/comms/channel-list.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { TimeAgo } from '@/components/shared';
+
+interface Channel {
+  pair: string;
+  agents: [string, string];
+  last_message: { text: string; timestamp: string; from: string };
+  message_count: number;
+  last_activity: string;
+  archived: boolean;
+}
+
+interface ChannelListProps {
+  channels: Channel[];
+  selectedPair: string | null;
+  onChannelClick: (pair: string) => void;
+}
+
+export function ChannelList({ channels, selectedPair, onChannelClick }: ChannelListProps) {
+  if (channels.length === 0) {
+    return (
+      <p className="py-8 text-center text-xs text-muted-foreground">
+        No channels yet
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-1">
+      {channels.map((ch) => (
+        <Card
+          key={ch.pair}
+          className={`interactive-card p-3 ${
+            selectedPair === ch.pair ? 'bg-primary/5 border-primary/30' : ''
+          } ${ch.archived ? 'opacity-60' : ''}`}
+          onClick={() => onChannelClick(ch.pair)}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <div className="min-w-0 flex-1">
+              <p className="text-sm font-medium text-foreground">
+                {ch.agents[0]} ↔ {ch.agents[1]}
+              </p>
+              <p className="text-xs text-muted-foreground truncate mt-0.5">
+                {ch.last_message.from}: {ch.last_message.text}
+              </p>
+            </div>
+            <div className="flex flex-col items-end gap-1 shrink-0">
+              <TimeAgo date={ch.last_activity} className="text-[10px]" />
+              <Badge variant="outline" className="text-[9px]">
+                {ch.message_count}
+              </Badge>
+              {ch.archived && (
+                <Badge variant="secondary" className="text-[9px]">
+                  archived
+                </Badge>
+              )}
+            </div>
+          </div>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/src/components/comms/channel-view.tsx
+++ b/dashboard/src/components/comms/channel-view.tsx
@@ -247,11 +247,9 @@ export function ChannelView({ pair, knownAgents, sortOrder = 'asc' }: ChannelVie
     if (fileInputRef.current) fileInputRef.current.value = '';
   }
 
-  // Ask 4 — clipboard paste. When the user pastes into the textarea, scan
-  // the clipboard items for image types and attach the first one found. Text
-  // paste still works as normal (the paste event is not prevented unless an
-  // image is found). Lets the user take a screenshot and Ctrl+V directly into
-  // the message instead of using the file picker.
+  // Clipboard paste: scan for image types and attach the first one found.
+  // Text paste still works normally (the paste event is not prevented unless
+  // an image is found).
   function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
     const items = e.clipboardData?.items;
     if (!items) return;

--- a/dashboard/src/components/comms/channel-view.tsx
+++ b/dashboard/src/components/comms/channel-view.tsx
@@ -7,7 +7,15 @@ import { IconSend, IconPhoto, IconX, IconMicrophone } from '@tabler/icons-react'
 
 // Polling cadence for the visible-tab live feed. Paused when the tab is
 // backgrounded so inactive dashboards do not accumulate network traffic.
-const POLL_MS = 2000;
+//
+// Configurable via NEXT_PUBLIC_COMMS_POLL_MS (read at build time by Next.js).
+// Default: 10000ms (10s). Enforced minimum: 2000ms so an accidental misconfig
+// cannot hammer the filesystem-backed API routes.
+const POLL_MS = (() => {
+  const raw = parseInt(process.env.NEXT_PUBLIC_COMMS_POLL_MS ?? '', 10);
+  if (!Number.isFinite(raw) || raw <= 0) return 10000;
+  return Math.max(raw, 2000);
+})();
 
 interface BusMessage {
   id: string;
@@ -138,8 +146,8 @@ export function ChannelView({ pair, knownAgents, sortOrder = 'asc' }: ChannelVie
     forceScrollRef.current = true;
   }, [sortOrder]);
 
-  // Live 2s polling — paused when the tab is backgrounded so inactive
-  // dashboards do not accumulate network traffic.
+  // Live polling (cadence from POLL_MS) — paused when the tab is backgrounded
+  // so inactive dashboards do not accumulate network traffic.
   useEffect(() => {
     let interval: ReturnType<typeof setInterval> | null = null;
 

--- a/dashboard/src/components/comms/channel-view.tsx
+++ b/dashboard/src/components/comms/channel-view.tsx
@@ -1,0 +1,443 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { IconSend, IconPhoto, IconX, IconMicrophone } from '@tabler/icons-react';
+
+// Polling cadence for the visible-tab live feed. Paused when the tab is
+// backgrounded so inactive dashboards do not accumulate network traffic.
+const POLL_MS = 2000;
+
+interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  priority: string;
+  timestamp: string;
+  text: string;
+  reply_to: string | null;
+  /** Optional: set by the channel API when the message origin is a voice note. */
+  media_type?: string;
+}
+
+interface ChannelViewProps {
+  pair: string;
+  /** Set of known agent names in the fleet — used to determine whether the
+   *  channel is a user-to-agent channel (which gets the chat bar) or an
+   *  agent-to-agent channel (which does not). */
+  knownAgents?: Set<string>;
+  /** Sort order for messages. 'asc' = oldest first, newest at bottom
+   *  (default). 'desc' = newest first, oldest at bottom. */
+  sortOrder?: 'asc' | 'desc';
+}
+
+function formatTime(iso: string): string {
+  try {
+    return new Date(iso).toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+  } catch { return iso; }
+}
+
+// Inline image rendering: if the message text contains a /api/media/ URL
+// matching an image extension, render it as an inline <img> instead of
+// leaving it as a raw link. Enables the paste-image flow where the sender
+// attached a pasted screenshot and the URL was appended to the message body.
+const IMAGE_URL_PATTERN = /\/api\/media\/[^\s]+\.(?:png|jpg|jpeg|gif|webp)/gi;
+
+function MessageContent({ text }: { text: string }) {
+  const parts: React.ReactNode[] = [];
+  let lastIndex = 0;
+  for (const match of text.matchAll(IMAGE_URL_PATTERN)) {
+    const idx = match.index ?? 0;
+    if (idx > lastIndex) {
+      const before = text.slice(lastIndex, idx).trim();
+      if (before) parts.push(<p key={`t-${lastIndex}`} className="whitespace-pre-wrap break-words">{before}</p>);
+    }
+    parts.push(
+      <a key={`i-${idx}`} href={match[0]} target="_blank" rel="noopener noreferrer">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={match[0]}
+          alt="Shared image"
+          className="mt-1 mb-1 max-h-64 max-w-full rounded-md"
+          loading="lazy"
+        />
+      </a>
+    );
+    lastIndex = idx + match[0].length;
+  }
+
+  if (lastIndex < text.length) {
+    const after = text.slice(lastIndex).trim();
+    if (after) parts.push(<p key={`t-${lastIndex}`} className="whitespace-pre-wrap break-words">{after}</p>);
+  }
+
+  if (parts.length === 0) {
+    return <p className="whitespace-pre-wrap break-words">{text}</p>;
+  }
+
+  return <>{parts}</>;
+}
+
+export function ChannelView({ pair, knownAgents, sortOrder = 'asc' }: ChannelViewProps) {
+  const [messages, setMessages] = useState<BusMessage[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [draft, setDraft] = useState('');
+  const [sendError, setSendError] = useState('');
+  const [attachment, setAttachment] = useState<File | null>(null);
+  const [attachPreview, setAttachPreview] = useState<string | null>(null);
+  const agents = pair.split('--');
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const sendingRef = useRef(false);
+  const [sending, setSending] = useState(false);
+
+
+  // Track whether the next scroll should force-anchor to the bottom. Set
+  // true on channel switch or after the user sends a message, so those
+  // actions always land the viewport at the newest content.
+  const forceScrollRef = useRef(true);
+  // Track whether the user is "pinned" to the bottom of the scroll
+  // container. Updated on every scroll event so the value reflects the
+  // state BEFORE new messages are rendered. The poll-update scroll path
+  // reads this instead of measuring post-render distance, which would
+  // be wrong because new messages increase scrollHeight before the
+  // check runs.
+  const pinnedRef = useRef(true);
+
+  // Detect if this is a user-to-agent channel. Only user-to-agent channels
+  // get the chat bar — agent-to-agent channels are observational only.
+  const isUserChannel = knownAgents
+    ? knownAgents.size > 0 && agents.some(a => !knownAgents.has(a))
+    : false;
+  const targetAgent = knownAgents
+    ? agents.find(a => knownAgents.has(a)) || agents[1]
+    : agents[1];
+
+  const fetchMessages = useCallback(async () => {
+    try {
+      const r = await fetch(`/api/comms/channel/${pair}?limit=200`);
+      const data: BusMessage[] = r.ok ? await r.json() : [];
+      setMessages(data);
+      setLoading(false);
+    } catch {
+      setLoading(false);
+    }
+  }, [pair]);
+
+  // Channel switch — reset state and fetch fresh.
+  useEffect(() => {
+    setLoading(true);
+    setMessages([]);
+    forceScrollRef.current = true;
+    fetchMessages();
+  }, [pair, fetchMessages]);
+
+  // Sort order change — re-anchor without refetching.
+  useEffect(() => {
+    forceScrollRef.current = true;
+  }, [sortOrder]);
+
+  // Live 2s polling — paused when the tab is backgrounded so inactive
+  // dashboards do not accumulate network traffic.
+  useEffect(() => {
+    let interval: ReturnType<typeof setInterval> | null = null;
+
+    function start() {
+      if (interval !== null) return;
+      interval = setInterval(fetchMessages, POLL_MS);
+    }
+    function stop() {
+      if (interval === null) return;
+      clearInterval(interval);
+      interval = null;
+    }
+
+    if (typeof document !== 'undefined' && document.visibilityState === 'visible') {
+      start();
+    }
+
+    function onVisChange() {
+      if (document.visibilityState === 'visible') {
+        fetchMessages();
+        start();
+      } else {
+        stop();
+      }
+    }
+
+    document.addEventListener('visibilitychange', onVisChange);
+    return () => {
+      stop();
+      document.removeEventListener('visibilitychange', onVisChange);
+    };
+  }, [pair, fetchMessages]);
+
+  // Track pin state from WHEEL events only — not scroll events. When
+  // React re-renders the message list, the DOM nodes get replaced and
+  // the scroll position can shift by hundreds of pixels. This triggers
+  // scroll events that look like "user scrolled up" but are actually
+  // just React layout shifts. Wheel events only fire on real mouse
+  // wheel input, so they reliably distinguish user scrolling from
+  // programmatic/layout-induced position changes.
+  useEffect(() => {
+    const container = scrollRef.current;
+    if (!container) return;
+
+    function onWheel() {
+      // Check pin state shortly after the wheel event settles.
+      setTimeout(() => {
+        if (!container) return;
+        if (sortOrder === 'asc') {
+          const dist = container.scrollHeight - container.scrollTop - container.clientHeight;
+          pinnedRef.current = dist < 50;
+        } else {
+          pinnedRef.current = container.scrollTop < 50;
+        }
+      }, 150);
+    }
+
+    container.addEventListener('wheel', onWheel, { passive: true });
+    return () => container.removeEventListener('wheel', onWheel);
+  }, [sortOrder, loading]);
+
+  // Auto-scroll: simple interval that pins the viewport to the bottom.
+  // Every 400ms, if the user is pinned (or force-scroll is requested),
+  // scroll to the bottom. Reads scrollRef.current inside the callback
+  // (not at effect creation time) so it picks up the real container
+  // after the loading state resolves and the DOM mounts.
+  useEffect(() => {
+    const iv = setInterval(() => {
+      const container = scrollRef.current;
+      if (!container) return;
+
+      if (forceScrollRef.current || pinnedRef.current) {
+        if (sortOrder === 'asc') {
+          container.scrollTop = container.scrollHeight;
+        } else {
+          container.scrollTop = 0;
+        }
+        if (forceScrollRef.current) {
+          forceScrollRef.current = false;
+          pinnedRef.current = true;
+        }
+      }
+    }, 400);
+
+    return () => clearInterval(iv);
+  }, [sortOrder]);
+
+  function handleFileSelect(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    applyAttachment(file);
+  }
+
+  function applyAttachment(file: File) {
+    setAttachment(file);
+    const url = URL.createObjectURL(file);
+    setAttachPreview(url);
+    setSendError('');
+  }
+
+  function clearAttachment() {
+    setAttachment(null);
+    if (attachPreview) URL.revokeObjectURL(attachPreview);
+    setAttachPreview(null);
+    if (fileInputRef.current) fileInputRef.current.value = '';
+  }
+
+  // Ask 4 — clipboard paste. When the user pastes into the textarea, scan
+  // the clipboard items for image types and attach the first one found. Text
+  // paste still works as normal (the paste event is not prevented unless an
+  // image is found). Lets the user take a screenshot and Ctrl+V directly into
+  // the message instead of using the file picker.
+  function handlePaste(e: React.ClipboardEvent<HTMLTextAreaElement>) {
+    const items = e.clipboardData?.items;
+    if (!items) return;
+    for (const item of Array.from(items)) {
+      if (item.kind === 'file' && item.type.startsWith('image/')) {
+        const file = item.getAsFile();
+        if (file) {
+          e.preventDefault();
+          applyAttachment(file);
+          return;
+        }
+      }
+    }
+  }
+
+  async function handleSend() {
+    // Ref-based in-flight lock — see comment on sendingRef above.
+    if (sendingRef.current) return;
+    if (!draft.trim() && !attachment) return;
+    sendingRef.current = true;
+    setSending(true);
+    setSendError('');
+    try {
+      let messageText = draft.trim();
+
+      if (attachment) {
+        const formData = new FormData();
+        formData.append('file', attachment);
+        const uploadRes = await fetch('/api/comms/upload', { method: 'POST', body: formData });
+        if (!uploadRes.ok) {
+          const data = await uploadRes.json().catch(() => ({}));
+          setSendError(data.error || 'Upload failed');
+          return;
+        }
+        const { url } = await uploadRes.json();
+        messageText = messageText ? `${messageText}\n${url}` : url;
+      }
+
+      const res = await fetch('/api/messages/send', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ agent: targetAgent, text: messageText }),
+      });
+      if (res.ok) {
+        setDraft('');
+        clearAttachment();
+        // Force-scroll after sending so the user's own message is
+        // immediately visible at the bottom.
+        forceScrollRef.current = true;
+        setTimeout(fetchMessages, 300);
+      } else {
+        const data = await res.json().catch(() => ({}));
+        setSendError(data.error || 'Failed to send');
+      }
+    } catch {
+      setSendError('Network error');
+    } finally {
+      sendingRef.current = false;
+      setSending(false);
+    }
+  }
+
+  // Sort messages for rendering. The `messages` array is always stored
+  // in ascending order (oldest first). Reverse for desc display.
+  const sortedMessages = sortOrder === 'desc' ? [...messages].reverse() : messages;
+
+  if (loading) {
+    return <div className="py-8 text-center text-sm text-muted-foreground">Loading...</div>;
+  }
+
+  return (
+    // Full-height chat. The parent (comms page grid) constrains the
+    // available height. This component fills it with a flex column:
+    // messages scroll, chat bar sticks to the bottom.
+    <div className="flex h-full min-h-0 flex-col">
+      {/* Messages area */}
+      <div ref={scrollRef} className="flex-1 min-h-0 space-y-3 overflow-y-auto px-3 py-3">
+        {sortedMessages.length === 0 ? (
+          <div className="py-8 text-center text-sm text-muted-foreground">No messages in this channel.</div>
+        ) : (
+          sortedMessages.map((msg) => {
+            const isFirst = msg.from === agents[0];
+            const isVoice = msg.media_type === 'voice';
+            return (
+              <div
+                key={msg.id}
+                className={`flex ${isFirst ? 'justify-start' : 'justify-end'}`}
+              >
+                <div
+                  className={`max-w-[75%] rounded-xl border px-3 py-2 text-sm shadow-sm ${
+                    isFirst
+                      ? 'rounded-bl-sm bg-muted/60 border-border/50'
+                      : 'rounded-br-sm bg-primary/10 border-primary/20'
+                  }`}
+                >
+                  <div className="mb-0.5 flex items-center gap-1.5">
+                    <span className="text-xs font-medium text-foreground">{msg.from}</span>
+                    {isVoice && (
+                      <IconMicrophone size={11} className="text-muted-foreground" aria-label="voice message" />
+                    )}
+                    {msg.priority === 'urgent' && (
+                      <Badge variant="destructive" className="h-3 px-1 text-[8px]">!</Badge>
+                    )}
+                  </div>
+                  <MessageContent text={msg.text} />
+                  <p className="mt-1 text-right text-[10px] text-muted-foreground">
+                    {formatTime(msg.timestamp)}
+                  </p>
+                </div>
+              </div>
+            );
+          })
+        )}
+      </div>
+
+      {/* Chat input — rendered only for user-to-agent channels. Agent-to-agent
+          channels are read-only so no chat bar, matching the conversation
+          semantics (users can message agents, agents message via the bus). */}
+      {isUserChannel && (
+        <div className="border-t bg-background p-2">
+          {sendError && (
+            <p className="mb-1 px-1 text-xs text-destructive">{sendError}</p>
+          )}
+          {attachPreview && (
+            <div className="relative mb-2 inline-block">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={attachPreview} alt="Attachment preview" className="max-h-24 rounded-md border" />
+              <button
+                onClick={clearAttachment}
+                className="absolute -right-1.5 -top-1.5 rounded-full bg-destructive p-0.5 text-destructive-foreground shadow-sm hover:bg-destructive/90"
+                aria-label="Remove attachment"
+              >
+                <IconX size={12} />
+              </button>
+            </div>
+          )}
+          <div className="flex gap-2">
+            <input
+              ref={fileInputRef}
+              type="file"
+              accept="image/jpeg,image/png,image/gif,image/webp"
+              className="hidden"
+              onChange={handleFileSelect}
+            />
+            <Button
+              variant="ghost"
+              size="sm"
+              className="shrink-0 self-end"
+              onClick={() => fileInputRef.current?.click()}
+              title="Attach image"
+              aria-label="Attach image"
+            >
+              <IconPhoto size={16} />
+            </Button>
+            <textarea
+              value={draft}
+              onChange={(e) => { setDraft(e.target.value); setSendError(''); }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  handleSend();
+                }
+              }}
+              onPaste={handlePaste}
+              placeholder={`Message ${targetAgent}...`}
+              rows={1}
+              className="min-h-[36px] max-h-[120px] flex-1 resize-none rounded-md border bg-background px-3 py-2 text-sm focus:border-primary focus:outline-none focus:ring-1 focus:ring-ring/30"
+              onInput={(e) => {
+                // Auto-grow the textarea as the user types, capped at 120px.
+                const el = e.target as HTMLTextAreaElement;
+                el.style.height = 'auto';
+                el.style.height = Math.min(el.scrollHeight, 120) + 'px';
+              }}
+            />
+            <Button
+              size="sm"
+              onClick={handleSend}
+              disabled={(!draft.trim() && !attachment) || sending}
+              className="shrink-0 self-end"
+              aria-label="Send message"
+            >
+              <IconSend size={14} className={sending ? 'animate-pulse' : ''} />
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/comms/message-feed.tsx
+++ b/dashboard/src/components/comms/message-feed.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import { Badge } from '@/components/ui/badge';
+import { Card } from '@/components/ui/card';
+import { TimeAgo } from '@/components/shared';
+import { IconArrowRight } from '@tabler/icons-react';
+
+interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  priority: string;
+  timestamp: string;
+  text: string;
+  reply_to: string | null;
+}
+
+interface MessageFeedProps {
+  messages: BusMessage[];
+  onAgentClick?: (agent: string) => void;
+  onMessageClick?: (pair: string) => void;
+}
+
+export function MessageFeed({ messages, onAgentClick, onMessageClick }: MessageFeedProps) {
+  if (messages.length === 0) {
+    return (
+      <p className="py-12 text-center text-sm text-muted-foreground">
+        No messages yet. Agent communication will appear here.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      {messages.map((msg) => (
+        <Card
+          key={msg.id}
+          className="cursor-pointer p-4 transition-colors hover:bg-muted/50"
+          onClick={() => {
+            const pair = [msg.from.toLowerCase(), msg.to.toLowerCase()].sort().join('--');
+            onMessageClick?.(pair);
+          }}
+        >
+          <div className="flex items-center gap-2 mb-1.5">
+            <span className="text-sm font-semibold text-foreground">{msg.from}</span>
+            <IconArrowRight size={12} className="text-muted-foreground/40" />
+            <span className="text-sm font-semibold text-foreground">{msg.to}</span>
+            {msg.priority === 'urgent' && (
+              <Badge className="text-[9px] h-4 px-1.5 font-semibold border-0" style={{ backgroundColor: 'rgba(142,20,41,0.12)', color: '#8E1429' }}>
+                urgent
+              </Badge>
+            )}
+            <TimeAgo date={msg.timestamp} className="ml-auto text-[11px] text-muted-foreground tabular-nums shrink-0" />
+          </div>
+          <p className="text-sm text-muted-foreground whitespace-pre-wrap break-words line-clamp-3">{msg.text}</p>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/src/components/comms/search-results.tsx
+++ b/dashboard/src/components/comms/search-results.tsx
@@ -1,0 +1,123 @@
+'use client';
+
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { TimeAgo } from '@/components/shared';
+import { IconArrowRight } from '@tabler/icons-react';
+
+interface BusMessage {
+  id: string;
+  from: string;
+  to: string;
+  priority: string;
+  timestamp: string;
+  text: string;
+  reply_to: string | null;
+}
+
+interface SearchResultsProps {
+  messages: BusMessage[];
+  query: string;
+  onResultClick?: (pair: string, messageId: string) => void;
+}
+
+/** Highlight occurrences of `query` in `text` using word-boundary matching. */
+function HighlightedText({ text, query }: { text: string; query: string }) {
+  if (!query.trim()) {
+    return <span>{text}</span>;
+  }
+
+  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  let regex: RegExp;
+  try {
+    regex = new RegExp(`(\\b${escaped})`, 'gi');
+  } catch {
+    return <span>{text}</span>;
+  }
+
+  const parts = text.split(regex);
+
+  return (
+    <span>
+      {parts.map((part, i) =>
+        regex.test(part) ? (
+          <mark key={i} className="rounded-sm bg-primary/20 px-0.5">
+            {part}
+          </mark>
+        ) : (
+          <span key={i}>{part}</span>
+        ),
+      )}
+    </span>
+  );
+}
+
+/** Score a message for relevance to the query.
+ *  2 = exact whole-word match, 1 = word-start match, 0 = substring only. */
+function relevanceScore(text: string, query: string): number {
+  const lower = text.toLowerCase();
+  const q = query.toLowerCase();
+  const escaped = q.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  try {
+    if (new RegExp(`\\b${escaped}\\b`, 'i').test(lower)) return 2;
+    if (new RegExp(`\\b${escaped}`, 'i').test(lower)) return 1;
+  } catch { /* fall through */ }
+  return 0;
+}
+
+export function SearchResults({ messages, query, onResultClick }: SearchResultsProps) {
+  if (messages.length === 0) {
+    return (
+      <div className="py-12 text-center">
+        <p className="text-sm text-muted-foreground">
+          No messages matching &quot;{query}&quot;
+        </p>
+      </div>
+    );
+  }
+
+  // Sort by relevance: exact whole-word matches first, then word-start
+  // matches, then everything else. Within each tier, preserve the
+  // chronological order from the API (newest first).
+  const sorted = [...messages].sort((a, b) => {
+    const scoreA = relevanceScore(a.text, query);
+    const scoreB = relevanceScore(b.text, query);
+    return scoreB - scoreA;
+  });
+
+  return (
+    <div className="space-y-1.5">
+      <p className="text-xs text-muted-foreground px-1">
+        {sorted.length} result{sorted.length !== 1 ? 's' : ''}
+      </p>
+      {sorted.map((msg) => {
+        const pair = [msg.from.toLowerCase(), msg.to.toLowerCase()].sort().join('--');
+        return (
+          <Card
+            key={msg.id}
+            className="cursor-pointer px-3 py-2.5 transition-colors hover:bg-muted/50"
+            onClick={() => onResultClick?.(pair, msg.id)}
+          >
+            <div className="flex items-center gap-2 mb-1">
+              <span className="text-xs font-semibold text-foreground">{msg.from}</span>
+              <IconArrowRight size={10} className="text-muted-foreground/40" />
+              <span className="text-xs font-semibold text-foreground">{msg.to}</span>
+              {msg.priority === 'urgent' && (
+                <Badge variant="destructive" className="h-3 px-1 text-[8px]">!</Badge>
+              )}
+              <span className="ml-auto text-[10px] text-muted-foreground tabular-nums shrink-0">
+                <TimeAgo date={msg.timestamp} />
+              </span>
+            </div>
+            <p className="text-sm text-muted-foreground whitespace-pre-wrap break-words">
+              <HighlightedText text={msg.text} query={query} />
+            </p>
+            <p className="mt-1 text-[10px] text-muted-foreground/60">
+              {pair.replace('--', ' \u2194 ')}
+            </p>
+          </Card>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/bottom-nav.tsx
+++ b/dashboard/src/components/layout/bottom-nav.tsx
@@ -12,6 +12,7 @@ import {
   IconDotsVertical,
   IconRobot,
   IconActivity,
+  IconMessages,
   IconBook2,
   IconFlask,
   IconPuzzle,
@@ -31,6 +32,7 @@ const mainTabs = [
 
 const morePages = [
   { label: 'Agents', href: '/agents', icon: IconRobot },
+  { label: 'Comms', href: '/comms', icon: IconMessages },
   { label: 'Activity', href: '/activity', icon: IconActivity },
   { label: 'Knowledge Base', href: '/knowledge-base', icon: IconBook2 },
   { label: 'Workflows', href: '/workflows', icon: IconClock },

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -17,6 +17,7 @@ import {
   IconSearch,
   IconClock,
   IconTarget,
+  IconMessages,
 } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
@@ -38,6 +39,7 @@ const navItems: NavItem[] = [
   { label: 'Activity', href: '/activity', icon: IconActivity, section: 'core' },
 
   // Operations
+  { label: 'Comms', href: '/comms', icon: IconMessages, section: 'ops' },
   { label: 'Approvals', href: '/approvals', icon: IconShieldCheck, section: 'ops' },
   { label: 'Workflows', href: '/workflows', icon: IconClock, section: 'ops' },
   { label: 'Strategy', href: '/strategy', icon: IconTarget, section: 'ops' },

--- a/dashboard/src/lib/comms-identity.ts
+++ b/dashboard/src/lib/comms-identity.ts
@@ -1,0 +1,82 @@
+/**
+ * Comms identity resolution — ensures all message sources (bus, Telegram,
+ * dashboard chat bar) resolve to the same channel pair key for the same
+ * logical conversation.
+ *
+ * The canonical user identity is the dashboard admin username
+ * (ADMIN_USERNAME env var). This is always present regardless of whether
+ * Telegram is configured, and serves as the anchor for pair key
+ * construction. Telegram from_name is display enrichment only — it does
+ * not affect channel grouping.
+ *
+ * Multi-user safe: the resolver normalizes all non-agent names to the
+ * canonical user identity. Future multi-user support would map additional
+ * Telegram chat_ids to additional dashboard users.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+export interface CommsIdentity {
+  /** Set of known agent names (lowercase). */
+  agents: Set<string>;
+  /** Canonical user identity — the dashboard admin username. Used as the
+   *  non-agent side of every pair key. */
+  canonicalUser: string;
+}
+
+/**
+ * Discover agent names and resolve the canonical user identity.
+ * Called once per API request.
+ */
+export function resolveIdentity(ctxRoot: string): CommsIdentity {
+  const agents = new Set<string>();
+
+  // Discover agents from enabled-agents.json — the authoritative registry.
+  // The inbox directory is NOT reliable because it contains non-agent dirs
+  // (dashboard, mobile-user, cortextos) that would pollute the agents set.
+  const configPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
+  if (fs.existsSync(configPath)) {
+    try {
+      const data = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      for (const name of Object.keys(data)) {
+        agents.add(name.toLowerCase());
+      }
+    } catch { /* ignore */ }
+  }
+
+  // Canonical user = dashboard admin username (always set in .env.local)
+  const canonicalUser = (process.env.ADMIN_USERNAME ?? 'user').toLowerCase();
+
+  return { agents, canonicalUser };
+}
+
+/**
+ * Normalize a message sender/recipient name to its canonical form.
+ * Agent names pass through unchanged. All non-agent names resolve to
+ * the canonical dashboard user identity.
+ */
+export function normalizeName(
+  name: string,
+  identity: CommsIdentity,
+): string {
+  const lower = name.toLowerCase();
+  if (identity.agents.has(lower)) return lower;
+  return identity.canonicalUser;
+}
+
+/**
+ * Build a canonical pair key from two message participants.
+ * Both names are normalized, then sorted alphabetically and joined
+ * with '--'. This ensures the same conversation always produces the
+ * same key regardless of message direction or source.
+ */
+export function buildPairKey(
+  from: string,
+  to: string,
+  identity: CommsIdentity,
+): string {
+  const a = normalizeName(from, identity);
+  const b = normalizeName(to, identity);
+  return [a, b].sort().join('--');
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,24 @@
 import { defineConfig } from 'vitest/config';
+import path from 'path';
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      // Matches the dashboard's tsconfig path alias so tests under
+      // dashboard/src/**/__tests__ can import dashboard source via "@/…".
+      '@': path.resolve(__dirname, 'dashboard/src'),
+      // Dashboard tests need to resolve `next/server` and other Next deps
+      // from dashboard/node_modules, because root's package.json does not
+      // depend on Next.js.
+      'next/server': path.resolve(__dirname, 'dashboard/node_modules/next/server.js'),
+    },
+  },
   test: {
     globals: true,
     testTimeout: 10000,
-    include: ['tests/**/*.test.ts'],
+    include: [
+      'tests/**/*.test.ts',
+      'dashboard/src/**/__tests__/**/*.test.ts',
+    ],
   },
 });


### PR DESCRIPTION
## Problem

cortextOS agents communicate via bus messages and Telegram, but there is no way to view these conversations in the dashboard. Operators cannot see agent-to-agent coordination, review message history, or send messages from the dashboard UI.

## Motivation

A centralized communication view lets operators:
- Monitor agent-to-agent coordination in real time
- Review conversation history across all channels
- Send messages to agents directly from the dashboard
- Search across the full message history to find specific discussions

## Implementation

14 files changed, +1760 lines. Entirely additive — no existing files refactored.

### Dashboard UI (4 components)
- **Comms page** (`/comms`) with two tabs: Meeting Room (org-wide feed) and Active Channels (per-pair chat)
- **ChannelView** — real-time chat interface with 2s polling, auto-scroll pinned to bottom, sort toggle (newest/oldest), chat bar for user-to-agent channels
- **SearchResults** — full-text search across all message history with highlighted matches, relevance sorting, click-to-navigate
- **ChannelList** — sidebar channel browser with agent-name filtering

### API Routes (5 routes)
- `GET /api/comms/feed` — aggregate message feed with full-history search (word-boundary matching, capped at 500 results)
- `GET /api/comms/channels` — channel list with archive toggle
- `GET /api/comms/channel/[pair]` — per-channel messages with voice transcript deduplication
- `POST /api/comms/upload` — image upload for chat bar attachments
- `PATCH /api/messages/send` — dashboard-originated messages use canonical user identity

### Identity Resolution (shared library)
- `comms-identity.ts` — resolves all message sources (Telegram, bus, dashboard) to a canonical user identity
- Uses `ADMIN_USERNAME` as the anchor (always present, works without Telegram)
- Agent discovery from `enabled-agents.json` (authoritative registry, not inbox directory scan)
- Multi-user safe: non-agent names normalize to the canonical user, preventing channel splits

### Scroll System
- Pin state tracked from wheel events only (immune to React re-render DOM shifts that cause false unpin)
- 400ms interval auto-scrolls when pinned (independent of React render cycle)
- Force-scroll on channel load, sort change, and message send
- User scrolling up unpins; scrolling back to bottom re-pins

### Navigation
- Comms page added to sidebar under Operations
- Added to mobile bottom nav More menu

## Design Decisions

1. **Identity from enabled-agents.json, not inbox scan** — inbox directories contain non-agent entries (dashboard, cortextos) that would create phantom channels
2. **Wheel events for pin tracking** — scroll events fire on React re-renders (200-message list replacement shifts DOM by hundreds of pixels), causing false unpin. Wheel events only fire on real user input.
3. **Separate search state per tab** — Meeting Room search and Active Channels filter are independent
4. **Full message text in search results** — search results panel is the destination, not a navigation aid. Users read matching messages in place with highlighted terms.
5. **No custom styling** — uses system default components (Card, Badge, hover:bg-muted/50). Works with any theme.

## Testing

- `next build`: clean (production build passes)
- Tested on a live 5-agent instance on Windows 11
- Verified: channel load anchor, live auto-scroll, sort toggle, search highlighting, channel switching, Meeting Room feed, image upload, identity consolidation

## Platform

- Windows 11 Home 10.0.26200
- Node.js v22.x
- Next.js 16.2.1
- cortextOS current main (32c1918)