### PR TITLE
test(slack): Slack watch test coverage (TC-S1–TC-S8)

### DIFF
--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -1,6 +1,24 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
-vi.mock('child_process', () => ({ exec: vi.fn() }));
+vi.mock('child_process', () => ({ exec: vi.fn(), execFile: vi.fn() }));
+vi.mock('../../../src/bus/message.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/bus/message.js')>();
+  return { ...actual, sendMessage: vi.fn() };
+});
+
+vi.mock('../../../src/slack/api.js', () => ({
+  SlackAPI: vi.fn().mockImplementation(() => ({
+    getHistory: vi.fn(),
+    getUserName: vi.fn().mockResolvedValue('Test User'),
+    postMessage: vi.fn(),
+  })),
+}));
+
+import { execFile } from 'child_process';
+import { sendMessage } from '../../../src/bus/message.js';
+import { SlackAPI } from '../../../src/slack/api.js';
+
+
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -782,4 +800,94 @@ describe('FastChecker', () => {
       expect(result).toContain("cortextos bus send-telegram 123456789 '<your reply>'");
     });
   });
+
+    describe('checkSlackWatch — Slack watch', () => {
+    let checker: FastChecker;
+    let mockApi: any;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      checker = new FastChecker(createMockAgent(), paths, '/framework', {
+        slackWatch: { channel: 'C1234567890', intervalMs: 60000, token: 'xoxb-test' },
+      });
+      (checker as any).slackLastCheckedAt = 0;
+      mockApi = vi.mocked(SlackAPI).mock.results[vi.mocked(SlackAPI).mock.results.length - 1].value;
+    });
+
+    it('TC-S1: empty channel — no messages, no inbox write', async () => {
+      mockApi.getHistory.mockResolvedValue([]);
+      await (checker as any).checkSlackWatch();
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('TC-S2: new message — wakes agent with correct inbox format', async () => {
+      mockApi.getHistory.mockResolvedValue([{ ts: '1234.0001', user: 'U123', text: 'Hello', type: 'message' }]);
+      mockApi.getUserName.mockResolvedValue('Brittany Hunter');
+      await (checker as any).checkSlackWatch();
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      const text = (sendMessage as any).mock.calls[0][4];
+      expect(text).toContain('=== SLACK from Brittany Hunter');
+      expect(text).toContain('channel:C1234567890');
+      expect(text).toContain('Hello');
+      expect(text).toContain('Reply using: cortextos bus send-slack');
+    });
+
+    it('TC-S3: cursor-based dedup — same message not processed twice', async () => {
+      mockApi.getHistory.mockResolvedValueOnce([{ ts: '100.0001', text: 'msg1', type: 'message', user: 'U1' }]);
+      await (checker as any).checkSlackWatch();
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect((checker as any).slackLastTs).toBe('100.0001');
+      (checker as any).slackLastCheckedAt = 0;
+      mockApi.getHistory.mockResolvedValueOnce([]);
+      await (checker as any).checkSlackWatch();
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      expect(mockApi.getHistory).toHaveBeenCalledWith('C1234567890', '100.0001');
+    });
+
+    it('TC-S4: cursor advances to newest message ts', async () => {
+      mockApi.getHistory.mockResolvedValue([
+        { ts: '100.0', text: 'first', type: 'message', user: 'U1' },
+        { ts: '200.0', text: 'second', type: 'message', user: 'U1' },
+      ]);
+      await (checker as any).checkSlackWatch();
+      expect((checker as any).slackLastTs).toBe('200.0');
+    });
+
+    it('TC-S5: rate limit response — no crash, no inbox write', async () => {
+      mockApi.getHistory.mockRejectedValue(new Error('Slack conversations.history failed: ratelimited'));
+      await expect((checker as any).checkSlackWatch()).resolves.not.toThrow();
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('TC-S6: invalid/expired token — no crash, no inbox write', async () => {
+      mockApi.getHistory.mockRejectedValue(new Error('Slack conversations.history failed: invalid_auth'));
+      await expect((checker as any).checkSlackWatch()).resolves.not.toThrow();
+      expect(sendMessage).not.toHaveBeenCalled();
+    });
+
+    it('TC-S7: network failure — recovers on next poll', async () => {
+      mockApi.getHistory.mockRejectedValueOnce(new Error('fetch failed: ECONNREFUSED'));
+      await expect((checker as any).checkSlackWatch()).resolves.not.toThrow();
+      expect(sendMessage).not.toHaveBeenCalled();
+      (checker as any).slackLastCheckedAt = 0;
+      mockApi.getHistory.mockResolvedValueOnce([{ ts: '500.0', text: 'recovered', type: 'message', user: 'U1' }]);
+      await (checker as any).checkSlackWatch();
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      const text = (sendMessage as any).mock.calls[0][4];
+      expect(text).toContain('recovered');
+    });
+
+    it('TC-S8: bot own messages ignored — no self-wake loop', async () => {
+      mockApi.getHistory.mockResolvedValue([
+        { ts: '100.0', user: 'U123', text: 'human msg', type: 'message' },
+        { ts: '200.0', text: 'bot msg', type: 'message', subtype: 'bot_message', bot_id: 'B001' },
+      ]);
+      await (checker as any).checkSlackWatch();
+      expect(sendMessage).toHaveBeenCalledTimes(1);
+      const text = (sendMessage as any).mock.calls[0][4];
+      expect(text).toContain('human msg');
+      expect(text).not.toContain('bot msg');
+    });
+  });
+
 });


### PR DESCRIPTION
Companion tests for PR #101 (Slack connector). Depends on that PR being merged first.

8 test cases: empty channel silent, correct inbox format, cursor dedup, cursor advancement, rate limit graceful, auth error graceful, network recovery, bot message filter. 1 file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)