### PR TITLE
fix(telegram): add fetch timeout so poller cannot silently hang

### DIFF
--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -218,7 +218,7 @@ export class TelegramAPI {
    */
   async downloadFile(filePath: string): Promise<Buffer> {
     const url = `https://api.telegram.org/file/bot${this.getToken()}/${filePath}`;
-    const response = await fetch(url);
+    const response = await fetch(url, { signal: AbortSignal.timeout(30000) });
     if (!response.ok) {
       throw new Error(`Failed to download file: ${response.status}`);
     }
@@ -242,6 +242,7 @@ export class TelegramAPI {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(data),
+        signal: AbortSignal.timeout(15000),
       });
       const result = await response.json() as any;
       if (!result.ok) {
@@ -251,6 +252,12 @@ export class TelegramAPI {
     } catch (err) {
       if (err instanceof Error && err.message.startsWith('Telegram API error')) {
         throw err;
+      }
+      // AbortSignal.timeout surfaces as DOMException name=TimeoutError (or AbortError).
+      // Surface as a clean retryable error so the poller loop recovers next tick
+      // instead of silently hanging on a wedged TCP connection.
+      if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+        throw new Error(`Telegram API request timed out after 15s: ${method}`);
       }
       throw new Error(`Telegram API request failed: ${err}`);
     }

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -97,6 +97,7 @@ export class TelegramAPI {
       const response = await fetch(`${this.baseUrl}/sendPhoto`, {
         method: 'POST',
         body: formData,
+        signal: AbortSignal.timeout(60000),
       });
       const result = await response.json() as any;
       if (!result.ok) {
@@ -106,6 +107,9 @@ export class TelegramAPI {
     } catch (err) {
       if (err instanceof Error && err.message.startsWith('Telegram API error')) {
         throw err;
+      }
+      if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+        throw new Error(`Telegram API request timed out after 60s: sendPhoto`);
       }
       throw new Error(`Telegram API request failed: ${err}`);
     }
@@ -144,6 +148,7 @@ export class TelegramAPI {
       const response = await fetch(`${this.baseUrl}/sendDocument`, {
         method: 'POST',
         body: formData,
+        signal: AbortSignal.timeout(60000),
       });
       const result = await response.json() as any;
       if (!result.ok) {
@@ -153,6 +158,9 @@ export class TelegramAPI {
     } catch (err) {
       if (err instanceof Error && err.message.startsWith('Telegram API error')) {
         throw err;
+      }
+      if (err instanceof Error && (err.name === 'TimeoutError' || err.name === 'AbortError')) {
+        throw new Error(`Telegram API request timed out after 60s: sendDocument`);
       }
       throw new Error(`Telegram API request failed: ${err}`);
     }

--- a/tests/unit/telegram/api.test.ts
+++ b/tests/unit/telegram/api.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { TelegramAPI } from '../../../src/telegram/api';
+
+describe('TelegramAPI fetch timeout', () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('throws a timeout error when fetch hangs indefinitely', async () => {
+    globalThis.fetch = vi.fn(
+      (_input: any, init?: any) =>
+        new Promise((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            const err = new Error('aborted');
+            err.name = 'AbortError';
+            reject(err);
+          });
+        }),
+    ) as any;
+
+    const api = new TelegramAPI('123:TEST');
+    await expect(api.getUpdates(0, 1)).rejects.toThrow(/timed out after 15s/);
+  }, 20000);
+
+  it('succeeds on normal fetch response', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: true, result: [] }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }),
+    ) as any;
+
+    const api = new TelegramAPI('123:TEST');
+    const res = await api.getUpdates(0, 1);
+    expect(res.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Node's built-in `fetch()` has no default client-side timeout. `src/telegram/api.ts` `post()` and `downloadFile()` were calling `fetch` with no `AbortSignal`. When the TCP connection to api.telegram.org hangs (NAT rebind, wifi hiccup, ISP buffering), the `await` never resolves and never throws — the per-agent Telegram pollers silently wedge.
- Live symptom: all 9 agents go quiet simultaneously for ~10 min with no typing indicator, no log errors, no PTY activity — then dump the accumulated backlog in one burst when the socket recovers and Telegram returns all queued updates.
- Fix: add `AbortSignal.timeout(15000)` to `post()` and `AbortSignal.timeout(30000)` to `downloadFile()`. Surface `AbortError`/`TimeoutError` as a retryable "Telegram API request timed out after 15s" so the poller's existing catch-loop recovers on next tick (1s pollInterval).
- No change needed in `poller.ts` — its try/catch + fixed-interval sleep already handles the new timeout error correctly.

## Test plan
- [x] `npm run build` clean
- [x] `npm test` passes 453/453 (existing 451 + 2 new in `tests/unit/telegram/api.test.ts`)
  - Hung-fetch test mocks fetch to honor AbortSignal and verifies the timeout error surfaces
  - Happy-path test verifies normal responses still succeed
- [ ] Deploy dist, `pm2 restart cortextos-daemon`, observe 20 min with no silent windows
- [ ] Operator (James) confirms burst pattern stopped

## Out of scope (follow-up)
Six other no-timeout `fetch()` calls in `src/bus/oauth.ts`, `src/bus/metrics.ts`, `src/hooks/hook-crash-alert.ts`, `src/hooks/hook-compact-telegram.ts`, `src/cli/setup.ts`. Event-driven and lower frequency so they don't cause the burst pattern. Will file a separate BUG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)