### PR TITLE
fix(org): normalize org casing at KB-write and dashboard sync

### DIFF
--- a/dashboard/src/lib/config.ts
+++ b/dashboard/src/lib/config.ts
@@ -120,26 +120,34 @@ export function getAgentDir(name: string, org?: string): string {
 // -- Discovery functions --
 
 export function getOrgs(): string[] {
-  const orgs = new Set<string>();
-
-  // Check state dir (CTX_ROOT/orgs/)
-  const stateOrgsDir = path.join(CTX_ROOT, 'orgs');
-  if (fs.existsSync(stateOrgsDir)) {
-    for (const d of fs.readdirSync(stateOrgsDir, { withFileTypes: true })) {
-      if (d.isDirectory()) orgs.add(d.name);
-    }
-  }
-
-  // Also check project/framework root (CTX_FRAMEWORK_ROOT/orgs/)
-  // This is where CLI creates org config files (context.json, knowledge.md)
+  // Read framework root FIRST — it is the source of truth for org naming.
+  // When the same org exists in both dirs with drifted casing (e.g. a ghost
+  // `acmecorp/` in state + canonical `AcmeCorp/` in framework),
+  // we keep the framework casing and discard the state-dir variant. Without
+  // this, dashboard sync hits both names and floods the log with lookup
+  // failures against the non-existent lowercase dir.
   const frameworkOrgsDir = path.join(CTX_FRAMEWORK_ROOT, 'orgs');
-  if (frameworkOrgsDir !== stateOrgsDir && fs.existsSync(frameworkOrgsDir)) {
+  const stateOrgsDir = path.join(CTX_ROOT, 'orgs');
+
+  // Map lowercase key -> canonical casing. Framework entries win over state
+  // entries. Within a single dir, we trust fs.readdirSync uniqueness.
+  const byLower = new Map<string, string>();
+
+  if (fs.existsSync(frameworkOrgsDir)) {
     for (const d of fs.readdirSync(frameworkOrgsDir, { withFileTypes: true })) {
-      if (d.isDirectory()) orgs.add(d.name);
+      if (d.isDirectory()) byLower.set(d.name.toLowerCase(), d.name);
     }
   }
 
-  return Array.from(orgs);
+  if (frameworkOrgsDir !== stateOrgsDir && fs.existsSync(stateOrgsDir)) {
+    for (const d of fs.readdirSync(stateOrgsDir, { withFileTypes: true })) {
+      if (d.isDirectory() && !byLower.has(d.name.toLowerCase())) {
+        byLower.set(d.name.toLowerCase(), d.name);
+      }
+    }
+  }
+
+  return Array.from(byLower.values());
 }
 
 export function getAgentsForOrg(org: string): string[] {

--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import type { BusPaths } from '../types/index.js';
+import { normalizeOrgName } from '../utils/org.js';
 
 /**
  * Knowledge base integration — calls mmrag.py directly (cross-platform,
@@ -57,12 +58,18 @@ function buildKBEnv(
   instanceId: string,
   agent?: string,
 ): Record<string, string> {
-  const kbRoot = join(homedir(), '.cortextos', instanceId, 'orgs', org, 'knowledge-base');
-  const secrets = loadSecretsEnv(frameworkRoot, org);
+  // Normalize org to its canonical filesystem casing BEFORE touching any
+  // paths. Without this, a lowercase --org arg produces a ghost state dir
+  // (~/.cortextos/<instance>/orgs/<lowercase>/knowledge-base/) with its own
+  // MMRAG config.json, splitting KB state across two directories and
+  // polluting dashboard sync with hits against a non-existent org.
+  const canonicalOrg = normalizeOrgName(frameworkRoot, org);
+  const kbRoot = join(homedir(), '.cortextos', instanceId, 'orgs', canonicalOrg, 'knowledge-base');
+  const secrets = loadSecretsEnv(frameworkRoot, canonicalOrg);
   return {
     ...process.env as Record<string, string>,
     ...secrets,
-    CTX_ORG: org,
+    CTX_ORG: canonicalOrg,
     CTX_AGENT_NAME: agent || '',
     CTX_INSTANCE_ID: instanceId,
     CTX_FRAMEWORK_ROOT: frameworkRoot,
@@ -105,7 +112,13 @@ export function queryKnowledgeBase(
     instanceId: string;
   },
 ): KBQueryResponse {
-  const { org, agent, scope = 'all', topK = 5, threshold = 0.5, frameworkRoot, instanceId } = options;
+  const { agent, scope = 'all', topK = 5, threshold = 0.5, frameworkRoot, instanceId } = options;
+  // Normalize once at the top so every downstream path join, env var, and
+  // ChromaDB collection name uses the canonical filesystem casing. Without
+  // this, `shared-acmecorp` and `shared-AcmeCorp` become two
+  // distinct ChromaDB collections and a case-drifted query silently hits
+  // the wrong one.
+  const org = normalizeOrgName(frameworkRoot, options.org);
 
   const env = buildKBEnv(frameworkRoot, org, instanceId, agent);
   const pythonPath = getVenvPython(frameworkRoot);
@@ -208,7 +221,9 @@ export function ingestKnowledgeBase(
     instanceId: string;
   },
 ): void {
-  const { org, agent, scope = 'shared', force, frameworkRoot, instanceId } = options;
+  const { agent, scope = 'shared', force, frameworkRoot, instanceId } = options;
+  // Normalize once (see queryKnowledgeBase for rationale).
+  const org = normalizeOrgName(frameworkRoot, options.org);
 
   const env = buildKBEnv(frameworkRoot, org, instanceId, agent);
   const pythonPath = getVenvPython(frameworkRoot);
@@ -250,9 +265,15 @@ export function ingestKnowledgeBase(
 
 /**
  * Ensure the knowledge base directories exist for an org.
+ *
+ * `frameworkRoot` is required so the org name can be normalized to its
+ * canonical filesystem casing — without that, a caller passing a drifted
+ * name (e.g. "acmecorp") would create a ghost state dir identical
+ * to the one this module was written to prevent.
  */
-export function ensureKBDirs(instanceId: string, org: string): void {
-  const kbRoot = join(homedir(), '.cortextos', instanceId, 'orgs', org, 'knowledge-base');
+export function ensureKBDirs(instanceId: string, frameworkRoot: string, org: string): void {
+  const canonicalOrg = normalizeOrgName(frameworkRoot, org);
+  const kbRoot = join(homedir(), '.cortextos', instanceId, 'orgs', canonicalOrg, 'knowledge-base');
   const chromaDir = join(kbRoot, 'chromadb');
   if (!existsSync(chromaDir)) {
     mkdirSync(chromaDir, { recursive: true });

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -883,7 +883,7 @@ busCommand
       process.exit(1);
     }
 
-    ensureKBDirs(env.instanceId, org);
+    ensureKBDirs(env.instanceId, env.frameworkRoot, org);
 
     ingestKnowledgeBase(paths, {
       org,

--- a/src/utils/org.ts
+++ b/src/utils/org.ts
@@ -1,0 +1,75 @@
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Map an org name to its canonical filesystem casing.
+ *
+ * cortextOS treats the filesystem-exact spelling of an org directory as the
+ * canonical identifier. When a caller supplies an org name with drifted
+ * casing (e.g. "acmecorp" instead of "AcmeCorp"), every
+ * downstream path join produces a SEPARATE state directory, which splits
+ * runtime artifacts across two ghost dirs and pollutes every consumer that
+ * scans the orgs/ parent. Before this helper existed, one lowercase
+ * `cortextos bus kb-* --org acmecorp` invocation was enough to
+ * bootstrap a phantom `~/.cortextos/default/orgs/acmecorp/` with a
+ * MMRAG config.json that then haunted dashboard sync forever.
+ *
+ * Resolution order:
+ *
+ *   1. If `{frameworkRoot}/orgs/{org}` exists with the exact casing given,
+ *      return it unchanged. This is the fast path for well-formed input
+ *      and guarantees we never change a caller's spelling unnecessarily.
+ *
+ *   2. Otherwise, read the framework `orgs/` directory and look for an
+ *      entry that matches case-insensitively. If exactly one such entry
+ *      exists, return IT — the on-disk canonical casing — instead of the
+ *      caller's input.
+ *
+ *   3. If the framework dir is missing, unreadable, or contains no
+ *      matching entry, return the input unchanged. Callers that actually
+ *      need the directory to exist will fail at their own file operations
+ *      with a clearer error than anything this helper could raise.
+ *
+ * Never returns a name that does not exist on disk. Never normalizes past
+ * an exact-case match (case-sensitive filesystems may legitimately host
+ * both `AcmeCorp` and `acmecorp` as distinct orgs — we do
+ * not want to collapse them).
+ */
+export function normalizeOrgName(frameworkRoot: string, org: string): string {
+  if (!org) return org;
+
+  const orgsDir = join(frameworkRoot, 'orgs');
+  const exactPath = join(orgsDir, org);
+
+  // Fast path: exact case match on disk.
+  try {
+    if (existsSync(exactPath) && statSync(exactPath).isDirectory()) {
+      return org;
+    }
+  } catch {
+    return org;
+  }
+
+  // Slow path: case-insensitive scan of the orgs dir.
+  let entries: string[];
+  try {
+    entries = readdirSync(orgsDir);
+  } catch {
+    return org;
+  }
+
+  const orgLower = org.toLowerCase();
+  for (const entry of entries) {
+    if (entry.toLowerCase() === orgLower) {
+      try {
+        if (statSync(join(orgsDir, entry)).isDirectory()) {
+          return entry;
+        }
+      } catch {
+        // Skip unreadable entry
+      }
+    }
+  }
+
+  return org;
+}

--- a/tests/unit/dashboard/config-getorgs.test.ts
+++ b/tests/unit/dashboard/config-getorgs.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Two temp dirs: one for state (CTX_ROOT), one for framework (CTX_FRAMEWORK_ROOT).
+// Both env vars must be set BEFORE we import ../config, because that module
+// resolves its path constants at import time.
+const tmpState = fs.mkdtempSync(path.join(os.tmpdir(), 'cortextos-state-'));
+const tmpFramework = fs.mkdtempSync(path.join(os.tmpdir(), 'cortextos-framework-'));
+process.env.CTX_ROOT = tmpState;
+process.env.CTX_FRAMEWORK_ROOT = tmpFramework;
+
+fs.mkdirSync(path.join(tmpState, 'orgs'), { recursive: true });
+fs.mkdirSync(path.join(tmpFramework, 'orgs'), { recursive: true });
+
+let getOrgs: typeof import('../../../dashboard/src/lib/config')['getOrgs'];
+
+beforeAll(async () => {
+  const configMod = await import('../../../dashboard/src/lib/config');
+  getOrgs = configMod.getOrgs;
+});
+
+function resetOrgs(): void {
+  for (const base of [path.join(tmpState, 'orgs'), path.join(tmpFramework, 'orgs')]) {
+    for (const entry of fs.readdirSync(base)) {
+      fs.rmSync(path.join(base, entry), { recursive: true, force: true });
+    }
+  }
+}
+
+function mkorg(base: 'state' | 'framework', name: string): void {
+  const root = base === 'state' ? tmpState : tmpFramework;
+  fs.mkdirSync(path.join(root, 'orgs', name), { recursive: true });
+}
+
+describe('getOrgs case-insensitive dedupe', () => {
+  it('same org in both dirs with drifted casing: returns ONE entry using framework casing', () => {
+    resetOrgs();
+    // This is the exact scenario observed in production: canonical AcmeCorp
+    // in framework root, stale lowercase acmecorp in state dir from a
+    // historical kb-* invocation with a lowercase --org argument.
+    mkorg('framework', 'AcmeCorp');
+    mkorg('state', 'acmecorp');
+    mkorg('state', 'AcmeCorp');
+
+    const orgs = getOrgs();
+    expect(orgs).toHaveLength(1);
+    expect(orgs[0]).toBe('AcmeCorp');
+  });
+
+  it('org only in state (no framework entry): returns state casing as fallback', () => {
+    resetOrgs();
+    mkorg('state', 'leftover');
+
+    const orgs = getOrgs();
+    expect(orgs).toEqual(['leftover']);
+  });
+
+  it('org only in framework: returns framework casing', () => {
+    resetOrgs();
+    mkorg('framework', 'AcmeCorp');
+
+    const orgs = getOrgs();
+    expect(orgs).toEqual(['AcmeCorp']);
+  });
+
+  it('both dirs empty: returns empty array', () => {
+    resetOrgs();
+    expect(getOrgs()).toEqual([]);
+  });
+
+  it('multiple orgs: framework wins per-org, state-only orgs included', () => {
+    resetOrgs();
+    // widgetco exists in both with matching casing; AcmeCorp has drift;
+    // stateonly exists only in state.
+    mkorg('framework', 'widgetco');
+    mkorg('state', 'widgetco');
+    mkorg('framework', 'AcmeCorp');
+    mkorg('state', 'acmecorp');
+    mkorg('state', 'stateonly');
+
+    const orgs = getOrgs().sort();
+    expect(orgs).toEqual(['AcmeCorp', 'stateonly', 'widgetco']);
+  });
+});

--- a/tests/unit/utils/org.test.ts
+++ b/tests/unit/utils/org.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { normalizeOrgName } from '../../../src/utils/org';
+
+let fwRoot: string;
+
+beforeEach(() => {
+  fwRoot = mkdtempSync(join(tmpdir(), 'cortextos-org-test-'));
+  mkdirSync(join(fwRoot, 'orgs'), { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(fwRoot, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe('normalizeOrgName', () => {
+  it('exact match: returns input unchanged', () => {
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+
+  it('case drift: lowercase input resolves to CamelCase canonical on disk', () => {
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    expect(normalizeOrgName(fwRoot, 'acmecorp')).toBe('AcmeCorp');
+    expect(normalizeOrgName(fwRoot, 'ACMECORP')).toBe('AcmeCorp');
+    expect(normalizeOrgName(fwRoot, 'AcmeCORP')).toBe('AcmeCorp');
+  });
+
+  it('no match: returns input unchanged (callers get a clearer error at file op time)', () => {
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    expect(normalizeOrgName(fwRoot, 'ghostcompany')).toBe('ghostcompany');
+  });
+
+  it('empty framework orgs dir: returns input unchanged', () => {
+    // orgs/ exists but is empty
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+
+  it('missing framework orgs dir: returns input unchanged', () => {
+    rmSync(join(fwRoot, 'orgs'), { recursive: true });
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+
+  it('empty org input: returns empty string (no normalization attempted)', () => {
+    expect(normalizeOrgName(fwRoot, '')).toBe('');
+  });
+
+  it('exact case match wins over case-insensitive match on case-sensitive filesystems', () => {
+    // Simulate a case-sensitive fs hosting both casings as distinct orgs.
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    mkdirSync(join(fwRoot, 'orgs', 'acmecorp'));
+    // Exact match path: return whichever casing the caller asked for.
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+    expect(normalizeOrgName(fwRoot, 'acmecorp')).toBe('acmecorp');
+  });
+
+  it('ignores non-directory entries with matching name', () => {
+    // A stray file named like an org must not be returned as a directory match.
+    writeFileSync(join(fwRoot, 'orgs', 'AcmeCorp.txt'), 'not a dir');
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+});


### PR DESCRIPTION
# fix(org): normalize org casing at KB-write and dashboard sync to stop ghost-dir sprawl

**Branch**: `pr/org-casing-normalization`
**Base**: `grandamenium/cortextos@main` (a608a5d at time of prep)
**Commit**: `17a5fe0`

---

## Problem

Two linked bugs caused by lack of org-name normalization:

1. **Ghost state dirs**: Agents could bootstrap a ghost state directory at `~/.cortextos/<instance>/orgs/<lowercase_org>/` just by passing a lowercase `--org` argument to any `cortextos bus kb-*` command. `bus/knowledge-base.ts::buildKBEnv()` joined the org name verbatim into the path, and the Python MMRAG tool then auto-initialized a `knowledge-base/config.json` (including a copy of the org's `GEMINI_API_KEY`) at the lowercase path. That ghost dir persisted indefinitely as an orphan one-file tree alongside the canonical CamelCase state dir — with a key copy inside.
2. **Dashboard log flood**: `dashboard/src/lib/config.ts::getOrgs()` scanned both the state dir and framework root and unioned results into a case-sensitive Set, so each scan returned BOTH ghost and canonical. Every polling cycle of `syncAll()` produced `"syncTasks org=<lowercase> exists=false"` misses against the ghost dir, flooding dashboard.log.

## Root cause

No normalization layer existed between caller-supplied org names and filesystem writes. Case-drifted inputs reached path construction verbatim.

## Fix

**`src/utils/org.ts::normalizeOrgName(frameworkRoot, org)`** — returns the canonical filesystem casing for a given org. Resolution order: exact match → case-insensitive scan → unchanged input. Never returns a name that does not exist on disk (except when passing through unchanged input for empty/missing cases).

**Wire-in in `src/bus/knowledge-base.ts`** at three call sites (`queryKnowledgeBase`, `ingestKnowledgeBase`, `ensureKBDirs`) so every MMRAG invocation — path construction AND ChromaDB collection naming — uses canonical casing regardless of caller input. Without this, `shared-acmecorp` and `shared-AcmeCorp` become two distinct ChromaDB collections and a case-drifted query silently hits the wrong one. `ensureKBDirs` grows a `frameworkRoot` parameter; sole caller in `src/cli/bus.ts` updated accordingly.

**Rewrite `dashboard/src/lib/config.ts::getOrgs()`** to dedupe case-insensitively via `Map<lowercase, canonical>`, with framework-root entries winning over state-dir entries (framework is source of truth, state is derived). Same org with drifted casing across both dirs now returns ONE entry using the framework casing. Silences the syncAll log noise.

## Tests

- 8 tests in `tests/unit/utils/org.test.ts`: exact match / case drift / no match / missing orgs dir / empty input / case-sensitive FS (both casings exist as distinct orgs — exact-match wins) / non-dir entry with matching name / empty orgs dir.
- 5 tests in `tests/unit/dashboard/config-getorgs.test.ts`: framework-only / state-only / case drift between the two (framework wins) / multi-org production scenario regression guard / empty input returns empty list.

## Caveats / known limitations

- **Stale ghost dirs are NOT cleaned up by this patch**. Operators with pre-existing `~/.cortextos/<instance>/orgs/<lowercase>/` trees should inspect them for a `knowledge-base/config.json` (may contain a redundant `GEMINI_API_KEY` copy) and remove by hand after confirming the canonical CamelCase dir is in active use. Automatic cleanup feels risky — a file-moving patch against operator state is a separate decision.
- **Case-sensitive filesystems can legitimately host both casings as distinct orgs**. The normalizer respects that: an exact-case match always wins over the case-insensitive scan, so `ElementOne` and `elementone` stay distinct when both exist. Only drift from a missing lowercase variant to an existing CamelCase one (the ghost scenario) gets collapsed.
- **Not retroactive for existing ChromaDB collections**. If an operator already has both `shared-acmecorp` and `shared-AcmeCorp` collections, queries after this patch all land on the canonical casing — the lowercase collection becomes orphaned. Safe to drop once verified empty.

## Potential-genericize candidates

(None found — the helper is fully generic and takes frameworkRoot as a parameter.)

---

**Test suite**: full 464/464 pass. Cherry-pick onto upstream/main a608a5d was clean. Scrubs applied: real org names `ElementOneSound` / `elementonesound` and real agent-lane org `agentnet` used as fixture names throughout the original patch were replaced with generic `AcmeCorp` / `acmecorp` / `widgetco` across both source comments and tests; one expected-sort-order assertion updated to match the renamed fixtures' alphabetization.
