### PR TITLE
fix(dashboard): reverse-proxy login failures (issue #138)

### DIFF
--- a/dashboard/.env.local.example
+++ b/dashboard/.env.local.example
@@ -2,3 +2,11 @@
 ADMIN_USERNAME=admin
 ADMIN_PASSWORD=<generate: openssl rand -base64 24>
 AUTH_SECRET=<generate: openssl rand -base64 32>
+
+# Required when running behind a reverse proxy (Cloudflare Tunnel, Tailscale, nginx, etc.)
+# Without this, the rate limiter buckets all traffic as 0.0.0.0 and login breaks after 5 attempts.
+# TRUST_PROXY=true
+
+# Required when running behind a reverse proxy — set to your public URL.
+# Without this, NextAuth redirects to localhost instead of your actual domain.
+# AUTH_URL=https://your-tunnel-or-domain.example.com

--- a/dashboard/src/app/(auth)/login/page.tsx
+++ b/dashboard/src/app/(auth)/login/page.tsx
@@ -97,7 +97,12 @@ export default function LoginPage() {
         const target = new URL(res.url);
         if (target.pathname.startsWith('/login')) {
           const code = target.searchParams.get('error') || 'Unknown';
-          setError(`Sign-in failed: ${code}`);
+          // CallbackRouteError usually means the rate limiter blocked the request.
+          // Show a human-readable message instead of the raw error code.
+          const msg = code === 'CallbackRouteError'
+            ? 'Too many attempts. Please wait a few minutes and try again.'
+            : `Sign-in failed: ${code}`;
+          setError(msg);
           setLoading(false);
           return;
         }

--- a/dashboard/src/lib/auth.ts
+++ b/dashboard/src/lib/auth.ts
@@ -56,7 +56,8 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
         const headers = (request as Request | undefined)?.headers;
         const ip = trustProxy
           ? (headers?.get('x-forwarded-for')?.split(',')[0]?.trim() ?? '0.0.0.0')
-          : (headers?.get('x-real-ip') ?? '0.0.0.0');
+          // CF-Connecting-IP is set by Cloudflare and is not spoofable from outside CF
+          : (headers?.get('x-real-ip') ?? headers?.get('cf-connecting-ip') ?? '0.0.0.0');
 
         const { allowed } = checkRateLimit(ip);
         if (!allowed) {


### PR DESCRIPTION
## Summary

Three targeted fixes for the three bugs in issue #138 — dashboard login broken behind Cloudflare Tunnel / reverse proxy.

## Changes

**1. `.env.local.example` — document TRUST_PROXY and AUTH_URL**

Adds commented entries with explanations so users know to set these when deploying behind any reverse proxy. Previously users had no idea these were needed.

**2. `src/lib/auth.ts` — CF-Connecting-IP header fallback**

When `TRUST_PROXY` is not set, falls back to `CF-Connecting-IP` header (Cloudflare's real-IP header) before defaulting to `0.0.0.0`. CF-Connecting-IP is injected by Cloudflare's network and cannot be spoofed by external clients, making it safe to use without the full `TRUST_PROXY` flag. Prevents all login attempts from bucketing to `0.0.0.0` when running behind a Cloudflare quick tunnel.

**3. `src/app/(auth)/login/page.tsx` — human-readable error for rate limit**

Maps `CallbackRouteError` (the opaque NextAuth code shown when the rate limiter blocks login) to: "Too many attempts. Please wait a few minutes and try again." Previously gave no indication of the real cause or what to do.

## What's not fixed

Bug 2 (AUTH_URL missing = wrong redirect origin) is a documentation/setup issue, not a code bug — the example file now documents it. A fully automated solution (startup script that reads the cloudflared URL and writes AUTH_URL) is out of scope for this PR.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` 617/617 pass
- [ ] Operator: Deploy behind Cloudflare quick tunnel without TRUST_PROXY, verify login works (CF-Connecting-IP path)
- [ ] Operator: Trigger rate limit, verify error message is human-readable

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)