### PR TITLE
feat(telegram): message_reaction update routing — surface emoji reactions to the agent

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -406,6 +406,33 @@ export class AgentManager {
         });
       });
 
+      poller.onReaction((reaction) => {
+        // ALLOWED_USER gate: same rule as message handler. If configured,
+        // ignore reactions from other users.
+        if (allowedUserId) {
+          const allowedId = parseInt(allowedUserId, 10);
+          if (reaction.user?.id !== allowedId) {
+            log('Ignoring reaction from unauthorized user (allowed_user gate)');
+            return;
+          }
+        }
+
+        const from = stripControlChars(reaction.user?.first_name || reaction.user?.username || 'Unknown');
+        const reactionChatId = reaction.chat?.id ?? chatId ?? '';
+        const formatted = FastChecker.formatTelegramReaction(
+          from,
+          reactionChatId,
+          reaction.message_id,
+          reaction.old_reaction ?? [],
+          reaction.new_reaction ?? [],
+        );
+        if (checker.isDuplicate(formatted)) {
+          log('Duplicate Telegram reaction suppressed');
+          return;
+        }
+        checker.queueTelegramMessage(formatted);
+      });
+
       poller.start().catch(err => {
         log(`Telegram poller error: ${err}`);
       });

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -246,6 +246,37 @@ ${lastSentCtx}Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
   }
 
   /**
+   * Format a Telegram message_reaction update for PTY injection.
+   * Reactions are emoji additions/removals on existing messages — they
+   * surface to the agent so it can follow up on positive acknowledgements
+   * or clarify after a negative reaction.
+   *
+   * `newReaction` is the current reaction state (an empty list means the
+   * user REMOVED their reaction). `oldReaction` lets the formatter
+   * distinguish "added X" from "removed Y". Custom emoji (type=custom_emoji)
+   * render as [custom_emoji] since we don't resolve the custom_emoji_id.
+   */
+  static formatTelegramReaction(
+    from: string,
+    chatId: string | number,
+    messageId: number,
+    oldReaction: Array<{ type: 'emoji'; emoji: string } | { type: 'custom_emoji'; custom_emoji_id: string }>,
+    newReaction: Array<{ type: 'emoji'; emoji: string } | { type: 'custom_emoji'; custom_emoji_id: string }>,
+  ): string {
+    const render = (list: typeof newReaction): string =>
+      list.length === 0
+        ? '(none)'
+        : list.map((r) => (r.type === 'emoji' ? r.emoji : '[custom_emoji]')).join(' ');
+
+    const removed = newReaction.length === 0 && oldReaction.length > 0;
+    const label = removed ? `removed ${render(oldReaction)}` : render(newReaction);
+
+    return `=== REACTION from [USER: ${from}] (chat_id:${chatId}) on message ${messageId}: ${label} ===
+
+`;
+  }
+
+  /**
    * Format a Telegram photo message for injection.
    * Matches bash fast-checker.sh format.
    */

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -266,7 +266,7 @@ export class TelegramAPI {
     return this.post('getUpdates', {
       offset,
       timeout,
-      allowed_updates: ['message', 'callback_query'],
+      allowed_updates: ['message', 'callback_query', 'message_reaction'],
     });
   }
 

--- a/src/telegram/poller.ts
+++ b/src/telegram/poller.ts
@@ -1,11 +1,12 @@
 import { readFileSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
-import type { TelegramUpdate, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
+import type { TelegramUpdate, TelegramMessage, TelegramCallbackQuery, TelegramMessageReaction } from '../types/index.js';
 import { TelegramAPI } from './api.js';
 import { ensureDir } from '../utils/atomic.js';
 
 export type MessageHandler = (msg: TelegramMessage) => void;
 export type CallbackHandler = (query: TelegramCallbackQuery) => void;
+export type ReactionHandler = (reaction: TelegramMessageReaction) => void;
 
 /**
  * Telegram polling loop. Replaces the Telegram portion of fast-checker.sh.
@@ -19,6 +20,7 @@ export class TelegramPoller {
   private offsetFileName: string;
   private messageHandlers: MessageHandler[] = [];
   private callbackHandlers: CallbackHandler[] = [];
+  private reactionHandlers: ReactionHandler[] = [];
   private pollInterval: number;
 
   /**
@@ -57,6 +59,16 @@ export class TelegramPoller {
    */
   onCallback(handler: CallbackHandler): void {
     this.callbackHandlers.push(handler);
+  }
+
+  /**
+   * Register a handler for message_reaction updates. These fire when a
+   * user adds or removes an emoji reaction on a chat message the bot can
+   * see. Requires the bot's getUpdates call to include `message_reaction`
+   * in allowed_updates (handled by TelegramAPI.getUpdates).
+   */
+  onReaction(handler: ReactionHandler): void {
+    this.reactionHandlers.push(handler);
   }
 
   /**
@@ -118,6 +130,18 @@ export class TelegramPoller {
             handler(update.callback_query);
           } catch (err) {
             console.error('[telegram-poller] Callback handler error:', err);
+            handlerFailed = true;
+            break;
+          }
+        }
+      }
+
+      if (!handlerFailed && update.message_reaction) {
+        for (const handler of this.reactionHandlers) {
+          try {
+            handler(update.message_reaction);
+          } catch (err) {
+            console.error('[telegram-poller] Reaction handler error:', err);
             handlerFailed = true;
             break;
           }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -212,6 +212,34 @@ export interface TelegramUpdate {
   update_id: number;
   message?: TelegramMessage;
   callback_query?: TelegramCallbackQuery;
+  message_reaction?: TelegramMessageReaction;
+}
+
+/**
+ * One item in a Telegram message's reaction list. Telegram supports
+ * `type: 'emoji'` (standard emoji, the only shape we handle today) and
+ * `type: 'custom_emoji'` (premium custom emoji, carrying a `custom_emoji_id`
+ * instead of an `emoji` character). Shaped as a tagged union so call sites
+ * can narrow safely.
+ */
+export type TelegramReactionType =
+  | { type: 'emoji'; emoji: string }
+  | { type: 'custom_emoji'; custom_emoji_id: string };
+
+/**
+ * A `message_reaction` update fires when a user adds or removes an
+ * emoji reaction on a chat message the bot can see. `old_reaction` and
+ * `new_reaction` are the reaction state before/after — empty means "no
+ * reaction", so the diff is (new) minus (old). Requires
+ * `allowed_updates: ['message_reaction']` in the getUpdates call.
+ */
+export interface TelegramMessageReaction {
+  chat: TelegramChat;
+  user?: TelegramUser;
+  message_id: number;
+  date: number;
+  old_reaction: TelegramReactionType[];
+  new_reaction: TelegramReactionType[];
 }
 
 export interface TelegramMessage {

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -648,6 +648,55 @@ describe('FastChecker', () => {
     });
   });
 
+  describe('formatTelegramReaction', () => {
+    it('formats a newly-added emoji reaction with user, chat, and message ids', () => {
+      const result = FastChecker.formatTelegramReaction(
+        'Alice',
+        '123456789',
+        42,
+        [],
+        [{ type: 'emoji', emoji: '👍' }],
+      );
+      expect(result).toContain('=== REACTION from [USER: Alice] (chat_id:123456789) on message 42: 👍 ===');
+    });
+
+    it('renders multiple concurrent emojis joined by spaces', () => {
+      const result = FastChecker.formatTelegramReaction(
+        'Alice',
+        '1',
+        7,
+        [],
+        [
+          { type: 'emoji', emoji: '👍' },
+          { type: 'emoji', emoji: '🔥' },
+        ],
+      );
+      expect(result).toContain('on message 7: 👍 🔥 ===');
+    });
+
+    it('marks a cleared reaction as "removed <old>" when new_reaction is empty', () => {
+      const result = FastChecker.formatTelegramReaction(
+        'Alice',
+        '1',
+        9,
+        [{ type: 'emoji', emoji: '❤️' }],
+        [],
+      );
+      expect(result).toContain('on message 9: removed ❤️ ===');
+    });
+
+    it('renders custom_emoji as [custom_emoji] placeholder', () => {
+      const result = FastChecker.formatTelegramReaction(
+        'Alice',
+        '1',
+        11,
+        [],
+        [{ type: 'custom_emoji', custom_emoji_id: '5123456789012345678' }],
+      );
+      expect(result).toContain('on message 11: [custom_emoji] ===');
+    });
+  });
+
   describe('formatTelegramPhotoMessage', () => {
     it('formats photo message with caption and local_file', () => {
       const result = FastChecker.formatTelegramPhotoMessage(

--- a/tests/unit/telegram/poller.test.ts
+++ b/tests/unit/telegram/poller.test.ts
@@ -168,4 +168,58 @@ describe('TelegramPoller — offset-after-handler', () => {
       expect(persisted).toBe('0');
     }
   });
+
+  it('routes message_reaction updates to registered reaction handlers and advances offset', async () => {
+    const reactionUpdate: TelegramUpdate = {
+      update_id: 500,
+      message_reaction: {
+        chat: { id: 42, type: 'private' },
+        user: { id: 7, first_name: 'alice' },
+        message_id: 123,
+        date: 1700000000,
+        old_reaction: [],
+        new_reaction: [{ type: 'emoji', emoji: '👍' }],
+      },
+    };
+    const { api } = makeStubApi([reactionUpdate]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    const received: Array<{ msgId: number; emoji: string }> = [];
+    poller.onReaction((r) => {
+      const emoji = r.new_reaction[0]?.type === 'emoji' ? r.new_reaction[0].emoji : '?';
+      received.push({ msgId: r.message_id, emoji });
+    });
+
+    await poller.pollOnce();
+
+    expect(received).toEqual([{ msgId: 123, emoji: '👍' }]);
+    const persisted = readFileSync(join(stateDir, '.telegram-offset'), 'utf-8').trim();
+    expect(persisted).toBe('501');
+  });
+
+  it('does NOT advance offset if a reaction handler throws', async () => {
+    const reactionUpdate: TelegramUpdate = {
+      update_id: 600,
+      message_reaction: {
+        chat: { id: 42, type: 'private' },
+        user: { id: 7, first_name: 'alice' },
+        message_id: 999,
+        date: 1700000000,
+        old_reaction: [],
+        new_reaction: [{ type: 'emoji', emoji: '🔥' }],
+      },
+    };
+    const { api } = makeStubApi([reactionUpdate]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    poller.onReaction(() => { throw new Error('reaction broke'); });
+
+    await poller.pollOnce();
+
+    const offsetFile = join(stateDir, '.telegram-offset');
+    if (existsSync(offsetFile)) {
+      const persisted = readFileSync(offsetFile, 'utf-8').trim();
+      expect(persisted).toBe('0');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Adds support for Telegram's `message_reaction` update type so agents can see when a user reacts with an emoji to one of the bot's messages. Reactions are injected into the PTY as a one-line `=== REACTION from ... ===` banner, the same path Telegram text messages use — agents can then follow up on positive acks or clarify after a negative signal.

## Changes

1. **`src/telegram/api.ts`** — append `'message_reaction'` to `allowed_updates` in `getUpdates`. Without this, Telegram filters reactions out server-side and the poller never sees them.
2. **`src/types/index.ts`** — new `TelegramMessageReaction` interface (chat, user, message_id, date, old_reaction[], new_reaction[]) and a `TelegramReactionType` tagged union (`emoji` | `custom_emoji`). Optional `message_reaction` field on `TelegramUpdate` — fully additive, no changes to existing updates' typing.
3. **`src/telegram/poller.ts`** — new `ReactionHandler` type, `onReaction()` registrar, and `pollOnce()` routing with the **same** `try/catch/handlerFailed` + offset-after-handler contract as the existing `message` and `callback_query` paths. A reaction-handler throw leaves the update un-acknowledged so Telegram re-delivers it.
4. **`src/daemon/fast-checker.ts`** — new `FastChecker.formatTelegramReaction()` static formatter. Handles three shapes:
   - *Added*: renders `new_reaction` emojis space-joined
   - *Removed*: `new_reaction` empty + `old_reaction` non-empty → renders `removed <old_emojis>`
   - *Custom emoji*: renders `[custom_emoji]` placeholder (we don't resolve `custom_emoji_id`)
5. **`src/daemon/agent-manager.ts`** — `poller.onReaction()` wire-in alongside the existing `onMessage`/`onCallback` handlers. Same `ALLOWED_USER` gate, same dedup via `FastChecker.isDuplicate`, same `queueTelegramMessage` PTY injection path — reactions flow through the same plumbing as text messages so they inherit rate limits and ordering.

## Breaking changes

None. All type additions are optional fields; existing handlers continue to work unchanged.

## Tests

- `tests/unit/telegram/poller.test.ts` (+2): routes `message_reaction` to the handler and advances offset; handler throw does NOT advance offset (same contract as message/callback handlers).
- `tests/unit/daemon/fast-checker.test.ts` (+4): single emoji, multiple concurrent emojis, removed reaction ("removed X"), `custom_emoji` placeholder.

Full suite: **623/623 green**, `npx tsc --noEmit` clean, `npm run build` clean.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 623/623 pass
- [x] `npx tsc --noEmit` clean
- [ ] Operator spot-check: react with 👍 to a bot message and confirm the agent sees `=== REACTION from [USER: ...] (chat_id:...) on message N: 👍 ===` in its PTY
- [ ] Operator spot-check: clear a reaction and confirm the agent sees `removed 👍`

## Caveat

`custom_emoji` reactions render as `[custom_emoji]` because resolving the `custom_emoji_id` to its underlying character requires an extra `getCustomEmojiStickers` API call per distinct id. Keeping it cheap here; easy follow-up if someone wants the resolved characters.