### PR TITLE
fix(pty): redact JWT-shaped tokens from OutputBuffer

### DIFF
--- a/src/pty/output-buffer.ts
+++ b/src/pty/output-buffer.ts
@@ -1,4 +1,5 @@
 import { appendFileSync } from 'fs';
+import { redactSecrets } from './redact.js';
 
 // Dynamic import for strip-ansi (ESM module)
 let stripAnsi: (text: string) => string;
@@ -27,9 +28,18 @@ export class OutputBuffer {
   /**
    * Push new output data into the buffer.
    * Also streams to log file if configured.
+   *
+   * Secret redaction runs once at the top via `redactSecrets` and the
+   * scrubbed string is used for BOTH the in-memory ring buffer AND the
+   * disk log. Without this, any JWT or session cookie an agent's shell
+   * happens to print (e.g. curl -v against an authenticated endpoint)
+   * would end up persisted to stdout.log verbatim. See src/pty/redact.ts
+   * for the rationale + the known chunk-boundary limitation.
    */
   push(data: string): void {
-    this.chunks.push(data);
+    const safe = redactSecrets(data);
+
+    this.chunks.push(safe);
     if (this.chunks.length > this.maxChunks) {
       this.chunks.shift();
     }
@@ -37,7 +47,7 @@ export class OutputBuffer {
     // Stream to log file (replaces tmux pipe-pane)
     if (this.logPath) {
       try {
-        appendFileSync(this.logPath, data, 'utf-8');
+        appendFileSync(this.logPath, safe, 'utf-8');
       } catch {
         // Ignore log write errors
       }

--- a/src/pty/redact.ts
+++ b/src/pty/redact.ts
@@ -1,0 +1,52 @@
+/**
+ * PTY output redaction.
+ *
+ * Secret-bearing output can reach the PTY capture stream whenever an agent
+ * runs a shell command that prints credentials — curl -v against an
+ * authenticated endpoint, wget --debug, openssl s_client, dumping a cookie
+ * jar, etc. The PTY's OutputBuffer ring captures everything the child
+ * process emits and also streams it verbatim to a persisted stdout.log.
+ * Without redaction, any JWT, bearer token, or session cookie that happens
+ * to appear in the agent's terminal ends up persisted to disk indefinitely.
+ *
+ * Origin: discovered via a baseline gitleaks audit of agent stdout logs
+ * which found 16 JWTs (`authjs.session-token=eyJ...`) emitted to stdout
+ * by `curl -v` against an authenticated NextAuth endpoint. Initial
+ * hypothesis was that a logging code path was at fault; the actual cause
+ * turned out to be agent-level shell commands the PTY captured faithfully.
+ * The fix therefore lives at the PTY layer (defense-in-depth for any
+ * future exposure via any tool) rather than in an individual code path.
+ *
+ * Known limitation: PTY data arrives in OS-buffered chunks (typically 4KB
+ * on Linux). If a chunk boundary happens to fall inside a JWT, neither
+ * chunk matches the regex and the token slips through unredacted across
+ * two push() calls. JWTs are typically 300-500 bytes so they fit in one
+ * chunk in the overwhelming majority of real cases — every observed leak
+ * in the origin audit fit in a single chunk. Buffer-aware redaction
+ * (carry a trailing partial-match buffer across chunks) is the follow-up
+ * if this edge case ever surfaces in production. Test `chunk-boundary
+ * regression guard` in output-buffer.test.ts locks this documented
+ * behavior in place so any future change has to be explicit.
+ */
+
+/**
+ * JWT shape: three base64url segments separated by dots, each at least
+ * 10 characters long. The length qualifier prevents false positives on
+ * random short alphanumeric sequences that happen to contain two dots
+ * (e.g. "a.b.c" or "v1.2.3" would not match). `eyJ` prefix anchors on
+ * the standard JWT header (base64 encoding of `{"alg":...` or
+ * `{"typ":...`).
+ */
+const JWT_PATTERN = /eyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}/g;
+
+/**
+ * Redact JWT-shaped tokens from a PTY output chunk.
+ *
+ * Replaces each JWT with the literal string `[REDACTED_JWT]` in-place.
+ * Non-token content (TUI ANSI escapes, regular stdout, shell prompts,
+ * etc.) passes through unchanged. Safe to call on every PTY chunk — the
+ * regex is stateless and scales linearly with input length.
+ */
+export function redactSecrets(data: string): string {
+  return data.replace(JWT_PATTERN, '[REDACTED_JWT]');
+}

--- a/tests/unit/pty/output-buffer.test.ts
+++ b/tests/unit/pty/output-buffer.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Mock fs.appendFileSync so tests don't actually write to disk. We still
+// need the real existsSync etc. for other imports in the module graph.
+const appendFileSyncMock = vi.fn();
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    appendFileSync: (...args: unknown[]) => appendFileSyncMock(...args),
+  };
+});
+
+const { OutputBuffer } = await import('../../../src/pty/output-buffer');
+
+// Synthetic JWT used across tests. Has the canonical 3-segment shape and
+// the `eyJ` header prefix so the redactor matches it. Length exceeds the
+// {10,} per-segment minimum.
+const FAKE_JWT =
+  'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJ0ZXN0LXNlc3Npb24taWQifQ.abcdefghij_-abcdefghij';
+
+beforeEach(() => {
+  appendFileSyncMock.mockReset();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('OutputBuffer redaction', () => {
+  it('single JWT in a single chunk: redacted in both disk log and in-memory buffer', () => {
+    const buf = new OutputBuffer(1000, '/tmp/fake-stdout.log');
+    buf.push(`session cookie: authjs.session-token=${FAKE_JWT}\n`);
+
+    expect(appendFileSyncMock).toHaveBeenCalledTimes(1);
+    const writtenData = String(appendFileSyncMock.mock.calls[0][1]);
+    expect(writtenData).toContain('[REDACTED_JWT]');
+    expect(writtenData).not.toContain(FAKE_JWT);
+
+    // In-memory ring buffer should also see the redacted form.
+    const recent = buf.getRecent();
+    expect(recent).toContain('[REDACTED_JWT]');
+    expect(recent).not.toContain(FAKE_JWT);
+  });
+
+  it('multiple JWTs in one chunk: all redacted', () => {
+    const buf = new OutputBuffer(1000, '/tmp/fake-stdout.log');
+    const another =
+      'eyJxxxxxxxxxxxxxx.yyyyyyyyyyyyyyyy.zzzzzzzzzzzzzzzz__';
+    buf.push(`a=${FAKE_JWT} b=${another} c=${FAKE_JWT}`);
+
+    const written = String(appendFileSyncMock.mock.calls[0][1]);
+    // Every JWT-shaped token replaced with the literal redaction marker.
+    expect(written).not.toContain(FAKE_JWT);
+    expect(written).not.toContain(another);
+    const matches = (written.match(/\[REDACTED_JWT\]/g) || []).length;
+    expect(matches).toBe(3);
+  });
+
+  it('non-JWT PTY data passes through unchanged (regression guard)', () => {
+    const buf = new OutputBuffer(1000, '/tmp/fake-stdout.log');
+    // TUI ANSI escapes, regular stdout, plausible-but-too-short alphanum.
+    const tuiOutput =
+      '\x1b[38;5;114m●\x1b[39m Running tests... version v1.2.3 hash=abc.def.ghi\n';
+    buf.push(tuiOutput);
+
+    const written = String(appendFileSyncMock.mock.calls[0][1]);
+    expect(written).toBe(tuiOutput); // byte-for-byte identical
+    expect(written).not.toContain('[REDACTED_JWT]');
+  });
+
+  it('bootstrap detection still works after redaction', () => {
+    const buf = new OutputBuffer(1000, '/tmp/fake-stdout.log');
+    // Claude Code's permissions status bar line — contains "permissions"
+    // which isBootstrapped() searches for. No JWT in this chunk — the
+    // test guards that redaction does not accidentally break the ring
+    // buffer's search path.
+    buf.push('\x1b[2m ? \x1b[0mfor shortcuts                  permissions: bypass\n');
+    expect(buf.isBootstrapped()).toBe(true);
+  });
+
+  it('chunk-boundary edge case is NOT redacted (documents the known limitation)', () => {
+    // Split a JWT across two push() calls. Neither chunk matches the
+    // regex on its own — the redactor is stateless and chunk-local. This
+    // test INTENTIONALLY asserts the un-redacted behavior so that any
+    // future refactor adding buffer-aware redaction has to be an
+    // explicit decision (the test fails and forces a re-review).
+    const buf = new OutputBuffer(1000, '/tmp/fake-stdout.log');
+    const half1 = FAKE_JWT.slice(0, 40);
+    const half2 = FAKE_JWT.slice(40);
+    buf.push(`prefix ${half1}`);
+    buf.push(`${half2} suffix`);
+
+    const firstWrite = String(appendFileSyncMock.mock.calls[0][1]);
+    const secondWrite = String(appendFileSyncMock.mock.calls[1][1]);
+    // Each half survives because neither chunk is a complete JWT shape.
+    expect(firstWrite).toContain(half1);
+    expect(secondWrite).toContain(half2);
+    // Neither chunk contains the redaction marker.
+    expect(firstWrite).not.toContain('[REDACTED_JWT]');
+    expect(secondWrite).not.toContain('[REDACTED_JWT]');
+  });
+
+  it('short alphanumeric that resembles a truncated JWT is NOT redacted (length guard)', () => {
+    const buf = new OutputBuffer(1000, '/tmp/fake-stdout.log');
+    // "eyJab.x.y" has the right header prefix and the right shape but
+    // segments are all too short — the {10,} length qualifier must
+    // prevent this from matching.
+    const shortTokenLike = 'eyJab.x.y';
+    buf.push(`debug_token=${shortTokenLike} ok=true\n`);
+
+    const written = String(appendFileSyncMock.mock.calls[0][1]);
+    expect(written).toContain(shortTokenLike);
+    expect(written).not.toContain('[REDACTED_JWT]');
+  });
+});


### PR DESCRIPTION
# fix(pty): redact JWT-shaped tokens from OutputBuffer

**Branch**: `pr/pty-redact-jwt-tokens`
**Base**: `grandamenium/cortextos@main` (a608a5d at time of prep)
**Commit**: `a4adae0`
**Priority**: SECURITY

---

## Problem

Anything an agent's shell writes to stdout gets captured by the cortextOS PTY and streamed both to the in-memory ring buffer (for bootstrap detection) and to a persisted log at `~/.cortextos/<instance>/logs/<agent>/stdout.log`. When an agent runs `curl -v` against an authenticated endpoint, curl's verbose output prints the response `Set-Cookie` header + its own `* Added cookie` trace line to stdout. If the response contains a session cookie (JWT, OAuth bearer, etc.), that token ends up persisted on disk with 600 perms — but still present indefinitely.

A baseline gitleaks audit of agent stdout logs found 16 JWTs this way (Telegram NextAuth `authjs.session-token` cookies, ~500 bytes each, eyJhb... shape). Zero were from cortextOS code paths logging tokens — 100% were from agent-run curl commands the PTY captured faithfully.

## Root cause

`src/pty/output-buffer.ts` `OutputBuffer.push(data)` is the single chokepoint where PTY output reaches both the ring buffer and the disk log. No redaction layer existed — the `push()` contract was byte-faithful capture, which is correct for bootstrap-detection needs but wrong for any token-bearing output that happens to flow through.

## Fix

- New `src/pty/redact.ts` exporting a single `redactSecrets(data)` helper.
- JWT pattern: requires the `eyJ` base64 header prefix + three dot-separated base64url segments of at least 10 characters each. Length qualifier prevents false positives on version strings (`v1.2.3`) or short alphanumeric fragments (`eyJab.x.y`). Matches replaced with the literal string `[REDACTED_JWT]`.
- `OutputBuffer.push()` applies `redactSecrets` once at the top; the scrubbed string is used for BOTH the ring buffer AND the disk log. Redacting both views keeps them consistent — no future footgun from the two paths diverging.
- Defense-in-depth design: this catches ANY tool that happens to print a JWT on stdout (curl, wget, openssl, dumps of a cookie jar, etc.), not just curl. Protects against secrets from tools the agent adopts later without the contributor needing to remember to scrub.

## Tests

6 new unit tests in `tests/unit/pty/output-buffer.test.ts`:

1. Single JWT in a single chunk → redacted in both the disk log AND the in-memory ring buffer
2. Multiple JWTs in one chunk → all replaced
3. Non-JWT PTY data (ANSI escapes + regular stdout + version strings) passes through unchanged — regression guard
4. `isBootstrapped()` still works after redaction — guards the ring buffer search path
5. **Chunk-boundary limitation**: JWT split across two `push()` calls is NOT redacted. Locked in as a regression guard so any future refactor that adds buffer-aware redaction has to be an explicit decision (test fails if the behavior silently changes).
6. Short alphanumeric resembling a truncated JWT (`eyJab.x.y`) is NOT redacted — length-qualifier false-positive guard.

## Caveats / known limitations

- **Chunk-boundary edge case**: PTY data arrives in OS-buffered chunks (typically 4KB). If a chunk boundary falls inside a JWT, neither chunk matches the regex and the token slips through across two `push()` calls. JWTs are typically 300-500 bytes so they fit in one chunk in the overwhelming majority of real cases. Buffer-aware redaction (carry a partial-match buffer across chunks) is the follow-up if this edge case ever surfaces in production. The test explicitly asserts this behavior so it cannot regress without notice.
- **JWT-only pattern today**: only eyJ-prefixed JWTs are redacted. Other token shapes (bare OAuth bearer tokens, API keys with provider-specific prefixes, PATs, etc.) are not covered by this helper. Additive — adding more patterns to `redactSecrets` is a trivial extension without structural change, and I'd expect those to accumulate as observed leaks surface.
- **Historical log scrub NOT included**: operators with existing leaked JWTs in their stdout logs should rotate the affected credentials and optionally `rm` the log. This patch prevents future leaks only.
- **In-memory buffer redaction is belt-and-suspenders**: bootstrap detection searches for the literal string `permissions`, which is never going to collide with JWT redaction. I chose to redact both views for consistency rather than only the disk path; if a reviewer prefers disk-only redaction, that's a 2-line change.

## Potential-genericize candidates

(None found in this patch — the code is generic; no framework-internal terms or paths are hardcoded.)

---

**Test suite**: full suite green pre-prep (524 tests). Cherry-pick is clean against upstream/main a608a5d — no conflicts.
