### PR TITLE
feat(slack): Slack connector — send-slack command + fast-checker polling

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -716,6 +716,45 @@ busCommand
   });
 
 busCommand
+busCommand
+  .command('send-slack')
+  .description('Send a message to a Slack channel')
+  .argument('<channel>', 'Slack channel ID (e.g. C1234567890) or name (e.g. #general)')
+  .argument('<message>', 'Message text')
+  .action(async (channel: string, message: string) => {
+    const env = resolveEnv();
+    let slackToken = '';
+
+    if (env.agentDir) {
+      const { readFileSync, existsSync } = require('fs');
+      const { join } = require('path');
+      const agentEnv = join(env.agentDir, '.env');
+      if (existsSync(agentEnv)) {
+        const content = readFileSync(agentEnv, 'utf-8') as string;
+        const match = content.match(/^SLACK_BOT_TOKEN=(.+)$/m);
+        if (match?.[1]?.trim()) slackToken = match[1].trim();
+      }
+    }
+
+    if (!slackToken) slackToken = process.env.SLACK_BOT_TOKEN ?? '';
+
+    if (!slackToken) {
+      console.error('Error: SLACK_BOT_TOKEN not set. Set it in your agent .env file or as SLACK_BOT_TOKEN env var.');
+      process.exit(1);
+    }
+
+    const { SlackAPI } = await import('../slack/api.js');
+    const api = new SlackAPI(slackToken);
+    try {
+      await api.postMessage(channel, message);
+      console.log(`Slack message sent to ${channel}`);
+    } catch (err) {
+      console.error(`Failed to send Slack message: ${err}`);
+      process.exit(1);
+    }
+  });
+
+busCommand
   .command('send-telegram')
   .description('Send a message to a Telegram chat')
   .argument('<chat-id>', 'Telegram chat ID')

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -238,6 +238,29 @@ export class AgentManager {
     }
 
     const agentProcess = new AgentProcess(name, env, config, log);
+
+    // Build slack_watch option if configured
+    let slackWatchOption: { channel: string; intervalMs: number; token: string } | undefined;
+    if (config.slack_watch?.channel) {
+      let slackToken = '';
+      const agentEnvPath = join(env.agentDir, '.env');
+      if (existsSync(agentEnvPath)) {
+        const envContent = readFileSync(agentEnvPath, 'utf-8');
+        const match = envContent.match(/^SLACK_BOT_TOKEN=(.+)$/m);
+        if (match?.[1]?.trim()) slackToken = match[1].trim();
+      }
+      if (!slackToken) slackToken = process.env.SLACK_BOT_TOKEN ?? '';
+      if (slackToken) {
+        slackWatchOption = {
+          channel: config.slack_watch.channel,
+          intervalMs: config.slack_watch.interval_ms ?? 60_000,
+          token: slackToken,
+        };
+      } else {
+        log(`Slack watch configured but SLACK_BOT_TOKEN not found in .env — skipping`);
+      }
+    }
+
     const checker = new FastChecker(agentProcess, paths, this.frameworkRoot, {
       log,
       telegramApi,

--- a/src/slack/api.ts
+++ b/src/slack/api.ts
@@ -1,0 +1,63 @@
+/**
+ * Minimal Slack Web API client using built-in fetch (Node 20+).
+ */
+
+export interface SlackMessage {
+  ts: string;
+  user?: string;
+  username?: string;
+  text: string;
+  type: string;
+  subtype?: string;
+  bot_id?: string;
+}
+
+export class SlackAPI {
+  private readonly baseUrl = 'https://slack.com/api';
+  private readonly token: string;
+
+  constructor(token: string) {
+    this.token = token;
+  }
+
+  async postMessage(channel: string, text: string): Promise<void> {
+    const response = await fetch(`${this.baseUrl}/chat.postMessage`, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${this.token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ channel, text }),
+    });
+    const data = await response.json() as { ok: boolean; error?: string };
+    if (!data.ok) {
+      throw new Error(`Slack postMessage failed: ${data.error ?? 'unknown'}`);
+    }
+  }
+
+  async getHistory(channel: string, oldest: string): Promise<SlackMessage[]> {
+    const params = new URLSearchParams({ channel, oldest, limit: '50', inclusive: 'false' });
+    const response = await fetch(`${this.baseUrl}/conversations.history?${params}`, {
+      headers: { 'Authorization': `Bearer ${this.token}` },
+    });
+    const data = await response.json() as { ok: boolean; messages?: SlackMessage[]; error?: string };
+    if (!data.ok) {
+      throw new Error(`Slack conversations.history failed: ${data.error ?? 'unknown'}`);
+    }
+    return (data.messages ?? []).reverse();
+  }
+
+  async getUserName(userId: string): Promise<string> {
+    try {
+      const params = new URLSearchParams({ user: userId });
+      const response = await fetch(`${this.baseUrl}/users.info?${params}`, {
+        headers: { 'Authorization': `Bearer ${this.token}` },
+      });
+      const data = await response.json() as { ok: boolean; user?: { real_name?: string; name?: string } };
+      if (data.ok && data.user) {
+        return data.user.real_name ?? data.user.name ?? userId;
+      }
+    } catch { /* fall through */ }
+    return userId;
+  }
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -150,6 +150,18 @@ export interface AgentConfig {
     never_ask: string[];
   };
   ecosystem?: EcosystemConfig;
+  /**
+   * Slack watch: when present, the fast-checker daemon polls a Slack channel
+   * every `interval_ms` (default 60 seconds) and writes an inbox message to
+   * wake Claude if new messages appear since the last check.
+   * Requires SLACK_BOT_TOKEN in the agent's .env.
+   */
+  slack_watch?: {
+    /** Slack channel ID to monitor (e.g. "C1234567890") */
+    channel: string;
+    /** Poll interval in milliseconds. Default: 60000 (60 seconds) */
+    interval_ms?: number;
+  };
 }
 
 export interface CronEntry {


### PR DESCRIPTION
Connector-first Slack integration. No new npm dependencies — uses built-in fetch (Node 20+). Send: cortextos bus send-slack. Receive: fast-checker polls conversations.history every 60s (configurable), new messages land in agent inbox formatted like Telegram. Bot's own messages filtered. 5 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)