### PR TITLE
fix(daemon): resolve Telegram photo paths from config.working_directory (BUG-049)

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -337,7 +337,10 @@ export class AgentManager {
             // BUG-046: Convert absolute paths to relative (from agent working dir).
             // Claude Code strips absolute paths from pasted user input, so the
             // agent never sees them. Relative paths survive injection.
-            const toRel = (p: string | undefined) => p ? relative(agentDir, p) : '';
+            // BUG-049: Use the agent's actual launch cwd (config.working_directory
+            // if set, else agentDir) so the path resolves when Read() is invoked.
+            const launchDir = config?.working_directory || agentDir;
+            const toRel = (p: string | undefined) => p ? relative(launchDir, p) : '';
             const relImagePath = toRel(media.image_path);
             const relFilePath = toRel(media.file_path);
 


### PR DESCRIPTION
## Summary

- `agent-manager.ts` computed relative photo paths from `agentDir`, but the agent process runs with `cwd = config.working_directory` when that field is set. Paths didn't resolve from the agent's actual cwd, so `Read()` on Telegram photos always failed silently.
- Fall back to `agentDir` when `working_directory` is unset — matches the pattern already used in `pty/agent-pty.ts:63` and `daemon/agent-process.ts:395`.

## Reproducer

1. Create an agent with `config.working_directory` set to a path other than its `agents/<name>` dir.
2. Send the agent a Telegram photo.
3. Daemon hands the agent a path relative to `agentDir`, but the agent's cwd is elsewhere — `Read()` fails, photo never processed.

## Fix

```ts
const launchDir = config?.working_directory || agentDir;
const toRel = (p: string | undefined) => p ? relative(launchDir, p) : '';
```

One-line change, zero risk for agents without `working_directory` override (falls back to `agentDir`).

## Test plan

- [x] Manual verification: zerocool agent with `working_directory` set to a separate repo, Telegram photo received and readable via `Read()` after patch.
- [ ] Optional: unit test covering the relative-path computation for both cases (with and without `working_directory`).
