### PR TITLE
fix(bus): auto-notify assignee on create-task (issue #78)

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -114,6 +114,13 @@ busCommand
       needsApproval: opts.needsApproval ?? false,
     });
     console.log(taskId);
+    // Auto-notify assignee so the task is visible immediately (issue #78)
+    if (opts.assignee && opts.assignee !== env.agentName) {
+      const assigneePaths = resolvePaths(opts.assignee, env.instanceId, env.org);
+      const desc = opts.desc ? ` — ${opts.desc.slice(0, 120)}` : '';
+      sendMessage(assigneePaths, env.agentName, opts.assignee, 'normal',
+        `Task assigned: [${opts.priority}] ${title}${desc} (id: ${taskId})`);
+    }
   });
 
 busCommand


### PR DESCRIPTION
## Summary

- When `cortextos bus create-task` is called with `--assignee`, automatically enqueue an inbox message to the assigned agent
- Agent receives: task ID, title, description snippet, priority
- No-op if assignee is the same as the creator (no self-notification)
- Closes #78
- 453/453 tests pass, build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)