### PR TITLE
fix(task): cross-org lookup for update-task and complete-task via findTaskFile helper

### DIFF
--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, renameSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, renameSync } from 'fs';
 import { join } from 'path';
 import type { Task, Priority, TaskStatus, BusPaths, StaleTaskReport, ArchiveReport } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
@@ -65,14 +65,85 @@ export function createTask(
 }
 
 /**
- * Update a task's status. Matches bash update-task.sh behavior.
+ * Find the on-disk path of a task file by ID, supporting cross-org lookup.
+ *
+ * cortextOS's standard dispatch pattern is an orchestrator in one org
+ * filing tasks that get assigned to specialists in other orgs. Before
+ * this helper existed, updateTask
+ * and completeTask hardcoded `join(paths.taskDir, taskId + '.json')` — which
+ * points at the CURRENT agent's org tasks dir — so the specialist could not
+ * drive the lifecycle of any task that was filed from a sibling org. Every
+ * cross-org assignment required a manual workaround dance where the filer
+ * ran update/complete on behalf of the assignee.
+ *
+ * This helper fixes that by using a two-tier lookup:
+ *
+ *   1. Fast path: check the caller's OWN org tasks dir first. Most tasks
+ *      live there and this check pays zero scan cost when it hits.
+ *   2. Fallback: scan every sibling org under `<ctxRoot>/orgs/*` for a
+ *      matching task file. Only runs when the fast path missed, so
+ *      same-org operations take no perf hit.
+ *
+ * Task IDs are generated as `task_<epoch_ms>_<3digit_random>` so real
+ * collisions are effectively impossible — but if the scan ever finds the
+ * same ID in multiple orgs (e.g. due to a bug in ID generation or a manual
+ * file copy), we warn loudly naming the task ID, the match count, AND the
+ * org names so an operator can investigate without having to grep the IDs
+ * themselves. We still return the first match and keep operations flowing;
+ * erroring on a theoretical collision would be worse UX than the warn.
+ *
+ * Exported because the helper is a useful primitive for any future caller
+ * that needs cross-org task lookup (e.g. a hypothetical `get-task` command,
+ * task-graph visualization, or cross-org list-tasks flag).
+ */
+export function findTaskFile(paths: BusPaths, taskId: string): string | null {
+  // Fast path: same-org lookup.
+  const sameOrg = join(paths.taskDir, `${taskId}.json`);
+  if (existsSync(sameOrg)) return sameOrg;
+
+  // Fallback: cross-org scan.
+  const orgsRoot = join(paths.ctxRoot, 'orgs');
+  const matches: Array<{ path: string; org: string }> = [];
+  try {
+    for (const entry of readdirSync(orgsRoot, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const candidate = join(orgsRoot, entry.name, 'tasks', `${taskId}.json`);
+      if (existsSync(candidate)) {
+        matches.push({ path: candidate, org: entry.name });
+      }
+    }
+  } catch {
+    return null; // orgs/ missing or unreadable
+  }
+
+  if (matches.length === 0) return null;
+  if (matches.length > 1) {
+    const orgList = matches.map((m) => m.org).join(', ');
+    console.warn(
+      `[task] Ambiguous task id ${taskId}: found in ${matches.length} orgs (${orgList}). ` +
+      `Operating on the first match in org '${matches[0].org}'. ` +
+      `Review task ID generation if this recurs.`,
+    );
+  }
+  return matches[0].path;
+}
+
+/**
+ * Update a task's status. Matches bash update-task.sh behavior, with the
+ * cross-org fallback from findTaskFile so an assignee in one org can drive
+ * the lifecycle of a task filed by an orchestrator in a sibling org.
  */
 export function updateTask(
   paths: BusPaths,
   taskId: string,
   status: TaskStatus,
 ): void {
-  const filePath = join(paths.taskDir, `${taskId}.json`);
+  const filePath = findTaskFile(paths, taskId);
+  if (!filePath) {
+    throw new Error(
+      `Task ${taskId} not found in any org under ${paths.ctxRoot}/orgs/`,
+    );
+  }
   try {
     const content = readFileSync(filePath, 'utf-8');
     const task: Task = JSON.parse(content);
@@ -80,20 +151,27 @@ export function updateTask(
     task.updated_at = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
     atomicWriteSync(filePath, JSON.stringify(task));
   } catch (err) {
-    throw new Error(`Task ${taskId} not found: ${err}`);
+    throw new Error(`Task ${taskId} update failed: ${err}`);
   }
 }
 
 /**
  * Complete a task. Sets status to done, completed_at, and optional result.
- * Matches bash complete-task.sh behavior.
+ * Matches bash complete-task.sh behavior, with the cross-org fallback from
+ * findTaskFile so an assignee in one org can complete a task filed by an
+ * orchestrator in a sibling org.
  */
 export function completeTask(
   paths: BusPaths,
   taskId: string,
   result?: string,
 ): void {
-  const filePath = join(paths.taskDir, `${taskId}.json`);
+  const filePath = findTaskFile(paths, taskId);
+  if (!filePath) {
+    throw new Error(
+      `Task ${taskId} not found in any org under ${paths.ctxRoot}/orgs/`,
+    );
+  }
   try {
     const content = readFileSync(filePath, 'utf-8');
     const task: Task = JSON.parse(content);
@@ -105,7 +183,7 @@ export function completeTask(
     }
     atomicWriteSync(filePath, JSON.stringify(task));
   } catch (err) {
-    throw new Error(`Task ${taskId} not found: ${err}`);
+    throw new Error(`Task ${taskId} complete failed: ${err}`);
   }
 }
 

--- a/tests/unit/bus/task.test.ts
+++ b/tests/unit/bus/task.test.ts
@@ -1,8 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { createTask, updateTask, completeTask, listTasks } from '../../../src/bus/task';
+import { createTask, updateTask, completeTask, listTasks, findTaskFile } from '../../../src/bus/task';
 import type { BusPaths } from '../../../src/types';
 
 describe('Task Management', () => {
@@ -110,5 +110,214 @@ describe('Task Management', () => {
       const pending = listTasks(paths, { status: 'pending' });
       expect(pending.length).toBe(1);
     });
+  });
+});
+
+/**
+ * Cross-org task lifecycle — exercises the findTaskFile fallback so an
+ * assignee in one org can drive the lifecycle of a task filed by an
+ * orchestrator in a sibling org. Standard cortextOS dispatch pattern:
+ * an orchestrator in one org files a task, a specialist in another org
+ * needs to update and complete it from their own agent session.
+ *
+ * These tests build a REAL nested filesystem layout (matching the
+ * production shape at ~/.cortextos/<instance>/orgs/<org>/tasks/) so they
+ * cover the actual cross-org path resolution, not a mocked shortcut.
+ */
+describe('Cross-org task lifecycle', () => {
+  let testDir: string;
+  let orgAPaths: BusPaths;
+  let orgBTaskDir: string;
+  let warnLog: string[];
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-crossorg-test-'));
+    // Nested layout: <ctxRoot>/orgs/{OrgA,OrgB}/tasks/
+    mkdirSync(join(testDir, 'orgs', 'OrgA', 'tasks'), { recursive: true });
+    mkdirSync(join(testDir, 'orgs', 'OrgB', 'tasks'), { recursive: true });
+
+    orgAPaths = {
+      ctxRoot: testDir,
+      inbox: join(testDir, 'inbox', 'agentA'),
+      inflight: join(testDir, 'inflight', 'agentA'),
+      processed: join(testDir, 'processed', 'agentA'),
+      logDir: join(testDir, 'logs', 'agentA'),
+      stateDir: join(testDir, 'state', 'agentA'),
+      taskDir: join(testDir, 'orgs', 'OrgA', 'tasks'),
+      approvalDir: join(testDir, 'orgs', 'OrgA', 'approvals'),
+      analyticsDir: join(testDir, 'orgs', 'OrgA', 'analytics'),
+      heartbeatDir: join(testDir, 'heartbeats'),
+    };
+    orgBTaskDir = join(testDir, 'orgs', 'OrgB', 'tasks');
+
+    warnLog = [];
+    originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnLog.push(args.map((a) => String(a)).join(' '));
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  /** Helper: drop a raw task JSON file into OrgB's tasks dir without
+   * going through createTask (which only knows about OrgA's taskDir). */
+  function writeOrgBTask(taskId: string, overrides: Record<string, unknown> = {}): void {
+    const task = {
+      id: taskId,
+      title: 'Cross-org task',
+      description: '',
+      type: 'agent',
+      needs_approval: false,
+      status: 'pending',
+      assigned_to: 'agentA',
+      created_by: 'orchestrator',
+      org: 'OrgB',
+      priority: 'normal',
+      project: '',
+      kpi_key: null,
+      created_at: '2026-04-11T20:00:00Z',
+      updated_at: '2026-04-11T20:00:00Z',
+      completed_at: null,
+      due_date: null,
+      archived: false,
+      ...overrides,
+    };
+    writeFileSync(join(orgBTaskDir, `${taskId}.json`), JSON.stringify(task), 'utf-8');
+  }
+
+  it('updateTask same-org happy path: still works via the fast path', () => {
+    // Regression guard for the existing single-org behavior. This is the
+    // hot path and must not pay any cross-org scan cost when it hits.
+    const taskId = createTask(orgAPaths, 'agentA', 'OrgA', 'Same-org task');
+    updateTask(orgAPaths, taskId, 'in_progress');
+
+    const content = JSON.parse(
+      readFileSync(join(orgAPaths.taskDir, `${taskId}.json`), 'utf-8'),
+    );
+    expect(content.status).toBe('in_progress');
+  });
+
+  it('updateTask cross-org: finds task in sibling org via findTaskFile fallback', () => {
+    // Repro: file a task in OrgB, try to update it from an OrgA-scoped
+    // session. Before findTaskFile, this threw "Task not found" because
+    // updateTask only looked at orgAPaths.taskDir.
+    const taskId = 'task_test_001';
+    writeOrgBTask(taskId);
+
+    updateTask(orgAPaths, taskId, 'in_progress');
+
+    // Verify the OrgB file got updated, NOT the (nonexistent) OrgA file.
+    const orgBContent = JSON.parse(
+      readFileSync(join(orgBTaskDir, `${taskId}.json`), 'utf-8'),
+    );
+    expect(orgBContent.status).toBe('in_progress');
+    // Explicit timestamp comparison: the seed updated_at is a fixed moment
+    // in the past, so the real Date.now() that updateTask stamps MUST be
+    // strictly greater. Avoids the brittle string-inequality form that
+    // would silently pass on any future refactor that changed the seed.
+    expect(new Date(orgBContent.updated_at).getTime()).toBeGreaterThan(
+      new Date('2026-04-11T20:00:00Z').getTime(),
+    );
+    expect(existsSync(join(orgAPaths.taskDir, `${taskId}.json`))).toBe(false);
+  });
+
+  it('updateTask not found anywhere: throws with a clear error naming ctxRoot', () => {
+    expect(() => updateTask(orgAPaths, 'task_999_000', 'in_progress')).toThrow(
+      /not found in any org under .*\/orgs\//,
+    );
+  });
+
+  it('completeTask cross-org: finds task in sibling org and marks it done', () => {
+    const taskId = 'task_test_002';
+    writeOrgBTask(taskId);
+
+    completeTask(orgAPaths, taskId, 'cross-org completion');
+
+    const orgBContent = JSON.parse(
+      readFileSync(join(orgBTaskDir, `${taskId}.json`), 'utf-8'),
+    );
+    expect(orgBContent.status).toBe('completed');
+    expect(orgBContent.completed_at).toBeTruthy();
+    expect(orgBContent.result).toBe('cross-org completion');
+  });
+
+  it('findTaskFile ambiguity: same ID in two orgs triggers warn naming both orgs', () => {
+    // Manually create the same task id in BOTH orgs. Real collisions
+    // should be vanishingly rare (epoch_ms + 3 digits), but the warn path
+    // must be tested so operators hitting it in production get actionable
+    // information.
+    const taskId = 'task_1_000';
+    writeOrgBTask(taskId);
+    // Write the same ID to OrgA via direct filesystem (bypassing
+    // createTask so we can reuse the exact ID).
+    const orgATaskPath = join(orgAPaths.taskDir, `${taskId}.json`);
+    writeFileSync(
+      orgATaskPath,
+      JSON.stringify({
+        id: taskId,
+        title: 'OrgA collision',
+        status: 'pending',
+        org: 'OrgA',
+        updated_at: '2026-04-11T20:00:00Z',
+        created_at: '2026-04-11T20:00:00Z',
+      }),
+      'utf-8',
+    );
+
+    // findTaskFile should return the OrgA path (same-org fast path wins)
+    // without ever emitting the ambiguity warning. The fast path only
+    // checks same-org; the cross-org scan is ONLY exercised when same-org
+    // misses. So the ambiguity warning path requires same-org to miss
+    // AND multiple sibling orgs to hit.
+    //
+    // To exercise the warn, delete the OrgA copy and write collisions
+    // into two OTHER orgs.
+    rmSync(orgATaskPath);
+    mkdirSync(join(testDir, 'orgs', 'OrgC', 'tasks'), { recursive: true });
+    writeFileSync(
+      join(testDir, 'orgs', 'OrgC', 'tasks', `${taskId}.json`),
+      JSON.stringify({
+        id: taskId,
+        title: 'OrgC collision',
+        status: 'pending',
+        org: 'OrgC',
+        updated_at: '2026-04-11T20:00:00Z',
+        created_at: '2026-04-11T20:00:00Z',
+      }),
+      'utf-8',
+    );
+
+    const result = findTaskFile(orgAPaths, taskId);
+    expect(result).not.toBeNull();
+    // Warn must have fired and must name BOTH the task id and the two orgs.
+    expect(warnLog.length).toBeGreaterThanOrEqual(1);
+    const warn = warnLog[0];
+    expect(warn).toContain(taskId);
+    expect(warn).toMatch(/found in 2 orgs/);
+    expect(warn).toContain('OrgB');
+    expect(warn).toContain('OrgC');
+  });
+
+  it('listTasks scoping regression: must remain single-org, NO cross-org leakage', () => {
+    // CRITICAL regression guard. Scoping contract:
+    // listTasks must remain single-org by default — cross-org listing
+    // requires an explicit opt-in flag that does not exist yet. A future
+    // well-meaning refactor that 'helpfully' makes listTasks cross-org by
+    // default would silently break the dashboard, which depends on
+    // per-org scoping for its sync loop. If this test fails, the refactor
+    // broke the contract and must be reverted or gated behind an opt-in
+    // flag.
+    const sameOrgId = createTask(orgAPaths, 'agentA', 'OrgA', 'Same-org task');
+    writeOrgBTask('task_other_1', { title: 'Sibling-org task 1' });
+    writeOrgBTask('task_other_2', { title: 'Sibling-org task 2' });
+
+    const tasks = listTasks(orgAPaths);
+    expect(tasks.length).toBe(1);
+    expect(tasks[0].id).toBe(sameOrgId);
+    expect(tasks[0].title).toBe('Same-org task');
   });
 });


### PR DESCRIPTION
# fix(task): cross-org lookup for update-task and complete-task via findTaskFile helper

**Branch**: `pr/task-cross-org-lookup`
**Base**: `grandamenium/cortextos@main` (a608a5d at time of prep)
**Commit**: `330ff99`

---

## Problem

The standard cortextOS dispatch pattern is an orchestrator in one org filing a task that gets assigned to a specialist in a different org. Before this patch, `updateTask` and `completeTask` hardcoded the task file path as `join(paths.taskDir, taskId + '.json')` — always the CALLER's org tasks dir. When the assignee tried to drive the lifecycle from their own session (`cortextos bus update-task <id> in_progress`), the command failed with "Task <id> not found: ENOENT" because the task file lived in the FILER's org. Every cross-org assignment required a manual workaround where the filer ran update/complete on behalf of the assignee.

## Root cause

Task file resolution was hardcoded to the caller's own tasks dir with no fallback. No helper existed for cross-org lookup.

## Fix

Adds a new exported `findTaskFile(paths, taskId)` helper with a two-tier lookup:

1. **Fast path**: check the caller's own org tasks dir first. Zero scan cost when it hits (same-org is the common case).
2. **Fallback**: scan every sibling org under `<ctxRoot>/orgs/*/tasks/` for a matching task file. Only runs when the fast path missed, so same-org operations take no perf hit.

`updateTask` and `completeTask` refactored to use `findTaskFile`. Error messages improved:
- Find-miss errors now name the actual search path (`<ctxRoot>/orgs/`) so operators can see where the scan looked.
- Post-find I/O errors get their own distinct "update failed" / "complete failed" prefix to separate them from path-resolution failures.

**Ambiguity handling**: if the fallback scan finds the same task ID in multiple orgs (theoretically possible due to `task_<epoch_ms>_<3digit>` collisions, practically vanishingly rare), warn loudly naming the task ID, match count, AND all org names where the collisions occurred, then return the first match. Operations keep flowing while the anomaly is surfaced.

**`listTasks` DELIBERATELY UNCHANGED** — stays single-org by default because the dashboard sync loop depends on per-org task listings. A cross-org list-tasks flag can land as a separate opt-in enhancement.

## Tests

6 new cases in `tests/unit/bus/task.test.ts` against a real nested filesystem layout (matching the production shape at `~/.cortextos/<instance>/orgs/<org>/tasks/`), not a mocked shortcut:

1. Same-org fast path regression guard
2. Cross-org update via fallback
3. Cross-org complete via fallback
4. Not-found error shape names the search path
5. Ambiguity — warn names all colliding orgs
6. `listTasks` scoping regression guard — explicitly documents the single-org contract in its comment so a future refactor cannot accidentally make listTasks cross-org without failing this test

## Caveats / known limitations

- **Fallback scan is `readdirSync` over `<ctxRoot>/orgs/`**. On a deployment with hundreds of orgs the fallback path gets slower linearly. Fast path still O(1) for same-org (the hot case); only the fallback pays for the scan.
- **Ambiguity returns the first match**. Not the "right" match — the first one `readdirSync` yields. The warn makes the anomaly visible so operators can investigate, but if multi-org ID collisions become real rather than theoretical, add a proper disambiguation policy.
- **No write-path cross-org support added**. `createTask` still writes to the caller's own org. Filing a task into a different org's tasks dir requires a separate API — out of scope for this patch.

## Potential-genericize candidates

(None found — no framework-internal terms or paths in the patch.)

---

**Test suite**: full 457/457 pass. Cherry-pick onto upstream/main a608a5d was clean. Scrubs applied: JSDoc example `(e.g. boss@ElementOneSound ... bob@agentnet)` removed from `findTaskFile`; test-fixture comments "The exact bug boss hit" / "Boss's explicit scoping note" rewritten in neutral provenance tone; timestamp-shaped test IDs `task_1775939913834_528/529` renamed to `task_test_001/002`.
