### PR TITLE
feat: deliverable outputs with preview panel, allowed roots, and enforcement toggle

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -20,6 +20,7 @@
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
         "date-fns": "^4.1.0",
+        "isomorphic-dompurify": "^3.9.0",
         "jose": "^6.2.2",
         "jsonwebtoken": "^9.0.3",
         "lucide-react": "^1.6.0",
@@ -61,6 +62,53 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.1.11",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+      "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@csstools/css-calc": "^3.2.0",
+        "@csstools/css-color-parser": "^4.1.0",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.10.tgz",
+      "integrity": "sha512-KyOb19eytNSELkmdqzZZUXWCU25byIlOld5qVFg0RYdS0T3tt7jeDByxk9hIAC73frclD8GKrHttr0SUjKCCdQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/generational-cache": "^1.0.1",
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/generational-cache": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+      "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "license": "MIT"
     },
     "node_modules/@auth/core": {
       "version": "0.41.0",
@@ -558,6 +606,152 @@
         }
       }
     },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+      "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+      "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+      "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
     "node_modules/@dnd-kit/accessibility": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
@@ -984,6 +1178,23 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -3416,6 +3627,13 @@
       "integrity": "sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==",
       "license": "MIT"
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
@@ -4558,6 +4776,15 @@
         "node": "20.x || 22.x || 23.x || 24.x || 25.x"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
@@ -5131,6 +5358,19 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -5287,6 +5527,19 @@
         "node": ">= 12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -5367,6 +5620,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "license": "MIT"
     },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
@@ -5550,6 +5809,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
     "node_modules/dotenv": {
       "version": "17.4.1",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.1.tgz",
@@ -5651,6 +5919,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/env-paths": {
@@ -6735,7 +7015,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7135,6 +7414,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/http-errors": {
@@ -7683,6 +7974,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -7898,6 +8195,19 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/isomorphic-dompurify": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-dompurify/-/isomorphic-dompurify-3.9.0.tgz",
+      "integrity": "sha512-3REwJAnIqjWO7qbfyKWMBI7hUHFhqUor7weFG3WbJW6Enq3V7cx60QuurWjGUXxbX57Iy4RJIkAZFObAqiqpxw==",
+      "license": "MIT",
+      "dependencies": {
+        "dompurify": "^3.4.0",
+        "jsdom": "^29.0.2"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7951,6 +8261,55 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "29.0.2",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.2.tgz",
+      "integrity": "sha512-9VnGEBosc/ZpwyOsJBCQ/3I5p7Q5ngOY14a9bf5btenAORmZfDse1ZEheMiWcJ3h81+Fv7HmJFdS0szo/waF2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.1.5",
+        "@asamuzakjp/dom-selector": "^7.0.6",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
+        "@exodus/bytes": "^1.15.0",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.7",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.1",
+        "undici": "^7.24.5",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.1",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/lru-cache": {
+      "version": "11.3.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+      "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/jsesc": {
@@ -8579,6 +8938,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -9433,6 +9798,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
@@ -9748,7 +10125,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -10363,6 +10739,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
     },
     "node_modules/scheduler": {
       "version": "0.27.0",
@@ -11136,6 +11524,12 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "license": "MIT"
+    },
     "node_modules/tabbable": {
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
@@ -11343,6 +11737,18 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -11596,6 +12002,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "7.25.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.25.0.tgz",
+      "integrity": "sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -12017,6 +12432,18 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/web-streams-polyfill": {
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
@@ -12024,6 +12451,38 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
       }
     },
     "node_modules/which": {
@@ -12233,6 +12692,21 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "license": "MIT"
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -23,6 +23,7 @@
         "jose": "^6.2.2",
         "jsonwebtoken": "^9.0.3",
         "lucide-react": "^1.6.0",
+        "marked": "^18.0.0",
         "next": "16.2.1",
         "next-auth": "^5.0.0-beta.30",
         "next-themes": "^0.4.6",
@@ -118,7 +119,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -575,7 +575,6 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
       "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@dnd-kit/accessibility": "^3.1.1",
         "@dnd-kit/utilities": "^3.2.2",
@@ -759,7 +758,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -818,7 +816,6 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
@@ -830,7 +827,6 @@
       "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1927,7 +1923,6 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -2054,7 +2049,6 @@
       "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.59.1"
       },
@@ -3402,7 +3396,6 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3413,7 +3406,6 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3481,7 +3473,6 @@
       "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.58.0",
         "@typescript-eslint/types": "8.58.0",
@@ -4133,7 +4124,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4654,7 +4644,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5908,7 +5897,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -6418,7 +6406,6 @@
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
       "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "^2.0.0",
         "body-parser": "^2.2.1",
@@ -7146,7 +7133,6 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.11.tgz",
       "integrity": "sha512-r4xbIa3mGGGoH9nN4A14DOg2wx7y2oQyJEb5O57C/xzETG/qx4c7CVDQ5WMeKHZ7ORk2W0hZ/sQKXTav3cmYBA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -8573,6 +8559,18 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/marked": {
+      "version": "18.0.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.0.tgz",
+      "integrity": "sha512-2e7Qiv/HJSXj8rDEpgTvGKsP8yYtI9xXHKDnrftrmnrJPaFNM7VRb2YCzWaX4BP1iCJ/XPduzDJZMFoqTCcIMA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -9616,7 +9614,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.3.tgz",
       "integrity": "sha512-Z2dPnBnMUfyQfSQ+GBdsGa16hz35YmLmtTLhM169uW944hYL6xzTYkJjC07j+Wosz733pMWx0fgON3JNw1jJQA==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"
@@ -9845,7 +9842,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9855,7 +9851,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -9875,7 +9870,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -10040,8 +10034,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -11284,7 +11277,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11555,7 +11547,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12383,7 +12374,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -21,6 +21,7 @@
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
     "date-fns": "^4.1.0",
+    "isomorphic-dompurify": "^3.9.0",
     "jose": "^6.2.2",
     "jsonwebtoken": "^9.0.3",
     "lucide-react": "^1.6.0",

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -24,6 +24,7 @@
     "jose": "^6.2.2",
     "jsonwebtoken": "^9.0.3",
     "lucide-react": "^1.6.0",
+    "marked": "^18.0.0",
     "next": "16.2.1",
     "next-auth": "^5.0.0-beta.30",
     "next-themes": "^0.4.6",

--- a/dashboard/src/app/(dashboard)/settings/page.tsx
+++ b/dashboard/src/app/(dashboard)/settings/page.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { TelegramTab } from '@/components/settings/telegram-tab';
 import { SystemTab } from '@/components/settings/system-tab';
 import { UsersTab } from '@/components/settings/users-tab';
+import { AllowedRootsTab } from '@/components/settings/allowed-roots-tab';
 import { AppearanceTab } from '@/components/settings/appearance-tab';
 import { OrganizationTab } from '@/components/settings/organization-tab';
 
@@ -23,6 +24,7 @@ export default function SettingsPage() {
           <TabsTrigger value="telegram">Telegram</TabsTrigger>
           <TabsTrigger value="system">System</TabsTrigger>
           <TabsTrigger value="users">Users</TabsTrigger>
+          <TabsTrigger value="allowed-roots">Allowed Roots</TabsTrigger>
           <TabsTrigger value="appearance">Appearance</TabsTrigger>
         </TabsList>
 
@@ -47,6 +49,12 @@ export default function SettingsPage() {
         <TabsContent value="users">
           <div className="mt-4 max-w-2xl">
             <UsersTab />
+          </div>
+        </TabsContent>
+
+        <TabsContent value="allowed-roots">
+          <div className="mt-4 max-w-3xl">
+            <AllowedRootsTab />
           </div>
         </TabsContent>
 

--- a/dashboard/src/app/api/media/[...filepath]/route.ts
+++ b/dashboard/src/app/api/media/[...filepath]/route.ts
@@ -1,9 +1,50 @@
 import { NextRequest } from 'next/server';
 import fs from 'fs';
 import path from 'path';
-import { getCTXRoot } from '@/lib/config';
+import { marked } from 'marked';
+import { getCTXRoot, getFrameworkRoot, getAllowedRootsConfigPath } from '@/lib/config';
 
 export const dynamic = 'force-dynamic';
+
+// ---------------------------------------------------------------------------
+// Allowed roots — controls which directories the media API can serve from.
+//
+// CTX_ROOT is always implicitly allowed. Additional directories can be added
+// via Settings > Allowed Roots so agents can reference files from project
+// trees outside the default runtime directory. The list is stored in
+// {CTX_ROOT}/config/allowed-roots.json and read on every request.
+// ---------------------------------------------------------------------------
+
+interface AllowedRootsFile {
+  additional_roots?: string[];
+}
+
+function readAllowedRoots(): string[] {
+  const configPath = getAllowedRootsConfigPath();
+  if (!fs.existsSync(configPath)) return [];
+  try {
+    const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8')) as AllowedRootsFile;
+    if (!Array.isArray(parsed.additional_roots)) return [];
+    return parsed.additional_roots.filter((r): r is string => typeof r === 'string');
+  } catch {
+    return [];
+  }
+}
+
+function isPathUnderAnyRoot(realPath: string, roots: string[]): boolean {
+  for (const root of roots) {
+    let realRoot: string;
+    try {
+      realRoot = fs.realpathSync(path.resolve(root));
+    } catch {
+      continue;
+    }
+    if (realPath === realRoot) return true;
+    const rootWithSep = realRoot.endsWith(path.sep) ? realRoot : realRoot + path.sep;
+    if (realPath.startsWith(rootWithSep)) return true;
+  }
+  return false;
+}
 
 const MIME_TYPES: Record<string, string> = {
   '.jpg': 'image/jpeg',
@@ -19,14 +60,28 @@ const MIME_TYPES: Record<string, string> = {
   '.opus': 'audio/opus',
   '.wav': 'audio/wav',
   '.pdf': 'application/pdf',
-  '.txt': 'text/plain',
+  '.txt': 'text/plain; charset=utf-8',
   '.json': 'application/json',
+  '.md': 'text/plain; charset=utf-8',
+  '.html': 'text/html; charset=utf-8',
+  '.htm': 'text/html; charset=utf-8',
+  '.ts': 'text/plain; charset=utf-8',
+  '.tsx': 'text/plain; charset=utf-8',
+  '.js': 'text/plain; charset=utf-8',
+  '.css': 'text/plain; charset=utf-8',
+  '.sh': 'text/plain; charset=utf-8',
+  '.csv': 'text/csv; charset=utf-8',
+  '.svg': 'image/svg+xml',
 };
+
+const IMAGE_EXTENSIONS = new Set(['.jpg', '.jpeg', '.png', '.gif', '.webp', '.svg']);
+const INLINE_EXTENSIONS = new Set(['.md', '.html', '.htm', '.txt', '.ts', '.tsx', '.js', '.css', '.sh', '.json', '.csv']);
 
 /**
  * GET /api/media/[...filepath]
- * Serve a local media file by its path relative to CTX_ROOT.
- * Used by the mobile app to display images/audio sent by agents or users.
+ * Serve a local file by its path relative to CTX_ROOT (or an absolute path
+ * if it falls within an allowed root). Supports ?render=true for markdown
+ * files to return rendered HTML instead of raw text.
  */
 export async function GET(
   _request: NextRequest,
@@ -35,43 +90,108 @@ export async function GET(
   const { filepath } = await params;
   const ctxRoot = getCTXRoot();
 
-  // Reconstruct the relative path from segments
+  // Reconstruct the relative path from the URL segments.
   const relativePath = filepath.join('/');
+  const frameworkRoot = getFrameworkRoot();
+  const additionalRoots = readAllowedRoots();
+  const validRoots = [ctxRoot, frameworkRoot, ...additionalRoots];
 
-  // Security: ensure the path stays within CTX_ROOT — prevent directory traversal
-  const fullPath = path.resolve(ctxRoot, relativePath);
+  // Resolve the file against configured roots in two passes.
+  //
+  // Pass 1 — direct resolve: path.resolve(root, relativePath).
+  // Works when the file sits directly under the root.
+  //
+  // Pass 2 — overlap-stripped resolve: when a root's tail matches the
+  // relative path's head, strip the overlap to avoid doubling path
+  // components. Example: root "C:/x/orgs/foo" + rel "orgs/foo/bar.md"
+  // → pass 1 tries "C:/x/orgs/foo/orgs/foo/bar.md" (wrong),
+  // → pass 2 strips "orgs/foo" overlap → "C:/x/orgs/foo/bar.md" (correct).
+  //
+  // Both passes enforce the same security check: the resolved real path
+  // must fall within a configured allowed root.
+  let realFullPath: string | null = null;
 
-  // Security: resolve symlinks on both sides to prevent escape via symlinks inside CTX_ROOT
-  let realFullPath: string;
-  let realCtxRoot: string;
-  try {
-    realFullPath = fs.realpathSync(fullPath);
-    realCtxRoot = fs.realpathSync(path.resolve(ctxRoot));
-  } catch {
-    return new Response('Not found', { status: 404 });
+  function tryResolve(candidate: string): boolean {
+    try {
+      const real = fs.realpathSync(candidate);
+      if (isPathUnderAnyRoot(real, validRoots)) {
+        realFullPath = real;
+        return true;
+      }
+    } catch {
+      // File doesn't exist at this path
+    }
+    return false;
   }
 
-  const rootWithSep = realCtxRoot.endsWith(path.sep) ? realCtxRoot : realCtxRoot + path.sep;
-  if (realFullPath !== realCtxRoot && !realFullPath.startsWith(rootWithSep)) {
-    return new Response('Forbidden', { status: 403 });
+  // Pass 1: direct resolve
+  for (const root of validRoots) {
+    if (tryResolve(path.resolve(root, relativePath))) break;
   }
 
-  const targetPath = fs.existsSync(realFullPath) ? realFullPath : null;
-
-  if (!targetPath || !fs.existsSync(targetPath)) {
-    return new Response('Not found', { status: 404 });
+  // Pass 2: overlap-stripped resolve
+  if (!realFullPath) {
+    const relParts = relativePath.split('/');
+    for (const root of validRoots) {
+      const rootParts = root.replace(/\\/g, '/').split('/');
+      const maxOverlap = Math.min(rootParts.length, relParts.length);
+      for (let n = maxOverlap; n > 0; n--) {
+        const rootTail = rootParts.slice(-n).join('/').toLowerCase();
+        const relHead = relParts.slice(0, n).join('/').toLowerCase();
+        if (rootTail === relHead) {
+          const stripped = relParts.slice(n).join('/');
+          if (!stripped) continue;
+          if (tryResolve(path.resolve(root, stripped))) break;
+        }
+      }
+      if (realFullPath) break;
+    }
   }
 
-  const ext = path.extname(targetPath).toLowerCase();
+  if (!realFullPath) {
+    // Suggest which directory to add based on the first root candidate tried
+    const suggestedDir = path.dirname(path.resolve(ctxRoot, relativePath)).replace(/\\/g, '/');
+    return new Response(
+      JSON.stringify({
+        error: 'not_found',
+        message: `File not found under any configured root. To fix: go to Settings > Allowed Roots and add the directory that contains this file (e.g. "${suggestedDir}"), or re-attach as a snapshot via save-output.`,
+        configured_roots: validRoots,
+      }),
+      { status: 404, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  const ext = path.extname(realFullPath).toLowerCase();
+  const renderMd = _request.nextUrl.searchParams.get('render') === 'true';
+
+  // Markdown render mode: convert to HTML fragment for the preview panel
+  if (renderMd && ext === '.md') {
+    const mdContent = fs.readFileSync(realFullPath, 'utf-8');
+    const htmlBody = marked.parse(mdContent) as string;
+    return new Response(htmlBody, {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/html; charset=utf-8',
+        'Content-Length': String(Buffer.byteLength(htmlBody)),
+        'Cache-Control': 'private, max-age=60',
+      },
+    });
+  }
+
   const mimeType = MIME_TYPES[ext] || 'application/octet-stream';
-  const fileBuffer = fs.readFileSync(targetPath);
+  const fileBuffer = fs.readFileSync(realFullPath);
 
-  return new Response(fileBuffer, {
-    status: 200,
-    headers: {
-      'Content-Type': mimeType,
-      'Content-Length': String(fileBuffer.length),
-      'Cache-Control': 'private, max-age=3600',
-    },
-  });
+  const headers: Record<string, string> = {
+    'Content-Type': mimeType,
+    'Content-Length': String(fileBuffer.length),
+    'Cache-Control': 'private, max-age=3600',
+  };
+
+  if (IMAGE_EXTENSIONS.has(ext) || INLINE_EXTENSIONS.has(ext)) {
+    headers['Content-Disposition'] = `inline; filename="${path.basename(realFullPath)}"`;
+  } else {
+    headers['Content-Disposition'] = `attachment; filename="${path.basename(realFullPath)}"`;
+  }
+
+  return new Response(fileBuffer, { status: 200, headers });
 }

--- a/dashboard/src/app/api/media/[...filepath]/route.ts
+++ b/dashboard/src/app/api/media/[...filepath]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import fs from 'fs';
 import path from 'path';
 import { marked } from 'marked';
+import DOMPurify from 'isomorphic-dompurify';
 import { getCTXRoot, getFrameworkRoot, getAllowedRootsConfigPath } from '@/lib/config';
 
 export const dynamic = 'force-dynamic';
@@ -164,10 +165,20 @@ export async function GET(
   const ext = path.extname(realFullPath).toLowerCase();
   const renderMd = _request.nextUrl.searchParams.get('render') === 'true';
 
-  // Markdown render mode: convert to HTML fragment for the preview panel
+  // Markdown render mode: convert to HTML fragment for the preview panel.
+  // Agent-generated markdown can contain raw inline HTML (e.g. <script>,
+  // onerror handlers, javascript: URIs). We sanitize the marked output with
+  // DOMPurify before returning it so the client can safely inject it via
+  // dangerouslySetInnerHTML. FORBID_TAGS covers the dangerous vectors that
+  // the default DOMPurify config doesn't already strip on some configs.
   if (renderMd && ext === '.md') {
     const mdContent = fs.readFileSync(realFullPath, 'utf-8');
-    const htmlBody = marked.parse(mdContent) as string;
+    const rawHtml = marked.parse(mdContent) as string;
+    const htmlBody = DOMPurify.sanitize(rawHtml, {
+      USE_PROFILES: { html: true },
+      FORBID_TAGS: ['script', 'style', 'iframe', 'object', 'embed', 'form', 'input', 'link', 'meta', 'base'],
+      FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur', 'onchange', 'onsubmit', 'formaction'],
+    });
     return new Response(htmlBody, {
       status: 200,
       headers: {

--- a/dashboard/src/app/api/org/config/route.ts
+++ b/dashboard/src/app/api/org/config/route.ts
@@ -44,7 +44,7 @@ export async function PATCH(request: NextRequest) {
   }
 
   // Validate editable fields
-  const allowed = ['timezone', 'day_mode_start', 'day_mode_end', 'default_approval_categories', 'communication_style', 'name', 'description', 'industry', 'icp', 'value_prop'];
+  const allowed = ['timezone', 'day_mode_start', 'day_mode_end', 'default_approval_categories', 'communication_style', 'name', 'description', 'industry', 'icp', 'value_prop', 'require_deliverables'];
   const timeRegex = /^\d{2}:\d{2}$/;
 
   if (body.day_mode_start && !timeRegex.test(body.day_mode_start as string)) {
@@ -52,6 +52,9 @@ export async function PATCH(request: NextRequest) {
   }
   if (body.day_mode_end && !timeRegex.test(body.day_mode_end as string)) {
     return Response.json({ error: 'day_mode_end must be HH:MM' }, { status: 400 });
+  }
+  if (body.require_deliverables !== undefined && typeof body.require_deliverables !== 'boolean') {
+    return Response.json({ error: 'require_deliverables must be a boolean' }, { status: 400 });
   }
   if (body.default_approval_categories !== undefined) {
     const dac = body.default_approval_categories;

--- a/dashboard/src/app/api/tasks/[id]/route.ts
+++ b/dashboard/src/app/api/tasks/[id]/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { spawnSync } from 'child_process';
+import fs from 'fs';
 import path from 'path';
 import { getTaskById } from '@/lib/data/tasks';
 import { getFrameworkRoot, getCTXRoot } from '@/lib/config';
@@ -52,6 +53,17 @@ export async function GET(
     if (!task) {
       return Response.json({ error: 'Task not found' }, { status: 404 });
     }
+
+    // Enrich with outputs from the source JSON file (outputs are not synced to SQLite)
+    if (task.source_file && fs.existsSync(task.source_file)) {
+      try {
+        const raw = JSON.parse(fs.readFileSync(task.source_file, 'utf-8'));
+        if (Array.isArray(raw.outputs)) {
+          task.outputs = raw.outputs;
+        }
+      } catch { /* non-fatal — outputs are optional */ }
+    }
+
     return Response.json(task);
   } catch (err) {
     console.error('[api/tasks/[id]] GET error:', err);

--- a/dashboard/src/components/settings/allowed-roots-tab.tsx
+++ b/dashboard/src/components/settings/allowed-roots-tab.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { fetchAllowedRoots, addAllowedRoot, removeAllowedRoot } from '@/lib/actions/settings';
+
+interface AllowedRootEntry {
+  path: string;
+  exists: boolean;
+}
+
+interface AllowedRootsView {
+  ctx_root: string;
+  additional_roots: AllowedRootEntry[];
+}
+
+/**
+ * Allowed Roots tab — controls which directories the dashboard media API
+ * is permitted to serve files from. CTX_ROOT is always implicitly allowed.
+ * Users add additional directories so agents can reference files from
+ * project trees outside the default runtime directory.
+ */
+export function AllowedRootsTab() {
+  const [view, setView] = useState<AllowedRootsView | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [newPath, setNewPath] = useState('');
+  const [error, setError] = useState('');
+  const [adding, setAdding] = useState(false);
+
+  const load = useCallback(async () => {
+    const data = await fetchAllowedRoots();
+    setView(data);
+    setLoading(false);
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function handleAdd() {
+    setAdding(true);
+    setError('');
+    const result = await addAllowedRoot(newPath);
+    if (result.success) {
+      setNewPath('');
+      await load();
+    } else {
+      setError(result.error ?? 'Failed to add allowed root');
+    }
+    setAdding(false);
+  }
+
+  async function handleDelete(path: string) {
+    setError('');
+    const result = await removeAllowedRoot(path);
+    if (result.success) {
+      await load();
+    } else {
+      setError(result.error ?? 'Failed to remove allowed root');
+    }
+  }
+
+  if (loading || !view) {
+    return <div className="h-48 rounded-xl bg-muted/30 animate-pulse" />;
+  }
+
+  const isEmpty = view.additional_roots.length === 0;
+
+  return (
+    <div className="space-y-4">
+      <Card>
+        <CardHeader>
+          <CardTitle>Allowed Roots</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Path</TableHead>
+                <TableHead className="w-32">Status</TableHead>
+                <TableHead className="w-20" />
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              <TableRow>
+                <TableCell className="font-mono text-xs">{view.ctx_root}</TableCell>
+                <TableCell>
+                  <span className="text-xs text-muted-foreground">system default</span>
+                </TableCell>
+                <TableCell />
+              </TableRow>
+              {view.additional_roots.map((entry) => (
+                <TableRow key={entry.path}>
+                  <TableCell className="font-mono text-xs">{entry.path}</TableCell>
+                  <TableCell>
+                    {entry.exists ? (
+                      <span className="text-xs text-green-600">exists</span>
+                    ) : (
+                      <span className="text-xs text-amber-600">missing</span>
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Button
+                      variant="destructive"
+                      size="xs"
+                      onClick={() => handleDelete(entry.path)}
+                    >
+                      Delete
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+          {isEmpty && (
+            <p className="mt-3 text-xs text-muted-foreground">
+              No additional allowed roots configured. By default, the dashboard can only serve files from{' '}
+              <span className="font-mono">{view.ctx_root}</span>. Add additional directories below to allow
+              agents to attach files from project trees as references.
+            </p>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Add Allowed Root</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col gap-3 max-w-lg">
+            <div className="grid gap-1.5">
+              <Label htmlFor="new-allowed-root">Absolute path</Label>
+              <Input
+                id="new-allowed-root"
+                value={newPath}
+                onChange={(e) => setNewPath(e.target.value)}
+                placeholder="/home/user/projects/my-project"
+                className="font-mono text-xs"
+              />
+              <p className="text-[11px] text-muted-foreground">
+                Must be an absolute path to an existing directory. System directories
+                (drive roots, /etc, /usr, C:/Windows, etc.) are blocked for security.
+              </p>
+            </div>
+            <Button onClick={handleAdd} disabled={adding} className="w-fit">
+              {adding ? 'Adding...' : 'Add Root'}
+            </Button>
+            {error && <p className="text-xs text-destructive">{error}</p>}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/dashboard/src/components/settings/organization-tab.tsx
+++ b/dashboard/src/components/settings/organization-tab.tsx
@@ -23,6 +23,7 @@ interface OrgConfig {
   day_mode_end?: string;
   communication_style?: string;
   default_approval_categories?: string[];
+  require_deliverables?: boolean;
 }
 
 interface OrgGoals {
@@ -85,6 +86,7 @@ export function OrganizationTab() {
             day_mode_end: d.config.day_mode_end || '',
             communication_style: d.config.communication_style || '',
             default_approval_categories: d.config.default_approval_categories || [],
+            require_deliverables: !!d.config.require_deliverables,
           });
         }
         setOpLoading(false);
@@ -354,6 +356,23 @@ export function OrganizationTab() {
                       </label>
                     ))}
                   </div>
+                </div>
+
+                <div>
+                  <Label className="text-xs text-muted-foreground">Task Deliverables</Label>
+                  <label className="flex items-center gap-2 mt-2 cursor-pointer">
+                    <input
+                      type="checkbox"
+                      checked={!!opConfig.require_deliverables}
+                      onChange={e => setOpConfig(p => ({ ...p, require_deliverables: e.target.checked }))}
+                      className="rounded"
+                    />
+                    <span className="text-sm">Require file deliverables on task completion</span>
+                  </label>
+                  <p className="text-xs text-muted-foreground mt-1">
+                    When enabled, agents must attach at least one file via save-output before completing a task.
+                    The deliverables section appears on task detail cards in the dashboard.
+                  </p>
                 </div>
 
                 {opMessage && (

--- a/dashboard/src/components/tasks/deliverable-preview.tsx
+++ b/dashboard/src/components/tasks/deliverable-preview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { useState, useEffect, useCallback, useRef } from 'react';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import DOMPurify from 'isomorphic-dompurify';
 import { Button } from '@/components/ui/button';
 import { IconX, IconFolderOpen, IconZoomIn, IconZoomOut, IconCode, IconBrowser } from '@tabler/icons-react';
 import type { TaskOutput } from '@/lib/types';
@@ -223,18 +224,28 @@ function RenderedMdPreview({
     };
   }, [html, parentPath, onFileRefClick]);
 
-  if (error) return <PreviewError message={error} />;
-  if (html === null) return <PreviewLoading />;
+  // Defense in depth: the server already sanitizes markdown-derived HTML
+  // with DOMPurify before returning it. We sanitize again on the client so
+  // that any intermediary (proxy, future change) cannot inject script or
+  // event-handler vectors into the DOM. Agent-authored markdown is NOT
+  // trusted — treat it the same as third-party user content.
+  const safeHtml = useMemo(() => {
+    if (html === null) return null;
+    return DOMPurify.sanitize(html, {
+      USE_PROFILES: { html: true },
+      FORBID_TAGS: ['script', 'style', 'iframe', 'object', 'embed', 'form', 'input', 'link', 'meta', 'base'],
+      FORBID_ATTR: ['style', 'onerror', 'onload', 'onclick', 'onmouseover', 'onfocus', 'onblur', 'onchange', 'onsubmit', 'formaction'],
+    });
+  }, [html]);
 
-  // Content served by /api/media is read from local disk files within
-  // allowed roots. The media route enforces a realpath check ensuring the
-  // file is inside an allowed root, so the HTML comes from trusted
-  // agent-generated markdown rendered server-side.
+  if (error) return <PreviewError message={error} />;
+  if (safeHtml === null) return <PreviewLoading />;
+
   return (
     <div
       ref={containerRef}
       className="w-full h-full overflow-auto p-6 md-preview"
-      dangerouslySetInnerHTML={{ __html: html }}
+      dangerouslySetInnerHTML={{ __html: safeHtml }}
     />
   );
 }

--- a/dashboard/src/components/tasks/deliverable-preview.tsx
+++ b/dashboard/src/components/tasks/deliverable-preview.tsx
@@ -1,0 +1,444 @@
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { IconX, IconFolderOpen, IconZoomIn, IconZoomOut, IconCode, IconBrowser } from '@tabler/icons-react';
+import type { TaskOutput } from '@/lib/types';
+
+interface DeliverablePreviewProps {
+  output: TaskOutput;
+  onClose: () => void;
+}
+
+const IMAGE_EXTS = /\.(png|jpg|jpeg|gif|webp|svg)$/i;
+const MD_EXTS = /\.md$/i;
+const HTML_EXTS = /\.html?$/i;
+const CODE_EXTS = /\.(ts|tsx|js|jsx|json|css|sh|txt|csv|log|yaml|yml|toml|py)$/i;
+
+// File reference patterns for auto-linking inside rendered markdown.
+// Matches relative paths, Windows drive-letter paths, and Unix absolute paths.
+// The /api/media route's allowed-roots + realpath check is the authoritative
+// security enforcement; this regex is a first-pass filter.
+const FILE_REF_EXTS = 'md|html|png|jpg|jpeg|gif|webp|json|csv|txt|ts|tsx|js|jsx|css|ogg|mp4|mp3|pdf|wav|opus';
+const FILE_REF_RE = new RegExp(`^[\\w\\-./]+\\.(${FILE_REF_EXTS})$`, 'i');
+const ABSOLUTE_DRIVE_RE = /^[a-z]:[\\/]/i;
+const ABSOLUTE_UNIX_RE = /^\//;
+const EXTERNAL_SCHEME_RE = /^(https?|mailto|tel|ftp|ws|wss|data|blob):/i;
+
+/**
+ * Classify a candidate file reference string as 'skip', 'relative', or
+ * 'absolute'. Used by the markdown walker to decide which code spans and
+ * anchor tags to make clickable for the overlay viewer.
+ */
+function classifyFileRef(raw: string): 'skip' | 'relative' | 'absolute' {
+  const ref = raw.trim();
+  if (!ref) return 'skip';
+  if (ref.includes('..')) return 'skip';
+  if (EXTERNAL_SCHEME_RE.test(ref)) return 'skip';
+  if (ABSOLUTE_DRIVE_RE.test(ref) || ABSOLUTE_UNIX_RE.test(ref)) return 'absolute';
+  if (FILE_REF_RE.test(ref)) return 'relative';
+  return 'skip';
+}
+
+function getMediaUrl(value: string, render?: boolean): string {
+  const segments = value.split('/').map(s => encodeURIComponent(s)).join('/');
+  const base = `/api/media/${segments}`;
+  return render ? `${base}?render=true` : base;
+}
+
+function PreviewLoading() {
+  return (
+    <div className="flex items-center justify-center h-full text-muted-foreground text-sm">
+      Loading preview...
+    </div>
+  );
+}
+
+function PreviewError({ message }: { message: string }) {
+  return (
+    <div className="flex items-center justify-center h-full text-destructive text-sm">
+      {message}
+    </div>
+  );
+}
+
+function ImagePreview({ src }: { src: string }) {
+  const [zoomed, setZoomed] = useState(false);
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-end p-2">
+        <Button
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => setZoomed(!zoomed)}
+          title={zoomed ? 'Zoom out' : 'Zoom in'}
+        >
+          {zoomed ? <IconZoomOut size={16} /> : <IconZoomIn size={16} />}
+        </Button>
+      </div>
+      <div className={`flex-1 overflow-auto p-4 ${zoomed ? '' : 'flex items-center justify-center'}`}>
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={src}
+          alt="Deliverable preview"
+          className={zoomed ? 'w-full' : 'max-w-full max-h-full object-contain'}
+        />
+      </div>
+    </div>
+  );
+}
+
+function RenderedMdPreview({
+  src,
+  parentPath,
+  onFileRefClick,
+}: {
+  src: string;
+  parentPath: string;
+  onFileRefClick: (resolvedPath: string, displayLabel: string) => void;
+}) {
+  const [html, setHtml] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    fetch(src)
+      .then(res => {
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        return res.text();
+      })
+      .then(setHtml)
+      .catch(e => setError(e.message));
+  }, [src]);
+
+  // Walk the rendered HTML for <code> spans and <a> tags that look like
+  // file references. Patch each with a click handler that opens the file
+  // in the overlay viewer. A MutationObserver re-runs the patch on DOM
+  // changes so React re-renders keep the handlers attached.
+  useEffect(() => {
+    if (!containerRef.current || html === null) return;
+    const container = containerRef.current;
+    const parentDir = parentPath.includes('/')
+      ? parentPath.slice(0, parentPath.lastIndexOf('/'))
+      : '';
+
+    const listeners: Array<() => void> = [];
+
+    function candidatesFor(ref: string, kind: 'relative' | 'absolute'): string[] {
+      if (kind === 'absolute') return [ref];
+      const out: string[] = [];
+      if (parentDir) out.push(`${parentDir}/${ref}`);
+      out.push(ref);
+      return out;
+    }
+
+    function makeOpenHandler(el: HTMLElement, ref: string, label: string, kind: 'relative' | 'absolute') {
+      const candidates = candidatesFor(ref, kind);
+      return async (ev: Event) => {
+        ev.preventDefault();
+        ev.stopPropagation();
+        for (const candidate of candidates) {
+          try {
+            const segments = candidate.split('/').map(s => encodeURIComponent(s)).join('/');
+            const r = await fetch(`/api/media/${segments}`, { method: 'HEAD' });
+            if (r.ok) {
+              onFileRefClick(candidate, label);
+              return;
+            }
+            console.warn(`[file-ref] HEAD returned ${r.status} for: ${candidate}`);
+          } catch (err) {
+            console.warn(`[file-ref] HEAD failed for: ${candidate}`, err);
+          }
+        }
+        // All HEAD checks failed. The file may still exist if auth/middleware
+        // blocked the HEAD request. Open the first candidate as a fallback —
+        // the preview component handles its own load errors.
+        console.warn(`[file-ref] All HEAD checks failed for "${ref}". Opening first candidate as fallback.`, candidates);
+        el.style.color = 'var(--color-destructive, #ef4444)';
+        el.style.textDecoration = 'line-through';
+        el.title = `Could not verify: ${ref} — opening anyway`;
+        onFileRefClick(candidates[0], label);
+      };
+    }
+
+    function patchCodeSpans() {
+      const codes = container.querySelectorAll('code');
+      codes.forEach((codeEl) => {
+        const el = codeEl as HTMLElement;
+        if (el.dataset.refPatched === 'true') return;
+        if (el.closest('pre')) return;
+        const text = (el.textContent || '').trim();
+        const kind = classifyFileRef(text);
+        if (kind === 'skip') return;
+
+        el.style.cursor = 'pointer';
+        el.style.textDecoration = 'underline';
+        el.setAttribute('role', 'button');
+        el.setAttribute('tabindex', '0');
+        el.title = `Click to open ${text}`;
+        el.dataset.refPatched = 'true';
+
+        const handleOpen = makeOpenHandler(el, text, text, kind);
+        el.addEventListener('click', handleOpen);
+        listeners.push(() => el.removeEventListener('click', handleOpen));
+      });
+    }
+
+    function patchAnchors() {
+      const anchors = container.querySelectorAll('a');
+      anchors.forEach((anchorEl) => {
+        const el = anchorEl as HTMLAnchorElement;
+        if (el.dataset.refPatched === 'true') return;
+        const href = (el.getAttribute('href') || '').trim();
+        if (!href) return;
+        const kind = classifyFileRef(href);
+        if (kind === 'skip') return;
+
+        const label = (el.textContent || href).trim() || href;
+        el.title = `Click to open ${href}`;
+        el.dataset.refPatched = 'true';
+        el.removeAttribute('href');
+        el.setAttribute('role', 'button');
+        el.style.cursor = 'pointer';
+
+        const handleOpen = makeOpenHandler(el, href, label, kind);
+        el.addEventListener('click', handleOpen);
+        listeners.push(() => el.removeEventListener('click', handleOpen));
+      });
+    }
+
+    patchCodeSpans();
+    patchAnchors();
+
+    const observer = new MutationObserver(() => {
+      patchCodeSpans();
+      patchAnchors();
+    });
+    observer.observe(container, { childList: true, subtree: true });
+
+    return () => {
+      observer.disconnect();
+      listeners.forEach(unsub => unsub());
+    };
+  }, [html, parentPath, onFileRefClick]);
+
+  if (error) return <PreviewError message={error} />;
+  if (html === null) return <PreviewLoading />;
+
+  // Content served by /api/media is read from local disk files within
+  // allowed roots. The media route enforces a realpath check ensuring the
+  // file is inside an allowed root, so the HTML comes from trusted
+  // agent-generated markdown rendered server-side.
+  return (
+    <div
+      ref={containerRef}
+      className="w-full h-full overflow-auto p-6 md-preview"
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}
+
+function HtmlPreview({ src }: { src: string }) {
+  const [showSource, setShowSource] = useState(false);
+  const [htmlContent, setHtmlContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(src)
+      .then(res => {
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        return res.text();
+      })
+      .then(setHtmlContent)
+      .catch(e => setError(e.message));
+  }, [src]);
+
+  if (error) return <PreviewError message={error} />;
+  if (htmlContent === null) return <PreviewLoading />;
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="flex justify-end p-2 gap-1 shrink-0">
+        <Button
+          variant={showSource ? 'outline' : 'default'}
+          size="xs"
+          onClick={() => setShowSource(false)}
+          title="Rendered page"
+        >
+          <IconBrowser size={14} />
+          <span className="ml-1">Preview</span>
+        </Button>
+        <Button
+          variant={showSource ? 'default' : 'outline'}
+          size="xs"
+          onClick={() => setShowSource(true)}
+          title="View source"
+        >
+          <IconCode size={14} />
+          <span className="ml-1">Source</span>
+        </Button>
+      </div>
+      <div className="flex-1 overflow-hidden">
+        {showSource ? (
+          <pre className="text-xs font-mono p-4 overflow-auto h-full whitespace-pre-wrap text-foreground leading-relaxed bg-popover">
+            {htmlContent}
+          </pre>
+        ) : (
+          <iframe
+            srcDoc={htmlContent}
+            className="w-full h-full border-0 bg-white"
+            sandbox="allow-scripts"
+            title="HTML preview"
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CodePreview({ src }: { src: string }) {
+  const [content, setContent] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch(src)
+      .then(res => {
+        if (!res.ok) throw new Error(`${res.status} ${res.statusText}`);
+        return res.text();
+      })
+      .then(setContent)
+      .catch(e => setError(e.message));
+  }, [src]);
+
+  if (error) return <PreviewError message={error} />;
+  if (content === null) return <PreviewLoading />;
+
+  return (
+    <pre className="text-xs font-mono p-4 overflow-auto h-full whitespace-pre-wrap text-foreground leading-relaxed bg-popover">
+      {content}
+    </pre>
+  );
+}
+
+// Markdown rendering styles — stock upstream palette, no custom colors.
+// Injected as a <style> tag only when previewing markdown or code content.
+const MD_STYLES = `
+.md-preview { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; line-height: 1.6; color: var(--color-popover-foreground); }
+.md-preview h1, .md-preview h2, .md-preview h3, .md-preview h4 { font-weight: 600; margin-top: 1.5em; margin-bottom: 0.5em; color: var(--color-popover-foreground); }
+.md-preview h1 { font-size: 1.5em; } .md-preview h2 { font-size: 1.25em; } .md-preview h3 { font-size: 1.1em; }
+.md-preview p { margin: 0.75em 0; }
+.md-preview code { background: rgba(0,0,0,0.08); padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+.md-preview pre { background: rgba(0,0,0,0.06); padding: 16px; border-radius: 8px; overflow-x: auto; }
+.md-preview pre code { background: none; padding: 0; }
+.md-preview a { color: #2563eb; }
+.md-preview table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+.md-preview th, .md-preview td { border: 1px solid rgba(0,0,0,0.15); padding: 8px 12px; text-align: left; }
+.md-preview th { background: rgba(0,0,0,0.04); font-weight: 600; }
+.md-preview blockquote { border-left: 3px solid rgba(0,0,0,0.2); margin-left: 0; padding-left: 16px; opacity: 0.8; }
+.md-preview hr { border: none; border-top: 1px solid rgba(0,0,0,0.15); margin: 24px 0; }
+.md-preview ul, .md-preview ol { padding-left: 24px; }
+.md-preview li { margin: 0.25em 0; }
+.md-preview strong { font-weight: 600; }
+`;
+
+/**
+ * Full-height deliverable preview panel. Renders inside the task detail
+ * sheet, replacing the detail content when a deliverable is clicked.
+ * Supports images (with zoom), markdown (server-rendered HTML), HTML
+ * (sandboxed iframe with source toggle), and code/text files.
+ */
+export function DeliverablePreview({ output, onClose }: DeliverablePreviewProps) {
+  const value = output.value;
+  const isImage = IMAGE_EXTS.test(value);
+  const isMd = MD_EXTS.test(value);
+  const isHtml = HTML_EXTS.test(value);
+  const isCode = CODE_EXTS.test(value);
+  const fileName = value.split('/').pop() || value;
+  const currentLabel = output.label || fileName;
+  const needsSolidBg = isMd || isCode || isHtml;
+
+  // Overlay: when a file reference is clicked inside rendered markdown,
+  // push a nested preview on top of this one.
+  const [overlay, setOverlay] = useState<TaskOutput | null>(null);
+
+  const handleFileRefClick = useCallback((resolvedPath: string, displayLabel: string) => {
+    setOverlay({ type: 'file', value: resolvedPath, label: displayLabel });
+  }, []);
+
+  const handleOpenInTab = useCallback(() => {
+    window.open(getMediaUrl(value), '_blank');
+  }, [value]);
+
+  // The MD_STYLES string is a static CSS block for markdown rendering.
+  // It uses only CSS custom properties from the theme (--color-popover-foreground)
+  // and generic system font stacks. Injected via <style> to scope the
+  // .md-preview class without requiring a global stylesheet change.
+  return (
+    <div className={`relative flex flex-col h-full ${needsSolidBg ? 'bg-popover' : ''}`}>
+      {needsSolidBg && <style>{MD_STYLES}</style>}
+
+      {/* Header */}
+      <div className="flex items-center justify-between gap-2 px-3 py-2 border-b shrink-0 bg-popover">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium truncate" title={currentLabel}>
+            {currentLabel}
+          </p>
+          <p className="text-[11px] text-muted-foreground truncate font-mono" title={value}>
+            {fileName}
+          </p>
+        </div>
+        <div className="flex items-center gap-1 shrink-0">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={handleOpenInTab}
+            title="Open file in new tab"
+          >
+            <IconFolderOpen size={14} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onClose}
+            title="Close preview"
+          >
+            <IconX size={14} />
+          </Button>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-hidden">
+        {isImage && <ImagePreview src={getMediaUrl(value)} />}
+        {isMd && (
+          <RenderedMdPreview
+            src={getMediaUrl(value, true)}
+            parentPath={value}
+            onFileRefClick={handleFileRefClick}
+          />
+        )}
+        {isHtml && <HtmlPreview src={getMediaUrl(value)} />}
+        {isCode && <CodePreview src={getMediaUrl(value)} />}
+        {!isImage && !isMd && !isHtml && !isCode && (
+          <div className="flex flex-col items-center justify-center h-full gap-3 text-muted-foreground">
+            <p className="text-sm">No preview available for this file type</p>
+            <Button variant="outline" size="sm" onClick={handleOpenInTab}>
+              Open File
+            </Button>
+          </div>
+        )}
+      </div>
+
+      {/* Overlay: nested preview for file references clicked inside markdown */}
+      {overlay && (
+        <div className="absolute inset-0 z-10 bg-popover shadow-2xl">
+          <DeliverablePreview
+            output={overlay}
+            onClose={() => setOverlay(null)}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/tasks/task-detail-sheet.tsx
+++ b/dashboard/src/components/tasks/task-detail-sheet.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   Sheet,
   SheetContent,
@@ -27,8 +27,9 @@ import {
   OrgBadge,
   TimeAgo,
 } from '@/components/shared';
-import { IconPencil } from '@tabler/icons-react';
-import type { Task, TaskStatus, TaskPriority } from '@/lib/types';
+import { IconPencil, IconFile, IconPhoto, IconFileText, IconCode } from '@tabler/icons-react';
+import { DeliverablePreview } from '@/components/tasks/deliverable-preview';
+import type { Task, TaskOutput, TaskStatus, TaskPriority } from '@/lib/types';
 
 export interface TaskDetailSheetProps {
   task: Task | null;
@@ -58,6 +59,14 @@ const STATUS_TRANSITIONS: Record<TaskStatus, { label: string; status: TaskStatus
   ],
 };
 
+function getOutputIcon(filePath: string) {
+  const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
+  if (['png', 'jpg', 'jpeg', 'gif', 'webp', 'svg'].includes(ext)) return IconPhoto;
+  if (ext === 'md') return IconFileText;
+  if (['ts', 'tsx', 'js', 'jsx', 'json', 'html', 'css', 'sh', 'py'].includes(ext)) return IconCode;
+  return IconFile;
+}
+
 export function TaskDetailSheet({
   task,
   open,
@@ -77,6 +86,39 @@ export function TaskDetailSheet({
   const [editAssignee, setEditAssignee] = useState<string>('');
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // Deliverables state
+  const [outputs, setOutputs] = useState<TaskOutput[]>([]);
+  const [deliverablesEnabled, setDeliverablesEnabled] = useState(false);
+  const [previewOutput, setPreviewOutput] = useState<TaskOutput | null>(null);
+
+  // Fetch outputs and deliverables setting when task detail opens
+  const fetchTaskOutputs = useCallback(async (taskId: string, org: string) => {
+    try {
+      const res = await fetch(`/api/tasks/${taskId}`);
+      if (res.ok) {
+        const data = await res.json();
+        setOutputs(Array.isArray(data.outputs) ? data.outputs : []);
+      }
+    } catch { /* non-fatal */ }
+
+    try {
+      const res = await fetch(`/api/org/config?org=${encodeURIComponent(org)}`);
+      if (res.ok) {
+        const data = await res.json();
+        setDeliverablesEnabled(!!data.config?.require_deliverables);
+      }
+    } catch { /* non-fatal */ }
+  }, []);
+
+  useEffect(() => {
+    if (open && task) {
+      fetchTaskOutputs(task.id, task.org);
+    } else {
+      setOutputs([]);
+      setPreviewOutput(null);
+    }
+  }, [open, task?.id, task?.org, fetchTaskOutputs, task]);
 
   if (!task) return null;
 
@@ -138,7 +180,8 @@ export function TaskDetailSheet({
   }
 
   return (
-    <Sheet open={open} onOpenChange={(o) => { onOpenChange(o); if (!o) { setEditing(false); setConfirmDelete(false); setError(null); } }}>
+    <>
+    <Sheet open={open} onOpenChange={(o) => { onOpenChange(o); if (!o) { setEditing(false); setConfirmDelete(false); setError(null); setPreviewOutput(null); } }}>
       <SheetContent side="right" className="sm:max-w-lg overflow-y-auto">
         <SheetHeader>
           {editing ? (
@@ -274,6 +317,51 @@ export function TaskDetailSheet({
             </>
           )}
 
+          {/* Deliverables section — visible when require_deliverables is enabled */}
+          {!editing && deliverablesEnabled && (
+            <>
+              <Separator />
+              <div>
+                <p className="text-sm text-muted-foreground mb-2">
+                  Deliverables{outputs.length > 0 && ` (${outputs.length})`}
+                </p>
+                {outputs.length === 0 ? (
+                  <p className="text-sm text-muted-foreground italic">No deliverables attached.</p>
+                ) : (
+                  <div className="space-y-1">
+                    {outputs.map((output, idx) => {
+                      const Icon = getOutputIcon(output.value);
+                      const filename = output.value.split('/').pop() ?? output.value;
+                      return (
+                        <button
+                          key={idx}
+                          onClick={() => setPreviewOutput(output)}
+                          className="flex items-center gap-2 w-full rounded-md px-2 py-1.5 text-left text-sm hover:bg-muted/50 transition-colors"
+                          onMouseEnter={(e) => {
+                            e.currentTarget.style.cursor = 'pointer';
+                            const label = e.currentTarget.querySelector('[data-deliverable-label]') as HTMLElement | null;
+                            if (label) label.style.textDecoration = 'underline';
+                          }}
+                          onMouseLeave={(e) => {
+                            const label = e.currentTarget.querySelector('[data-deliverable-label]') as HTMLElement | null;
+                            if (label) label.style.textDecoration = 'none';
+                          }}
+                          style={{ cursor: 'pointer' } as React.CSSProperties}
+                        >
+                          <Icon size={16} className="shrink-0 text-primary" />
+                          <div className="min-w-0 flex-1">
+                            <p data-deliverable-label className="font-medium text-sm text-primary break-words">{output.label ?? filename}</p>
+                            <p className="text-xs text-muted-foreground break-all">{filename}</p>
+                          </div>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </>
+          )}
+
           {!editing && (
             <>
               <Separator />
@@ -350,5 +438,30 @@ export function TaskDetailSheet({
         )}
       </SheetContent>
     </Sheet>
+
+    {/* Deliverable preview — fixed-position sibling outside the Sheet.
+        Three responsive breakpoints match the reference layout. */}
+    {open && previewOutput && (
+      <>
+        {/* Desktop: full height panel, left edge to sheet edge */}
+        <div className="hidden lg:block fixed inset-y-0 left-0 right-96 z-[55] animate-in slide-in-from-left-4 duration-200">
+          <DeliverablePreview output={previewOutput} onClose={() => setPreviewOutput(null)} />
+        </div>
+
+        {/* Tablet: centered modal with backdrop */}
+        <div className="hidden md:block lg:hidden fixed inset-0 z-[60]">
+          <div className="fixed inset-0 bg-black/40" onClick={() => setPreviewOutput(null)} />
+          <div className="fixed inset-4 z-[61] bg-background rounded-xl shadow-2xl overflow-hidden animate-in fade-in zoom-in-95 duration-200">
+            <DeliverablePreview output={previewOutput} onClose={() => setPreviewOutput(null)} />
+          </div>
+        </div>
+
+        {/* Mobile: full takeover */}
+        <div className="block md:hidden fixed inset-0 z-[60] bg-background animate-in slide-in-from-bottom duration-200">
+          <DeliverablePreview output={previewOutput} onClose={() => setPreviewOutput(null)} />
+        </div>
+      </>
+    )}
+    </>
   );
 }

--- a/dashboard/src/lib/actions/settings.ts
+++ b/dashboard/src/lib/actions/settings.ts
@@ -4,7 +4,7 @@ import fs from 'fs';
 import path from 'path';
 import bcrypt from 'bcryptjs';
 import { revalidatePath } from 'next/cache';
-import { CTX_ROOT, getOrgs, getAgentsForOrg, getAgentDir, getOrgContextPath, getOrgBrandVoicePath } from '@/lib/config';
+import { CTX_ROOT, getOrgs, getAgentsForOrg, getAgentDir, getOrgContextPath, getOrgBrandVoicePath, getAllowedRootsConfigPath } from '@/lib/config';
 import { db } from '@/lib/db';
 import type { ActionResult, User } from '@/lib/types';
 
@@ -320,4 +320,158 @@ export async function fetchOrgMetadata() {
   }
 
   return { context, brandVoice };
+}
+
+// ---------------------------------------------------------------------------
+// Allowed Roots — controls which directories the /api/media route can serve
+// ---------------------------------------------------------------------------
+
+interface AllowedRootsView {
+  ctx_root: string;
+  additional_roots: AllowedRootEntry[];
+}
+
+interface AllowedRootEntry {
+  path: string;
+  exists: boolean;
+}
+
+const SYSTEM_BLOCKLIST: string[] = [
+  '/',
+  'C:/',
+  'D:/',
+  'E:/',
+  '/usr',
+  '/etc',
+  '/var',
+  '/sys',
+  '/proc',
+  '/boot',
+  '/dev',
+  '/root',
+  '/System',
+  'C:/Windows',
+  'C:/Program Files',
+  'C:/Program Files (x86)',
+];
+
+function normalizeFsPath(p: string): string {
+  let n = p.replace(/\\/g, '/');
+  if (n.length > 1 && n.endsWith('/') && !/^[A-Za-z]:\/$/.test(n)) {
+    n = n.slice(0, -1);
+  }
+  return n;
+}
+
+export async function fetchAllowedRoots(): Promise<AllowedRootsView> {
+  const ctxRoot = normalizeFsPath(CTX_ROOT);
+  const configPath = getAllowedRootsConfigPath();
+
+  let additional: string[] = [];
+  if (fs.existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (Array.isArray(parsed.additional_roots)) {
+        additional = parsed.additional_roots
+          .filter((r: unknown): r is string => typeof r === 'string')
+          .map((r: string) => normalizeFsPath(r));
+      }
+    } catch { /* malformed file — treat as empty */ }
+  }
+
+  return {
+    ctx_root: ctxRoot,
+    additional_roots: additional.map((p) => ({
+      path: p,
+      exists: fs.existsSync(p),
+    })),
+  };
+}
+
+export async function addAllowedRoot(rawPath: string): Promise<ActionResult> {
+  const trimmed = rawPath.trim();
+  if (!trimmed) return { success: false, error: 'Path is required' };
+  if (!path.isAbsolute(trimmed)) {
+    return { success: false, error: 'Path must be absolute (start with / or a drive letter)' };
+  }
+
+  const normalized = normalizeFsPath(trimmed);
+
+  for (const blocked of SYSTEM_BLOCKLIST) {
+    if (normalized === normalizeFsPath(blocked)) {
+      return { success: false, error: `Cannot add system directory: ${normalized}. This path is on the security blocklist.` };
+    }
+  }
+
+  if (!fs.existsSync(normalized)) {
+    return { success: false, error: `Path does not exist: ${normalized}` };
+  }
+
+  let stat: fs.Stats;
+  try {
+    stat = fs.statSync(normalized);
+  } catch {
+    return { success: false, error: `Path is not readable: ${normalized}` };
+  }
+  if (!stat.isDirectory()) {
+    return { success: false, error: `Path is not a directory: ${normalized}` };
+  }
+
+  const configPath = getAllowedRootsConfigPath();
+  let current: { additional_roots: string[] } = { additional_roots: [] };
+  if (fs.existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (Array.isArray(parsed.additional_roots)) {
+        current.additional_roots = parsed.additional_roots
+          .filter((r: unknown): r is string => typeof r === 'string')
+          .map((r: string) => normalizeFsPath(r));
+      }
+    } catch { /* malformed — treat as empty */ }
+  }
+
+  if (current.additional_roots.includes(normalized)) {
+    return { success: false, error: `Path is already in the allowed roots list: ${normalized}` };
+  }
+
+  const updated = { additional_roots: [...current.additional_roots, normalized] };
+  const configDir = path.dirname(configPath);
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+  const tmpPath = configPath + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(updated, null, 2));
+  fs.renameSync(tmpPath, configPath);
+
+  revalidatePath('/settings');
+  return { success: true };
+}
+
+export async function removeAllowedRoot(rawPath: string): Promise<ActionResult> {
+  const normalized = normalizeFsPath(rawPath.trim());
+  const configPath = getAllowedRootsConfigPath();
+
+  let current: { additional_roots: string[] } = { additional_roots: [] };
+  if (fs.existsSync(configPath)) {
+    try {
+      const parsed = JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+      if (Array.isArray(parsed.additional_roots)) {
+        current.additional_roots = parsed.additional_roots
+          .filter((r: unknown): r is string => typeof r === 'string')
+          .map((r: string) => normalizeFsPath(r));
+      }
+    } catch { /* malformed — treat as empty */ }
+  }
+
+  const updated = { additional_roots: current.additional_roots.filter((r) => r !== normalized) };
+  const configDir = path.dirname(configPath);
+  if (!fs.existsSync(configDir)) {
+    fs.mkdirSync(configDir, { recursive: true });
+  }
+  const tmpPath = configPath + '.tmp';
+  fs.writeFileSync(tmpPath, JSON.stringify(updated, null, 2));
+  fs.renameSync(tmpPath, configPath);
+
+  revalidatePath('/settings');
+  return { success: true };
 }

--- a/dashboard/src/lib/config.ts
+++ b/dashboard/src/lib/config.ts
@@ -201,3 +201,7 @@ export function getAllAgents(): Array<{ name: string; org: string }> {
 
   return agents;
 }
+
+export function getAllowedRootsConfigPath(): string {
+  return path.join(CTX_ROOT, 'config', 'allowed-roots.json');
+}

--- a/dashboard/src/lib/types.ts
+++ b/dashboard/src/lib/types.ts
@@ -47,6 +47,12 @@ export interface Heartbeat {
 export type TaskStatus = 'pending' | 'in_progress' | 'blocked' | 'completed';
 export type TaskPriority = 'critical' | 'urgent' | 'high' | 'normal' | 'low';
 
+export interface TaskOutput {
+  type: 'file';
+  value: string;
+  label?: string;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -62,6 +68,7 @@ export interface Task {
   completed_at?: string;
   notes?: string;
   source_file?: string;
+  outputs?: TaskOutput[];
 }
 
 // -- Approval Types --

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "tslib": "^2.4.0"
       }
@@ -1583,7 +1584,6 @@
       "integrity": "sha512-tO4ZIRKNC+MDWV4qKVZe3Ql/woTnmHDr5JD8UI5hn2pwBrHEwOEMZK7WlNb5RKB6EoJ02gwmQS9OrjuFnZYdpg==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.18.0"
       }
@@ -1923,7 +1923,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -2606,7 +2605,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2688,7 +2686,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -3182,7 +3179,6 @@
       "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "~0.27.0",
         "get-tsconfig": "^4.7.5"
@@ -3218,7 +3214,6 @@
       "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/src/bus/save-output.ts
+++ b/src/bus/save-output.ts
@@ -1,0 +1,128 @@
+import {
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  unlinkSync,
+} from 'fs';
+import { basename, extname, join, posix, relative, sep } from 'path';
+import type { BusPaths, Task, TaskOutput } from '../types/index.js';
+import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+
+export interface SaveOutputOptions {
+  /** Source file to copy or move into the deliverables tree. */
+  sourcePath: string;
+  /** Target task ID. The task must already exist. */
+  taskId: string;
+  /** Optional human-readable label for the linked output. Defaults to the basename. */
+  label?: string;
+  /**
+   * If true, delete the source file after a successful copy.
+   * Defaults to false (copy semantics).
+   */
+  move?: boolean;
+  /**
+   * If true, skip appending the entry to task.outputs[].
+   * The file is still saved into the deliverables tree.
+   */
+  noLink?: boolean;
+}
+
+export interface SaveOutputResult {
+  /** Absolute path of the saved file inside the deliverables tree. */
+  targetPath: string;
+  /**
+   * Path stored in task.outputs[].value when linked.
+   * Always relative to ctxRoot, always forward-slash separated for cross-platform
+   * dashboard rendering (the /api/media route accepts forward-slash paths on every OS).
+   */
+  storedPath: string;
+  /** True if the entry was appended to task.outputs[]. */
+  linked: boolean;
+}
+
+/**
+ * Copy a file into the per-task deliverables tree and (by default) link it
+ * to the task as a `file` output entry. Single atomic surface so callers
+ * cannot forget the link half of the operation.
+ *
+ * Layout (under CTX_ROOT so /api/media can serve it):
+ *   {ctxRoot}/orgs/{org}/deliverables/{agent}/{task_id}/{filename}
+ *
+ * Filename collisions append `-1`, `-2`, ... before the extension until unique.
+ */
+export function saveOutput(
+  paths: BusPaths,
+  options: SaveOutputOptions,
+): SaveOutputResult {
+  const { sourcePath, taskId, label, move = false, noLink = false } = options;
+
+  if (!existsSync(sourcePath)) {
+    throw new Error(`Source file not found: ${sourcePath}`);
+  }
+
+  const taskFile = join(paths.taskDir, `${taskId}.json`);
+  if (!existsSync(taskFile)) {
+    throw new Error(`Task not found: ${taskId}`);
+  }
+  const task: Task = JSON.parse(readFileSync(taskFile, 'utf-8'));
+
+  const taskDir = join(paths.deliverablesDir, task.assigned_to, taskId);
+  ensureDir(taskDir);
+
+  const sourceName = basename(sourcePath);
+  const targetPath = resolveCollision(taskDir, sourceName);
+
+  copyFileSync(sourcePath, targetPath);
+  if (move) {
+    try {
+      unlinkSync(sourcePath);
+    } catch (err) {
+      throw new Error(
+        `Copied to ${targetPath} but failed to remove source ${sourcePath}: ${(err as Error).message}`,
+      );
+    }
+  }
+
+  const storedPath = toPosixRelative(paths.ctxRoot, targetPath);
+
+  if (noLink) {
+    return { targetPath, storedPath, linked: false };
+  }
+
+  const entry: TaskOutput = {
+    type: 'file',
+    value: storedPath,
+    label: label ?? basename(targetPath),
+  };
+  task.outputs = [...(task.outputs ?? []), entry];
+  task.updated_at = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+  atomicWriteSync(taskFile, JSON.stringify(task, null, 2));
+
+  return { targetPath, storedPath, linked: true };
+}
+
+/**
+ * Find a non-colliding filename inside `dir` for `desiredName`.
+ * Strategy: if `foo.png` exists, try `foo-1.png`, `foo-2.png`, ...
+ */
+function resolveCollision(dir: string, desiredName: string): string {
+  const candidate = join(dir, desiredName);
+  if (!existsSync(candidate)) return candidate;
+
+  const ext = extname(desiredName);
+  const stem = ext ? desiredName.slice(0, -ext.length) : desiredName;
+  for (let i = 1; i < 10_000; i++) {
+    const next = join(dir, `${stem}-${i}${ext}`);
+    if (!existsSync(next)) return next;
+  }
+  throw new Error(`Could not resolve unique filename in ${dir} for ${desiredName}`);
+}
+
+/**
+ * Convert an absolute path under `root` to a forward-slash relative path,
+ * suitable for storing in task.outputs[].value and serving via /api/media.
+ */
+function toPosixRelative(root: string, abs: string): string {
+  const rel = relative(root, abs);
+  return rel.split(sep).join(posix.sep);
+}

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 import { sendMessage, checkInbox, ackInbox } from '../bus/message.js';
 import { validateAgentName } from '../utils/validate.js';
 import { createTask, updateTask, completeTask, listTasks, checkStaleTasks, archiveTasks, checkHumanTasks } from '../bus/task.js';
+import { saveOutput } from '../bus/save-output.js';
 import { logEvent } from '../bus/event.js';
 import { updateHeartbeat, readAllHeartbeats } from '../bus/heartbeat.js';
 import { selfRestart, hardRestart, autoCommit, checkGoalStaleness, postActivity } from '../bus/system.js';
@@ -20,7 +21,43 @@ import { resolveEnv } from '../utils/env.js';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { logOutboundMessage, cacheLastSent } from '../telegram/logging.js';
-import type { Priority, TaskStatus, EventCategory, EventSeverity, ApprovalCategory, ApprovalStatus } from '../types/index.js';
+import type { Priority, Task, TaskStatus, EventCategory, EventSeverity, ApprovalCategory, ApprovalStatus, OrgContext } from '../types/index.js';
+
+/**
+ * Check if the org requires deliverables and the task has none attached.
+ * Returns an error message if the transition should be blocked, or null if allowed.
+ */
+function checkDeliverableRequirement(taskId: string, frameworkRoot: string, org: string, taskDir: string): string | null {
+  // Read org context to check require_deliverables setting
+  const contextPath = join(frameworkRoot, 'orgs', org, 'context.json');
+  if (!existsSync(contextPath)) return null;
+
+  let ctx: OrgContext;
+  try {
+    ctx = JSON.parse(readFileSync(contextPath, 'utf-8'));
+  } catch {
+    return null; // cannot read config — allow the transition
+  }
+
+  if (!ctx.require_deliverables) return null;
+
+  // Check if the task has outputs
+  const taskFile = join(taskDir, `${taskId}.json`);
+  if (!existsSync(taskFile)) return null;
+
+  let task: Task;
+  try {
+    task = JSON.parse(readFileSync(taskFile, 'utf-8'));
+  } catch {
+    return null;
+  }
+
+  if (!task.outputs || task.outputs.length === 0) {
+    return `Cannot submit task ${taskId}: require_deliverables is enabled but this task has no file deliverables attached. Use "cortextos bus save-output ${taskId} <file>" to attach a deliverable first.`;
+  }
+
+  return null;
+}
 
 export const busCommand = new Command('bus')
   .description('Bus commands for agent messaging, tasks, and events');
@@ -128,6 +165,18 @@ busCommand
     }
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
+
+    // Guard: block review/completion when deliverables are required but missing.
+    // Checks both ready_for_review (approval workflow) and completed (vanilla upstream)
+    // so the validator works regardless of which status set is installed.
+    if ((status === 'ready_for_review' || status === 'completed') && env.org) {
+      const err = checkDeliverableRequirement(id, env.frameworkRoot, env.org, paths.taskDir);
+      if (err) {
+        console.error(err);
+        process.exit(1);
+      }
+    }
+
     updateTask(paths, id, status as TaskStatus);
     console.log(`Updated ${id} -> ${status}`);
   });
@@ -142,8 +191,48 @@ busCommand
     const effectiveResult = opts.result ?? resultArg;
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
+
+    // Guard: block completion when deliverables are required but missing
+    if (env.org) {
+      const err = checkDeliverableRequirement(id, env.frameworkRoot, env.org, paths.taskDir);
+      if (err) {
+        console.error(err);
+        process.exit(1);
+      }
+    }
+
     completeTask(paths, id, effectiveResult);
     console.log(`Completed ${id}`);
+  });
+
+busCommand
+  .command('save-output')
+  .description('Copy a file into the per-task deliverables tree and link it to the task as a file output')
+  .argument('<task-id>', 'Target task ID')
+  .argument('<source>', 'Source file to save (absolute or relative to cwd)')
+  .option('--label <label>', 'Human-readable label for the linked output (defaults to filename)')
+  .option('--move', 'Delete the source file after a successful copy')
+  .option('--no-link', 'Save file without linking to task.outputs[]')
+  .action((taskId: string, source: string, opts: { label?: string; move?: boolean; link?: boolean }) => {
+    const noLink = opts.link === false;
+    const env = resolveEnv();
+    const paths = resolvePaths(env.agentName, env.instanceId, env.org);
+    try {
+      const result = saveOutput(paths, {
+        taskId,
+        sourcePath: source,
+        label: opts.label,
+        move: opts.move ?? false,
+        noLink,
+      });
+      console.log(result.targetPath);
+      if (result.linked) {
+        console.log(`Linked to ${taskId} as [snapshot] ${opts.label ?? result.storedPath}`);
+      }
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
   });
 
 busCommand

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -405,13 +405,15 @@ export class AgentProcess {
 
     const nowUtc = new Date().toISOString();
     const reminderBlock = this.buildReminderBlock();
-    return `You are starting a new session. Current UTC time: ${nowUtc}. Read AGENTS.md and all bootstrap files listed there. Then restore your crons from config.json: for each entry with type "recurring" (or no type field), call /loop {interval} {prompt}; for each entry with type "once", compare fire_at against the current UTC time above — if fire_at is still in the future recreate the CronCreate, if fire_at is in the past delete that entry from config.json. Run CronList first to avoid duplicates.${reminderBlock} After setting up crons, send a Telegram message to the user saying you are back online.${onboardingAppend}`;
+    const deliverablesBlock = this.buildDeliverablesBlock();
+    return `You are starting a new session. Current UTC time: ${nowUtc}. Read AGENTS.md and all bootstrap files listed there. Then restore your crons from config.json: for each entry with type "recurring" (or no type field), call /loop {interval} {prompt}; for each entry with type "once", compare fire_at against the current UTC time above — if fire_at is still in the future recreate the CronCreate, if fire_at is in the past delete that entry from config.json. Run CronList first to avoid duplicates.${reminderBlock}${deliverablesBlock} After setting up crons, send a Telegram message to the user saying you are back online.${onboardingAppend}`;
   }
 
   private buildContinuePrompt(): string {
     const nowUtc = new Date().toISOString();
     const reminderBlock = this.buildReminderBlock();
-    return `SESSION CONTINUATION: Your CLI process was restarted with --continue to reload configs. Current UTC time: ${nowUtc}. Your full conversation history is preserved. Re-read AGENTS.md and ALL bootstrap files listed there. Restore your crons from config.json: recurring entries use /loop, once entries use CronCreate only if fire_at is still in the future (delete expired ones from config.json). Run CronList first — no duplicates.${reminderBlock} Check inbox. Resume normal operations. After restoring crons and checking inbox, send a Telegram message to the user saying you are back online.`;
+    const deliverablesBlock = this.buildDeliverablesBlock();
+    return `SESSION CONTINUATION: Your CLI process was restarted with --continue to reload configs. Current UTC time: ${nowUtc}. Your full conversation history is preserved. Re-read AGENTS.md and ALL bootstrap files listed there. Restore your crons from config.json: recurring entries use /loop, once entries use CronCreate only if fire_at is still in the future (delete expired ones from config.json). Run CronList first — no duplicates.${reminderBlock}${deliverablesBlock} Check inbox. Resume normal operations. After restoring crons and checking inbox, send a Telegram message to the user saying you are back online.`;
   }
 
   /**
@@ -428,6 +430,26 @@ export class AgentProcess {
         `  - [${r.id}] (due ${r.fire_at}): ${r.prompt}`,
       ).join('\n');
       return ` You also have ${overdue.length} overdue persistent reminder(s) from before this restart — handle each one, then run: cortextos bus ack-reminder <id>\n${items}`;
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * Build a deliverable-standard instruction block for the boot prompt.
+   * When require_deliverables is enabled in the org's context.json, agents
+   * are told that every task submitted for review must have at least one
+   * file attached via save-output. The instruction is injected dynamically
+   * so existing agents pick up the rule on their next boot with zero file
+   * changes, and toggling it off removes it from the next startup prompt.
+   */
+  private buildDeliverablesBlock(): string {
+    try {
+      const contextPath = join(this.env.frameworkRoot, 'orgs', this.env.org, 'context.json');
+      if (!existsSync(contextPath)) return '';
+      const ctx = JSON.parse(readFileSync(contextPath, 'utf-8'));
+      if (!ctx.require_deliverables) return '';
+      return ' DELIVERABLE STANDARD: Every task you submit for review MUST have at least one file deliverable attached via the save-output bus command. A task with zero file deliverables will be sent back. Attach files with: cortextos bus save-output <task-id> <file-path> --label "<descriptive label>". Labels must be human-readable at a glance: describe WHAT it is plus enough context to understand at a glance. Good: "Traffic Growth Plan — 10 channels, 30-day launch sequence". Bad: "traffic-growth-plan.md" or "output-1". Notes are for context only, never file paths or URLs.';
     } catch {
       return '';
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -29,6 +29,15 @@ export interface InboxMessage {
 
 export type TaskStatus = 'pending' | 'in_progress' | 'completed' | 'blocked' | 'cancelled';
 
+export interface TaskOutput {
+  /** Output kind. "file" links to a saved deliverable; other shapes reserved. */
+  type: 'file';
+  /** For type:"file", the path to the file relative to CTX_ROOT (forward-slash separated). */
+  value: string;
+  /** Optional human-readable label shown in dashboard task detail. */
+  label?: string;
+}
+
 export interface Task {
   id: string;
   title: string;
@@ -48,6 +57,8 @@ export interface Task {
   due_date: string | null;
   archived: boolean;
   result?: string;
+  /** Linked deliverables (files saved via `cortextos bus save-output`). */
+  outputs?: TaskOutput[];
 }
 
 // Event Types
@@ -179,6 +190,11 @@ export interface OrgContext {
   default_approval_categories?: string[];
   communication_style?: string;
   dashboard_url?: string;
+  /** When true, agents are instructed at startup that every task submitted
+   *  for review must have at least one file deliverable attached via
+   *  save-output. The instruction is injected into the boot prompt
+   *  dynamically — no agent markdown files are modified. */
+  require_deliverables?: boolean;
 }
 
 // Telegram Types
@@ -298,6 +314,12 @@ export interface BusPaths {
   taskDir: string;
   approvalDir: string;
   analyticsDir: string;
+  /**
+   * Per-org deliverables root: {ctxRoot}/orgs/{org}/deliverables/.
+   * Files saved here are servable by the dashboard's /api/media route because
+   * they live under CTX_ROOT.
+   */
+  deliverablesDir: string;
 }
 
 // IPC Types

--- a/src/utils/allowed-roots.ts
+++ b/src/utils/allowed-roots.ts
@@ -1,0 +1,197 @@
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { dirname, isAbsolute } from 'path';
+import { atomicWriteSync } from './atomic.js';
+
+/**
+ * Allowed-roots config layer for the deliverables system.
+ *
+ * The config file at {ctxRoot}/config/allowed-roots.json lists ADDITIONAL
+ * absolute directories that the dashboard /api/media route is permitted to
+ * serve from, beyond the implicit CTX_ROOT default.
+ *
+ * On a fresh install the file is missing and the additional list is empty,
+ * which means snapshot-only is enforced (the existing CTX_ROOT-prefix-check
+ * behavior). The user adds entries via the Settings > Allowed Roots tab.
+ */
+
+export interface AllowedRootsFile {
+  additional_roots: string[];
+}
+
+export interface AddAllowedRootResult {
+  success: boolean;
+  error?: string;
+  config?: AllowedRootsFile;
+}
+
+export interface RemoveAllowedRootResult {
+  success: boolean;
+  error?: string;
+  config?: AllowedRootsFile;
+}
+
+/**
+ * System directories that should never be added as allowed roots. Adding any
+ * of these would let the dashboard serve files from places like /etc, ~/.ssh,
+ * or the entire root of the drive.
+ */
+export const SYSTEM_BLOCKLIST: ReadonlyArray<string> = [
+  '/',
+  'C:/',
+  'D:/',
+  'E:/',
+  '/usr',
+  '/etc',
+  '/var',
+  '/sys',
+  '/proc',
+  '/boot',
+  '/dev',
+  '/root',
+  '/System',
+  'C:/Windows',
+  'C:/Program Files',
+  'C:/Program Files (x86)',
+];
+
+/**
+ * Read the allowed-roots config from disk. Returns an empty config if the
+ * file is missing or unreadable.
+ */
+export function readAllowedRoots(configPath: string): AllowedRootsFile {
+  const empty: AllowedRootsFile = { additional_roots: [] };
+  if (!existsSync(configPath)) return empty;
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object') return empty;
+    const roots = Array.isArray(parsed.additional_roots) ? parsed.additional_roots : [];
+    return {
+      additional_roots: roots
+        .filter((r: unknown): r is string => typeof r === 'string')
+        .map((r: string) => normalizePath(r)),
+    };
+  } catch {
+    return empty;
+  }
+}
+
+/**
+ * Append a new allowed root after validating it.
+ */
+export function addAllowedRoot(
+  configPath: string,
+  rawPath: string,
+): AddAllowedRootResult {
+  const trimmed = rawPath.trim();
+  if (!trimmed) {
+    return { success: false, error: 'Path is required' };
+  }
+
+  if (!isAbsolute(trimmed)) {
+    return { success: false, error: 'Path must be absolute (start with / or a drive letter)' };
+  }
+
+  const normalized = normalizePath(trimmed);
+
+  if (isSystemBlocklisted(normalized)) {
+    return {
+      success: false,
+      error: `Cannot add system directory: ${normalized}. This path is on the security blocklist.`,
+    };
+  }
+
+  if (!existsSync(normalized)) {
+    return { success: false, error: `Path does not exist: ${normalized}` };
+  }
+
+  const current = readAllowedRoots(configPath);
+  if (current.additional_roots.includes(normalized)) {
+    return { success: false, error: `Path is already in the allowed roots list: ${normalized}` };
+  }
+
+  const updated: AllowedRootsFile = {
+    additional_roots: [...current.additional_roots, normalized],
+  };
+
+  ensureConfigDir(configPath);
+  atomicWriteSync(configPath, JSON.stringify(updated, null, 2));
+
+  return { success: true, config: updated };
+}
+
+/**
+ * Remove an allowed root by exact path match.
+ */
+export function removeAllowedRoot(
+  configPath: string,
+  rawPath: string,
+): RemoveAllowedRootResult {
+  const normalized = normalizePath(rawPath.trim());
+  const current = readAllowedRoots(configPath);
+  const updated: AllowedRootsFile = {
+    additional_roots: current.additional_roots.filter((r) => r !== normalized),
+  };
+
+  ensureConfigDir(configPath);
+  atomicWriteSync(configPath, JSON.stringify(updated, null, 2));
+
+  return { success: true, config: updated };
+}
+
+/**
+ * Compute the full set of valid roots: CTX_ROOT plus any additional entries.
+ */
+export function computeValidRoots(
+  ctxRoot: string,
+  configPath: string,
+): string[] {
+  const config = readAllowedRoots(configPath);
+  const set = new Set<string>([
+    normalizePath(ctxRoot),
+    ...config.additional_roots,
+  ]);
+  return Array.from(set);
+}
+
+/**
+ * Check whether a given absolute path falls within any of the supplied roots.
+ */
+export function isPathUnderRoots(
+  normalizedPath: string,
+  roots: string[],
+): boolean {
+  for (const root of roots) {
+    const rootWithSep = root.endsWith('/') ? root : root + '/';
+    if (normalizedPath === root || normalizedPath.startsWith(rootWithSep)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function normalizePath(p: string): string {
+  let normalized = p.replace(/\\/g, '/');
+  if (normalized.length > 1 && normalized.endsWith('/') && !/^[A-Za-z]:\/$/.test(normalized)) {
+    normalized = normalized.slice(0, -1);
+  }
+  return normalized;
+}
+
+function isSystemBlocklisted(normalizedPath: string): boolean {
+  for (const blocked of SYSTEM_BLOCKLIST) {
+    const normalizedBlocked = normalizePath(blocked);
+    if (normalizedPath === normalizedBlocked) return true;
+  }
+  return false;
+}
+
+function ensureConfigDir(configPath: string): void {
+  const dir = dirname(configPath);
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+}

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -44,6 +44,7 @@ export function resolvePaths(
     taskDir: join(orgBase, 'tasks'),
     approvalDir: join(orgBase, 'approvals'),
     analyticsDir: join(orgBase, 'analytics'),
+    deliverablesDir: join(orgBase, 'deliverables'),
   };
 }
 

--- a/tests/unit/utils/allowed-roots.test.ts
+++ b/tests/unit/utils/allowed-roots.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { existsSync, mkdtempSync, rmSync, writeFileSync, mkdirSync, symlinkSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, sep } from 'path';
+import {
+  addAllowedRoot,
+  removeAllowedRoot,
+  readAllowedRoots,
+  computeValidRoots,
+  isPathUnderRoots,
+  SYSTEM_BLOCKLIST,
+} from '../../../src/utils/allowed-roots.js';
+
+// Adversarial path-traversal / root-enforcement tests for the deliverables
+// allowed-roots system. These guard the media API resolver's security
+// contract: agent-controlled relative paths must never resolve to a file
+// outside an allowed root, no matter what escaping they attempt.
+
+let tmpRoot: string;
+let configPath: string;
+let ctxRoot: string;
+let allowedExtra: string;
+let forbiddenSibling: string;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'ctx-roots-'));
+  ctxRoot = join(tmpRoot, 'ctx');
+  allowedExtra = join(tmpRoot, 'allowed-extra');
+  forbiddenSibling = join(tmpRoot, 'forbidden-sibling');
+  mkdirSync(ctxRoot, { recursive: true });
+  mkdirSync(allowedExtra, { recursive: true });
+  mkdirSync(forbiddenSibling, { recursive: true });
+  configPath = join(ctxRoot, 'config', 'allowed-roots.json');
+});
+
+afterEach(() => {
+  try {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    // best-effort cleanup
+  }
+});
+
+describe('readAllowedRoots', () => {
+  it('returns empty when file missing', () => {
+    expect(readAllowedRoots(configPath)).toEqual({ additional_roots: [] });
+  });
+
+  it('returns empty when file contains invalid JSON', () => {
+    mkdirSync(join(ctxRoot, 'config'));
+    writeFileSync(configPath, '{not json');
+    expect(readAllowedRoots(configPath)).toEqual({ additional_roots: [] });
+  });
+
+  it('strips non-string entries defensively', () => {
+    mkdirSync(join(ctxRoot, 'config'));
+    writeFileSync(
+      configPath,
+      JSON.stringify({ additional_roots: [allowedExtra, 42, null, { x: 1 }] }),
+    );
+    const out = readAllowedRoots(configPath);
+    expect(out.additional_roots).toEqual([allowedExtra.replace(/\\/g, '/')]);
+  });
+});
+
+describe('addAllowedRoot — adversarial inputs', () => {
+  it('rejects empty paths', () => {
+    expect(addAllowedRoot(configPath, '').success).toBe(false);
+    expect(addAllowedRoot(configPath, '   ').success).toBe(false);
+  });
+
+  it('rejects relative paths', () => {
+    const r = addAllowedRoot(configPath, '../../../etc');
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/absolute/i);
+  });
+
+  it('rejects every entry on the system blocklist', () => {
+    for (const blocked of SYSTEM_BLOCKLIST) {
+      const r = addAllowedRoot(configPath, blocked);
+      expect(r.success, `should block ${blocked}`).toBe(false);
+      // Either reason is fine — "not absolute" (Windows drive paths on Unix)
+      // or "blocklist". The key requirement is that every blocklisted path
+      // is refused.
+      expect(r.error).toBeDefined();
+    }
+  });
+
+  it('rejects nonexistent paths', () => {
+    const r = addAllowedRoot(configPath, join(tmpRoot, 'does-not-exist'));
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects duplicate entries', () => {
+    expect(addAllowedRoot(configPath, allowedExtra).success).toBe(true);
+    const r = addAllowedRoot(configPath, allowedExtra);
+    expect(r.success).toBe(false);
+    expect(r.error).toMatch(/already/i);
+  });
+
+  it('accepts a valid absolute path and persists it', () => {
+    const r = addAllowedRoot(configPath, allowedExtra);
+    expect(r.success).toBe(true);
+    expect(existsSync(configPath)).toBe(true);
+    const re = readAllowedRoots(configPath);
+    expect(re.additional_roots).toContain(allowedExtra.replace(/\\/g, '/'));
+  });
+});
+
+describe('removeAllowedRoot', () => {
+  it('removes a previously-added path', () => {
+    addAllowedRoot(configPath, allowedExtra);
+    const r = removeAllowedRoot(configPath, allowedExtra);
+    expect(r.success).toBe(true);
+    expect(readAllowedRoots(configPath).additional_roots).not.toContain(
+      allowedExtra.replace(/\\/g, '/'),
+    );
+  });
+
+  it('is a no-op when path was never added', () => {
+    const r = removeAllowedRoot(configPath, allowedExtra);
+    expect(r.success).toBe(true);
+  });
+});
+
+describe('isPathUnderRoots — traversal resistance', () => {
+  const roots = ['/home/user/ctx', '/allowed/extra'];
+
+  it('accepts exact root match', () => {
+    expect(isPathUnderRoots('/home/user/ctx', roots)).toBe(true);
+  });
+
+  it('accepts nested path under a root', () => {
+    expect(isPathUnderRoots('/home/user/ctx/sub/file.md', roots)).toBe(true);
+  });
+
+  it('rejects a path that is only a prefix sibling (not under root)', () => {
+    // Classic startsWith() bug: /home/user/ctx-evil starts with /home/user/ctx
+    // but is NOT inside /home/user/ctx. Must be rejected.
+    expect(isPathUnderRoots('/home/user/ctx-evil/secrets', roots)).toBe(false);
+    expect(isPathUnderRoots('/home/user/ctxevil', roots)).toBe(false);
+  });
+
+  it('rejects sibling of allowed-extra', () => {
+    expect(isPathUnderRoots('/allowed/extra-evil/x', roots)).toBe(false);
+  });
+
+  it('rejects a parent directory of a root', () => {
+    expect(isPathUnderRoots('/home/user', roots)).toBe(false);
+    expect(isPathUnderRoots('/home', roots)).toBe(false);
+    expect(isPathUnderRoots('/', roots)).toBe(false);
+  });
+
+  it('rejects unrelated paths', () => {
+    expect(isPathUnderRoots('/etc/passwd', roots)).toBe(false);
+    expect(isPathUnderRoots('/root/.ssh/id_rsa', roots)).toBe(false);
+  });
+});
+
+describe('computeValidRoots', () => {
+  it('always includes CTX_ROOT even when config file missing', () => {
+    const roots = computeValidRoots(ctxRoot, configPath);
+    expect(roots).toContain(ctxRoot.replace(/\\/g, '/'));
+  });
+
+  it('dedupes CTX_ROOT if it is also in additional_roots', () => {
+    addAllowedRoot(configPath, ctxRoot);
+    const roots = computeValidRoots(ctxRoot, configPath);
+    const normalized = ctxRoot.replace(/\\/g, '/');
+    expect(roots.filter(r => r === normalized).length).toBe(1);
+  });
+
+  it('includes both CTX_ROOT and extra roots', () => {
+    addAllowedRoot(configPath, allowedExtra);
+    const roots = computeValidRoots(ctxRoot, configPath);
+    expect(roots).toContain(ctxRoot.replace(/\\/g, '/'));
+    expect(roots).toContain(allowedExtra.replace(/\\/g, '/'));
+  });
+});
+
+describe('realpath-based traversal (integration)', () => {
+  // This test simulates the full media-route security check: build the roots,
+  // simulate a relative path with ../ escape, resolve it, and verify that
+  // isPathUnderRoots correctly rejects the escaped path.
+  it('rejects ../ traversal that escapes CTX_ROOT', () => {
+    addAllowedRoot(configPath, allowedExtra);
+    writeFileSync(join(forbiddenSibling, 'secret.txt'), 'SECRET');
+
+    const roots = computeValidRoots(ctxRoot, configPath).map(r => r.replace(/\\/g, '/'));
+    // Simulate what the API would compute: join(ctxRoot, '../forbidden-sibling/secret.txt')
+    const escaped = join(ctxRoot, '..', 'forbidden-sibling', 'secret.txt')
+      .replace(/\\/g, '/');
+
+    expect(isPathUnderRoots(escaped, roots)).toBe(false);
+  });
+
+  it('rejects absolute path that is not under any root', () => {
+    addAllowedRoot(configPath, allowedExtra);
+    const roots = computeValidRoots(ctxRoot, configPath).map(r => r.replace(/\\/g, '/'));
+    expect(isPathUnderRoots('/etc/passwd', roots)).toBe(false);
+    expect(isPathUnderRoots(forbiddenSibling.replace(/\\/g, '/'), roots)).toBe(false);
+  });
+
+  it('accepts path that is genuinely under an allowed extra root', () => {
+    addAllowedRoot(configPath, allowedExtra);
+    const fileInAllowed = join(allowedExtra, 'inside.md').replace(/\\/g, '/');
+    writeFileSync(fileInAllowed, '# ok');
+
+    const roots = computeValidRoots(ctxRoot, configPath).map(r => r.replace(/\\/g, '/'));
+    expect(isPathUnderRoots(fileInAllowed, roots)).toBe(true);
+  });
+
+  it('rejects a symlink target that escapes the root when NOT realpath-resolved', () => {
+    // Skip on platforms that don't support symlinks reliably in tmp
+    if (process.platform === 'win32') return;
+
+    const link = join(allowedExtra, 'link-to-secret');
+    writeFileSync(join(forbiddenSibling, 'secret.txt'), 'SECRET');
+    try {
+      symlinkSync(join(forbiddenSibling, 'secret.txt'), link);
+    } catch {
+      return; // cannot create symlinks in this sandbox
+    }
+
+    // The lexical path (under allowedExtra) would pass isPathUnderRoots.
+    // This test documents that the media route MUST call realpathSync to
+    // resolve the symlink to its real target before calling isPathUnderRoots
+    // — otherwise the check could be bypassed via symlinks. The realpath
+    // target `forbiddenSibling/secret.txt` is correctly rejected below.
+    const roots = computeValidRoots(ctxRoot, configPath).map(r => r.replace(/\\/g, '/'));
+    const linkLexical = link.replace(/\\/g, '/');
+    const realTarget = join(forbiddenSibling, 'secret.txt').replace(/\\/g, '/');
+
+    expect(isPathUnderRoots(linkLexical, [allowedExtra.replace(/\\/g, '/')])).toBe(true);
+    expect(isPathUnderRoots(realTarget, roots)).toBe(false);
+  });
+});
+
+describe('null-byte and control-char inputs', () => {
+  it('does not crash on null-byte paths', () => {
+    // Adding a path with null byte should fail cleanly (existsSync returns false)
+    const r = addAllowedRoot(configPath, '/tmp/evil\0/../etc');
+    expect(r.success).toBe(false);
+  });
+
+  it('does not crash on extremely long paths', () => {
+    const longPath = '/' + 'a'.repeat(4096);
+    const r = addAllowedRoot(configPath, longPath);
+    expect(r.success).toBe(false);
+  });
+});
+
+// sep is referenced to silence unused-import warning on some platforms.
+void sep;


### PR DESCRIPTION
## Problem

Agents produce files but cortextOS has no way to attach outputs to tasks, preview them inline, or enforce deliverables before submission.

## Solution

Complete deliverables system: save-output bus command, task detail deliverables section, inline preview panel (markdown with auto-linked file refs, HTML, images, code), configurable allowed roots with multi-root resolution, and an enforcement toggle that controls UI visibility + blocks submission without attachments.

18 files, +1543 lines. tsc clean. Universal.

## Testing

1. Enable toggle in Settings > Organization
2. Attempt to complete task without files - blocked
3. Attach file via save-output, verify in task detail
4. Click to preview - verify rendering
5. Test markdown file-ref drill-down
6. Check allowed roots in Settings
7. Toggle off/on - data persists

## Platform

Windows 11, Node.js 22, Next.js 14, TypeScript strict