### PR TITLE
fix(agents-md): single-quote send-telegram examples to prevent dollar-sign stripping (BUG-052)

### DIFF
--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -23,7 +23,7 @@ Complete the following in order. Do not skip steps.
 
 1. **Send boot message first** — before reading anything else:
    ```bash
-   cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Booting up... one moment"
+   cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID 'Booting up... one moment'
    ```
 2. Read all bootstrap files: IDENTITY.md, SOUL.md, GUARDRAILS.md, GOALS.md, HEARTBEAT.md, MEMORY.md, USER.md, TOOLS.md, SYSTEM.md
    - TOOLS.md is a compact command index — load the relevant skill (e.g. `tasks/SKILL.md`, `comms/SKILL.md`) when you need full docs for a workflow
@@ -68,11 +68,11 @@ MEMEOF
 3. Log session end: `cortextos bus log-event action session_end info --meta '{"agent":"'$CTX_AGENT_NAME'","reason":"[why]"}'`
 4. **Hard restart only** — notify user on Telegram:
    ```bash
-   cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Restarting now — will be back in a moment."
+   cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID 'Restarting now — will be back in a moment.'
    ```
 5. **Context exhaustion only** — notify first, then hard-restart:
    ```bash
-   cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Context window full. Hard-restarting with fresh session. Resuming from memory."
+   cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID 'Context window full. Hard-restarting with fresh session. Resuming from memory.'
    cortextos bus hard-restart --reason "context exhaustion"
    ```
 
@@ -112,7 +112,7 @@ date +'Current time: %A %B %-d %Y at %-I:%M %p %Z'
 If `CTX_TIMEZONE` is empty, check `config.json` or ask the user to set it:
 ```bash
 # User sets timezone — update config.json and tell them to restart
-cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Your timezone is not configured. What timezone are you in? (e.g. America/New_York, Europe/London, Asia/Tokyo)"
+cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID 'Your timezone is not configured. What timezone are you in? (e.g. America/New_York, Europe/London, Asia/Tokyo)'
 ```
 
 ---
@@ -200,7 +200,7 @@ Before ANY external action (email, deploy, post, delete data, financial, merge t
 APPR_ID=$(cortextos bus create-approval "<what you want to do>" "<category>" "<context and draft>")
 
 # Notify user immediately
-cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Approval needed: <title> — check dashboard"
+cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID 'Approval needed: <title> — check dashboard'
 
 # Block your task
 cortextos bus update-task <task_id> blocked
@@ -380,7 +380,7 @@ Messages arrive in real time via the fast-checker daemon:
 ```
 === TELEGRAM from <name> (chat_id:<id>) ===
 <text>
-Reply using: cortextos bus send-telegram <chat_id> "<reply>"
+Reply using: cortextos bus send-telegram <chat_id> '<reply>'
 ```
 
 **CRITICAL: When a Telegram message arrives, you MUST reply BEFORE doing any work.** The user is waiting. Acknowledge immediately, then execute. Never leave the user as the last person to have sent a message — always follow up when work is done, when something changes, or when you are waiting on something. The user should never have to ask "are you still there?"


### PR DESCRIPTION
## Summary

- AGENTS.md template used double-quoted \`send-telegram\` examples — agents learned to compose proactive messages with double quotes
- When messages contained dollar amounts (\$1,277 MRR), bash expanded \$1 to empty, sending \`,277 MRR\` instead
- BUG-050 (PR #41) fixed the reactive fast-checker.ts reply template but missed this teaching pattern
- Fix: all 6 send-telegram examples in the template now use single quotes

## Root cause chain

1. Agent reads AGENTS.md example: \`send-telegram $CTX_TELEGRAM_CHAT_ID "Booting up..."\`
2. Agent copies the double-quote pattern when composing its own reports
3. Shell expands \`\$1,277\` → \`\` + \`277\` = \`,277\` before the bus command sees it
4. User sees garbled output: \`565 members, ,277 MRR\`

## Test plan

- [ ] All send-telegram examples in templates/agent/AGENTS.md use single quotes
- [ ] `grep 'send-telegram.*"' templates/agent/AGENTS.md` returns no matches
- [ ] Per-agent AGENTS.md files in orgs/ updated separately via sed (not git-tracked)
- [ ] Agents composing proactive messages with dollar amounts send them correctly after next session restart

Closes #52 (if filed) / follow-on to #41 (BUG-050)

🤖 Generated with [Claude Code](https://claude.com/claude-code)