### PR TITLE
fix(hooks): remove hook-extract-facts from PreCompact

### DIFF
--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -72,11 +72,6 @@
             "type": "command",
             "command": "cortextos bus hook-compact-telegram",
             "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "cortextos bus hook-extract-facts",
-            "timeout": 15
           }
         ]
       }

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -61,11 +61,6 @@
             "type": "command",
             "command": "cortextos bus hook-compact-telegram",
             "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "cortextos bus hook-extract-facts",
-            "timeout": 15
           }
         ]
       }

--- a/templates/orchestrator/.claude/settings.json
+++ b/templates/orchestrator/.claude/settings.json
@@ -61,11 +61,6 @@
             "type": "command",
             "command": "cortextos bus hook-compact-telegram",
             "timeout": 10
-          },
-          {
-            "type": "command",
-            "command": "cortextos bus hook-extract-facts",
-            "timeout": 15
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Removes `hook-extract-facts` from the `PreCompact` hook list across all 3 agent templates
- `PreCompact` now only runs `hook-compact-telegram` (the Telegram "Context compacting..." notification)

## Why

`hook-extract-facts` assumed Claude Code sends a compaction `summary` via stdin. It actually sends `transcript_path`. The hook has never successfully written a single facts file across any agent since initial release. The `recall-facts` command has always returned empty.

Removing it entirely. The Telegram notification (already fixed in #134 with a 5s fetch timeout) is all that's needed here.

## Test plan

- [x] Build passes
- [x] Tests pass
- [ ] Verify "Context compacting..." Telegram message fires on next compaction

🤖 Generated with [Claude Code](https://claude.com/claude-code)