### PR TITLE
fix(hooks): quiet hours + dedup + rate-limit reclassification for crash alert

### DIFF
--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -1,11 +1,103 @@
-
 /**
  * SessionEnd hook - crash alert via Telegram.
  * Categorizes session end type and sends notification.
+ *
+ * Behavior:
+ *   - Detects Anthropic weekly/5h rate-limit messages in stdout.log and
+ *     classifies the exit as "rate-limited" so it is suppressed rather than
+ *     spamming a 🚨 CRASH alert every 30 minutes while the daemon respawn
+ *     loop continues hitting the wall.
+ *   - Applies quiet hours (22:00-07:00 America/Los_Angeles) for routine end
+ *     types (planned-restart, session-refresh, daemon-stop, user-*,
+ *     rate-limited). A real unexpected crash still pages at night.
+ *   - Deduplicates identical alerts for the same agent within 10 minutes so a
+ *     broken watchdog loop results in at most one notification, not a buzz
+ *     storm.
  */
-import { existsSync, readFileSync, writeFileSync, appendFileSync, unlinkSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, appendFileSync, unlinkSync, mkdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+
+const DEDUP_WINDOW_MS = 10 * 60 * 1000;         // 10 minutes
+const QUIET_HOUR_START_LA = 22;                 // 22:00 America/Los_Angeles
+const QUIET_HOUR_END_LA = 7;                    // 07:00 America/Los_Angeles
+
+// End types that are routine and should be suppressed during quiet hours.
+// "crash" is deliberately NOT in this list — a genuine unexpected crash at
+// 3am is worth waking up for.
+const QUIET_SUPPRESSED_TYPES = new Set([
+  'planned-restart',
+  'session-refresh',
+  'daemon-stop',
+  'user-restart',
+  'user-disable',
+  'user-stop',
+  'rate-limited',
+]);
+
+function isQuietHoursLA(now: Date): boolean {
+  const laString = now.toLocaleString('en-US', {
+    timeZone: 'America/Los_Angeles',
+    hour12: false,
+  });
+  const m = laString.match(/\d+\/\d+\/\d+,?\s+(\d+):/);
+  if (!m) return false;
+  const hour = parseInt(m[1], 10);
+  // Window wraps midnight: 22:00-23:59 OR 00:00-06:59
+  return hour >= QUIET_HOUR_START_LA || hour < QUIET_HOUR_END_LA;
+}
+
+/**
+ * Scan the tail of stdout.log for Anthropic rate-limit or weekly-limit
+ * signatures. Mirrors OutputBuffer.hasRateLimitSignature so the hook and the
+ * daemon use the same detection logic.
+ */
+function detectRateLimitInLog(logPath: string): boolean {
+  try {
+    const size = statSync(logPath).size;
+    const readBytes = Math.min(size, 200 * 1024); // last 200 KB
+    const fd = readFileSync(logPath);
+    const slice = fd.slice(Math.max(0, fd.length - readBytes)).toString('utf-8');
+    const text = slice.replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').toLowerCase();
+    return (
+      text.includes('overloaded_error') ||
+      text.includes('rate_limit_error') ||
+      text.includes('rate limit') ||
+      text.includes('rate-limit') ||
+      text.includes('too many requests') ||
+      text.includes('quota exceeded') ||
+      text.includes('usage limit') ||
+      text.includes('weekly limit') ||
+      text.includes('5-hour limit') ||
+      text.includes('5h limit') ||
+      /used \d+% of your/.test(text)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return true if an identical (agent, type) alert was already sent within
+ * the dedup window. Side effect: records this attempt when it is the first.
+ */
+function shouldSuppressDedup(stateDir: string, endType: string): boolean {
+  const dedupFile = join(stateDir, '.crash_alert_dedup.json');
+  const now = Date.now();
+  let last: Record<string, number> = {};
+  try {
+    last = JSON.parse(readFileSync(dedupFile, 'utf-8')) as Record<string, number>;
+  } catch { /* missing or corrupt — start fresh */ }
+  const prev = last[endType] ?? 0;
+  if (now - prev < DEDUP_WINDOW_MS) {
+    return true;
+  }
+  last[endType] = now;
+  try {
+    writeFileSync(dedupFile, JSON.stringify(last), 'utf-8');
+  } catch { /* ignore */ }
+  return false;
+}
 
 async function main(): Promise<void> {
   const agentName = process.env.CTX_AGENT_NAME;
@@ -16,11 +108,11 @@ async function main(): Promise<void> {
   const stateDir = join(ctxRoot, 'state', agentName);
   const logDir = join(ctxRoot, 'logs', agentName);
 
-  // Ensure directories exist
   mkdirSync(stateDir, { recursive: true });
   mkdirSync(logDir, { recursive: true });
 
-  // Determine end type from state markers
+  // Determine end type from state markers (written by other parts of the system
+  // before the Claude Code session exits).
   let endType = 'crash';
   let reason = '';
 
@@ -28,13 +120,8 @@ async function main(): Promise<void> {
     { file: '.restart-planned', type: 'planned-restart' },
     { file: '.session-refresh', type: 'session-refresh' },
     { file: '.user-restart', type: 'user-restart' },
-    // BUG-036: distinguish intentional disable/stop from crashes so the user
-    // does not get a false 🚨 CRASH alarm when they themselves shut the agent down.
     { file: '.user-disable', type: 'user-disable' },
     { file: '.user-stop', type: 'user-stop' },
-    // BUG-034 partial: distinguish daemon shutdown (e.g., `pm2 restart`,
-    // `pm2 stop cortextos-daemon`) from a real agent crash. Written by
-    // AgentManager.stopAll() before each agent's PTY is killed.
     { file: '.daemon-stop', type: 'daemon-stop' },
   ];
 
@@ -50,7 +137,18 @@ async function main(): Promise<void> {
     }
   }
 
-  // Track crash count
+  // If no marker matched but the stdout tail shows a rate-limit signature,
+  // reclassify as rate-limited. Prevents the 30-minute 🚨 CRASH buzz storm
+  // when the weekly limit is exhausted.
+  if (endType === 'crash') {
+    const stdoutPath = join(logDir, 'stdout.log');
+    if (existsSync(stdoutPath) && detectRateLimitInLog(stdoutPath)) {
+      endType = 'rate-limited';
+      reason = 'anthropic rate limit detected in stdout.log';
+    }
+  }
+
+  // Track crash count (real crashes only).
   const today = new Date().toISOString().split('T')[0];
   const countFile = join(stateDir, '.crash_count_today');
   let crashCount = 0;
@@ -74,14 +172,23 @@ async function main(): Promise<void> {
     lastTask = hb.status || '';
   } catch { /* ignore */ }
 
-  // Log to crashes.log
+  // Always log to crashes.log — we want visibility even when alerts are muted.
   const timestamp = new Date().toISOString();
   const logLine = `${timestamp} type=${endType} reason=${reason || 'none'} last_task=${lastTask}\n`;
   try {
     appendFileSync(join(logDir, 'crashes.log'), logLine);
   } catch { /* ignore */ }
 
-  // Send Telegram alert
+  // Decide whether to actually send to Telegram.
+  const now = new Date();
+  const quiet = isQuietHoursLA(now);
+  if (quiet && QUIET_SUPPRESSED_TYPES.has(endType)) {
+    return;
+  }
+  if (shouldSuppressDedup(stateDir, endType)) {
+    return;
+  }
+
   const botToken = process.env.BOT_TOKEN;
   const chatId = process.env.CHAT_ID;
   if (!botToken || !chatId) return;
@@ -108,6 +215,9 @@ async function main(): Promise<void> {
     case 'daemon-stop':
       message = `🛑 ${agentName} stopped (daemon shutdown).`;
       if (reason) message += ` (${reason})`;
+      break;
+    case 'rate-limited':
+      message = `⏳ ${agentName} paused — Anthropic rate limit hit. Will resume when the window resets.`;
       break;
     case 'crash':
       message = `🚨 CRASH: ${agentName} died unexpectedly.`;


### PR DESCRIPTION
## Problem

The SessionEnd crash-alert hook pages Telegram on every non-crash end type (`planned-restart`, `session-refresh`, `daemon-stop`, `user-*`) regardless of time, and has no deduplication.

A single misclassified crash loop — e.g. the Claude Code CLI weekly-limit wall, which surfaces as the status-bar line `You've used 100% of your weekly limit · resets 10pm (America/Los_Angeles)` rather than an API error body — results in a 🚨 CRASH Telegram alert every ~30 minutes all night. We hit this on our `revops-global` org yesterday when an agent exhausted the Claude Code weekly limit. 7 crashes → 7 middle-of-the-night buzzes before manual intervention.

The existing `OutputBuffer.hasRateLimitSignature()` (added in #49) only matches Anthropic **API error bodies** (`overloaded_error`, `rate_limit_error`, HTTP 529, etc.), not the **Claude Code CLI status-bar** format. Even once #49 lands, the hook itself has no time-of-day guardrail.

## What this PR changes

Three related changes to `src/hooks/hook-crash-alert.ts`, all scoped to the hook:

### 1. Stdout-based rate-limit reclassification

When no marker file matches and the exit would fall through to `crash`, the hook now scans the tail of `stdout.log` for rate-limit signatures and reclassifies the exit as a new `rate-limited` end type. Patterns matched (case-insensitive, ANSI stripped):

- `overloaded_error`
- `rate_limit_error`
- `rate limit`, `rate-limit`
- `too many requests`
- `quota exceeded`
- `usage limit`
- `weekly limit`, `5-hour limit`, `5h limit`
- `/used \d+% of your/` — the Claude Code CLI status-bar regex

This is deliberately duplicated from `OutputBuffer.hasRateLimitSignature()` because the hook runs as a standalone short-lived process and cannot share the daemon's in-memory buffer. Both detectors should stay in sync going forward.

The new `rate-limited` branch emits a calmer ⏳ message (`"paused — Anthropic rate limit hit. Will resume when the window resets."`) and is subject to quiet hours.

### 2. Quiet hours (22:00–07:00 America/Los_Angeles)

Routine end types are suppressed during the quiet-hour window:

- `planned-restart`
- `session-refresh`
- `daemon-stop`
- `user-restart`, `user-disable`, `user-stop`
- `rate-limited`

**Real unexpected `crash` events are deliberately NOT suppressed** — that is the only end type worth waking an operator up for.

Timezone resolution uses `Intl` via `toLocaleString('en-US', { timeZone: 'America/Los_Angeles' })` so it does not depend on the host TZ. The quiet-hour window is defined as module constants (`QUIET_HOUR_START_LA = 22`, `QUIET_HOUR_END_LA = 7`) so operators can fork and adjust easily. A follow-up could make these configurable per-agent via `config.json` — happy to do that in a second pass if you prefer.

### 3. Dedup within 10-minute window

Identical `(agent, type)` alerts within a 10-minute window are suppressed via a `.crash_alert_dedup.json` state file in the agent's state dir. A broken watchdog loop now produces at most one notification instead of a buzz storm.

`DEDUP_WINDOW_MS = 10 * 60 * 1000` is a module constant.

## What does not change

- **All events still log to `crashes.log`** regardless of whether the Telegram alert is actually sent. Post-hoc visibility is preserved — operators can `tail crashes.log` in the morning to see what happened.
- The existing marker-file detection (`.restart-planned`, `.session-refresh`, `.user-*`, `.daemon-stop`) is unchanged.
- The crash-count tracking (`.crash_count_today`) is unchanged and still only increments for the `crash` end type.
- The Telegram API call itself is unchanged.

## Out of scope (follow-up)

Matching the weekly-limit patterns in `OutputBuffer.hasRateLimitSignature()` and parsing `"resets Xpm"` to compute a smarter daemon pause duration. That requires changes to `src/pty/output-buffer.ts` and `src/daemon/agent-process.ts` which currently live behind #49 (not yet merged). I have that extension ready locally and will open it as a separate PR once #49 lands so the history is clean.

## Testing

- `npm run typecheck` — clean
- `npm run build` — success, `dist/hooks/hook-crash-alert.js` 6.47 KB
- `npm test` — 35 files, 490 tests pass
- **Field-tested**: deployed to the VM running our `revops-global` org. Stopped a 7×30-minute overnight alert loop on an agent that had hit the Claude weekly limit. The daemon kept respawning the agent (correct — crash recovery), but the hook correctly suppressed the misclassified alerts while logging each attempt to `crashes.log` for visibility.

No new test file is included because this hook does not currently have a test file in `tests/unit/hooks/`. I can add one if you want — the helper functions (`isQuietHoursLA`, `detectRateLimitInLog`, `shouldSuppressDedup`) are pure and easy to test in isolation. Let me know what you prefer.