### PR TITLE
fix(cli): add-agent --working-directory installs hooks into cwd

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -1,17 +1,19 @@
 import { Command } from 'commander';
-import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, chmodSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, chmodSync, statSync } from 'fs';
 import { join, resolve } from 'path';
 import { homedir } from 'os';
 import { OrgContext } from '../types';
 import { validateAgentName } from '../utils/validate';
+import { mergeAgentSettingsIntoWorkingDir, ClaudeSettings } from '../utils/merge-settings';
 
 export const addAgentCommand = new Command('add-agent')
   .argument('<name>', 'Agent name')
   .option('--template <type>', 'Agent template (orchestrator, analyst, agent)', 'agent')
   .option('--org <org>', 'Organization name')
   .option('--instance <id>', 'Instance ID', 'default')
+  .option('--working-directory <path>', 'External cwd where Claude Code should run. Installs cortextOS hooks into <path>/.claude/settings.local.json so the agent stays instrumented even when running outside its agent dir.')
   .description('Add a new agent to the organization')
-  .action(async (name: string, options: { template: string; org?: string; instance: string }) => {
+  .action(async (name: string, options: { template: string; org?: string; instance: string; workingDirectory?: string }) => {
     // BUG-041 fix: validate the agent name BEFORE creating anything on disk.
     // Without this, mixed-case names like 'CortextDesigner' pass through
     // add-agent, get written to disk, and THEN fail every `cortextos bus *`
@@ -244,6 +246,75 @@ export const addAgentCommand = new Command('add-agent')
       };
       writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
       console.log(`  Registered in enabled-agents.json`);
+    }
+
+    // --- --working-directory: install cortextOS hooks into external cwd ---
+    // When an agent runs with a cwd OUTSIDE its agent dir, Claude Code reads
+    // `.claude/settings.json` from the cwd and never sees the hooks we wrote
+    // into the agent dir. We merge them into the cwd's `settings.local.json`
+    // (gitignored, non-destructive) so the hooks still fire.
+    if (options.workingDirectory) {
+      const workingDir = resolve(options.workingDirectory);
+
+      if (!existsSync(workingDir)) {
+        console.error(`\nError: --working-directory "${workingDir}" does not exist.`);
+        console.error('Create the directory first, then re-run `cortextos add-agent`.');
+        process.exit(1);
+      }
+      if (!statSync(workingDir).isDirectory()) {
+        console.error(`\nError: --working-directory "${workingDir}" is not a directory.`);
+        process.exit(1);
+      }
+      if (resolve(workingDir) === resolve(agentDir)) {
+        console.error(`\nError: --working-directory equals the agent directory. Drop the flag — this is the default.`);
+        process.exit(1);
+      }
+
+      // Persist to agent's config.json so daemon spawns Claude Code with this cwd.
+      try {
+        const agentConfigPath = join(agentDir, 'config.json');
+        const agentCfg = JSON.parse(readFileSync(agentConfigPath, 'utf-8'));
+        agentCfg.working_directory = workingDir;
+        writeFileSync(agentConfigPath, JSON.stringify(agentCfg, null, 2) + '\n', 'utf-8');
+      } catch (err) {
+        console.error(`\nError writing working_directory to agent config.json: ${(err as Error).message}`);
+        process.exit(1);
+      }
+
+      // Read the agent's .claude/settings.json (just produced by the template
+      // copy) and merge it into <workingDir>/.claude/settings.local.json.
+      const agentSettingsPath = join(agentDir, '.claude', 'settings.json');
+      if (!existsSync(agentSettingsPath)) {
+        console.log(`\n  Skipped hook install: ${agentSettingsPath} not found. Template may not include settings.json.`);
+      } else {
+        try {
+          const agentSettings = JSON.parse(readFileSync(agentSettingsPath, 'utf-8')) as ClaudeSettings;
+          const merge = mergeAgentSettingsIntoWorkingDir(workingDir, agentSettings);
+
+          console.log(`\n  Working directory: ${workingDir}`);
+          console.log(`  Installed cortextOS hooks into ${merge.target}`);
+          console.log(`    ${merge.fileExistedBefore ? 'Merged into existing file' : 'Created new file'}`);
+          console.log(`    Hooks installed: ${merge.hooksInstalled}, already present: ${merge.hooksAlreadyPresent}, skipped (conflict): ${merge.hooksSkipped}`);
+          if (merge.permissionsAdded) {
+            console.log(`    Permissions added: ${merge.permissionsAdded}`);
+          }
+          if (merge.statusLineInstalled) {
+            console.log(`    statusLine installed`);
+          } else if (merge.statusLineKept) {
+            console.log(`    statusLine: kept existing (see warning)`);
+          }
+
+          if (merge.warnings.length) {
+            console.log('');
+            for (const w of merge.warnings) {
+              console.log(`  WARNING: ${w}`);
+            }
+          }
+        } catch (err) {
+          console.error(`\nError installing hooks into ${workingDir}: ${(err as Error).message}`);
+          process.exit(1);
+        }
+      }
     }
 
     console.log(`\n  Agent "${name}" created.`);

--- a/src/utils/merge-settings.ts
+++ b/src/utils/merge-settings.ts
@@ -1,0 +1,201 @@
+/**
+ * Merge an agent's `.claude/settings.json` into the working directory's
+ * `.claude/settings.local.json`, so Claude Code picks up cortextOS hooks
+ * (statusLine, hook-ask-telegram, hook-permission-telegram, …) when spawned
+ * with a cwd OUTSIDE the agent directory.
+ *
+ * Why `settings.local.json` and not `settings.json`? The working directory is
+ * typically the user's own repo. Claude Code merges `settings.json` + the
+ * gitignored `settings.local.json` at runtime, so we can install our hooks
+ * into the local file without touching anything the user owns.
+ *
+ * Per-matcher merge rules:
+ *   - No existing entry with our matcher  → install ours.
+ *   - Existing entry already includes our exact command  → no-op (idempotent).
+ *   - Existing entry has a DIFFERENT command for the same matcher  → skip +
+ *     warn. The user has customized this matcher and we refuse to silently
+ *     overwrite it. Other matchers still install.
+ *
+ * `statusLine` follows the same rule — if the user set one that is different
+ * from ours, keep theirs and warn.
+ */
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+
+export interface HookCommand {
+  type: string;
+  command: string;
+  timeout?: number;
+  [k: string]: unknown;
+}
+
+export interface HookEntry {
+  matcher?: string;
+  hooks: HookCommand[];
+  [k: string]: unknown;
+}
+
+export interface StatusLine {
+  type: string;
+  command: string;
+  [k: string]: unknown;
+}
+
+export interface ClaudeSettings {
+  permissions?: { allow?: string[]; deny?: string[]; [k: string]: unknown };
+  hooks?: Record<string, HookEntry[]>;
+  statusLine?: StatusLine;
+  [k: string]: unknown;
+}
+
+export interface MergeResult {
+  target: string;
+  fileExistedBefore: boolean;
+  hooksInstalled: number;
+  hooksAlreadyPresent: number;
+  hooksSkipped: number;
+  permissionsAdded: number;
+  statusLineInstalled: boolean;
+  statusLineKept: boolean;
+  warnings: string[];
+}
+
+const matcherKey = (m: HookEntry['matcher']): string => (m === undefined ? '__NO_MATCHER__' : m);
+
+export function mergeAgentSettingsIntoWorkingDir(
+  workingDir: string,
+  agentSettings: ClaudeSettings,
+): MergeResult {
+  const claudeDir = join(workingDir, '.claude');
+  const targetPath = join(claudeDir, 'settings.local.json');
+
+  mkdirSync(claudeDir, { recursive: true });
+
+  const fileExistedBefore = existsSync(targetPath);
+  let existing: ClaudeSettings = {};
+  if (fileExistedBefore) {
+    try {
+      const raw = readFileSync(targetPath, 'utf-8');
+      existing = raw.trim() ? (JSON.parse(raw) as ClaudeSettings) : {};
+    } catch (err) {
+      // Corrupt JSON shouldn't silently destroy the user's file. Abort with
+      // a clear error that the caller can surface.
+      throw new Error(
+        `Cannot parse existing ${targetPath}: ${(err as Error).message}. ` +
+        `Fix or remove the file and re-run.`
+      );
+    }
+  }
+
+  const result: MergeResult = {
+    target: targetPath,
+    fileExistedBefore,
+    hooksInstalled: 0,
+    hooksAlreadyPresent: 0,
+    hooksSkipped: 0,
+    permissionsAdded: 0,
+    statusLineInstalled: false,
+    statusLineKept: false,
+    warnings: [],
+  };
+
+  const merged: ClaudeSettings = { ...existing };
+
+  // --- permissions.allow: union ---
+  if (agentSettings.permissions?.allow?.length) {
+    const existingAllow = Array.isArray(merged.permissions?.allow) ? merged.permissions!.allow! : [];
+    const existingSet = new Set(existingAllow);
+    const toAdd = agentSettings.permissions.allow.filter(p => !existingSet.has(p));
+    if (toAdd.length) {
+      merged.permissions = {
+        ...(merged.permissions ?? {}),
+        allow: [...existingAllow, ...toAdd],
+      };
+      result.permissionsAdded = toAdd.length;
+    }
+  }
+
+  // --- hooks: per-event, per-matcher safe merge ---
+  if (agentSettings.hooks) {
+    const mergedHooks: Record<string, HookEntry[]> = { ...(merged.hooks ?? {}) };
+    for (const [event, ourEntries] of Object.entries(agentSettings.hooks)) {
+      if (!Array.isArray(ourEntries)) continue;
+      const existingEntries = Array.isArray(mergedHooks[event]) ? [...mergedHooks[event]] : [];
+
+      // Index existing entries by matcher for O(1) lookup
+      const existingByMatcher = new Map<string, HookEntry>();
+      for (const entry of existingEntries) {
+        existingByMatcher.set(matcherKey(entry.matcher), entry);
+      }
+
+      for (const ourEntry of ourEntries) {
+        if (!Array.isArray(ourEntry.hooks)) continue;
+        const key = matcherKey(ourEntry.matcher);
+        const existingEntry = existingByMatcher.get(key);
+
+        if (!existingEntry) {
+          existingEntries.push(ourEntry);
+          result.hooksInstalled += 1;
+          existingByMatcher.set(key, ourEntry);
+          continue;
+        }
+
+        // Existing entry for this matcher — check each of OUR hooks against
+        // theirs. Identical command = no-op. Different command = skip + warn
+        // (do NOT overwrite user customization silently).
+        const existingCommands = new Set(
+          (existingEntry.hooks ?? []).map(h => `${h.type}::${h.command}`)
+        );
+        let allOursAlreadyPresent = true;
+        for (const ourHook of ourEntry.hooks) {
+          const sig = `${ourHook.type}::${ourHook.command}`;
+          if (!existingCommands.has(sig)) {
+            allOursAlreadyPresent = false;
+            break;
+          }
+        }
+
+        if (allOursAlreadyPresent) {
+          result.hooksAlreadyPresent += 1;
+          continue;
+        }
+
+        // User has their own command under the same matcher and ours isn't
+        // present. Refuse to mutate the array — warn so they can reconcile.
+        const matcherLabel = ourEntry.matcher ?? '(no matcher)';
+        const ourCommands = ourEntry.hooks.map(h => h.command).join(', ');
+        result.hooksSkipped += 1;
+        result.warnings.push(
+          `${event} hook with matcher "${matcherLabel}" already exists with a different command. ` +
+          `Skipped installing cortextOS hook: ${ourCommands}. ` +
+          `Edit ${targetPath} to resolve, or remove the conflicting entry and re-run.`
+        );
+      }
+
+      mergedHooks[event] = existingEntries;
+    }
+    merged.hooks = mergedHooks;
+  }
+
+  // --- statusLine ---
+  if (agentSettings.statusLine) {
+    const ours = agentSettings.statusLine;
+    const theirs = merged.statusLine;
+    if (!theirs) {
+      merged.statusLine = ours;
+      result.statusLineInstalled = true;
+    } else if (theirs.type === ours.type && theirs.command === ours.command) {
+      result.hooksAlreadyPresent += 1; // already matches
+    } else {
+      result.statusLineKept = true;
+      result.warnings.push(
+        `statusLine already set to "${theirs.command}" (type=${theirs.type}). ` +
+        `Kept existing value. cortextOS statusLine not installed. ` +
+        `Edit ${targetPath} to switch.`
+      );
+    }
+  }
+
+  writeFileSync(targetPath, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
+  return result;
+}

--- a/tests/unit/utils/merge-settings.test.ts
+++ b/tests/unit/utils/merge-settings.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Unit tests for mergeAgentSettingsIntoWorkingDir.
+ *
+ * Background: `cortextos add-agent --working-directory <path>` installs the
+ * agent's hooks into `<path>/.claude/settings.local.json` so Claude Code
+ * picks them up when it runs with cwd = <path>. The merge must be safe:
+ * preserve user-owned customizations, refuse to overwrite conflicting hooks,
+ * stay idempotent on re-runs.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { mergeAgentSettingsIntoWorkingDir, ClaudeSettings } from '../../../src/utils/merge-settings';
+
+const AGENT_SETTINGS: ClaudeSettings = {
+  permissions: { allow: ['Bash', 'Read', 'Edit', 'Write', 'WebFetch', 'WebSearch'] },
+  hooks: {
+    PermissionRequest: [
+      {
+        matcher: 'ExitPlanMode',
+        hooks: [{ type: 'command', command: 'cortextos bus hook-planmode-telegram', timeout: 1860 }],
+      },
+      {
+        hooks: [{ type: 'command', command: 'cortextos bus hook-permission-telegram', timeout: 1860 }],
+      },
+    ],
+    PreToolUse: [
+      {
+        matcher: 'AskUserQuestion',
+        hooks: [{ type: 'command', command: 'cortextos bus hook-ask-telegram', timeout: 10 }],
+      },
+    ],
+    Stop: [{ hooks: [{ type: 'command', command: 'cortextos bus hook-idle-flag', timeout: 5 }] }],
+  },
+  statusLine: { type: 'command', command: 'bash /framework/bus/hook-statusline.sh' },
+};
+
+describe('mergeAgentSettingsIntoWorkingDir', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'merge-settings-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  const readResult = (): ClaudeSettings =>
+    JSON.parse(readFileSync(join(tempDir, '.claude', 'settings.local.json'), 'utf-8')) as ClaudeSettings;
+
+  it('creates .claude/settings.local.json from scratch when the working dir is empty', () => {
+    const result = mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+
+    expect(result.fileExistedBefore).toBe(false);
+    expect(result.hooksInstalled).toBe(4); // 2 PermissionRequest + 1 PreToolUse + 1 Stop
+    expect(result.hooksSkipped).toBe(0);
+    expect(result.statusLineInstalled).toBe(true);
+    expect(result.warnings).toEqual([]);
+
+    const written = readResult();
+    expect(written.permissions?.allow).toContain('Bash');
+    expect(written.hooks?.PermissionRequest).toHaveLength(2);
+    expect(written.statusLine?.command).toContain('hook-statusline.sh');
+  });
+
+  it('is idempotent — re-running the same merge produces no changes and no warnings', () => {
+    mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+    const snapshot = readResult();
+
+    const second = mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+    expect(second.fileExistedBefore).toBe(true);
+    expect(second.hooksInstalled).toBe(0);
+    expect(second.hooksAlreadyPresent).toBeGreaterThanOrEqual(4);
+    expect(second.hooksSkipped).toBe(0);
+    expect(second.warnings).toEqual([]);
+
+    expect(readResult()).toEqual(snapshot);
+  });
+
+  it('preserves user-owned keys not touched by the agent settings', () => {
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'settings.local.json'),
+      JSON.stringify(
+        {
+          mcpServers: { custom: { command: 'my-mcp' } },
+          customKey: { foo: 'bar' },
+          permissions: { allow: ['Grep'] },
+        },
+        null,
+        2
+      )
+    );
+
+    mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+    const written = readResult() as any;
+
+    expect(written.mcpServers.custom.command).toBe('my-mcp');
+    expect(written.customKey.foo).toBe('bar');
+    // permissions.allow should be union
+    expect(written.permissions.allow).toContain('Grep');
+    expect(written.permissions.allow).toContain('Bash');
+  });
+
+  it('skips + warns when user has the same matcher with a DIFFERENT command', () => {
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'settings.local.json'),
+      JSON.stringify(
+        {
+          hooks: {
+            PreToolUse: [
+              {
+                matcher: 'AskUserQuestion',
+                hooks: [{ type: 'command', command: 'my-custom-ask-hook.sh', timeout: 30 }],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      )
+    );
+
+    const result = mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+
+    expect(result.hooksSkipped).toBeGreaterThanOrEqual(1);
+    expect(result.warnings.length).toBeGreaterThanOrEqual(1);
+    expect(result.warnings[0]).toContain('AskUserQuestion');
+    expect(result.warnings[0]).toContain('hook-ask-telegram');
+
+    // User's custom hook is untouched
+    const written = readResult();
+    const ask = written.hooks?.PreToolUse?.find(e => e.matcher === 'AskUserQuestion');
+    expect(ask?.hooks[0].command).toBe('my-custom-ask-hook.sh');
+
+    // But our OTHER hooks still installed
+    expect(written.hooks?.PermissionRequest).toBeDefined();
+    expect(written.hooks?.Stop).toBeDefined();
+  });
+
+  it('keeps the user statusLine and warns when it differs from ours', () => {
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(
+      join(tempDir, '.claude', 'settings.local.json'),
+      JSON.stringify(
+        { statusLine: { type: 'command', command: 'my-custom-statusline.sh' } },
+        null,
+        2
+      )
+    );
+
+    const result = mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+
+    expect(result.statusLineInstalled).toBe(false);
+    expect(result.statusLineKept).toBe(true);
+    expect(result.warnings.some(w => w.includes('statusLine'))).toBe(true);
+
+    const written = readResult();
+    expect(written.statusLine?.command).toBe('my-custom-statusline.sh');
+  });
+
+  it('creates .claude subdirectory if it does not exist', () => {
+    expect(existsSync(join(tempDir, '.claude'))).toBe(false);
+    mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+    expect(existsSync(join(tempDir, '.claude'))).toBe(true);
+    expect(existsSync(join(tempDir, '.claude', 'settings.local.json'))).toBe(true);
+  });
+
+  it('throws a clear error if the existing settings.local.json is unparseable', () => {
+    mkdirSync(join(tempDir, '.claude'), { recursive: true });
+    writeFileSync(join(tempDir, '.claude', 'settings.local.json'), '{ this is not json');
+
+    expect(() => mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS)).toThrow(
+      /Cannot parse existing .*settings\.local\.json/
+    );
+  });
+
+  it('handles agent settings with no hooks / no statusLine (graceful partial)', () => {
+    const minimal: ClaudeSettings = { permissions: { allow: ['Bash'] } };
+    const result = mergeAgentSettingsIntoWorkingDir(tempDir, minimal);
+    expect(result.hooksInstalled).toBe(0);
+    expect(result.statusLineInstalled).toBe(false);
+    expect(result.permissionsAdded).toBe(1);
+    expect(result.warnings).toEqual([]);
+
+    const written = readResult();
+    expect(written.permissions?.allow).toEqual(['Bash']);
+  });
+
+  it('treats entries with no matcher as a single bucket (no-matcher matcher key)', () => {
+    // Ensure the no-matcher entry from PermissionRequest also installs cleanly.
+    const result = mergeAgentSettingsIntoWorkingDir(tempDir, AGENT_SETTINGS);
+    expect(result.warnings).toEqual([]);
+
+    const written = readResult();
+    const noMatcher = written.hooks?.PermissionRequest?.find(e => e.matcher === undefined);
+    expect(noMatcher).toBeDefined();
+    expect(noMatcher?.hooks[0].command).toBe('cortextos bus hook-permission-telegram');
+  });
+});


### PR DESCRIPTION
## Summary

- Agents spawned with `working_directory` pointing outside their agent dir silently lose all cortextOS hooks — Claude Code reads `.claude/settings.json` from cwd, not agent dir. Hit in production when Max had to be manually patched.
- New flag `cortextos add-agent --working-directory <path>` merges the agent's hooks into `<path>/.claude/settings.local.json` (gitignored layer, never touches the user's own `settings.json`).
- Per-matcher, per-command safe merge: idempotent re-runs, user customizations preserved, conflicts skip + warn instead of overwrite.

## Scope

In:
- `src/cli/add-agent.ts` — new `--working-directory` option, persists to agent `config.json`, calls merge helper, prints summary + warnings.
- `src/utils/merge-settings.ts` — pure helper with union merge on `permissions.allow`, per-matcher hook merge with conflict detection, `statusLine` rule, clear error on corrupt existing JSON.
- `tests/unit/utils/merge-settings.test.ts` — 9 tests.

Out (filed as follow-ups):
- Daemon-side self-heal if `settings.local.json` goes missing at spawn time.
- `cortextos agent sync-hooks <name>` for post-creation template updates.
- Retrofit for agents already misconfigured via manual `config.json` edit.

## Conflict behavior

If `<workingDir>/.claude/settings.local.json` already has a hook under one of our matchers with a DIFFERENT command, we **skip that one hook** and emit a warning to stdout pointing at the file to edit. The other hooks still install. `statusLine` follows the same rule. This was the explicit call from the reviewing orchestrator: do not silently overwrite user customizations; prefer a visible warning over a `--force` flag.

## Test plan

- [x] `npm run build` — clean
- [x] `npm run typecheck` — clean
- [x] `npm test` — 626/626 pass (43 test files, 9 new)
- [x] Manual E2E: throwaway agent with `--working-directory` pointing at an empty dir → file created with all 6 hooks
- [x] Manual E2E: throwaway agent with `--working-directory` pointing at a dir pre-seeded with a conflicting `AskUserQuestion` hook + custom `statusLine` + user `mcpServers` key → conflict hook skipped with warning, custom `statusLine` kept with warning, user `mcpServers` preserved, other 5 hooks installed
- [ ] Reviewer to verify the help text for `--working-directory` is clear
- [ ] Reviewer to sanity-check that writing to `settings.local.json` (not `settings.json`) matches cortextOS convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)