### PR TITLE
fix(cli): goals generate-md accepts mixed-case agent and org names

### DIFF
--- a/src/cli/goals.ts
+++ b/src/cli/goals.ts
@@ -14,7 +14,7 @@ goalsCommand
   .action((options: { agent: string; org: string }) => {
     const frameworkRoot = process.env.CTX_FRAMEWORK_ROOT || process.cwd();
 
-    if (!/^[a-z0-9_-]+$/.test(options.agent) || !/^[a-z0-9_-]+$/.test(options.org)) {
+    if (!/^[A-Za-z0-9_-]+$/.test(options.agent) || !/^[A-Za-z0-9_-]+$/.test(options.org)) {
       process.stderr.write('Error: agent and org must be alphanumeric/dash/underscore only\n');
       process.exit(1);
     }


### PR DESCRIPTION
## Summary

`cortextos goals generate-md` rejected any `--agent` or `--org` argument containing an uppercase character, which made it impossible to run the command against mixed-case org directories that predate the strict-lowercase policy. Users hit `Error: agent and org must be alphanumeric/dash/underscore only` on arguments that the filesystem has already accepted.

## Root cause

The goals subcommand has its own inline validator at `src/cli/goals.ts:17`: `/^[a-z0-9_-]+$/`. The same class of bug was fixed in `src/utils/validate.ts` in an earlier patch, but the goals subcommand's inline check was missed.

## Fix

One-char-class change: `[a-z0-9_-]` → `[A-Za-z0-9_-]` on both agent and org arguments. Scope is intentionally minimal — the length check, path-traversal guard, and whitespace rejection are all preserved. Only the case class is relaxed.

## Breaking changes

None. Lowercase arguments continue to work unchanged; the only new behavior is that uppercase characters no longer cause a hard reject on an argument the filesystem will accept.

## Tests

Full suite: **617/617 green**, `npx tsc --noEmit` clean, `npm run build` clean. No new tests added for this 1-line relaxation of an over-strict check — the existing suite covers the happy path, and the verification below exercises the bug directly.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 617/617 pass
- [x] `npx tsc --noEmit` clean
- [x] Verified live: `cortextos goals generate-md --agent <name> --org <CamelCaseOrg>` returns `Generated GOALS.md for <name>` instead of the "alphanumeric/dash/underscore only" error.