### PR TITLE
fix(hooks): add timeouts to PreCompact hooks to prevent compaction abort

### DIFF
--- a/src/hooks/hook-compact-telegram.ts
+++ b/src/hooks/hook-compact-telegram.ts
@@ -5,6 +5,10 @@
  *
  * This hook fires and returns immediately — it never blocks the compaction.
  * Registered in settings.json under the "PreCompact" event.
+ *
+ * Safety: fetch is raced against a 5s abort signal so this process always
+ * exits well within the 10s settings.json timeout. A timed-out or failed
+ * Telegram call must never abort compaction.
  */
 
 import { loadEnv } from './index.js';
@@ -16,6 +20,9 @@ async function main(): Promise<void> {
 
   const agentName = env.agentName || 'agent';
 
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+
   try {
     const url = `https://api.telegram.org/bot${env.botToken}/sendMessage`;
     await fetch(url, {
@@ -25,9 +32,12 @@ async function main(): Promise<void> {
         chat_id: env.chatId,
         text: `[${agentName}] Context compacting... resuming shortly`,
       }),
+      signal: controller.signal,
     });
   } catch {
     // Never fail — compaction must not be blocked
+  } finally {
+    clearTimeout(timer);
   }
 }
 

--- a/src/hooks/hook-extract-facts.ts
+++ b/src/hooks/hook-extract-facts.ts
@@ -73,8 +73,14 @@ async function main(): Promise<void> {
   const env = loadEnv();
 
   try {
-    // Read PreCompact payload from stdin
-    const raw = await readStdin();
+    // Read PreCompact payload from stdin with a 10s timeout — if Claude Code
+    // does not close stdin, readStdin() hangs and hits the settings.json
+    // 15s timeout, which aborts compaction. Race against a timer so we always
+    // exit cleanly with whatever data arrived.
+    const raw = await Promise.race([
+      readStdin(),
+      new Promise<string>(resolve => setTimeout(() => resolve(''), 10_000)),
+    ]);
     let payload: PreCompactPayload = {};
 
     if (raw.trim()) {


### PR DESCRIPTION
## Problem

Both PreCompact hooks can hit their settings.json timeouts (10s for compact-telegram, 15s for extract-facts), causing Claude Code to abort compaction entirely. The agent then stays stuck at 100% context with no recovery path.

Observed symptom: no "Context compacting" Telegram message for 24+ hours, meaning compaction is never completing.

**hook-compact-telegram:** `fetch()` to the Telegram API had no abort signal. A slow Telegram response (>10s) hit the hook timeout and aborted compaction.

**hook-extract-facts:** `readStdin()` waits indefinitely for stdin to close. If Claude Code doesn't close stdin before the 15s timeout, compaction aborts.

## Fix

- `hook-compact-telegram`: add 5s `AbortController` to `fetch()` — the Telegram call resolves or aborts within 5s, well inside the 10s hook timeout
- `hook-extract-facts`: race `readStdin()` against a 10s `Promise` — exits cleanly with empty payload if stdin doesn't close, well inside the 15s hook timeout

Both hooks already had `catch` blocks to swallow errors. The timeout just ensures they exit fast enough that Claude Code never kills them.

## Test plan

- [x] `npm run build` passes
- [x] `npm test` passes (617 tests)
- [ ] Verify "Context compacting" Telegram message fires on next compaction event

🤖 Generated with [Claude Code](https://claude.com/claude-code)