### PR TITLE
feat: per-org dashboard branding via context.json

### DIFF
--- a/dashboard/src/app/(auth)/login/page.tsx
+++ b/dashboard/src/app/(auth)/login/page.tsx
@@ -19,6 +19,7 @@ export default function LoginPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [showSplash, setShowSplash] = useState(false);
+  const [brand, setBrand] = useState({ name: 'cortextOS', shortName: 'cortextOS' });
 
   // Redirect to setup if no users exist
   useEffect(() => {
@@ -31,6 +32,19 @@ export default function LoginPage() {
       })
       .catch(() => {});
   }, [router]);
+
+  // Load the dashboard's default brand so login header/footer reflect it.
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/brand')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data) return;
+        setBrand({ name: data.name, shortName: data.shortName });
+      })
+      .catch(() => { /* keep default */ });
+    return () => { cancelled = true; };
+  }, []);
 
   // CSRF token strategy: fetch once, hold in a ref, inject on submit.
   // React state bound with value={csrfToken} and imperative writes via
@@ -132,7 +146,7 @@ export default function LoginPage() {
           <div className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-primary text-primary-foreground text-lg font-bold">
             cO
           </div>
-          <h1 className="text-xl font-semibold tracking-tight">cortextOS</h1>
+          <h1 className="text-xl font-semibold tracking-tight">{brand.name}</h1>
           <p className="text-sm text-muted-foreground">
             Persistent AI Agent Orchestration
           </p>
@@ -183,7 +197,7 @@ export default function LoginPage() {
         </Card>
 
         <p className="text-center text-[11px] text-muted-foreground/60">
-          cortextOS v2
+          {brand.shortName} v2
         </p>
       </div>
     </div>

--- a/dashboard/src/app/(auth)/login/page.tsx
+++ b/dashboard/src/app/(auth)/login/page.tsx
@@ -19,7 +19,7 @@ export default function LoginPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const [showSplash, setShowSplash] = useState(false);
-  const [brand, setBrand] = useState({ name: 'cortextOS', shortName: 'cortextOS' });
+  const [brand, setBrand] = useState({ name: 'cortextOS', shortName: 'cortextOS', initials: 'cO' });
 
   // Redirect to setup if no users exist
   useEffect(() => {
@@ -40,7 +40,7 @@ export default function LoginPage() {
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (cancelled || !data) return;
-        setBrand({ name: data.name, shortName: data.shortName });
+        setBrand({ name: data.name, shortName: data.shortName, initials: data.initials ?? 'cO' });
       })
       .catch(() => { /* keep default */ });
     return () => { cancelled = true; };
@@ -144,7 +144,7 @@ export default function LoginPage() {
         {/* Logo */}
         <div className="text-center space-y-2">
           <div className="inline-flex h-12 w-12 items-center justify-center rounded-xl bg-primary text-primary-foreground text-lg font-bold">
-            cO
+            {brand.initials}
           </div>
           <h1 className="text-xl font-semibold tracking-tight">{brand.name}</h1>
           <p className="text-sm text-muted-foreground">

--- a/dashboard/src/app/api/brand/route.ts
+++ b/dashboard/src/app/api/brand/route.ts
@@ -1,0 +1,19 @@
+// GET /api/brand — returns the default brand for this dashboard instance.
+//
+// Used by unauthenticated surfaces (login page, splash) that need branding
+// before an org is selected. Resolves per the rules in getDefaultBrand():
+// CTX_DEFAULT_ORG env var → single-org fallback → cortextOS framework default.
+
+import { NextResponse } from 'next/server';
+import { getDefaultBrand, getOrgBrand } from '@/lib/data/organization';
+
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const org = url.searchParams.get('org');
+
+  // When called with ?org=<name>, return that specific org's brand.
+  // Otherwise fall back to the dashboard's default brand.
+  const brand = org ? getOrgBrand(org) : getDefaultBrand();
+
+  return NextResponse.json(brand);
+}

--- a/dashboard/src/app/api/org/config/route.ts
+++ b/dashboard/src/app/api/org/config/route.ts
@@ -44,7 +44,7 @@ export async function PATCH(request: NextRequest) {
   }
 
   // Validate editable fields
-  const allowed = ['timezone', 'day_mode_start', 'day_mode_end', 'default_approval_categories', 'communication_style', 'name', 'description', 'industry', 'icp', 'value_prop', 'require_deliverables'];
+  const allowed = ['timezone', 'day_mode_start', 'day_mode_end', 'default_approval_categories', 'communication_style', 'name', 'description', 'industry', 'icp', 'value_prop', 'require_deliverables', 'brand_name', 'brand_short_name'];
   const timeRegex = /^\d{2}:\d{2}$/;
 
   if (body.day_mode_start && !timeRegex.test(body.day_mode_start as string)) {

--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Sora, JetBrains_Mono } from "next/font/google";
 import { ThemeProvider } from "@/components/theme-provider";
 import { SessionProvider } from "@/components/session-provider";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { getDefaultBrand } from "@/lib/data/organization";
 import "./globals.css";
 
 const sora = Sora({
@@ -16,16 +17,24 @@ const jetbrainsMono = JetBrains_Mono({
   variable: "--font-jetbrains",
 });
 
-export const metadata: Metadata = {
-  title: "cortextOS Dashboard",
-  description: "cortextOS agent orchestration dashboard",
-  viewport: "width=device-width, initial-scale=1, viewport-fit=cover",
-  appleWebApp: {
-    capable: true,
-    statusBarStyle: "default",
-    title: "cortextOS",
-  },
-};
+// Resolved at request time so metadata reflects the currently active brand
+// without needing a dashboard rebuild when org context.json changes.
+export async function generateMetadata(): Promise<Metadata> {
+  const brand = getDefaultBrand();
+  const descriptionSuffix = brand.isOrgBrand
+    ? `${brand.name} agent orchestration dashboard`
+    : "cortextOS agent orchestration dashboard";
+  return {
+    title: `${brand.name} Dashboard`,
+    description: descriptionSuffix,
+    viewport: "width=device-width, initial-scale=1, viewport-fit=cover",
+    appleWebApp: {
+      capable: true,
+      statusBarStyle: "default",
+      title: brand.shortName,
+    },
+  };
+}
 
 export default function RootLayout({
   children,

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import { useOrg } from '@/hooks/use-org';
+import { useBrand } from '@/hooks/use-brand';
 import {
   IconLayoutDashboard,
   IconRobot,
@@ -70,6 +71,7 @@ export function Sidebar({
   onNavigate,
   onSearchClick,
 }: SidebarProps) {
+  const brand = useBrand();
   const pathname = usePathname();
   const { currentOrg } = useOrg();
 
@@ -99,9 +101,9 @@ export function Sidebar({
       {/* Logo */}
       <div className="flex h-14 items-center gap-2 px-4">
         <div className="flex h-7 w-7 items-center justify-center rounded-md bg-primary text-primary-foreground text-xs font-bold">
-          cO
+          {brand.initials}
         </div>
-        <span className="text-sm font-semibold tracking-tight">cortextOS</span>
+        <span className="text-sm font-semibold tracking-tight">{brand.shortName}</span>
       </div>
 
       {/* Search trigger */}

--- a/dashboard/src/components/layout/splash-screen.tsx
+++ b/dashboard/src/components/layout/splash-screen.tsx
@@ -8,6 +8,22 @@ interface SplashScreenProps {
 
 export function SplashScreen({ onComplete }: SplashScreenProps) {
   const [phase, setPhase] = useState<'enter' | 'hold' | 'fade'>('enter');
+  const [brand, setBrand] = useState({ name: 'cortextOS', initials: 'cO' });
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch('/api/brand')
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data) return;
+        setBrand({
+          name: data.name ?? 'cortextOS',
+          initials: data.initials ?? 'cO',
+        });
+      })
+      .catch(() => { /* keep default */ });
+    return () => { cancelled = true; };
+  }, []);
 
   useEffect(() => {
     const t1 = setTimeout(() => setPhase('hold'), 100);
@@ -93,10 +109,10 @@ export function SplashScreen({ onComplete }: SplashScreenProps) {
           }}
         >
           <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary text-primary-foreground text-2xl font-bold shadow-xl shadow-primary/25">
-            cO
+            {brand.initials}
           </div>
           <div className="text-center">
-            <h1 className="text-xl font-semibold tracking-tight">cortextOS</h1>
+            <h1 className="text-xl font-semibold tracking-tight">{brand.name}</h1>
             <p className="text-xs text-muted-foreground mt-1">Agent Orchestration</p>
           </div>
         </div>

--- a/dashboard/src/hooks/use-brand.ts
+++ b/dashboard/src/hooks/use-brand.ts
@@ -1,0 +1,78 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useOrg } from './use-org';
+
+interface Brand {
+  /** Full brand name for titles, headers, metadata. */
+  name: string;
+  /** Short name for compact slots (favicons, mobile nav, PWA title). */
+  shortName: string;
+  /** True when the brand resolved from an org (not the framework default). */
+  isOrgBrand: boolean;
+}
+
+const DEFAULT_BRAND: Brand = {
+  name: 'cortextOS',
+  shortName: 'cortextOS',
+  isOrgBrand: false,
+};
+
+/**
+ * Resolves the active brand from the currently selected org.
+ *
+ * Resolution order per org:
+ *   1. `brand_name` / `brand_short_name` explicitly set in context.json
+ *   2. Fallback: smart-cased `name` (e.g. "ascendops" → "AscendOps")
+ *   3. Fallback: "cortextOS" framework default
+ *
+ * When no org is selected (currentOrg === 'all') or org context lookup
+ * fails, falls back to the cortextOS default so the framework identity
+ * is preserved in cross-org views.
+ */
+export function useBrand(): Brand {
+  const { currentOrg } = useOrg();
+  const [brand, setBrand] = useState<Brand>(DEFAULT_BRAND);
+
+  useEffect(() => {
+    if (!currentOrg || currentOrg === 'all') {
+      setBrand(DEFAULT_BRAND);
+      return;
+    }
+
+    let cancelled = false;
+    fetch(`/api/org/config?org=${encodeURIComponent(currentOrg)}`)
+      .then(r => (r.ok ? r.json() : null))
+      .then(data => {
+        if (cancelled || !data) return;
+        const name =
+          (typeof data.brand_name === 'string' && data.brand_name.trim()) ||
+          smartCase(data.name || currentOrg) ||
+          DEFAULT_BRAND.name;
+        const shortName =
+          (typeof data.brand_short_name === 'string' && data.brand_short_name.trim()) ||
+          name;
+        setBrand({ name, shortName, isOrgBrand: true });
+      })
+      .catch(() => {
+        // Silent fallback — never crash UI on brand lookup failure
+        if (!cancelled) setBrand(DEFAULT_BRAND);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [currentOrg]);
+
+  return brand;
+}
+
+/** Convert "ascendops" → "AscendOps", "acme-corp" → "Acme Corp". */
+function smartCase(raw: string): string {
+  if (!raw) return '';
+  return raw
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}

--- a/dashboard/src/hooks/use-brand.ts
+++ b/dashboard/src/hooks/use-brand.ts
@@ -8,6 +8,8 @@ interface Brand {
   name: string;
   /** Short name for compact slots (favicons, mobile nav, PWA title). */
   shortName: string;
+  /** 1–3 letter monogram for compact logo slots (sidebar, splash, login). */
+  initials: string;
   /** True when the brand resolved from an org (not the framework default). */
   isOrgBrand: boolean;
 }
@@ -15,6 +17,7 @@ interface Brand {
 const DEFAULT_BRAND: Brand = {
   name: 'cortextOS',
   shortName: 'cortextOS',
+  initials: 'cO',
   isOrgBrand: false,
 };
 
@@ -41,18 +44,17 @@ export function useBrand(): Brand {
     }
 
     let cancelled = false;
-    fetch(`/api/org/config?org=${encodeURIComponent(currentOrg)}`)
+    fetch(`/api/brand?org=${encodeURIComponent(currentOrg)}`)
       .then(r => (r.ok ? r.json() : null))
       .then(data => {
         if (cancelled || !data) return;
-        const name =
-          (typeof data.brand_name === 'string' && data.brand_name.trim()) ||
-          smartCase(data.name || currentOrg) ||
-          DEFAULT_BRAND.name;
-        const shortName =
-          (typeof data.brand_short_name === 'string' && data.brand_short_name.trim()) ||
-          name;
-        setBrand({ name, shortName, isOrgBrand: true });
+        // Server computes name, shortName, initials — just pass through.
+        setBrand({
+          name: data.name ?? DEFAULT_BRAND.name,
+          shortName: data.shortName ?? DEFAULT_BRAND.shortName,
+          initials: data.initials ?? DEFAULT_BRAND.initials,
+          isOrgBrand: Boolean(data.isOrgBrand),
+        });
       })
       .catch(() => {
         // Silent fallback — never crash UI on brand lookup failure
@@ -67,12 +69,3 @@ export function useBrand(): Brand {
   return brand;
 }
 
-/** Convert "ascendops" → "AscendOps", "acme-corp" → "Acme Corp". */
-function smartCase(raw: string): string {
-  if (!raw) return '';
-  return raw
-    .split(/[\s_-]+/)
-    .filter(Boolean)
-    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
-    .join(' ');
-}

--- a/dashboard/src/lib/data/organization.ts
+++ b/dashboard/src/lib/data/organization.ts
@@ -18,6 +18,9 @@ export interface OrgContext {
 export interface Brand {
   name: string;
   shortName: string;
+  /** 1–3 letter monogram for compact logo slots (sidebar, splash, login).
+   *  Derived from the name — e.g. "AscendOps" → "AO", "Acme Corp" → "AC". */
+  initials: string;
   isOrgBrand: boolean;
 }
 
@@ -34,6 +37,7 @@ const DEFAULT_CONTEXT: OrgContext = {
 const FRAMEWORK_BRAND: Brand = {
   name: 'cortextOS',
   shortName: 'cortextOS',
+  initials: 'cO',
   isOrgBrand: false,
 };
 
@@ -103,6 +107,48 @@ function smartCase(raw: string): string {
 }
 
 /**
+ * Derive a 1-3 letter monogram from a brand name.
+ *
+ * Multi-word names take first letter of each word (up to 3):
+ *   "AscendOps"  → "AO"   (CamelCase treated as two words via regex below)
+ *   "Acme Corp"  → "AC"
+ *   "Joe's PM Co" → "JPC"
+ *
+ * Single lowercase-word names take first 2 chars uppercased:
+ *   "acme"       → "AC"
+ *
+ * Empty input → empty string; caller should fall back to framework default.
+ */
+export function deriveInitials(name: string): string {
+  if (!name) return '';
+  const trimmed = name.trim();
+  if (!trimmed) return '';
+
+  // Split on whitespace / hyphens / underscores first
+  const words = trimmed.split(/[\s_-]+/).filter(Boolean);
+
+  // If we got multiple words, use first letter of each (up to 3)
+  if (words.length > 1) {
+    return words
+      .slice(0, 3)
+      .map(w => w.charAt(0).toUpperCase())
+      .join('');
+  }
+
+  // Single word — try CamelCase split (e.g. "AscendOps" → ["Ascend", "Ops"])
+  const camelParts = trimmed.match(/[A-Z][a-z]*|[a-z]+/g) || [];
+  if (camelParts.length > 1) {
+    return camelParts
+      .slice(0, 3)
+      .map(p => p.charAt(0).toUpperCase())
+      .join('');
+  }
+
+  // True single word — first 2 chars uppercased
+  return trimmed.slice(0, 2).toUpperCase();
+}
+
+/**
  * Resolve the brand for a specific org.
  *
  * Priority: explicit `brand_name` → smart-cased `name` → framework default.
@@ -115,7 +161,8 @@ export function getOrgBrand(org: string): Brand {
     FRAMEWORK_BRAND.name;
   const shortName =
     (ctx.brand_short_name && ctx.brand_short_name.trim()) || name;
-  return { name, shortName, isOrgBrand: true };
+  const initials = deriveInitials(shortName) || FRAMEWORK_BRAND.initials;
+  return { name, shortName, initials, isOrgBrand: true };
 }
 
 /**

--- a/dashboard/src/lib/data/organization.ts
+++ b/dashboard/src/lib/data/organization.ts
@@ -2,7 +2,8 @@
 // Reads context.json and brand-voice.md from the framework root org directory.
 
 import fs from 'fs';
-import { getOrgContextPath, getOrgBrandVoicePath } from '@/lib/config';
+import path from 'path';
+import { getOrgContextPath, getOrgBrandVoicePath, CTX_FRAMEWORK_ROOT } from '@/lib/config';
 
 export interface OrgContext {
   name: string;
@@ -10,6 +11,14 @@ export interface OrgContext {
   industry: string;
   icp: string;
   value_prop: string;
+  brand_name: string;
+  brand_short_name: string;
+}
+
+export interface Brand {
+  name: string;
+  shortName: string;
+  isOrgBrand: boolean;
 }
 
 const DEFAULT_CONTEXT: OrgContext = {
@@ -18,6 +27,14 @@ const DEFAULT_CONTEXT: OrgContext = {
   industry: '',
   icp: '',
   value_prop: '',
+  brand_name: '',
+  brand_short_name: '',
+};
+
+const FRAMEWORK_BRAND: Brand = {
+  name: 'cortextOS',
+  shortName: 'cortextOS',
+  isOrgBrand: false,
 };
 
 /**
@@ -37,6 +54,8 @@ export function getOrganizationContext(org: string): OrgContext {
       industry: data.industry ?? '',
       icp: data.icp ?? '',
       value_prop: data.value_prop ?? '',
+      brand_name: data.brand_name ?? '',
+      brand_short_name: data.brand_short_name ?? '',
     };
   } catch {
     return { ...DEFAULT_CONTEXT };
@@ -56,4 +75,69 @@ export function getBrandVoice(org: string): string {
   } catch {
     return '';
   }
+}
+
+/** List all org directory names under the framework root. */
+export function listOrgs(): string[] {
+  const orgsDir = path.join(CTX_FRAMEWORK_ROOT, 'orgs');
+  if (!fs.existsSync(orgsDir)) return [];
+  try {
+    return fs
+      .readdirSync(orgsDir, { withFileTypes: true })
+      .filter(d => d.isDirectory() && !d.name.startsWith('.'))
+      .map(d => d.name)
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+/** Convert "ascendops" → "AscendOps", "acme-corp" → "Acme Corp". */
+function smartCase(raw: string): string {
+  if (!raw) return '';
+  return raw
+    .split(/[\s_-]+/)
+    .filter(Boolean)
+    .map(w => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(' ');
+}
+
+/**
+ * Resolve the brand for a specific org.
+ *
+ * Priority: explicit `brand_name` → smart-cased `name` → framework default.
+ */
+export function getOrgBrand(org: string): Brand {
+  const ctx = getOrganizationContext(org);
+  const name =
+    (ctx.brand_name && ctx.brand_name.trim()) ||
+    smartCase(ctx.name || org) ||
+    FRAMEWORK_BRAND.name;
+  const shortName =
+    (ctx.brand_short_name && ctx.brand_short_name.trim()) || name;
+  return { name, shortName, isOrgBrand: true };
+}
+
+/**
+ * Resolve the brand used for server-rendered metadata (page title, etc).
+ *
+ * Selection:
+ *   1. If `CTX_DEFAULT_ORG` env var is set and that org exists, use its brand
+ *   2. If exactly one org exists, use its brand
+ *   3. Otherwise return the framework default (cortextOS)
+ *
+ * This runs at request time server-side, so it picks up org changes without
+ * a dashboard rebuild.
+ */
+export function getDefaultBrand(): Brand {
+  const envOrg = process.env.CTX_DEFAULT_ORG?.trim();
+  const orgs = listOrgs();
+
+  if (envOrg && orgs.includes(envOrg)) {
+    return getOrgBrand(envOrg);
+  }
+  if (orgs.length === 1) {
+    return getOrgBrand(orgs[0]);
+  }
+  return { ...FRAMEWORK_BRAND };
 }

--- a/dashboard/src/middleware.ts
+++ b/dashboard/src/middleware.ts
@@ -69,9 +69,13 @@ export async function middleware(request: NextRequest) {
 
   // Allow public paths
   // Security (H7): SSE endpoints require ?token=<jwt> auth — removed from public whitelist
+  // /api/brand is intentionally public — the login page fetches it pre-auth
+  // to render the configured brand name. Returns only non-sensitive display
+  // strings (brand name, short name). See getDefaultBrand() / getOrgBrand().
   if (
     pathname.startsWith('/login') ||
     pathname.startsWith('/api/auth') ||
+    pathname === '/api/brand' ||
     pathname.startsWith('/_next') ||
     pathname === '/favicon.ico'
   ) {

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -67,6 +67,8 @@ export const initCommand = new Command('init')
         day_mode_end: '00:00',
         default_approval_categories: ['external-comms', 'financial', 'deployment', 'data-deletion'],
         communication_style: 'direct and casual',
+        brand_name: '',
+        brand_short_name: '',
       }, null, 2) + '\n', 'utf-8');
       console.log('  Created org context.json');
     } else {
@@ -79,6 +81,8 @@ export const initCommand = new Command('init')
         if (!ctx.day_mode_end) ctx.day_mode_end = '00:00';
         if (!ctx.default_approval_categories) ctx.default_approval_categories = ['external-comms', 'financial', 'deployment', 'data-deletion'];
         if (!ctx.communication_style) ctx.communication_style = 'direct and casual';
+        if (ctx.brand_name === undefined) ctx.brand_name = '';
+        if (ctx.brand_short_name === undefined) ctx.brand_short_name = '';
         writeFileSync(contextPath, JSON.stringify(ctx, null, 2) + '\n', 'utf-8');
       } catch { /* ignore */ }
     }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -190,6 +190,12 @@ export interface OrgContext {
   default_approval_categories?: string[];
   communication_style?: string;
   dashboard_url?: string;
+  /** Display name shown on dashboard (title bar, login page, sidebar header).
+   *  If unset, falls back to `name` with smart-casing, then to "cortextOS". */
+  brand_name?: string;
+  /** Short brand name for compact UI slots (favicon caption, mobile nav).
+   *  If unset, falls back to `brand_name` or `name`. */
+  brand_short_name?: string;
   /** When true, agents are instructed at startup that every task submitted
    *  for review must have at least one file deliverable attached via
    *  save-output. The instruction is injected into the boot prompt

--- a/templates/org/context.json
+++ b/templates/org/context.json
@@ -14,5 +14,7 @@
     "deployment",
     "data-deletion"
   ],
-  "communication_style": "direct and casual"
+  "communication_style": "direct and casual",
+  "brand_name": "",
+  "brand_short_name": ""
 }


### PR DESCRIPTION
## Summary

Adds two optional fields to org `context.json` — `brand_name` and `brand_short_name` — that the dashboard uses to customize page title, login page header, and PWA metadata per active org.

Multi-tenant cortextOS installs currently show "cortextOS Dashboard" regardless of which org is active, which pushes forks to reimplement per-org branding ad-hoc. This contributes the feature upstream so every install benefits and fork-level divergence on dashboard UI stays minimal.

## Resolution order

**Server-side** (request-time, for SSR metadata):
1. `CTX_DEFAULT_ORG` env var → that org's brand
2. Single-org install → that org's brand
3. Framework default ("cortextOS")

**Per-org** (used by `/api/brand?org=<name>` and the new `getOrgBrand()` helper):
1. Explicit `brand_name` / `brand_short_name` in `context.json`
2. Smart-cased `name` (`ascendops` → `AscendOps`, `acme-corp` → `Acme Corp`)
3. Framework default

## Files

- `src/types/index.ts` — add optional `brand_name`, `brand_short_name` to `OrgContext`
- `src/cli/init.ts` — initialize empty brand fields on org create; upgrade path fills missing fields
- `templates/org/context.json` — include empty brand fields in template
- `dashboard/src/lib/data/organization.ts` — `getOrgBrand()`, `getDefaultBrand()`, `listOrgs()`, `Brand` interface, smart-casing helper
- `dashboard/src/app/layout.tsx` — `generateMetadata()` resolves brand at request time
- `dashboard/src/app/api/brand/route.ts` (new) — public GET returning `{name, shortName, isOrgBrand}`, supports `?org=<name>`
- `dashboard/src/app/(auth)/login/page.tsx` — fetch `/api/brand` on mount, render in header + footer
- `dashboard/src/middleware.ts` — whitelist `/api/brand` as public (login fetches pre-auth; returns only display strings)
- `dashboard/src/app/api/org/config/route.ts` — brand fields in PATCH allowlist
- `dashboard/src/hooks/use-brand.ts` (new) — client hook for reactive brand on org switch (scaffolding for future sidebar/topbar branding)

## Backward compatibility

All brand fields are optional. Orgs without them fall through to the smart-cased `name`; installs without any orgs still show the cortextOS default. No existing `context.json` files need changes.

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `npm test` — 581 passing, 0 failing
- [ ] Manual: set `brand_name` on an org → dashboard title + login reflect it
- [ ] Manual: clear `brand_name` → falls back to smart-cased org name
- [ ] Manual: 2nd org with no brand → default stays "cortextOS" (or whichever `CTX_DEFAULT_ORG` points at)
- [ ] Manual: `/api/brand` accessible pre-auth; `/api/brand?org=<name>` returns per-org