### PR TITLE
feat(skills): services health check in morning review (Phase 0E)

### DIFF
--- a/community/skills/morning-review/SKILL.md
+++ b/community/skills/morning-review/SKILL.md
@@ -89,6 +89,57 @@ cortextos bus complete-task "$TASK_ID" --result "<what was produced>"
 
 ---
 
+## Phase 0E: Services Health Check
+
+Probe each configured external service BEFORE the briefing. Auth failures discovered here get into the briefing as actionable items — not discovered 3 hours later when the user needs the service.
+
+**For each service, run the probe. If it fails, create a [HUMAN] task immediately.**
+
+### Google Calendar
+```bash
+# Try listing 1 event via MCP. If the tool errors or returns auth failure:
+gcal_list_events (limit 1)
+```
+- **OK**: note "GCal OK" for the briefing
+- **FAIL**: create a human task and flag it:
+  ```bash
+  cortextos bus create-task "[HUMAN] Google Calendar reauth needed — OAuth token expired or revoked" \
+    --desc "GCal probe failed during morning review. Reauth at https://accounts.google.com. Agents cannot create/read calendar events until fixed." \
+    --priority high --assignee human
+  ```
+
+### Notion
+```bash
+# Try a trivial search via MCP
+notion-search (query: "test", page_size: 1)
+```
+- **OK**: note "Notion OK"
+- **FAIL**: create human task with reauth instructions
+
+### Knowledge Base
+```bash
+cortextos bus kb-query "health check" --org $CTX_ORG
+```
+- **OK or empty results**: note "KB configured"
+- **Not configured warning**: note "KB not configured" (informational, not a failure)
+
+### Telegram
+Already implicitly validated by the boot message in Phase 0. If the boot message failed to send, the agent would not have reached this phase.
+
+### Briefing integration
+Include a **Services** line in Message 1 of the briefing:
+```
+Services: GCal OK | Notion OK | KB configured
+```
+Or if any failed:
+```
+Services: GCal FAILED (reauth needed — task created) | Notion OK | KB not configured
+```
+
+Auth failures are the "silent productivity killer" class — everything looks healthy on the dashboard but the agent can't do real work. This check surfaces them proactively.
+
+---
+
 ## Phase 1: Goals Cascade (MANDATORY — before task scheduling)
 
 ### 1A: Read org goals

--- a/templates/orchestrator/.claude/skills/morning-review/SKILL.md
+++ b/templates/orchestrator/.claude/skills/morning-review/SKILL.md
@@ -88,6 +88,55 @@ cortextos bus complete-task "$TASK_ID" --result "<what was produced>"
 
 ---
 
+## Phase 0E: Services Health Check
+
+Probe each configured external service BEFORE the briefing. Auth failures discovered here get into the briefing as actionable items — not discovered hours later when the user needs the service.
+
+**For each service, run the probe. If it fails, create a [HUMAN] task immediately.**
+
+### Google Calendar
+```bash
+# Try listing 1 event via MCP. If the tool errors or returns auth failure:
+gcal_list_events (limit 1)
+```
+- **OK**: note "GCal OK" for the briefing
+- **FAIL**: create a human task:
+  ```bash
+  cortextos bus create-task "[HUMAN] Google Calendar reauth needed — OAuth token expired or revoked" \
+    --desc "GCal probe failed during morning review. Reauth at https://accounts.google.com. Agents cannot create/read calendar events until fixed." \
+    --priority high --assignee human
+  ```
+
+### Notion
+```bash
+# Try a trivial search via MCP
+notion-search (query: "test", page_size: 1)
+```
+- **OK**: note "Notion OK"
+- **FAIL**: create human task with reauth instructions
+
+### Knowledge Base
+```bash
+cortextos bus kb-query "health check" --org $CTX_ORG
+```
+- **OK or empty results**: note "KB configured"
+- **Not configured warning**: note "KB not configured" (informational, not a failure)
+
+### Telegram
+Already implicitly validated by the boot message. If it failed, the agent would not have reached this phase.
+
+### Briefing integration
+Include a **Services** line in Message 1:
+```
+Services: GCal OK | Notion OK | KB configured
+```
+Or if any failed:
+```
+Services: GCal FAILED (reauth needed — task created) | Notion OK | KB not configured
+```
+
+---
+
 ## Phase 1: Goals Cascade (MANDATORY — before task scheduling)
 
 ### 1A: Read org goals


### PR DESCRIPTION
## Summary

Adds a services health check step (Phase 0E) to the morning review skill. Probes external service auth before the briefing so failures surface proactively — not hours later when the user needs the service.

## Problem

External service auth (Google Calendar OAuth, Notion API, etc.) can expire silently overnight. The dashboard shows agents as healthy, tasks are completing, but when the user asks for a calendar update, the auth is dead. This check catches that failure at morning review time and creates an actionable [HUMAN] task.

## Services probed

| Service | Probe | On failure |
|---------|-------|-----------|
| Google Calendar | `gcal_list_events` (1 event, MCP) | Creates `[HUMAN]` task with reauth URL |
| Notion | `notion-search` (trivial query, MCP) | Creates `[HUMAN]` task |
| Knowledge Base | `cortextos bus kb-query` | Notes "not configured" (informational) |
| Telegram | Implicit (boot message) | Already caught before this phase |

## Briefing integration

Message 1 gets a "Services:" line:
```
Services: GCal OK | Notion OK | KB configured
Services: GCal FAILED (reauth needed — task created) | Notion OK | KB not configured
```

## Files changed

- `community/skills/morning-review/SKILL.md` — canonical skill
- `templates/orchestrator/.claude/skills/morning-review/SKILL.md` — template

## Breaking changes

None. Additive phase between Phase 0D and Phase 1.