### PR TITLE
fix(bus): manage-cycle list respects --agent filter instead of returning global list

### DIFF
--- a/src/bus/experiment.ts
+++ b/src/bus/experiment.ts
@@ -488,6 +488,12 @@ export function manageCycle(
     }
 
     case 'list': {
+      // When an agent filter is supplied, return only that agent's cycles.
+      // Omitting the agent returns the full list (back-compat for callers
+      // that explicitly want a global view).
+      if (options.agent) {
+        return config.cycles.filter((c) => c.agent === options.agent);
+      }
       return config.cycles;
     }
 

--- a/tests/sprint3-experiments.test.ts
+++ b/tests/sprint3-experiments.test.ts
@@ -307,6 +307,22 @@ describe('Sprint 3: Experiment Framework', () => {
       expect(cycles).toHaveLength(2);
     });
 
+    it("list with agent filter returns only that agent's cycles", () => {
+      manageCycle(testDir, 'create', { name: 'c1', agent: 'alice', metric: 'm1' });
+      manageCycle(testDir, 'create', { name: 'c2', agent: 'alice', metric: 'm2' });
+      manageCycle(testDir, 'create', { name: 'c3', agent: 'widgetbot', metric: 'm3' });
+
+      const aliceCycles = manageCycle(testDir, 'list', { agent: 'alice' });
+      expect(aliceCycles.map((c) => c.name).sort()).toEqual(['c1', 'c2']);
+
+      const widgetCycles = manageCycle(testDir, 'list', { agent: 'widgetbot' });
+      expect(widgetCycles.map((c) => c.name)).toEqual(['c3']);
+
+      // No filter still returns all (back-compat)
+      const all = manageCycle(testDir, 'list', {});
+      expect(all).toHaveLength(3);
+    });
+
     it('throws when modifying non-existent cycle', () => {
       expect(() => manageCycle(testDir, 'modify', { name: 'ghost' })).toThrow('not found');
     });


### PR DESCRIPTION
## Summary

`cortextos bus manage-cycle list <agent>` was returning every cycle in `config.json` regardless of the agent argument. Cycle-to-agent attribution in storage was already correct (each record carries its own `agent` field) — the bug was purely in the list path ignoring the filter.

## Fix

In the `list` case of `manageCycle()` in `src/bus/experiment.ts`: when `options.agent` is set, return `config.cycles.filter(c => c.agent === options.agent)`. When the caller omits the agent, the full list is still returned so existing callers that deliberately want a global view keep working (back-compat).

## Breaking changes

None. Callers that already pass `--agent` now get the filtered list they expected; callers that don't pass `--agent` keep getting the global list.

## Tests

New regression in `tests/sprint3-experiments.test.ts::manageCycle`: seed 3 cycles across 2 agents, assert that `list --agent=<first>` returns only the first agent's 2 cycles, `list --agent=<second>` returns only the second agent's 1 cycle, and `list` with no filter still returns all 3.

Full suite green, `npx tsc --noEmit` clean, `npm run build` clean.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` passes
- [x] `npx tsc --noEmit` clean
- [ ] Operator spot-check: seed 2 cycles per agent across several agents, run `cortextos bus manage-cycle list <agent>` and confirm only that agent's cycles come back