### PR TITLE
fix(org): use readdirSync for exact-case match — fixes macOS case-insensitive fs

### DIFF
--- a/src/utils/org.ts
+++ b/src/utils/org.ts
@@ -1,0 +1,71 @@
+import { existsSync, readdirSync, statSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Map an org name to its canonical filesystem casing.
+ *
+ * cortextOS treats the filesystem-exact spelling of an org directory as the
+ * canonical identifier. When a caller supplies an org name with drifted
+ * casing (e.g. "acmecorp" instead of "AcmeCorp"), every
+ * downstream path join produces a SEPARATE state directory, which splits
+ * runtime artifacts across two ghost dirs and pollutes every consumer that
+ * scans the orgs/ parent. Before this helper existed, one lowercase
+ * `cortextos bus kb-* --org acmecorp` invocation was enough to
+ * bootstrap a phantom `~/.cortextos/default/orgs/acmecorp/` with a
+ * MMRAG config.json that then haunted dashboard sync forever.
+ *
+ * Resolution order:
+ *
+ *   1. If `{frameworkRoot}/orgs/{org}` exists with the exact casing given,
+ *      return it unchanged. This is the fast path for well-formed input
+ *      and guarantees we never change a caller's spelling unnecessarily.
+ *
+ *   2. Otherwise, read the framework `orgs/` directory and look for an
+ *      entry that matches case-insensitively. If exactly one such entry
+ *      exists, return IT — the on-disk canonical casing — instead of the
+ *      caller's input.
+ *
+ *   3. If the framework dir is missing, unreadable, or contains no
+ *      matching entry, return the input unchanged. Callers that actually
+ *      need the directory to exist will fail at their own file operations
+ *      with a clearer error than anything this helper could raise.
+ *
+ * Never returns a name that does not exist on disk. Never normalizes past
+ * an exact-case match (case-sensitive filesystems may legitimately host
+ * both `AcmeCorp` and `acmecorp` as distinct orgs — we do
+ * not want to collapse them).
+ */
+export function normalizeOrgName(frameworkRoot: string, org: string): string {
+  if (!org) return org;
+
+  const orgsDir = join(frameworkRoot, 'orgs');
+
+  // Read the directory once. Using readdirSync for both paths avoids the
+  // case-insensitive filesystem trap where existsSync('orgs/acmecorp')
+  // returns true on macOS/Windows even when the dir was created as 'AcmeCorp'.
+  let entries: string[];
+  try {
+    entries = readdirSync(orgsDir);
+  } catch {
+    return org;
+  }
+
+  // Fast path: exact case match in the listing.
+  if (entries.includes(org)) {
+    try {
+      if (statSync(join(orgsDir, org)).isDirectory()) return org;
+    } catch { /* fall through */ }
+  }
+
+  // Slow path: case-insensitive scan — return the on-disk canonical casing.
+  const orgLower = org.toLowerCase();
+  for (const entry of entries) {
+    if (entry.toLowerCase() === orgLower) {
+      try {
+        if (statSync(join(orgsDir, entry)).isDirectory()) return entry;
+      } catch { /* skip unreadable entry */ }
+    }
+  }
+
+  return org;
+}

--- a/tests/unit/utils/org.test.ts
+++ b/tests/unit/utils/org.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { normalizeOrgName } from '../../../src/utils/org';
+
+let fwRoot: string;
+
+beforeEach(() => {
+  fwRoot = mkdtempSync(join(tmpdir(), 'cortextos-org-test-'));
+  mkdirSync(join(fwRoot, 'orgs'), { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    rmSync(fwRoot, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+describe('normalizeOrgName', () => {
+  it('exact match: returns input unchanged', () => {
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+
+  it('case drift: lowercase input resolves to CamelCase canonical on disk', () => {
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    expect(normalizeOrgName(fwRoot, 'acmecorp')).toBe('AcmeCorp');
+    expect(normalizeOrgName(fwRoot, 'ACMECORP')).toBe('AcmeCorp');
+    expect(normalizeOrgName(fwRoot, 'AcmeCORP')).toBe('AcmeCorp');
+  });
+
+  it('no match: returns input unchanged (callers get a clearer error at file op time)', () => {
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    expect(normalizeOrgName(fwRoot, 'ghostcompany')).toBe('ghostcompany');
+  });
+
+  it('empty framework orgs dir: returns input unchanged', () => {
+    // orgs/ exists but is empty
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+
+  it('missing framework orgs dir: returns input unchanged', () => {
+    rmSync(join(fwRoot, 'orgs'), { recursive: true });
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+
+  it('empty org input: returns empty string (no normalization attempted)', () => {
+    expect(normalizeOrgName(fwRoot, '')).toBe('');
+  });
+
+  it('exact case match wins over case-insensitive match on case-sensitive filesystems', () => {
+    // macOS/Windows are case-insensitive — both dirs map to the same inode,
+    // so this scenario cannot be simulated there. Skip gracefully.
+    mkdirSync(join(fwRoot, 'orgs', 'AcmeCorp'));
+    try {
+      mkdirSync(join(fwRoot, 'orgs', 'acmecorp'));
+    } catch {
+      return; // case-insensitive filesystem — test not applicable on this OS
+    }
+    // Exact match path: return whichever casing the caller asked for.
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+    expect(normalizeOrgName(fwRoot, 'acmecorp')).toBe('acmecorp');
+  });
+
+  it('ignores non-directory entries with matching name', () => {
+    // A stray file named like an org must not be returned as a directory match.
+    writeFileSync(join(fwRoot, 'orgs', 'AcmeCorp.txt'), 'not a dir');
+    expect(normalizeOrgName(fwRoot, 'AcmeCorp')).toBe('AcmeCorp');
+  });
+});


### PR DESCRIPTION
## Problem

`normalizeOrgName` uses `existsSync` for its fast-path exact-case check. On macOS and Windows (case-insensitive filesystems), `existsSync('orgs/acmecorp')` returns `true` even when the directory was created as `orgs/AcmeCorp`. This causes the function to return the caller's input unchanged instead of resolving to the canonical on-disk casing — the opposite of what it's designed to do.

## Fix

Replace `existsSync` with `readdirSync` + `Array.includes()`. The directory listing contains the actual on-disk names, so the exact-case check operates on real entries rather than a case-folded filesystem lookup.

Also fix the case-sensitive-fs test to skip gracefully on macOS where `mkdirSync('acmecorp')` throws `EEXIST` when `AcmeCorp` already exists (the test is only meaningful on Linux CI).

## Files changed

- `src/utils/org.ts` — readdirSync-based exact-case check, one readdir call covers both fast and slow paths
- `tests/unit/utils/org.test.ts` — skip case-sensitive test on macOS with try/catch around second mkdirSync

## Test plan

- [ ] `npm test -- tests/unit/utils/org.test.ts` passes on macOS (8/8)
- [ ] `npm test -- tests/unit/utils/org.test.ts` passes on Linux CI (all 8 tests including the case-sensitive one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)