### PR TITLE
feat(skills): post-merge npm-audit gate in upstream sync workflow

### DIFF
--- a/community/skills/framework-upstream-auto-update/SKILL.md
+++ b/community/skills/framework-upstream-auto-update/SKILL.md
@@ -73,10 +73,21 @@ CORTEXTOS_CONFIRM_UPSTREAM_MERGE=yes cortextos bus check-upstream --apply
 After applying:
 ```bash
 cd /path/to/cortextos
+npm install
+npm audit --audit-level=moderate
 npm run build
 npm test
 ```
-Both must succeed. If either fails, DO NOT revert silently — report the failure to [ORCHESTRATOR] with the full error output and wait for instructions. The framework remains in its applied state; [ORCHESTRATOR] will decide whether to revert or patch.
+
+**Security gate (v2):** `npm audit --audit-level=moderate` runs AFTER `npm install` and BEFORE the build/test gate. If it reports any moderate+ vulnerability:
+- **BLOCK the merge** — do NOT proceed to build/test
+- Record the audit output (advisory IDs, affected packages, severity)
+- Report to [ORCHESTRATOR]: "Upstream merge blocked by npm audit: [advisory IDs]. Packages: [list]. Severity: [level]. Manual resolution required."
+- The merge stays unapplied until the vulnerability is resolved (upstream fix, manual override, or dep pin)
+
+This gate catches security regressions where upstream merges silently downgrade a dependency that was previously patched (e.g. carrying a pinned old version that reintroduces a known CVE).
+
+Build and test must also succeed. If either fails, DO NOT revert silently — report the failure to [ORCHESTRATOR] with the full error output and wait for instructions. The framework remains in its applied state; [ORCHESTRATOR] will decide whether to revert or patch.
 
 ### Step 5 — Handle feature or mixed batches (no apply)
 If any new commit is feature or mixed but all paths are safe:

--- a/templates/analyst/.claude/skills/upstream-sync/SKILL.md
+++ b/templates/analyst/.claude/skills/upstream-sync/SKILL.md
@@ -40,8 +40,25 @@ The script fetches from upstream and returns a JSON summary categorizing changes
 cortextos bus check-upstream --apply
 ```
 
-### Step 4: Post-apply
+### Step 4: Security audit gate
 
+After the merge applies, run the security gate BEFORE verifying build/tests:
+
+```bash
+npm install
+npm audit --audit-level=moderate
+```
+
+If `npm audit` reports any moderate+ vulnerability:
+- **BLOCK** — do not proceed to build/test
+- Record advisory IDs, affected packages, and severity
+- Report to orchestrator: "Upstream merge blocked by npm audit: [details]. Manual resolution required."
+
+This catches upstream merges that silently downgrade a dependency that was previously security-patched.
+
+### Step 5: Post-apply verification
+
+- Run `npm run build` and `npm test` — both must pass
 - Verify the merge was clean
 - Check if any agent bootstrap files need updating (template changes)
 - Report results to orchestrator


### PR DESCRIPTION
## Summary

Adds an `npm audit --audit-level=moderate` step to the upstream merge workflow skills, running AFTER `npm install` and BEFORE build/test verification. If audit reports any moderate+ vulnerability, the merge is blocked and the orchestrator is notified with advisory IDs, affected packages, and severity.

## Problem

Upstream merges can silently downgrade a security-patched dependency by carrying a pinned older version in `package.json`. Without an automated check at merge time, the regression goes unnoticed until the next manual `npm audit` — which may be days or weeks later. This gate closes that window.

## Changes

- `community/skills/framework-upstream-auto-update/SKILL.md` — audit gate added to Step 4 (post-apply, pre-build/test). Detailed block/report instructions.
- `templates/analyst/.claude/skills/upstream-sync/SKILL.md` — equivalent gate added as new Step 4, existing post-apply becomes Step 5.

## Breaking changes

None. The gate is additive — it adds a check step but does not change the existing build/test verification behavior.

## Test plan

- [x] Skill files are syntactically valid markdown
- [x] The `npm audit --audit-level=moderate` command documented in the skill is a standard npm CLI command — no new dependencies
- [ ] Operator validation: run an upstream merge on a repo with a known vulnerable dep and confirm the gate blocks + reports