### PR TITLE
docs(skills): adopt agent-browser CLI in templates (replaces Playwright MCP guidance)

### DIFF
--- a/templates/agent/.claude/skills/agent-browser/SKILL.md
+++ b/templates/agent/.claude/skills/agent-browser/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: agent-browser
+description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
+---
+
+# agent-browser
+
+Browser automation CLI for AI agents. Uses Chrome/Chromium via CDP directly.
+
+Install: `npm i -g agent-browser && agent-browser install`
+
+## Loading Skills
+
+**You must run `agent-browser skills get <name>` before running any agent-browser commands.**
+This file does not contain command syntax, flags, or workflows. That content is served
+by the CLI and changes between versions. Guessing at commands without loading the skill
+will produce incorrect or outdated invocations.
+
+```bash
+agent-browser skills get agent-browser    # Required before any browser automation
+agent-browser skills get <name> --full    # Include references and templates
+```
+
+## Available Skills
+
+- **agent-browser** — Core browser automation
+- **dogfood** — Exploratory testing and QA
+- **electron** — Electron desktop app automation
+- **slack** — Slack workspace automation
+- **vercel-sandbox** — Browser automation in Vercel Sandbox
+- **agentcore** — Browser automation on AWS Bedrock AgentCore
+
+## Why agent-browser
+
+- Fast native Rust CLI, not a Node.js wrapper
+- Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
+- Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
+- Accessibility-tree snapshots with element refs for reliable interaction
+- Sessions, authentication vault, state persistence, video recording
+- Specialized skills for Electron apps, Slack, exploratory testing, cloud providers

--- a/templates/agent/.claude/skills/bus-reference/SKILL.md
+++ b/templates/agent/.claude/skills/bus-reference/SKILL.md
@@ -454,12 +454,13 @@ cortextos bus submit-community-item <item-name> <item-type> "<description>" [--d
 | Check for updates                 | `check-upstream`          |
 
 
-### Playwright (Browser Automation)
-- **Binary**: `playwright` (Python)
-- **Use for**: Scraping websites, browser-based automation
-- **Chromium installed**: Yes (headless)
-- **Usage**: Write Python scripts using `from playwright.sync_api import sync_playwright` or use Playwright MCP if configured
-- **Env**: Service credentials available via environment variables if configured
+### agent-browser (Browser Automation — replaces Playwright)
+- **Binary**: `agent-browser` (Rust CLI, npm-installed globally; Chrome auto-downloaded by `agent-browser install`)
+- **Use for**: Scraping websites, browser-based automation, OSINT, form filling, screenshots, login flows — anything previously done via the Playwright MCP server
+- **Skill loaded**: `.claude/skills/agent-browser/SKILL.md` — that skill instructs running `agent-browser skills get <name>` to fetch current per-version command syntax from the CLI itself
+- **Quick verify**: `agent-browser open https://example.com && agent-browser get title && agent-browser close`
+- **Snapshot-ref pattern**: prefer `agent-browser snapshot` (returns a11y tree with refs e1/e2/...) then `agent-browser click @e1` / `fill @e2 "text"` — more reliable than text-search selectors for AI-driven flows
+- **NOT to be confused with**: dashboard E2E tests under `dashboard/` which use Playwright DIRECTLY (not via MCP). agent-browser only replaces the agent-facing browser MCP layer that was previously `mcp__plugin_playwright_*`. The dashboard's Playwright dependency stays
 
 
 ### Peekaboo (macOS Desktop Automation)

--- a/templates/agent/.claude/skills/m2c1-worker/SKILL.md
+++ b/templates/agent/.claude/skills/m2c1-worker/SKILL.md
@@ -239,20 +239,20 @@ Before the worker starts building, ask yourself:
 ```bash
 # 1. Create or update the worker's MCP config
 mkdir -p "$PROJECT_DIR/.claude"
-node -e "
-const fs = require('fs');
-const path = '$PROJECT_DIR/.claude/settings.json';
-const cfg = fs.existsSync(path) ? JSON.parse(fs.readFileSync(path)) : {};
-cfg.mcpServers = cfg.mcpServers || {};
-cfg.mcpServers.playwright = { command: 'npx', args: ['@anthropic-ai/mcp-playwright'] };
-fs.writeFileSync(path, JSON.stringify(cfg, null, 2));
-console.log('MCP config updated');
-"
+# For browser automation, use the agent-browser CLI (replaces the
+# previous Playwright MCP server). Install once on the worker host:
+which agent-browser || npm install -g agent-browser
+agent-browser install   # Downloads Chrome from Chrome for Testing
 
-# 2. Worker must restart to pick up MCP config
-# Send via bus message:
+# Copy the agent-browser SKILL.md into the worker's .claude/skills/ so
+# it is teachable to the worker session:
+mkdir -p "$PROJECT_DIR/.claude/skills/agent-browser"
+cp "$CTX_FRAMEWORK_ROOT/templates/agent/.claude/skills/agent-browser/SKILL.md" \
+   "$PROJECT_DIR/.claude/skills/agent-browser/SKILL.md"
+
+# 2. Worker can use agent-browser via Bash (no MCP restart required):
 cortextos bus send-message <worker-name> normal \
-  'MCP config updated at .claude/settings.json. Please restart your session with --continue to pick it up, then test Playwright by taking a screenshot of google.com.'
+  'agent-browser is available globally. Test by running: agent-browser open https://example.com && agent-browser get title && agent-browser close. Use snapshot-then-ref pattern for AI-driven flows. The .claude/skills/agent-browser/SKILL.md was added — invoke `agent-browser skills get <name>` for current per-version command syntax.'
 ```
 
 ### Iterative Tool Verification
@@ -285,8 +285,9 @@ cortextos bus send-message <worker-name> normal 'Source .env in your project dir
 
 Copy relevant cortextOS skills to the worker's project:
 ```bash
-# If the worker needs browser automation knowledge, install via community catalog:
-cortextos bus install-community-item playwright-automation
+# If the worker needs browser automation knowledge, the agent-browser skill
+# is already in templates/agent/.claude/skills/agent-browser/SKILL.md and
+# was copied into $PROJECT_DIR above during MCP/tool setup.
 ```
 
 ---

--- a/templates/agent/TOOLS.md
+++ b/templates/agent/TOOLS.md
@@ -140,10 +140,12 @@ Agent secrets: `orgs/{org}/agents/{agent}/.env`
 
 ## Tools Available in This Session
 
-### Playwright (Browser Automation)
-- `playwright` Python binary, Chromium installed (headless)
-- `from playwright.sync_api import sync_playwright` in Python scripts
-- Or use Playwright MCP if configured
+### agent-browser (Browser Automation — replaces Playwright)
+- `agent-browser` CLI (Rust binary, npm-installed globally) drives Chrome via CDP
+- Snapshot-then-ref interaction pattern: `agent-browser snapshot` returns an a11y tree with refs (e1, e2, ...), then `agent-browser click @e1` / `fill @e2 "text"` operate by ref
+- Loaded via `.claude/skills/agent-browser/SKILL.md` — that skill says to run `agent-browser skills get <name>` for current command syntax (workflow docs are versioned with the binary, so always fetch fresh)
+- Quick verify: `agent-browser open https://example.com && agent-browser get title && agent-browser close`
+- Dashboard E2E tests still use Playwright DIRECTLY (different surface) — agent-browser only replaces the agent-facing browser MCP layer that was previously `mcp__plugin_playwright_*`
 
 ### Peekaboo (macOS Desktop Automation)
 - `peekaboo image` (screenshot), `peekaboo list` (apps), `peekaboo run <script>`

--- a/templates/analyst/.claude/skills/agent-browser/SKILL.md
+++ b/templates/analyst/.claude/skills/agent-browser/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: agent-browser
+description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
+---
+
+# agent-browser
+
+Browser automation CLI for AI agents. Uses Chrome/Chromium via CDP directly.
+
+Install: `npm i -g agent-browser && agent-browser install`
+
+## Loading Skills
+
+**You must run `agent-browser skills get <name>` before running any agent-browser commands.**
+This file does not contain command syntax, flags, or workflows. That content is served
+by the CLI and changes between versions. Guessing at commands without loading the skill
+will produce incorrect or outdated invocations.
+
+```bash
+agent-browser skills get agent-browser    # Required before any browser automation
+agent-browser skills get <name> --full    # Include references and templates
+```
+
+## Available Skills
+
+- **agent-browser** — Core browser automation
+- **dogfood** — Exploratory testing and QA
+- **electron** — Electron desktop app automation
+- **slack** — Slack workspace automation
+- **vercel-sandbox** — Browser automation in Vercel Sandbox
+- **agentcore** — Browser automation on AWS Bedrock AgentCore
+
+## Why agent-browser
+
+- Fast native Rust CLI, not a Node.js wrapper
+- Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
+- Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
+- Accessibility-tree snapshots with element refs for reliable interaction
+- Sessions, authentication vault, state persistence, video recording
+- Specialized skills for Electron apps, Slack, exploratory testing, cloud providers

--- a/templates/analyst/.claude/skills/bus-reference/SKILL.md
+++ b/templates/analyst/.claude/skills/bus-reference/SKILL.md
@@ -454,12 +454,13 @@ cortextos bus submit-community-item <item-name> <item-type> "<description>" [--d
 | Check for updates                 | `check-upstream`          |
 
 
-### Playwright (Browser Automation)
-- **Binary**: `playwright` (Python)
-- **Use for**: Scraping websites, browser-based automation
-- **Chromium installed**: Yes (headless)
-- **Usage**: Write Python scripts using `from playwright.sync_api import sync_playwright` or use Playwright MCP if configured
-- **Env**: Service credentials available via environment variables if configured
+### agent-browser (Browser Automation — replaces Playwright)
+- **Binary**: `agent-browser` (Rust CLI, npm-installed globally; Chrome auto-downloaded by `agent-browser install`)
+- **Use for**: Scraping websites, browser-based automation, OSINT, form filling, screenshots, login flows — anything previously done via the Playwright MCP server
+- **Skill loaded**: `.claude/skills/agent-browser/SKILL.md` — that skill instructs running `agent-browser skills get <name>` to fetch current per-version command syntax from the CLI itself
+- **Quick verify**: `agent-browser open https://example.com && agent-browser get title && agent-browser close`
+- **Snapshot-ref pattern**: prefer `agent-browser snapshot` (returns a11y tree with refs e1/e2/...) then `agent-browser click @e1` / `fill @e2 "text"` — more reliable than text-search selectors for AI-driven flows
+- **NOT to be confused with**: dashboard E2E tests under `dashboard/` which use Playwright DIRECTLY (not via MCP). agent-browser only replaces the agent-facing browser MCP layer that was previously `mcp__plugin_playwright_*`. The dashboard's Playwright dependency stays
 
 
 ### Peekaboo (macOS Desktop Automation)

--- a/templates/analyst/.claude/skills/m2c1-worker/SKILL.md
+++ b/templates/analyst/.claude/skills/m2c1-worker/SKILL.md
@@ -239,20 +239,20 @@ Before the worker starts building, ask yourself:
 ```bash
 # 1. Create or update the worker's MCP config
 mkdir -p "$PROJECT_DIR/.claude"
-node -e "
-const fs = require('fs');
-const path = '$PROJECT_DIR/.claude/settings.json';
-const cfg = fs.existsSync(path) ? JSON.parse(fs.readFileSync(path)) : {};
-cfg.mcpServers = cfg.mcpServers || {};
-cfg.mcpServers.playwright = { command: 'npx', args: ['@anthropic-ai/mcp-playwright'] };
-fs.writeFileSync(path, JSON.stringify(cfg, null, 2));
-console.log('MCP config updated');
-"
+# For browser automation, use the agent-browser CLI (replaces the
+# previous Playwright MCP server). Install once on the worker host:
+which agent-browser || npm install -g agent-browser
+agent-browser install   # Downloads Chrome from Chrome for Testing
 
-# 2. Worker must restart to pick up MCP config
-# Send via bus message:
+# Copy the agent-browser SKILL.md into the worker's .claude/skills/ so
+# it is teachable to the worker session:
+mkdir -p "$PROJECT_DIR/.claude/skills/agent-browser"
+cp "$CTX_FRAMEWORK_ROOT/templates/agent/.claude/skills/agent-browser/SKILL.md" \
+   "$PROJECT_DIR/.claude/skills/agent-browser/SKILL.md"
+
+# 2. Worker can use agent-browser via Bash (no MCP restart required):
 cortextos bus send-message <worker-name> normal \
-  'MCP config updated at .claude/settings.json. Please restart your session with --continue to pick it up, then test Playwright by taking a screenshot of google.com.'
+  'agent-browser is available globally. Test by running: agent-browser open https://example.com && agent-browser get title && agent-browser close. Use snapshot-then-ref pattern for AI-driven flows. The .claude/skills/agent-browser/SKILL.md was added — invoke `agent-browser skills get <name>` for current per-version command syntax.'
 ```
 
 ### Iterative Tool Verification
@@ -285,8 +285,9 @@ cortextos bus send-message <worker-name> normal 'Source .env in your project dir
 
 Copy relevant cortextOS skills to the worker's project:
 ```bash
-# If the worker needs browser automation knowledge, install via community catalog:
-cortextos bus install-community-item playwright-automation
+# If the worker needs browser automation knowledge, the agent-browser skill
+# is already in templates/agent/.claude/skills/agent-browser/SKILL.md and
+# was copied into $PROJECT_DIR above during MCP/tool setup.
 ```
 
 ---

--- a/templates/analyst/TOOLS.md
+++ b/templates/analyst/TOOLS.md
@@ -140,10 +140,12 @@ Agent secrets: `orgs/{org}/agents/{agent}/.env`
 
 ## Tools Available in This Session
 
-### Playwright (Browser Automation)
-- `playwright` Python binary, Chromium installed (headless)
-- `from playwright.sync_api import sync_playwright` in Python scripts
-- Or use Playwright MCP if configured
+### agent-browser (Browser Automation — replaces Playwright)
+- `agent-browser` CLI (Rust binary, npm-installed globally) drives Chrome via CDP
+- Snapshot-then-ref interaction pattern: `agent-browser snapshot` returns an a11y tree with refs (e1, e2, ...), then `agent-browser click @e1` / `fill @e2 "text"` operate by ref
+- Loaded via `.claude/skills/agent-browser/SKILL.md` — that skill says to run `agent-browser skills get <name>` for current command syntax (workflow docs are versioned with the binary, so always fetch fresh)
+- Quick verify: `agent-browser open https://example.com && agent-browser get title && agent-browser close`
+- Dashboard E2E tests still use Playwright DIRECTLY (different surface) — agent-browser only replaces the agent-facing browser MCP layer that was previously `mcp__plugin_playwright_*`
 
 ### Peekaboo (macOS Desktop Automation)
 - `peekaboo image` (screenshot), `peekaboo list` (apps), `peekaboo run <script>`

--- a/templates/orchestrator/.claude/skills/agent-browser/SKILL.md
+++ b/templates/orchestrator/.claude/skills/agent-browser/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: agent-browser
+description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
+allowed-tools: Bash(agent-browser:*), Bash(npx agent-browser:*)
+---
+
+# agent-browser
+
+Browser automation CLI for AI agents. Uses Chrome/Chromium via CDP directly.
+
+Install: `npm i -g agent-browser && agent-browser install`
+
+## Loading Skills
+
+**You must run `agent-browser skills get <name>` before running any agent-browser commands.**
+This file does not contain command syntax, flags, or workflows. That content is served
+by the CLI and changes between versions. Guessing at commands without loading the skill
+will produce incorrect or outdated invocations.
+
+```bash
+agent-browser skills get agent-browser    # Required before any browser automation
+agent-browser skills get <name> --full    # Include references and templates
+```
+
+## Available Skills
+
+- **agent-browser** — Core browser automation
+- **dogfood** — Exploratory testing and QA
+- **electron** — Electron desktop app automation
+- **slack** — Slack workspace automation
+- **vercel-sandbox** — Browser automation in Vercel Sandbox
+- **agentcore** — Browser automation on AWS Bedrock AgentCore
+
+## Why agent-browser
+
+- Fast native Rust CLI, not a Node.js wrapper
+- Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
+- Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
+- Accessibility-tree snapshots with element refs for reliable interaction
+- Sessions, authentication vault, state persistence, video recording
+- Specialized skills for Electron apps, Slack, exploratory testing, cloud providers


### PR DESCRIPTION
# docs(templates): replace Playwright MCP references with agent-browser CLI

**Branch**: `pr/agent-browser-skill`
**Base**: `grandamenium/cortextos@main` (a608a5d at time of prep)
**Commit**: `cd33f6d`

---

## Problem

The agent-facing browser tooling across cortextOS agent templates pointed at the Playwright MCP server. vercel-labs/agent-browser offers a materially different (and lighter-weight) UX for agents: a Rust CLI binary invoked via Bash with a snapshot-then-ref interaction pattern, rather than typed `mcp__plugin_playwright_*` tool calls. The templates needed to reflect that swap so any new agent spawned via `cortextos add-agent` inherits the right teaching layer.

## Root cause

Not a bug — a tooling choice. Templates were authored when Playwright MCP was the default; this patch updates them for the new default.

## Fix

Pure docs/templates patch — no TypeScript changes.

- **NEW**: `templates/{agent,analyst,orchestrator}/.claude/skills/agent-browser/SKILL.md` — direct copy of the upstream skill from vercel-labs/agent-browser. Thin pointer (~40 lines) that teaches agents to run `agent-browser skills get <name>` to fetch current per-version command syntax from the binary itself. Versions the workflow guidance WITH the executable so our copy can't go stale.
- **`templates/{agent,analyst}/TOOLS.md`**: replace the Playwright section with agent-browser. Documents the snapshot-ref pattern, quick-verify command, and explicit disambiguation from dashboard E2E tests (which still use Playwright as a library — unaffected).
- **`templates/{agent,analyst}/.claude/skills/bus-reference/SKILL.md`**: same replacement, longer-form context.
- **`templates/{agent,analyst}/.claude/skills/m2c1-worker/SKILL.md`**: the worker-process tool-setup section had an `mcpServers.playwright` config snippet — replaced with `npm install -g agent-browser` + copy SKILL.md into the worker's project dir. Worker no longer needs `--continue` restart to pick up browser tooling because the CLI lives outside the MCP layer.

## Tests

No unit tests — this is templates/docs only. Build + existing suite verified unaffected: `npm run build` clean, 451/451 tests pass.

Smoke verification was run against the agent-browser CLI itself (documented in commit message): `open`, `snapshot`, `close` against `example.com` and a real GitHub user page returned expected structured output with 85+ a11y refs.

## Caveats / known limitations

- **Operator step required**: this patch changes docs. Operators need to run the runtime swap themselves (`npm install -g agent-browser`, ensure a Chrome for Testing binary is discoverable, `claude plugin disable playwright@claude-plugins-official`). Documenting this in the templates was preferred over a runtime-assert in the daemon.
- **Orchestrator template** gets the SKILL.md but not the TOOLS.md / bus-reference / m2c1-worker updates because those files either don't exist in the orchestrator template or carry different content there. Checked each file's presence before editing; no orchestrator-specific follow-up is implied.
- **Dashboard E2E stays on Playwright**. `tests/playwright/` uses Playwright as a library directly, not through the Claude Code MCP layer — no change needed and none made.
- **Upstream drift risk**: the agent-browser SKILL.md is copied verbatim. If vercel-labs/agent-browser releases a breaking change to the thin-pointer pattern, a small follow-up is needed to re-sync. The `agent-browser skills get <name>` indirection was chosen specifically to minimize that risk.

## Potential-genericize candidates

(None found — the patch already uses neutral language throughout.)

---

**Test suite**: 451/451 pass, build clean. Cherry-pick onto upstream/main a608a5d was clean. Zero scrub hits across the 9 changed files — the patch as shipped to fleet contained no agent-name breadcrumbs in the affected files. Commit message scrubbed of "Per Clint directive", "performed live before this commit" self-reference, and a live-agent-drift follow-up note.
