### PR TITLE
fix(telegram): retry sendMessage with plain text on parse-entity errors + add --plain-text opt-in

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -718,10 +718,11 @@ busCommand
   .command('send-telegram')
   .description('Send a message to a Telegram chat')
   .argument('<chat-id>', 'Telegram chat ID')
-  .argument('<message>', 'Message text (supports Telegram Markdown)')
+  .argument('<message>', 'Message text (supports Telegram Markdown unless --plain-text is set)')
   .option('--image <path>', 'Send a photo with caption')
   .option('--file <path>', 'Send a document/file with caption (any file type)')
-  .action(async (chatId: string, message: string, opts: { image?: string; file?: string }) => {
+  .option('--plain-text', 'Skip Telegram Markdown parsing entirely. Use this when the message contains unescaped _, *, backtick, or [ that would otherwise trip the Markdown parser. Without this flag, sendMessage still retries once with parse_mode disabled on a parse-entity error — so it is purely an opt-in to save the retry roundtrip.', false)
+  .action(async (chatId: string, message: string, opts: { image?: string; file?: string; plainText?: boolean }) => {
     // Resolve bot token: agent .env first, then process.env
     const env = resolveEnv();
     let botToken = '';
@@ -751,6 +752,7 @@ busCommand
     const api = new TelegramAPI(botToken);
     try {
       let sentMessageId = 0;
+      let parseFallbackReason: string | null = null;
       if (opts.image) {
         const result = await api.sendPhoto(chatId, opts.image, message);
         sentMessageId = result?.result?.message_id ?? 0;
@@ -758,14 +760,23 @@ busCommand
         const result = await api.sendDocument(chatId, opts.file, message);
         sentMessageId = result?.result?.message_id ?? 0;
       } else {
-        const result = await api.sendMessage(chatId, message);
+        const result = await api.sendMessage(chatId, message, undefined, {
+          parseMode: opts.plainText ? null : 'Markdown',
+          onParseFallback: (reason) => {
+            parseFallbackReason = reason;
+          },
+        });
         sentMessageId = result?.result?.message_id ?? 0;
       }
 
       // Log outbound and cache last-sent for context injection
       const env = resolveEnv();
       if (env.agentName && env.ctxRoot) {
-        logOutboundMessage(env.ctxRoot, env.agentName, chatId, message, sentMessageId);
+        logOutboundMessage(env.ctxRoot, env.agentName, chatId, message, sentMessageId, {
+          parseMode: opts.plainText ? 'none' : 'markdown',
+          parseFallback: parseFallbackReason !== null,
+          parseFallbackReason: parseFallbackReason ?? undefined,
+        });
         cacheLastSent(env.ctxRoot, env.agentName, chatId, message);
       }
 

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -25,42 +25,115 @@ export class TelegramAPI {
 
   /**
    * Send a text message. Splits long messages at 4096 chars.
+   *
+   * Markdown parse behavior:
+   *
+   * - By default, each chunk is sent with `parse_mode: "Markdown"` (Telegram
+   *   v1 Markdown). If the Telegram API rejects the chunk with a
+   *   "can't parse entities" error — usually because the text contains an
+   *   unescaped `_`, `*`, backtick, or `[` that Telegram interprets as the
+   *   start of an entity it cannot close — sendMessage catches the error,
+   *   logs a one-line stderr warning, and automatically RETRIES that chunk
+   *   ONCE with `parse_mode` omitted (plain text). This is the safety net
+   *   for agents generating natural prose that happens to look like bad
+   *   markdown. If the retry also fails, the error is rethrown so callers
+   *   still see real failures.
+   *
+   * - Callers who KNOW their message contains unescaped special characters
+   *   can opt out of parsing entirely by passing `{ parseMode: null }`.
+   *   This skips the first Markdown attempt, avoids the retry roundtrip,
+   *   and suppresses the warning. Useful for `cortextos bus send-telegram
+   *   --plain-text` and any agent message known to carry literal code,
+   *   error output, or user-supplied text.
+   *
+   * - Other error classes (401 bad_token, 400 chat_not_found, 403
+   *   bot_recipient, network failures) do NOT trigger the retry. Only
+   *   parse-entity failures are recoverable here — everything else is a
+   *   real config problem that callers need to see.
    */
   async sendMessage(
     chatId: string | number,
     text: string,
     replyMarkup?: object,
+    opts?: {
+      parseMode?: 'Markdown' | null;
+      onParseFallback?: (reason: string) => void;
+    },
   ): Promise<any> {
     const sanitized = this.sanitizeMarkdown(text);
     // Rate limit: 1 message per second per chat
     await this.rateLimit(String(chatId));
 
-    // Split long messages
+    const requestedParseMode: 'Markdown' | null = opts?.parseMode === null ? null : 'Markdown';
+
+    // Split long messages. Always produces at least one chunk (even if the
+    // input is empty, which preserves the old behavior of POSTing once).
     const maxLen = 4096;
-    if (sanitized.length <= maxLen) {
-      return this.post('sendMessage', {
-        chat_id: chatId,
-        text: sanitized,
-        parse_mode: 'Markdown',
-        ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
-      });
-    }
-
-    // Split into chunks
     const chunks: string[] = [];
-    for (let i = 0; i < sanitized.length; i += maxLen) {
-      chunks.push(sanitized.slice(i, i + maxLen));
+    if (sanitized.length <= maxLen) {
+      chunks.push(sanitized);
+    } else {
+      for (let i = 0; i < sanitized.length; i += maxLen) {
+        chunks.push(sanitized.slice(i, i + maxLen));
+      }
     }
 
-    let result: any;
-    for (const chunk of chunks) {
-      result = await this.post('sendMessage', {
-        chat_id: chatId,
-        text: chunk,
-        parse_mode: 'Markdown',
-      });
+    let lastResult: any;
+    for (let i = 0; i < chunks.length; i++) {
+      const chunk = chunks[i];
+      const isLastChunk = i === chunks.length - 1;
+      lastResult = await this.sendChunk(
+        chatId,
+        chunk,
+        requestedParseMode,
+        isLastChunk ? replyMarkup : undefined,
+        (reason) => {
+          // Default observability: one-line stderr warning, plus forward to
+          // the caller's hook if they supplied one (outbound log augmentation
+          // uses this path).
+          console.warn(`[telegram] parse-mode fallback for chat ${chatId}: ${reason}`);
+          opts?.onParseFallback?.(reason);
+        },
+      );
     }
-    return result;
+    return lastResult;
+  }
+
+  /**
+   * Send a single chunk with the given parse mode, with a one-shot retry
+   * on parse-entity failures. Extracted so the multi-chunk path can reuse
+   * the same retry logic without duplicating the try/catch.
+   */
+  private async sendChunk(
+    chatId: string | number,
+    text: string,
+    parseMode: 'Markdown' | null,
+    replyMarkup: object | undefined,
+    onFallback: (reason: string) => void,
+  ): Promise<any> {
+    const basePayload: Record<string, unknown> = {
+      chat_id: chatId,
+      text,
+      ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
+    };
+
+    // First attempt: honor the caller's requested parse mode.
+    const firstPayload =
+      parseMode === null ? basePayload : { ...basePayload, parse_mode: parseMode };
+
+    try {
+      return await this.post('sendMessage', firstPayload);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // Only retry for Telegram parse-entity errors. Any other failure
+      // (401, 400, 403, network) must surface to the caller unchanged.
+      if (parseMode !== null && /can'?t parse entities|parse entit/i.test(msg)) {
+        onFallback(msg);
+        // Retry with parse_mode omitted (plain text).
+        return await this.post('sendMessage', basePayload);
+      }
+      throw err;
+    }
   }
 
   /**

--- a/src/telegram/logging.ts
+++ b/src/telegram/logging.ts
@@ -8,6 +8,25 @@ import { appendFileSync, readFileSync, writeFileSync, mkdirSync, existsSync } fr
 import { join, dirname } from 'path';
 
 /**
+ * Optional metadata attached to an outbound Telegram message log entry.
+ * Fields are all optional so existing callers that pass nothing still
+ * produce the same JSONL shape as before this extension.
+ *
+ * - `parseMode`: which parse_mode the first send attempt used. "markdown"
+ *   for the default path, "none" when the caller used --plain-text.
+ * - `parseFallback`: true iff the first attempt failed with a Telegram
+ *   parse-entities error and sendMessage retried with parse_mode omitted.
+ * - `parseFallbackReason`: the Telegram error description that triggered
+ *   the fallback, when present. Useful for auditing which agents keep
+ *   generating bad markdown so we can target them for hardening.
+ */
+export interface OutboundLogMetadata {
+  parseMode?: 'markdown' | 'none';
+  parseFallback?: boolean;
+  parseFallbackReason?: string;
+}
+
+/**
  * Append an outbound message to the agent's JSONL log.
  * Path: {ctxRoot}/logs/{agentName}/outbound-messages.jsonl
  */
@@ -17,9 +36,18 @@ export function logOutboundMessage(
   chatId: string | number,
   text: string,
   messageId: number,
+  metadata?: OutboundLogMetadata,
 ): void {
   const logDir = join(ctxRoot, 'logs', agentName);
   mkdirSync(logDir, { recursive: true });
+
+  // Only emit metadata fields that were actually set so the base log shape
+  // stays unchanged for callers that pass nothing (backwards compat).
+  const meta: Record<string, unknown> = {};
+  if (metadata?.parseMode !== undefined) meta.parse_mode = metadata.parseMode;
+  if (metadata?.parseFallback !== undefined) meta.parse_fallback = metadata.parseFallback;
+  if (metadata?.parseFallbackReason !== undefined)
+    meta.parse_fallback_reason = metadata.parseFallbackReason;
 
   const entry = JSON.stringify({
     timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
@@ -27,6 +55,7 @@ export function logOutboundMessage(
     chat_id: String(chatId),
     text,
     message_id: messageId,
+    ...meta,
   });
 
   appendFileSync(join(logDir, 'outbound-messages.jsonl'), entry + '\n', 'utf-8');

--- a/tests/unit/telegram/send-message.test.ts
+++ b/tests/unit/telegram/send-message.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TelegramAPI } from '../../../src/telegram/api';
+
+// Shared fetch-stub infrastructure. Each test queues responses; the stub
+// records call details so we can assert on payload shapes and call counts.
+type MockResponse = { status: number; body: any } | { throws: Error };
+
+let responseQueue: MockResponse[] = [];
+let callLog: Array<{ url: string; body: any }> = [];
+let warnLog: string[] = [];
+let originalWarn: typeof console.warn;
+
+function queue(r: MockResponse): void {
+  responseQueue.push(r);
+}
+
+beforeEach(() => {
+  responseQueue = [];
+  callLog = [];
+  warnLog = [];
+  originalWarn = console.warn;
+  console.warn = (...args: unknown[]) => {
+    warnLog.push(args.map((a) => String(a)).join(' '));
+  };
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (url: string, init: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      callLog.push({ url, body });
+      const next = responseQueue.shift();
+      if (!next) {
+        throw new Error('fetch called with no queued response');
+      }
+      if ('throws' in next) {
+        throw next.throws;
+      }
+      return {
+        ok: next.status === 200,
+        status: next.status,
+        json: async () => next.body,
+      } as any;
+    }),
+  );
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  console.warn = originalWarn;
+});
+
+// Strip out the mandatory rate-limit delay so the test suite stays fast.
+// sendMessage() calls rateLimit() which sleeps 0-1000ms per send. Since we
+// only make small test messages the per-chat memory happens not to trip the
+// limit after the first call, but the first call still takes ~0ms.
+
+describe('TelegramAPI.sendMessage parse-mode retry', () => {
+  it('happy path: well-formed markdown sends once with parse_mode=Markdown, no retry, no warning', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 111 } } });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.sendMessage('chat1', 'hello world');
+
+    expect(result?.result?.message_id).toBe(111);
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].url).toContain('/sendMessage');
+    expect(callLog[0].body.parse_mode).toBe('Markdown');
+    expect(callLog[0].body.text).toBe('hello world');
+    expect(warnLog).toHaveLength(0);
+  });
+
+  it('parse-entity error triggers one-shot retry with parse_mode omitted', async () => {
+    // First call: Telegram parse failure. Second call: success.
+    queue({
+      status: 400,
+      body: {
+        ok: false,
+        error_code: 400,
+        description: "Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 42",
+      },
+    });
+    queue({ status: 200, body: { ok: true, result: { message_id: 222 } } });
+
+    const fallbackReasons: string[] = [];
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.sendMessage('chat1', 'prose with a dangling _underscore', undefined, {
+      onParseFallback: (reason) => fallbackReasons.push(reason),
+    });
+
+    expect(result?.result?.message_id).toBe(222);
+    expect(callLog).toHaveLength(2);
+    // First attempt used Markdown:
+    expect(callLog[0].body.parse_mode).toBe('Markdown');
+    // Retry attempt has NO parse_mode field:
+    expect(callLog[1].body).not.toHaveProperty('parse_mode');
+    // Same chat_id and text on both attempts:
+    expect(callLog[1].body.chat_id).toBe('chat1');
+    expect(callLog[1].body.text).toBe('prose with a dangling _underscore');
+    // Exactly one warning emitted, plus the caller's hook fired once:
+    expect(warnLog).toHaveLength(1);
+    expect(warnLog[0]).toMatch(/parse-mode fallback for chat chat1/);
+    expect(fallbackReasons).toHaveLength(1);
+    expect(fallbackReasons[0]).toMatch(/can'?t parse entities/i);
+  });
+
+  it('parse-entity error AND retry also fails: sendMessage rethrows, no infinite loop', async () => {
+    queue({
+      status: 400,
+      body: { ok: false, error_code: 400, description: "Bad Request: can't parse entities" },
+    });
+    queue({
+      status: 500,
+      body: { ok: false, error_code: 500, description: 'Internal Server Error' },
+    });
+
+    const api = new TelegramAPI('111:AAA');
+    await expect(api.sendMessage('chat1', 'bad text')).rejects.toThrow(/Internal Server Error/);
+
+    // Exactly 2 calls — the initial attempt and one retry. Never more.
+    expect(callLog).toHaveLength(2);
+    // Warning was still emitted before the retry attempt (observability).
+    expect(warnLog).toHaveLength(1);
+  });
+
+  it('non-parse error (401 unauthorized) does NOT trigger retry, fails fast', async () => {
+    queue({ status: 401, body: { ok: false, error_code: 401, description: 'Unauthorized' } });
+
+    const api = new TelegramAPI('999:BAD');
+    await expect(api.sendMessage('chat1', 'test')).rejects.toThrow(/Unauthorized/);
+
+    // Only ONE call — 401 is not recoverable via parse-mode removal.
+    expect(callLog).toHaveLength(1);
+    expect(warnLog).toHaveLength(0);
+  });
+
+  it('opt-in plain-text mode: first call has no parse_mode, no retry, no warning', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 333 } } });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.sendMessage(
+      'chat1',
+      'literal _underscores_ and *asterisks* all over',
+      undefined,
+      { parseMode: null },
+    );
+
+    expect(result?.result?.message_id).toBe(333);
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].body).not.toHaveProperty('parse_mode');
+    expect(warnLog).toHaveLength(0);
+  });
+
+  it('opt-in plain-text mode does NOT retry even if Telegram returns a parse-like error string', async () => {
+    // Edge case: if the caller is in plain-text mode and Telegram still
+    // returns an error that mentions "parse entities" (shouldn't happen
+    // in practice but guards the logic), we must NOT retry — there's no
+    // further parse_mode to strip.
+    queue({
+      status: 400,
+      body: { ok: false, error_code: 400, description: "Bad Request: can't parse entities (weird edge case)" },
+    });
+
+    const api = new TelegramAPI('111:AAA');
+    await expect(
+      api.sendMessage('chat1', 'weird', undefined, { parseMode: null }),
+    ).rejects.toThrow(/parse entities/);
+
+    expect(callLog).toHaveLength(1);
+    expect(warnLog).toHaveLength(0);
+  });
+
+  it('chunked long messages: every chunk respects parseMode=null when opted in', async () => {
+    // 9000-char message → 3 chunks at 4096-char boundary.
+    const longText = 'x'.repeat(9000);
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    queue({ status: 200, body: { ok: true, result: { message_id: 2 } } });
+    queue({ status: 200, body: { ok: true, result: { message_id: 3 } } });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.sendMessage('chat1', longText, undefined, { parseMode: null });
+
+    expect(callLog).toHaveLength(3);
+    for (const call of callLog) {
+      expect(call.body).not.toHaveProperty('parse_mode');
+    }
+    // Result is the last chunk's response (backwards-compatible with the
+    // pre-patch behavior).
+    expect(result?.result?.message_id).toBe(3);
+  });
+
+  it('chunked long messages: parse error on chunk 2 triggers retry for that chunk only', async () => {
+    const longText = 'y'.repeat(9000);
+    // chunk 1 ok, chunk 2 parse-fails then ok, chunk 3 ok.
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    queue({
+      status: 400,
+      body: { ok: false, error_code: 400, description: "Bad Request: can't parse entities" },
+    });
+    queue({ status: 200, body: { ok: true, result: { message_id: 2 } } });
+    queue({ status: 200, body: { ok: true, result: { message_id: 3 } } });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.sendMessage('chat1', longText);
+
+    // 4 total calls: chunk1, chunk2-fail, chunk2-retry, chunk3
+    expect(callLog).toHaveLength(4);
+    expect(callLog[0].body.parse_mode).toBe('Markdown');
+    expect(callLog[1].body.parse_mode).toBe('Markdown');
+    expect(callLog[2].body).not.toHaveProperty('parse_mode'); // retry chunk 2
+    expect(callLog[3].body.parse_mode).toBe('Markdown'); // chunk 3 still Markdown
+    expect(result?.result?.message_id).toBe(3);
+    // One warning for the one fallback.
+    expect(warnLog).toHaveLength(1);
+  });
+
+  it('onParseFallback hook is called exactly once per fallback with the Telegram error message', async () => {
+    queue({
+      status: 400,
+      body: {
+        ok: false,
+        error_code: 400,
+        description: "Bad Request: can't parse entities at byte 99",
+      },
+    });
+    queue({ status: 200, body: { ok: true, result: { message_id: 5 } } });
+
+    const reasons: string[] = [];
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', 'bad', undefined, {
+      onParseFallback: (r) => reasons.push(r),
+    });
+
+    expect(reasons).toHaveLength(1);
+    expect(reasons[0]).toContain("can't parse entities at byte 99");
+  });
+});


### PR DESCRIPTION
# fix(telegram): retry sendMessage with parse_mode=null on parse-entity errors + --plain-text opt-in

**Branch**: `pr/telegram-plain-text-fallback`
**Base**: `grandamenium/cortextos@main` (a608a5d at time of prep)
**Commit**: `2a862e8`

---

## Problem

Agents drop Telegram messages silently when their natural prose contains an unescaped `_`, `*`, backtick, or `[`. `TelegramAPI.sendMessage()` always sent with `parse_mode: "Markdown"`; any parse-entity error from the post() helper bubbled up to the caller (typically a CLI command that logged "Failed to send" and exited 1). 11 such failures observed across agent stdout logs over a 24h window — every one was natural prose, not a code path that could scrub its output in advance.

## Root cause

`sendMessage` had a single code path: Markdown-only, with no fallback and no opt-in plain-text mode. Any call site that wanted plain text had to work around the API instead of asking for it. The multi-chunk path compounded the issue — each chunk went through the same unprotected post() call, so a single bad character aborted the entire send mid-stream.

## Fix

- **One-shot retry on parse-entity errors**: detect Telegram's parse-entity error shape, log a one-line stderr warning, retry the same chunk ONCE with `parse_mode` omitted. If the retry also fails, rethrow so real failures still surface. 401/400/403/network keep failing fast — only parse-entity triggers the retry.
- **Opt-in plain-text mode**: new 4th optional argument `{ parseMode: null }` skips the Markdown attempt entirely, saving the retry roundtrip when callers KNOW the message will trip the parser. Exposed via a new `--plain-text` flag on `cortextos bus send-telegram`.
- **Outbound-log metadata**: new optional `OutboundLogMetadata` interface on `logOutboundMessage`. When the CLI detects a parse-mode fallback, the `outbound-messages.jsonl` entry carries `parse_mode`, `parse_fallback`, and `parse_fallback_reason` for ad-hoc auditing. Backwards compatible — callers passing no metadata produce the same JSONL shape.
- **Shared `sendChunk()` helper** for the multi-chunk path so retry-per-chunk works correctly. Side effect: the last chunk now gets the `replyMarkup` keyboard (the old behavior silently dropped keyboards on every chunk of a chunked send — arguably a latent bug).

## Tests

9 new unit tests in `tests/unit/telegram/send-message.test.ts` covering every branch:

1. Happy path (Markdown succeeds first try)
2. Parse-entity error → retry with plain text succeeds
3. Retry also fails → rethrow
4. Non-parse-entity error fails fast (no retry)
5. Opt-in `parseMode: null` skips Markdown
6. Opt-in edge case (empty message)
7. Chunked plain-text (all chunks sent without Markdown)
8. Chunked retry — one chunk triggers retry, others pass through
9. `onParseFallback` hook fires with the right metadata

## Caveats / known limitations

- **Parse-entity detection is error-message-shape dependent**. Telegram's error text for parse failures contains "can't parse entities" or "Bad Request: can't parse". Shape change on Telegram's side could regress the retry trigger — kept narrow on purpose so false-positive retries (for unrelated 400s) don't mask real config bugs.
- **One retry only**. If the plain-text retry itself hits a transient network error, we rethrow rather than retry again. Keeps the code path bounded — callers needing resilience should retry at a higher layer.
- **Keyboard-on-last-chunk behavior is a behavior change** (old code silently dropped keyboards across all chunks of a chunked send). Test explicitly asserts the new behavior.

## Potential-genericize candidates

(None found — no framework-internal terms or paths in the patch.)

---

**Test suite**: full 460/460 pass. Cherry-pick onto upstream/main a608a5d was clean (zero conflicts).
