### PR TITLE
fix(daemon): classify PM2 shutdown PTY exits as planned stops

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { appendFileSync, existsSync, readFileSync, statSync, writeFileSync } from 'fs';
 import { join, sep } from 'path';
 import { homedir } from 'os';
 import type { AgentConfig, AgentStatus, CtxEnv } from '../types/index.js';
@@ -309,6 +309,29 @@ export class AgentProcess {
     this.pty = null;
     this.clearSessionTimer();
 
+    // When the cortextos daemon is shut down by PM2, SIGTERM propagates to
+    // the whole process group and reaches each PTY's Claude Code child
+    // BEFORE the daemon's stopAll() loop has a chance to call stopAgent() on
+    // it. Those children exit cleanly (code 0) but arrive at handleExit with
+    // stopRequested=false, which used to classify the exit as a crash and
+    // inflate .crash_count_today by one per agent, per PM2 restart.
+    //
+    // agent-manager.ts:stopAll() already writes a `.daemon-stop` marker in
+    // every agent's state dir at the START of its shutdown loop for an
+    // unrelated reason (SessionEnd crash-alert hook). We reuse that marker
+    // here as the authoritative "the daemon is going down" signal. If the
+    // marker exists AND is recent (written within the last 60s), any PTY
+    // exit is a shutdown casualty, not a real crash — swallow it.
+    //
+    // The 60s window guards against a stale marker from a previous shutdown
+    // that wasn't cleaned up: we do NOT want an old marker to silently mask
+    // a genuine crash days later. handleExit does NOT delete the marker —
+    // cleanup stays with agent-manager / hook-crash-alert per the existing
+    // separation of concerns.
+    if (this.isDaemonShuttingDown()) {
+      return;
+    }
+
     // BUG-040 fix: check stopRequested instead of (only) stopping. The
     // stopping flag is cleared inside stop() after a 15s timeout window —
     // which means a slow PTY shutdown can fire handleExit AFTER stopping is
@@ -333,6 +356,7 @@ export class AgentProcess {
 
     if (this.crashCount >= this.maxCrashesPerDay) {
       this.log(`HALTED: exceeded ${this.maxCrashesPerDay} crashes today`);
+      this.appendCrashToRestartsLog(exitCode, 0, 'HALTED');
       this.status = 'halted';
       this.notifyStatusChange();
       return;
@@ -341,6 +365,11 @@ export class AgentProcess {
     // Exponential backoff restart
     const backoff = Math.min(5000 * Math.pow(2, this.crashCount - 1), 300000);
     this.log(`Crash recovery: restart in ${backoff / 1000}s (crash #${this.crashCount})`);
+    // Persist the crash to restarts.log so operators have a durable audit
+    // trail. Previously only planned SELF-RESTART / HARD-RESTART from
+    // bus/system.ts wrote here, which left daemon-classified crashes
+    // invisible outside the rotating PM2 daemon stdout log.
+    this.appendCrashToRestartsLog(exitCode, backoff, 'CRASH');
     this.status = 'crashed';
     this.notifyStatusChange();
 
@@ -476,6 +505,56 @@ export class AgentProcess {
     if (this.sessionTimer) {
       clearTimeout(this.sessionTimer);
       this.sessionTimer = null;
+    }
+  }
+
+  /**
+   * Check whether the daemon is currently in its shutdown sequence.
+   *
+   * Returns true iff a `.daemon-stop` marker exists in this agent's state
+   * dir AND was written within the last 60 seconds. The marker is written
+   * by AgentManager.stopAll() before it begins iterating stopAgent() calls.
+   * A stale marker older than 60s is treated as leftover from a prior
+   * shutdown and ignored — real crashes must not be masked indefinitely.
+   */
+  private isDaemonShuttingDown(): boolean {
+    const marker = join(this.env.ctxRoot, 'state', this.name, '.daemon-stop');
+    try {
+      if (!existsSync(marker)) return false;
+      const ageMs = Date.now() - statSync(marker).mtimeMs;
+      return ageMs < 60_000;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Append an unplanned-exit entry to restarts.log. Complements the planned
+   * SELF-RESTART / HARD-RESTART entries written by src/bus/system.ts so that
+   * a single file gives the complete restart history for an agent.
+   *
+   * Format matches bus/system.ts: `[ISO] <KIND>: <details>`. appendFileSync
+   * uses write(2) with O_APPEND on Linux, which is atomic for writes under
+   * PIPE_BUF (~4KB) — each CRASH line fits comfortably. All errors are
+   * swallowed: logging must never break crash recovery.
+   */
+  private appendCrashToRestartsLog(
+    exitCode: number,
+    backoffMs: number,
+    kind: 'CRASH' | 'HALTED',
+  ): void {
+    try {
+      const logDir = join(this.env.ctxRoot, 'logs', this.name);
+      ensureDir(logDir);
+      const timestamp = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+      const details =
+        kind === 'HALTED'
+          ? `exit_code=${exitCode} crash_count=${this.crashCount} max_crashes=${this.maxCrashesPerDay}`
+          : `exit_code=${exitCode} crash_count=${this.crashCount} backoff_s=${backoffMs / 1000}`;
+      const logLine = `[${timestamp}] ${kind}: ${details}\n`;
+      appendFileSync(join(logDir, 'restarts.log'), logLine, 'utf-8');
+    } catch {
+      /* swallow — never break crash recovery on a logging failure */
     }
   }
 

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -42,14 +42,40 @@ vi.mock('../../../src/utils/paths.js', () => ({
   resolvePaths: vi.fn().mockReturnValue({}),
 }));
 
+const fsMocks = {
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  appendFileSync: vi.fn(),
+  statSync: vi.fn(),
+};
+
 vi.mock('fs', async () => {
   const actual = await vi.importActual<typeof import('fs')>('fs');
+  // Getter-based exposure of the fsMocks vi.fn()s. Two consumer patterns
+  // need to coexist on this file:
+  //   (1) `fsMocks.X.mockReset()` — used by the BUG-040 / restarts.log
+  //       tests added by this patch
+  //   (2) `vi.mocked(fs.X).mockImplementation(...)` — used by the
+  //       verifyCronsAfterIdle tests + BUG-048 reschedule tests
+  // For (2) to work, `fs.X` MUST resolve to the same vi.fn() instance as
+  // `fsMocks.X`. Naive direct reference (`existsSync: fsMocks.existsSync`)
+  // breaks because vi.mock factories are hoisted + executed BEFORE the
+  // `const fsMocks = {...}` initializer — so the lookup captures
+  // `undefined`. Arrow wrappers (`(...args) => fsMocks.X(...args)`) keep
+  // (1) working but break (2) because `fs.X` is no longer a vi.fn — it's
+  // a plain arrow function, and `vi.mocked()` does not recognize it as
+  // mockable. Getters thread the needle: the lookup is deferred until
+  // call time (after fsMocks is initialized), and the value returned IS
+  // the underlying vi.fn so `vi.mocked()` recognizes it.
   return {
     ...actual,
     mkdirSync: vi.fn(),
-    existsSync: vi.fn().mockReturnValue(false),
-    readFileSync: vi.fn(),
-    writeFileSync: vi.fn(),
+    get existsSync() { return fsMocks.existsSync; },
+    get readFileSync() { return fsMocks.readFileSync; },
+    get writeFileSync() { return fsMocks.writeFileSync; },
+    get appendFileSync() { return fsMocks.appendFileSync; },
+    get statSync() { return fsMocks.statSync; },
   };
 });
 
@@ -74,6 +100,11 @@ beforeEach(() => {
   mockPty.isAlive.mockReturnValue(true);
   mockPty.onExit.mockClear();
   mockInjectMessage.mockClear();
+  fsMocks.existsSync.mockReset().mockReturnValue(false);
+  fsMocks.readFileSync.mockReset();
+  fsMocks.writeFileSync.mockReset();
+  fsMocks.appendFileSync.mockReset();
+  fsMocks.statSync.mockReset();
 });
 
 describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
@@ -129,6 +160,75 @@ describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
 
     // The agent should be in 'crashed' state (crash recovery scheduled)
     expect(ap.getStatus().status).toBe('crashed');
+  });
+
+  it('unexpected PTY exit persists a CRASH line to restarts.log', async () => {
+    // Default fs mocks: no .daemon-stop marker, no .crash_count_today file.
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+    expect(ap.getStatus().status).toBe('running');
+
+    // Fire exit handler WITHOUT calling stop() first — simulates a real crash.
+    capturedOnExit!(1, 0);
+
+    expect(ap.getStatus().status).toBe('crashed');
+    // restarts.log must have received a CRASH entry with the exit code and
+    // crash counter. Before the fix, daemon-classified crashes only wrote
+    // to stdout and left restarts.log empty.
+    expect(fsMocks.appendFileSync).toHaveBeenCalledTimes(1);
+    const [logPath, logLine] = fsMocks.appendFileSync.mock.calls[0];
+    expect(String(logPath)).toContain('/logs/alice/restarts.log');
+    expect(String(logLine)).toMatch(/\] CRASH: exit_code=1 crash_count=1 backoff_s=5\b/);
+    expect(String(logLine).endsWith('\n')).toBe(true);
+  });
+
+  it('PTY exit during daemon shutdown is NOT classified as a crash', async () => {
+    // Simulate agent-manager.ts:stopAll() having written a fresh .daemon-stop
+    // marker moments ago. handleExit should recognize the shutdown-in-progress
+    // signal and bail out before touching the crash counter or restarts.log.
+    fsMocks.existsSync.mockImplementation((p: any) => {
+      const path = String(p);
+      return path.endsWith('/state/alice/.daemon-stop');
+    });
+    fsMocks.statSync.mockImplementation((p: any) => ({ mtimeMs: Date.now() - 2_000 }));
+
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+    expect(ap.getStatus().status).toBe('running');
+
+    // PM2 SIGTERM propagated to the PTY's Claude Code child: it exits
+    // cleanly with code 0 before its own stopAgent() call has a chance to
+    // set stopRequested. Before the fix, this produced a phantom crash
+    // and incremented .crash_count_today.
+    capturedOnExit!(0, 0);
+
+    // Agent state is 'running' still — handleExit returned early without
+    // toggling status. No crash write, no log append, no restart scheduled.
+    expect(ap.getStatus().status).toBe('running');
+    expect(fsMocks.appendFileSync).not.toHaveBeenCalled();
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('.crash_count_today'),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('stale .daemon-stop marker (>60s old) does NOT mask a real crash', async () => {
+    // Regression guard: if a prior shutdown failed to clean up its marker,
+    // we do NOT want it to silently swallow genuine crashes hours later.
+    // The 60s window in isDaemonShuttingDown() is the load-bearing check.
+    fsMocks.existsSync.mockImplementation((p: any) =>
+      String(p).endsWith('/state/alice/.daemon-stop'),
+    );
+    fsMocks.statSync.mockImplementation((p: any) => ({ mtimeMs: Date.now() - 3_600_000 })); // 1h old
+
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+    capturedOnExit!(1, 0);
+
+    expect(ap.getStatus().status).toBe('crashed');
+    expect(fsMocks.appendFileSync).toHaveBeenCalledTimes(1);
+    expect(String(fsMocks.appendFileSync.mock.calls[0][1])).toMatch(/\] CRASH: /);
   });
 
   it('sessionRefresh() delegates to stop() then start() (in order)', async () => {


### PR DESCRIPTION
# fix(daemon): classify PM2 shutdown PTY exits as planned stops, persist crash audit to restarts.log

**Branch**: `pr/daemon-classify-pm2-shutdown-exits`
**Base**: `grandamenium/cortextos@main` (a608a5d at time of prep)
**Commit**: `0fc31c5`
**Closes**: #27

---

## Problem

Every `pm2 restart cortextos-daemon` (or `pm2 stop`) was silently inflating each running agent's `.crash_count_today` by one, even though the shutdown was planned and the agents had exited cleanly. Scheduled restarts with `crash #N` attached were logged to the daemon's stdout but never actually ran (the daemon itself was going down), leaving an audit trail that was both wrong AND incomplete.

Additionally: when a REAL crash DID happen, there was no persistent record of it anywhere the operator would look. `restarts.log` only received planned restarts from `src/bus/system.ts` (SELF-RESTART, HARD-RESTART). Daemon-classified crashes (handleExit's crash-recovery path + HALTED path) only emitted to the daemon's stdout, which rotates through PM2 and gets lost.

## Root cause

When PM2 stops the daemon, it sends SIGTERM to the entire process group. Every PTY's Claude Code child receives SIGTERM directly from the OS process group AT THE SAME TIME the daemon begins its graceful shutdown. The daemon's `stopAll()` iterates agents sequentially; any agent whose PTY has already exited (cleanly, code 0) by the time `stopAgent()` reaches it arrives at `handleExit()` with `stopRequested=false`. That short-circuit check (`if (this.stopRequested || this.stopping)`) was the only gate protecting against misclassification — and during a PM2 shutdown it's not set yet.

## Fix

Two changes in `src/daemon/agent-process.ts::handleExit()`:

1. **Honor the `.daemon-stop` marker** that `agent-manager.ts::stopAll()` already writes at the START of its shutdown sequence (originally added for the crash-alert hook to distinguish daemon shutdown from crashes). If the marker exists and is fresh (age < 60s), treat the exit as intentional and return early before touching the crash counter. Stale markers (>60s) are ignored so they cannot silently mask a genuine crash indefinitely after a prior shutdown failed to clean up.

2. **Append every daemon-classified unplanned exit to `restarts.log`** — both the CRASH-recovery path and the HALTED path. Format matches the existing SELF-RESTART/HARD-RESTART lines so operators have one file to read. Write is wrapped in try/catch and swallows errors to never break crash recovery on a logging failure.

## Tests

3 new unit tests in `tests/unit/daemon/agent-process.test.ts`:

1. Unexpected PTY exit → `restarts.log` gets a `CRASH: exit_code=... crash_count=... backoff_s=...` line (the fix's happy path)
2. Fresh `.daemon-stop` marker present → exit is NOT classified as a crash, `restarts.log` unchanged, no restart scheduled (PM2 shutdown path)
3. Stale `.daemon-stop` marker (mtime > 60s ago) → exit IS still classified as a crash (regression guard against leftover markers silently masking real crashes)

Full suite: 454 tests pass against upstream/main baseline + this patch.

## Caveats / known limitations

- **60s marker staleness window** is a judgment call. Shorter would reduce the mask-a-real-crash window further but risks false positives during a slow shutdown where `stopAll()` takes a while to iterate. Longer would tolerate slower shutdowns at the cost of a bigger real-crash mask window. 60s felt right for a daemon whose normal shutdown completes in <5s; adjust if your deployment has pathologically slow shutdowns.
- **The `restarts.log` write is append-only + best-effort.** Concurrent crashes of multiple agents won't corrupt the file (appendFileSync is atomic for small writes via O_APPEND + write(2)), but a crash-recovery path that itself crashes mid-write could leave a truncated line. The try/catch swallows the error — the operator loses one audit line but the daemon keeps running.
- **The HALTED path logs `max_crashes=N`** instead of `backoff_s` because at HALTED there's no retry scheduled. Separate field matches the code path shape; parsers reading restarts.log can key on the prefix (`CRASH:` vs `HALTED:` vs `SELF-RESTART:` vs `HARD-RESTART:`).

## Potential-genericize candidates

- `src/daemon/agent-process.ts:365` has a pre-existing JSDoc comment using `boss` as an example agent name in a path-translation example: `// e.g. /Users/foo/agents/boss -> -Users-foo-agents-boss (leading sep becomes -)`. Not touched by this patch. `boss` is a conventional orchestrator name in cortextOS installs but worth flagging if upstream prefers a more neutral example like `orchestrator` or `agent`.

---

**Cherry-pick note**: one conflict in `tests/unit/daemon/agent-process.test.ts` `beforeEach` block where upstream's `mockInjectMessage.mockClear()` and this patch's `fsMocks.*.mockReset()` calls both need to live — resolved by keeping both. Also adjusted the `vi.mock('fs', ...)` factory to return direct `fsMocks.X` references instead of arrow-wrapped calls, so both `fsMocks.X.mockReset()` (used by this patch's tests) and `vi.mocked(fs.X).mockImplementation()` (used by upstream's verifyCronsAfterIdle + BUG-048 tests) work against the same underlying vi.fn(). Full suite green post-resolution.
