### PR TITLE
fix(daemon): treat missing cron-state entry as cold-start, not skip (issue #110)

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -652,8 +652,9 @@ export class AgentProcess {
     if (monitorable.length === 0) return;
 
     const generation = this.lifecycleGeneration;
+    const loopStartedAt = Date.now();
 
-    this.runGapDetectionLoop(monitorable, generation).catch(err => {
+    this.runGapDetectionLoop(monitorable, generation, loopStartedAt).catch(err => {
       this.log(`Cron gap detection failed (non-fatal): ${err}`);
     });
   }
@@ -661,6 +662,7 @@ export class AgentProcess {
   private async runGapDetectionLoop(
     crons: Array<{ name: string; interval?: string }>,
     generation: number,
+    loopStartedAt: number,
   ): Promise<void> {
     const GAP_POLL_MS = 10 * 60 * 1000;   // poll every 10 minutes
     const GAP_MULTIPLIER = 2.0;            // nudge when gap > 2x expected interval
@@ -680,14 +682,17 @@ export class AgentProcess {
         const intervalMs = parseDurationMs(cronDef.interval!);
 
         const record = state.crons.find(r => r.name === cronDef.name);
+        let lastFireMs: number;
         if (!record) {
-          // No fire record yet — cron may not have fired once. Skip to avoid
-          // false positives on freshly started agents.
-          continue;
+          // No fire record yet (cold start or daemon restart before first cron fire).
+          // Treat the loop start time as the implicit last fire. This means gap
+          // detection will nudge if the cron hasn't fired within 2x its interval
+          // AFTER the daemon restarted — preventing dead zones on cold starts.
+          lastFireMs = loopStartedAt;
+        } else {
+          lastFireMs = Date.parse(record.last_fire);
+          if (isNaN(lastFireMs)) continue;
         }
-
-        const lastFireMs = Date.parse(record.last_fire);
-        if (isNaN(lastFireMs)) continue;
 
         const gapMs = now - lastFireMs;
         const threshold = intervalMs * GAP_MULTIPLIER;


### PR DESCRIPTION
## Problem

PR #68 added cron gap detection. However, gap detection silently skips any cron with no fire record in cron-state.json. On fresh deploy or after daemon restart, all entries are missing — the detection loop runs every 10 minutes but never fires a single nudge, creating guaranteed dead zones.

Evidence: Dead zone #15 (12:30-16:30 UTC Apr 15) — 4h dead zone immediately after a daemon restart with no gap nudges fired.

## Fix

Pass `loopStartedAt` (the timestamp when `scheduleGapDetection` was called) into `runGapDetectionLoop`. When no cron-state record exists, use `loopStartedAt` as the implicit `last_fire`. Gap detection then fires a nudge if the cron has not fired within 2× its interval after the daemon started.

## Behavior change

**Before:** Missing record → `continue` (never nudges on cold start)  
**After:** Missing record → treat daemon start as last fire → nudges if cron silent for 2× interval after restart

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 581/581 pass
- [ ] Manual: restart daemon, verify gap nudge fires after 2× interval if cron hasn't registered

Closes #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)