### PR TITLE
fix(kb): warn-and-skip on missing knowledge-base config instead of unhandled crash

### DIFF
--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -49,6 +49,22 @@ function loadSecretsEnv(frameworkRoot: string, org: string): Record<string, stri
 }
 
 /**
+ * Check whether the knowledge base config file exists for a given env.
+ *
+ * The Python MMRAG tool loads its config from env.MMRAG_CONFIG
+ * (`knowledge-base/config.json` under the org's state dir) and exits with
+ * "Config not found. Run setup first" if the file is absent. When that
+ * happens, execFileSync throws a non-zero-exit error which — if not caught
+ * — produces a user-facing unhandled-throw stack dump on top of the
+ * already-printed Python error. This helper lets callers detect the
+ * missing-config state UP FRONT and respond gracefully (warn + return)
+ * instead of relying on brittle stderr string matching after the throw.
+ */
+function kbConfigured(env: Record<string, string>): boolean {
+  return existsSync(env.MMRAG_CONFIG);
+}
+
+/**
  * Build the full env object needed by mmrag.py calls.
  */
 function buildKBEnv(
@@ -108,6 +124,21 @@ export function queryKnowledgeBase(
   const { org, agent, scope = 'all', topK = 5, threshold = 0.5, frameworkRoot, instanceId } = options;
 
   const env = buildKBEnv(frameworkRoot, org, instanceId, agent);
+
+  // UX safety net: if the KB is not configured for this org (no config.json
+  // on disk yet), skip the python probe entirely and return empty results
+  // with a visible warning. Previously the inner runQuery() try/catch would
+  // swallow the Config-not-found error silently and the operator would see
+  // "0 results" with no hint about WHY — indistinguishable from a legitimate
+  // empty query against a configured KB. The warn-and-empty shape makes the
+  // distinction obvious and actionable.
+  if (!kbConfigured(env)) {
+    console.warn(
+      `[kb] Knowledge base not configured for org ${org}. Returning empty results — run setup to enable.`,
+    );
+    return { results: [], total: 0, query: question, collection: `shared-${org}` };
+  }
+
   const pythonPath = getVenvPython(frameworkRoot);
   const mmragPath = join(frameworkRoot, 'knowledge-base', 'scripts', 'mmrag.py');
 
@@ -211,6 +242,23 @@ export function ingestKnowledgeBase(
   const { org, agent, scope = 'shared', force, frameworkRoot, instanceId } = options;
 
   const env = buildKBEnv(frameworkRoot, org, instanceId, agent);
+
+  // Correctness fix: if the KB is not configured for this org, the underlying
+  // python MMRAG tool exits with "Config not found. Run setup first" and
+  // execFileSync (below, stdio: inherit) throws a non-zero-exit error. That
+  // throw used to bubble up through the CLI action handler as an unhandled
+  // exception, dumping a full Node stack trace on top of the python error
+  // message — ugly and alarming for operators who were just running ingest
+  // without setting up the KB first. Detect the missing-config state
+  // up-front and warn-and-skip instead of letting execFileSync crash.
+  if (!kbConfigured(env)) {
+    console.warn(
+      `[kb] Knowledge base not configured for org ${org}. Skipping ingest — ` +
+      `run setup to enable (see HEARTBEAT.md step 10 for the config path).`,
+    );
+    return;
+  }
+
   const pythonPath = getVenvPython(frameworkRoot);
   const mmragPath = join(frameworkRoot, 'knowledge-base', 'scripts', 'mmrag.py');
 

--- a/tests/unit/bus/knowledge-base.test.ts
+++ b/tests/unit/bus/knowledge-base.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// Path-aware fs mocks. existsSync is the one we actually drive per-test:
+// it returns true for any path EXCEPT the MMRAG_CONFIG one (when the test
+// wants to simulate a missing config) so loadSecretsEnv and other path
+// lookups still work normally inside the module under test.
+const fsMocks = {
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+};
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: (...args: Parameters<typeof fsMocks.existsSync>) => fsMocks.existsSync(...args),
+    readFileSync: (...args: Parameters<typeof fsMocks.readFileSync>) => fsMocks.readFileSync(...args),
+    mkdirSync: (...args: Parameters<typeof fsMocks.mkdirSync>) => fsMocks.mkdirSync(...args),
+  };
+});
+
+// Mock execFileSync so we can assert whether it was called (and optionally
+// simulate a successful python response).
+const execFileSyncMock = vi.fn();
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    execFileSync: (...args: unknown[]) => execFileSyncMock(...args),
+  };
+});
+
+// Mock normalizeOrgName to a passthrough identity — we are not testing org
+// normalization here, that has its own dedicated test file.
+vi.mock('../../../src/utils/org.js', () => ({
+  normalizeOrgName: (_root: string, org: string) => org,
+}));
+
+const { queryKnowledgeBase, ingestKnowledgeBase } = await import('../../../src/bus/knowledge-base.js');
+
+// Minimal BusPaths stub — knowledge-base.ts doesn't actually USE the paths
+// object at call time, just the options/env it constructs.
+const dummyPaths = {
+  stateDir: '/tmp/agent/state',
+  logDir: '/tmp/agent/logs',
+  ctxRoot: '/tmp/agent',
+  instanceId: 'test',
+  agentName: 'tester',
+  org: 'TestOrg',
+  inboxDir: '/tmp/agent/inbox',
+  inflightDir: '/tmp/agent/inflight',
+  processedDir: '/tmp/agent/processed',
+  outboxDir: '/tmp/agent/outbox',
+} as any;
+
+const baseOptions = {
+  org: 'TestOrg',
+  agent: 'tester',
+  frameworkRoot: '/home/test/cortextOS',
+  instanceId: 'test',
+};
+
+let warnLog: string[] = [];
+let originalWarn: typeof console.warn;
+let logLog: string[] = [];
+let originalLog: typeof console.log;
+
+beforeEach(() => {
+  fsMocks.existsSync.mockReset();
+  fsMocks.readFileSync.mockReset().mockReturnValue('');
+  fsMocks.mkdirSync.mockReset();
+  execFileSyncMock.mockReset();
+
+  warnLog = [];
+  logLog = [];
+  originalWarn = console.warn;
+  originalLog = console.log;
+  console.warn = (...args: unknown[]) => {
+    warnLog.push(args.map((a) => String(a)).join(' '));
+  };
+  console.log = (...args: unknown[]) => {
+    logLog.push(args.map((a) => String(a)).join(' '));
+  };
+});
+
+afterEach(() => {
+  console.warn = originalWarn;
+  console.log = originalLog;
+});
+
+/**
+ * Helper: make existsSync return false ONLY for paths that end with
+ * knowledge-base/config.json (i.e. the MMRAG_CONFIG file), true for everything
+ * else. Simulates a freshly-created agent with no KB configured yet.
+ */
+function mockMissingKbConfig(): void {
+  fsMocks.existsSync.mockImplementation((p: any) => {
+    const path = String(p);
+    if (path.endsWith('/knowledge-base/config.json')) return false;
+    return true;
+  });
+}
+
+/**
+ * Helper: make existsSync return true for everything, simulating a fully
+ * configured KB with config.json present on disk.
+ */
+function mockConfiguredKb(): void {
+  fsMocks.existsSync.mockImplementation(() => true);
+}
+
+describe('ingestKnowledgeBase — graceful missing-config', () => {
+  it('missing config: warn + return cleanly, execFileSync NEVER called', () => {
+    mockMissingKbConfig();
+
+    // Must NOT throw. Previously this path threw an unhandled execFileSync
+    // error that dumped a Node stack trace on top of the python stderr.
+    expect(() =>
+      ingestKnowledgeBase(['/some/file.md'], baseOptions),
+    ).not.toThrow();
+
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    // Warn must include the org name AND an actionable hint ("run setup").
+    expect(warnLog.some((m) => m.includes('TestOrg') && /run setup/i.test(m))).toBe(true);
+    // Warn must carry the [kb] prefix so operators can filter log lines.
+    expect(warnLog.some((m) => m.includes('[kb]'))).toBe(true);
+  });
+
+  it('config present: execFileSync IS called with the mmrag ingest args', () => {
+    mockConfiguredKb();
+    execFileSyncMock.mockReturnValue('');
+
+    ingestKnowledgeBase(['/some/file.md'], baseOptions);
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    // First positional arg is the python path, second is the argv array.
+    const [pythonPath, argv] = execFileSyncMock.mock.calls[0] as [string, string[], object];
+    expect(String(pythonPath)).toMatch(/python/);
+    expect(argv).toEqual(expect.arrayContaining(['ingest', '/some/file.md']));
+    // Happy path emits no [kb] warning.
+    expect(warnLog.filter((m) => m.includes('[kb]'))).toHaveLength(0);
+  });
+});
+
+describe('queryKnowledgeBase — graceful missing-config', () => {
+  it('missing config: warn + return empty KBQueryResponse, execFileSync NEVER called', () => {
+    mockMissingKbConfig();
+
+    const result = queryKnowledgeBase(dummyPaths, 'what is cortextos?', baseOptions);
+
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      results: [],
+      total: 0,
+      query: 'what is cortextos?',
+      collection: 'shared-TestOrg',
+    });
+    expect(warnLog.some((m) => m.includes('TestOrg') && /run setup/i.test(m))).toBe(true);
+    expect(warnLog.some((m) => m.includes('[kb]'))).toBe(true);
+  });
+
+  it('config present: execFileSync IS called, happy-path query returns results', () => {
+    mockConfiguredKb();
+    // Mock mmrag.py --json output: a JSON blob with one result.
+    execFileSyncMock.mockReturnValue(
+      JSON.stringify({
+        results: [
+          { content: 'hit', similarity: 0.9, source: 'foo.md', type: 'markdown' },
+        ],
+      }),
+    );
+
+    const result = queryKnowledgeBase(dummyPaths, 'test query', baseOptions);
+
+    expect(execFileSyncMock).toHaveBeenCalled();
+    expect(result.total).toBeGreaterThan(0);
+    expect(result.results[0].content).toBe('hit');
+    // Happy path emits no [kb] warning.
+    expect(warnLog.filter((m) => m.includes('[kb]'))).toHaveLength(0);
+  });
+});
+
+describe('kb warn messages — UX invariants', () => {
+  it('both warn messages name the org and suggest "run setup"', () => {
+    // Drive ingest path
+    mockMissingKbConfig();
+    ingestKnowledgeBase(['/f.md'], { ...baseOptions, org: 'SpecificOrg' });
+    // Drive query path
+    mockMissingKbConfig();
+    queryKnowledgeBase(dummyPaths, 'q', { ...baseOptions, org: 'SpecificOrg' });
+
+    // At least one warn per call site, each containing the org name + hint
+    const specificOrgWarns = warnLog.filter((m) => m.includes('SpecificOrg'));
+    expect(specificOrgWarns.length).toBeGreaterThanOrEqual(2);
+    expect(specificOrgWarns.every((m) => /run setup/i.test(m))).toBe(true);
+  });
+});


### PR DESCRIPTION
# fix(kb): warn-and-skip on missing knowledge-base config instead of unhandled crash

**Branch**: `pr/kb-ingest-graceful-missing-config`
**Base**: `grandamenium/cortextos@main` (a608a5d at time of prep)
**Commit**: `29a069a`

---

## Problem

Running `cortextos bus kb-ingest` against an org whose `knowledge-base/config.json` was never created used to produce an ungraceful crash: the underlying python MMRAG tool exited with "Config not found. Run setup first", the subprocess wrapper threw the non-zero-exit error, and Node dumped a full JS stack trace on top of the python stderr. Alarming for operators and indistinguishable from a real bug.

`queryKnowledgeBase` had the symmetric UX bug: the inner `runQuery()` try/catch already swallowed the Config-not-found throw and returned empty results, but the operator got zero hits with no indication of *why* — indistinguishable from a legitimate empty query.

## Root cause

Neither call site checked for the config file before invoking the python tool. `ingestKnowledgeBase` had no try/catch at all around the spawn, so the throw became an unhandled exception. `queryKnowledgeBase` had a catch that discarded the error silently.

## Fix

- New `kbConfigured(env)` helper — a one-line `existsSync(env.MMRAG_CONFIG)` check.
- `ingestKnowledgeBase`: upfront check emits a `[kb]` warn naming the org + a "run setup" hint, then returns cleanly. No throw, no stack dump, exit code 0.
- `queryKnowledgeBase`: upfront check emits the same-style warn and returns the same empty shape the rest of the code path expects.
- Both warn messages use the `[kb]` prefix for grep-ability and name the org so multi-org operators can identify which config is missing.

## Tests

5 new unit tests in `tests/unit/bus/knowledge-base.test.ts` (first test file for `src/bus/knowledge-base.ts`):

1. `ingestKnowledgeBase` with missing config → warns, returns, does NOT spawn python
2. `ingestKnowledgeBase` with config present → proceeds to spawn (happy path)
3. `queryKnowledgeBase` with missing config → warns, returns empty shape, no spawn
4. `queryKnowledgeBase` with config present → proceeds to spawn
5. Warn-message shape invariant — regression guard that the `[kb]` prefix + org-name format stays stable for log grepping

## Caveats / known limitations

- **Silent-success after the warn is intentional**. The CLI command still exits 0 because "no KB configured" is an expected state for a fresh org, not an error. If a deployment treats missing config as a hard failure, wrap the call site and check the warn output.
- **Warn goes to stderr via `console.warn`** — matches the rest of the bus module's convention. Not configurable to a structured logger at this layer.

## Potential-genericize candidates

(None found — no framework-internal terms or paths in the patch.)

---

**Test suite**: full 456/456 pass. Cherry-pick onto upstream/main a608a5d was clean. Scrub: `/tmp/bob/...` fixture paths in the test file were renamed to `/tmp/agent/...` to keep the test corpus agent-name-neutral.
