### PR TITLE
fix(daemon): replace exec() with execFile() in heartbeat watchdog (issue #54)

### DIFF
--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, existsSync, writeFileSync, unlinkSync } from 'fs';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
@@ -94,7 +94,7 @@ export class FastChecker {
     const agentName = this.agent.name;
     this.heartbeatTimer = setInterval(() => {
       const ts = new Date().toISOString();
-      exec(`cortextos bus update-heartbeat "[watchdog] ${agentName} alive — idle session ${ts}"`, (err) => {
+      execFile('cortextos', ['bus', 'update-heartbeat', `[watchdog] ${agentName} alive — idle session ${ts}`], (err) => {
         if (err) this.log(`Heartbeat watchdog error: ${err.message}`);
       });
     }, HEARTBEAT_INTERVAL_MS);

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-vi.mock('child_process', () => ({ exec: vi.fn() }));
+vi.mock('child_process', () => ({ execFile: vi.fn() }));
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -568,13 +568,14 @@ describe('FastChecker', () => {
     afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
 
     it('fires exec after bootstrap at 50-min interval', async () => {
-      const { exec } = await import('child_process');
+      const { execFile } = await import('child_process');
       const agent = createMockAgent('my-agent');
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
-      expect(exec).toHaveBeenCalledWith(
-        expect.stringContaining('[watchdog] my-agent alive — idle session'),
+      expect(execFile).toHaveBeenCalledWith(
+        'cortextos',
+        expect.arrayContaining(['bus', 'update-heartbeat', expect.stringContaining('[watchdog] my-agent alive — idle session')]),
         expect.any(Function),
       );
       checker.stop();
@@ -582,8 +583,8 @@ describe('FastChecker', () => {
     });
 
     it('clears timer on stop — no further exec calls after stop', async () => {
-      const { exec } = await import('child_process');
-      const execMock = exec as ReturnType<typeof vi.fn>;
+      const { execFile } = await import('child_process');
+      const execMock = execFile as ReturnType<typeof vi.fn>;
       const agent = createMockAgent('my-agent');
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
@@ -597,14 +598,15 @@ describe('FastChecker', () => {
     });
 
     it('does not fire before bootstrap completes', async () => {
-      const { exec } = await import('child_process');
+      const { execFile } = await import('child_process');
       const agent = createMockAgent('my-agent');
       agent.isBootstrapped.mockReturnValue(false);
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(20 * 1000);
-      expect(exec).not.toHaveBeenCalledWith(
-        expect.stringContaining('[watchdog]'),
+      expect(execFile).not.toHaveBeenCalledWith(
+        'cortextos',
+        expect.arrayContaining([expect.stringContaining('[watchdog]')]),
         expect.any(Function),
       );
       checker.stop();


### PR DESCRIPTION
## Summary

- Replaces `exec()` string-interpolation call in the 50-min heartbeat watchdog with `execFile()` passing args as an array
- Eliminates shell parsing of `agentName` entirely — defense-in-depth regardless of upstream validation changes
- Updates test mock from `exec` → `execFile` and assertion from string-match to array-match

## Why

`exec()` with any template interpolation means safety depends entirely on every upstream validation path. `execFile()` with an args array bypasses the shell completely — there is nothing to inject into.

Identified during Hermes v0.9.0 security comparison audit. Hermes fixed an identical pattern (PR #7940) using `shlex.quote()`. Our fix is stronger — no shell at all.

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm test` — 451/451 passing (heartbeat watchdog tests updated to assert `execFile` with array args)

Closes #54