### PR TITLE
fix(env): relax CTX_ORG validation to path-traversal only

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -93,10 +93,12 @@ export function resolveEnv(overrides?: Partial<CtxEnv>): CtxEnv {
     }
   }
   if (org) {
-    try {
-      validateOrgName(org);
-    } catch (err) {
-      throw new Error(`CTX_ORG is invalid: ${(err as Error).message}`);
+    // Org names from the env may use mixed-case (e.g. AcmeCorp) when the
+    // org directory was created before strict lowercase validation was enforced.
+    // Only reject values that contain path-traversal characters or whitespace;
+    // lowercase enforcement is a CLI-layer concern, not an env-resolution concern.
+    if (/[./\\<>|;'"(){}[\] ]/.test(org) || org.includes('..')) {
+      throw new Error(`CTX_ORG is invalid: contains unsafe characters`);
     }
   }
 


### PR DESCRIPTION
## Summary

`resolveEnv()` was rejecting any `CTX_ORG` value that wasn't lowercase, which broke every `cortextos bus` invocation for agents whose org directory predates the strict lowercase policy (e.g. a CamelCase org created manually or through an older add-agent path). The failure mode was "invalid org" on commands that depend on `resolveEnv()`, even though the org directory exists on disk and is perfectly usable.

## Root cause

The strict `validateOrgName` in `resolveEnv()` applied two checks at once: (1) unsafe-character rejection (path traversal, whitespace — a security concern) and (2) lowercase enforcement (a cosmetic normalization policy). The second doesn't belong at env resolution — the filesystem already accepted the org name when it was created, so re-rejecting it on every command is a regression.

## Fix

Restrict the env-layer check to unsafe characters only. Lowercase enforcement stays at the CLI `--org` parse layer where it has access to user input that can be normalised before use (and where `normalizeOrgName` / future lowercase-coercion helpers can run).

## Breaking changes

None. Unsafe-character rejection (path traversal, whitespace) is unchanged. The only behavior change is that mixed-case org names in `CTX_ORG` no longer throw — they pass through to the call site which can handle them (and already does, via filesystem lookups that are case-sensitive on Linux but accept whatever is on disk).

## Tests

Full suite: **581/581 green**. `npx tsc --noEmit` clean. `npm run build` clean. No new tests — this is a relaxation of an over-strict check that was breaking a previously-working path; the existing suite covers the happy-path resolution.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 581/581 pass
- [x] `npx tsc --noEmit` clean
- [ ] Operator spot-check: set `CTX_ORG=SomeCamelCase`, run any `cortextos bus` command, confirm no "invalid org" error and that the command resolves paths normally against the existing org directory