### PR TITLE
feat(scripts): add setup-hooks.sh + pre-push build+test gate

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# pre-push hook — installed by scripts/setup-hooks.sh
+#
+# Runs npm run build && npm test before any push.
+# Fails the push if either step fails, so broken code never reaches CI.
+#
+# To bypass in an emergency (last resort):
+#   git push --no-verify
+# Do NOT use --no-verify routinely. Fix the error instead.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+echo "[pre-push] Running build..."
+if ! npm run build --silent; then
+  echo ""
+  echo "[pre-push] Build failed. Fix the error before pushing." >&2
+  echo "[pre-push] Push aborted." >&2
+  exit 1
+fi
+
+echo "[pre-push] Running tests..."
+if ! npm test --silent; then
+  echo ""
+  echo "[pre-push] Tests failed. Fix the failing tests before pushing." >&2
+  echo "[pre-push] Push aborted." >&2
+  exit 1
+fi
+
+echo "[pre-push] Build and tests passed. Pushing..."

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# setup-hooks.sh — Install cortextOS git hooks into the local repo
+#
+# Run once after cloning:
+#   bash scripts/setup-hooks.sh
+#
+# Installs a pre-push hook that runs npm run build && npm test before
+# any push. If either fails, the push is aborted and you fix it locally
+# rather than failing on CI.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
+  echo "Error: must be run from inside a git repository." >&2
+  exit 1
+}
+
+HOOKS_DIR="$REPO_ROOT/.git/hooks"
+
+install_hook() {
+  local name="$1"
+  local src="$REPO_ROOT/scripts/hooks/$name"
+  local dest="$HOOKS_DIR/$name"
+
+  if [[ ! -f "$src" ]]; then
+    echo "Warning: hook source not found: $src (skipping)" >&2
+    return
+  fi
+
+  cp "$src" "$dest"
+  chmod +x "$dest"
+  echo "  Installed: .git/hooks/$name"
+}
+
+echo "Installing cortextOS git hooks..."
+install_hook pre-push
+echo "Done. Hooks active for this repo clone."


### PR DESCRIPTION
## Summary

Two CI failures overnight were caused by TypeScript errors and missing deps that weren't caught before pushing. James directive: fail locally, not on CI.

This PR adds a lightweight, dependency-free git hook setup:

- **`scripts/setup-hooks.sh`** — one-time setup script. Run once after cloning to install hooks.
- **`scripts/hooks/pre-push`** — pre-push hook that runs `npm run build && npm test` before any push. Aborts on failure.

No husky or external dependencies. Follows the no-external-runtime-deps policy.

## Usage

```bash
# Run once after cloning
bash scripts/setup-hooks.sh
```

After that, every push automatically runs build + test. Broken code never reaches CI.

## Why not commit `.git/hooks/` directly?

Git hooks live in `.git/hooks/` which is not versioned. `setup-hooks.sh` bridges this by copying versioned hook sources into the local `.git/hooks/` directory. Each contributor runs it once after cloning.

## Test plan
- [x] `bash scripts/setup-hooks.sh` installs hook correctly
- [x] Hook is executable after install
- [x] `npm run build` — clean
- [x] `npm test` — 581/581 pass
- [ ] Verify hook aborts push on build failure (manual test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)