### PR TITLE
feat(daemon): persist cron fire timestamps and add gap-detection nudge (issue #67)

### DIFF
--- a/src/bus/cron-state.ts
+++ b/src/bus/cron-state.ts
@@ -1,0 +1,95 @@
+/**
+ * Daemon-side cron fire timestamp registry (cron-state.json).
+ *
+ * Solves the dead zone problem (issue #67): context compression silently drops
+ * in-session CronCreate schedules. This module records when each named cron
+ * last fired in a file that survives all restarts. AgentProcess polls the file
+ * and injects a gap-nudge when a cron has been silent for >2x its interval.
+ *
+ * Lifecycle:
+ *   1. Agent calls `cortextos bus update-cron-fire <name> --interval <interval>`
+ *      at the end of each cron prompt execution.
+ *   2. Daemon gap-detection loop reads cron-state.json every 10 minutes.
+ *   3. If last_fire is >2x interval ago, daemon injects a nudge into the agent PTY.
+ *
+ * Storage: state/<agent>/cron-state.json (same dir as pending-reminders.json).
+ */
+
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { ensureDir } from '../utils/atomic.js';
+
+export interface CronFireRecord {
+  name: string;
+  last_fire: string;   // ISO 8601 UTC
+  interval?: string;   // e.g. "6h", "24h", "30m" — copied from update call
+}
+
+interface CronStateFile {
+  updated_at: string;
+  crons: CronFireRecord[];
+}
+
+function cronStatePath(stateDir: string): string {
+  return join(stateDir, 'cron-state.json');
+}
+
+export function readCronState(stateDir: string): CronStateFile {
+  const filePath = cronStatePath(stateDir);
+  if (!existsSync(filePath)) {
+    return { updated_at: new Date().toISOString(), crons: [] };
+  }
+  try {
+    const raw = readFileSync(filePath, 'utf-8');
+    const parsed = JSON.parse(raw);
+    return parsed && Array.isArray(parsed.crons)
+      ? parsed
+      : { updated_at: new Date().toISOString(), crons: [] };
+  } catch {
+    return { updated_at: new Date().toISOString(), crons: [] };
+  }
+}
+
+/**
+ * Record that a cron just fired. Creates or updates the entry for `cronName`.
+ * Called by agents via `cortextos bus update-cron-fire <name> --interval <interval>`.
+ */
+export function updateCronFire(
+  stateDir: string,
+  cronName: string,
+  interval?: string,
+): void {
+  ensureDir(stateDir);
+  const state = readCronState(stateDir);
+  const now = new Date().toISOString();
+
+  const idx = state.crons.findIndex(r => r.name === cronName);
+  const record: CronFireRecord = { name: cronName, last_fire: now, ...(interval ? { interval } : {}) };
+
+  if (idx === -1) {
+    state.crons.push(record);
+  } else {
+    state.crons[idx] = record;
+  }
+
+  state.updated_at = now;
+  writeFileSync(cronStatePath(stateDir), JSON.stringify(state, null, 2) + '\n', 'utf-8');
+}
+
+/**
+ * Parse an interval string like "6h", "30m", "1d", "2w" into milliseconds.
+ * Returns NaN for unrecognised formats (e.g. cron expressions like "0 8 * * *").
+ */
+export function parseDurationMs(interval: string): number {
+  const match = /^(\d+)(m|h|d|w)$/.exec(interval.trim());
+  if (!match) return NaN;
+  const n = parseInt(match[1], 10);
+  const unit = match[2];
+  const multipliers: Record<string, number> = {
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+    w: 604_800_000,
+  };
+  return n * multipliers[unit];
+}

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -13,6 +13,7 @@ import { browseCatalog, installCommunityItem, prepareSubmission, submitCommunity
 import { collectMetrics, parseUsageOutput, storeUsageData, checkUpstream, collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
 import { createApproval, updateApproval } from '../bus/approval.js';
 import { createReminder, listReminders, ackReminder, pruneReminders } from '../bus/reminders.js';
+import { updateCronFire } from '../bus/cron-state.js';
 import { queryKnowledgeBase, ingestKnowledgeBase, ensureKBDirs } from '../bus/knowledge-base.js';
 import { checkUsageApi, refreshOAuthToken, rotateOAuth, loadAccounts, ALERT_5H, ALERT_7D } from '../bus/oauth.js';
 import { resolvePaths } from '../utils/paths.js';
@@ -1519,6 +1520,18 @@ busCommand
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
     const pruned = pruneReminders(paths, parseInt(opts.days ?? '7', 10));
     console.log(`Pruned ${pruned} acked reminder(s)`);
+  });
+
+busCommand
+  .command('update-cron-fire')
+  .argument('<cron-name>', 'Name of the cron as defined in config.json')
+  .option('--interval <interval>', 'Expected interval, e.g. "6h", "24h", "30m"')
+  .description('Record that a named cron just fired (enables daemon gap detection for dead zones)')
+  .action((cronName: string, opts: { interval?: string }) => {
+    const env = resolveEnv();
+    const paths = resolvePaths(env.agentName, env.instanceId, env.org);
+    updateCronFire(paths.stateDir, cronName, opts.interval);
+    console.log(`Recorded fire for cron "${cronName}"`);
   });
 
 busCommand

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -271,6 +271,10 @@ export class AgentManager {
     // matches config.json. Handles both fresh and --continue restarts safely.
     agentProcess.scheduleCronVerification();
 
+    // Schedule background cron gap detection: polls cron-state.json every 10 min
+    // and nudges the agent if any cron has been silent >2x its expected interval.
+    agentProcess.scheduleGapDetection();
+
     // Start fast checker in background
     checker.start().catch(err => {
       console.error(`[${name}] Fast checker error:`, err);

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -7,6 +7,7 @@ import { MessageDedup, injectMessage } from '../pty/inject.js';
 import { ensureDir } from '../utils/atomic.js';
 import { writeCortextosEnv } from '../utils/env.js';
 import { getOverdueReminders } from '../bus/reminders.js';
+import { readCronState, parseDurationMs } from '../bus/cron-state.js';
 import { resolvePaths } from '../utils/paths.js';
 
 type LogFn = (msg: string) => void;
@@ -530,6 +531,80 @@ export class AgentProcess {
     this.verifyCronsAfterIdle(recurringNames, generation).catch(err => {
       this.log(`Cron verification failed (non-fatal): ${err}`);
     });
+  }
+
+  /**
+   * Starts a background gap-detection loop for recurring interval-based crons.
+   * Reads cron-state.json every 10 minutes; injects a nudge if any cron has
+   * been silent for >2x its expected interval.
+   *
+   * Fire-and-forget: errors are logged but never propagated.
+   */
+  scheduleGapDetection(): void {
+    const crons = this.config.crons;
+    if (!crons || crons.length === 0) return;
+
+    // Only monitor recurring crons with a parseable interval (skip cron expressions)
+    const monitorable = crons.filter(
+      c => c.type !== 'once' && c.interval && !isNaN(parseDurationMs(c.interval)),
+    );
+    if (monitorable.length === 0) return;
+
+    const generation = this.lifecycleGeneration;
+
+    this.runGapDetectionLoop(monitorable, generation).catch(err => {
+      this.log(`Cron gap detection failed (non-fatal): ${err}`);
+    });
+  }
+
+  private async runGapDetectionLoop(
+    crons: Array<{ name: string; interval?: string }>,
+    generation: number,
+  ): Promise<void> {
+    const GAP_POLL_MS = 10 * 60 * 1000;   // poll every 10 minutes
+    const GAP_MULTIPLIER = 2.0;            // nudge when gap > 2x expected interval
+
+    const stateDir = join(this.env.ctxRoot, 'state', this.name);
+
+    // Initial wait — give the agent time to boot and register crons before first check
+    await sleep(GAP_POLL_MS);
+
+    while (true) {
+      if (generation !== this.lifecycleGeneration || this.status !== 'running') return;
+
+      const now = Date.now();
+      const state = readCronState(stateDir);
+
+      for (const cronDef of crons) {
+        const intervalMs = parseDurationMs(cronDef.interval!);
+
+        const record = state.crons.find(r => r.name === cronDef.name);
+        if (!record) {
+          // No fire record yet — cron may not have fired once. Skip to avoid
+          // false positives on freshly started agents.
+          continue;
+        }
+
+        const lastFireMs = Date.parse(record.last_fire);
+        if (isNaN(lastFireMs)) continue;
+
+        const gapMs = now - lastFireMs;
+        const threshold = intervalMs * GAP_MULTIPLIER;
+
+        if (gapMs > threshold) {
+          const gapMin = Math.round(gapMs / 60_000);
+          const expectedMin = Math.round(intervalMs / 60_000);
+          const nudge = `[SYSTEM] Cron gap detected for "${cronDef.name}": last fired ${gapMin} minutes ago (expected every ${expectedMin} minutes). Run CronList to verify the cron is still active. If missing, restore it from config.json: /loop ${cronDef.interval} <cron prompt>.`;
+
+          this.log(`Gap nudge: ${cronDef.name} silent ${gapMin}min (threshold: ${Math.round(threshold / 60_000)}min)`);
+          if (this.pty && this.status === 'running') {
+            injectMessage((data) => this.pty!.write(data), nudge);
+          }
+        }
+      }
+
+      await sleep(GAP_POLL_MS);
+    }
   }
 
   private async verifyCronsAfterIdle(

--- a/tests/unit/bus/cron-state.test.ts
+++ b/tests/unit/bus/cron-state.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { updateCronFire, readCronState, parseDurationMs } from '../../../src/bus/cron-state';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cron-state-test-'));
+});
+
+function cleanup() {
+  try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
+}
+
+describe('parseDurationMs', () => {
+  it('parses minutes', () => {
+    expect(parseDurationMs('30m')).toBe(30 * 60_000);
+  });
+
+  it('parses hours', () => {
+    expect(parseDurationMs('6h')).toBe(6 * 3_600_000);
+    expect(parseDurationMs('24h')).toBe(24 * 3_600_000);
+  });
+
+  it('parses days', () => {
+    expect(parseDurationMs('1d')).toBe(86_400_000);
+  });
+
+  it('parses weeks', () => {
+    expect(parseDurationMs('2w')).toBe(2 * 604_800_000);
+  });
+
+  it('returns NaN for cron expressions', () => {
+    expect(parseDurationMs('0 8 * * *')).toBeNaN();
+    expect(parseDurationMs('*/5 * * * *')).toBeNaN();
+  });
+
+  it('returns NaN for empty string', () => {
+    expect(parseDurationMs('')).toBeNaN();
+  });
+
+  it('returns NaN for unknown unit', () => {
+    expect(parseDurationMs('5y')).toBeNaN();
+    expect(parseDurationMs('10s')).toBeNaN();
+  });
+});
+
+describe('readCronState', () => {
+  it('returns empty state when file does not exist', () => {
+    const state = readCronState(tmpDir);
+    expect(state.crons).toEqual([]);
+    cleanup();
+  });
+});
+
+describe('updateCronFire', () => {
+  it('creates a record when none exists', () => {
+    updateCronFire(tmpDir, 'heartbeat', '6h');
+    const state = readCronState(tmpDir);
+    expect(state.crons).toHaveLength(1);
+    expect(state.crons[0].name).toBe('heartbeat');
+    expect(state.crons[0].interval).toBe('6h');
+    expect(Date.parse(state.crons[0].last_fire)).not.toBeNaN();
+    cleanup();
+  });
+
+  it('updates existing record for the same cron name', () => {
+    updateCronFire(tmpDir, 'heartbeat', '6h');
+    const first = readCronState(tmpDir).crons[0].last_fire;
+
+    // Ensure time advances
+    const before = Date.now();
+    updateCronFire(tmpDir, 'heartbeat', '6h');
+    const second = readCronState(tmpDir).crons[0].last_fire;
+
+    expect(Date.parse(second)).toBeGreaterThanOrEqual(before);
+    expect(readCronState(tmpDir).crons).toHaveLength(1); // no duplicate
+    cleanup();
+  });
+
+  it('accumulates records for different cron names', () => {
+    updateCronFire(tmpDir, 'heartbeat', '6h');
+    updateCronFire(tmpDir, 'autoresearch', '24h');
+    const state = readCronState(tmpDir);
+    expect(state.crons).toHaveLength(2);
+    const names = state.crons.map(r => r.name);
+    expect(names).toContain('heartbeat');
+    expect(names).toContain('autoresearch');
+    cleanup();
+  });
+
+  it('works without interval argument', () => {
+    updateCronFire(tmpDir, 'heartbeat');
+    const state = readCronState(tmpDir);
+    expect(state.crons[0].name).toBe('heartbeat');
+    expect(state.crons[0].interval).toBeUndefined();
+    cleanup();
+  });
+
+  it('survives a read-write-read cycle with correct values', () => {
+    updateCronFire(tmpDir, 'inbox-triage', '2h');
+    updateCronFire(tmpDir, 'heartbeat', '4h');
+    const state = readCronState(tmpDir);
+    const inbox = state.crons.find(r => r.name === 'inbox-triage');
+    const hb = state.crons.find(r => r.name === 'heartbeat');
+    expect(inbox?.interval).toBe('2h');
+    expect(hb?.interval).toBe('4h');
+    cleanup();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `src/bus/cron-state.ts` — file-backed cron fire timestamp registry at `state/<agent>/cron-state.json`. Agents report each cron execution via `cortextos bus update-cron-fire <name> --interval <interval>`.
- Adds `AgentProcess.scheduleGapDetection()` — background daemon loop that polls `cron-state.json` every 10 minutes. If any recurring cron has been silent >2x its expected interval, injects a `[SYSTEM]` nudge into the agent PTY to restore the missing cron.
- Adds `cortextos bus update-cron-fire` CLI command for agent self-reporting.
- 13 new unit tests for the cron-state module. 464/464 passing.

## Why

Context compression silently drops in-session `CronCreate` schedules. 8 confirmed fleet-wide dead zones in TW5-TW6. PR #26 (fast-checker watchdog) was insufficient — the fast-checker session itself goes dark during compression. This fix lives in the daemon process which survives all session resets.

**Key design decision:** agents use `config.json` as source of truth (already there) and self-report fires via a bus command (same pattern as `update-heartbeat`). No daemon-side `CronCreate` interception needed.

## Test plan

- [x] `npm run build` — compiles cleanly
- [x] `npm test` — 464/464 passing (13 new cron-state tests)
- [ ] Manual: write a stale `cron-state.json` (last_fire = 14h ago for a 6h cron), verify nudge appears in agent PTY within 10 minutes
- [ ] Manual: call `cortextos bus update-cron-fire heartbeat --interval 6h`, verify `cron-state.json` is updated

Closes #67

## Architecture note

`scheduleGapDetection()` uses the same lifecycle-generation guard as `scheduleCronVerification()` — it self-terminates cleanly on agent restart without leaving stale goroutines.