### PR TITLE
docs: Agent Awareness Standard + PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+<!-- 1-3 sentences: what changed and why -->
+
+## Test plan
+<!-- How to verify this change works -->
+
+## Checklist
+
+- [ ] `npm run build` passes
+- [ ] `npm test` passes
+- [ ] No new secrets or credentials committed
+- [ ] **Agent Awareness:** if this adds a command, endpoint, hook, or behavior change — updated the relevant `templates/*/CLAUDE.md` template(s)
+- [ ] **Migration Parity:** if this changes agent-installed files (hooks, settings.json defaults, CLAUDE.md sections) — existing agents will receive the change on next restart, not just new agents via `init`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,20 @@ Once approved, `review_status` will be set to `"approved"` and the item will app
 
 ---
 
+## Agent Awareness Standard
+
+cortextOS agents discover features through their CLAUDE.md template. A feature that exists in code but isn't mentioned in the agent template is invisible — no agent will ever use it.
+
+**Before merging any feature PR**, verify:
+
+- [ ] **Does this feature add a new bus command, CLI command, or API endpoint?** If yes, add it to `templates/agent/CLAUDE.md` (and `templates/orchestrator/CLAUDE.md`, `templates/analyst/CLAUDE.md`, `templates/security/CLAUDE.md` if applicable) with a usage example.
+- [ ] **Does this feature change agent behavior or add a new hook?** If yes, update the relevant template's session-start or workflow section.
+- [ ] **Does this feature add or modify a skill?** If yes, ensure the skill's `SKILL.md` has a current `description` and `triggers` list so agents know when to load it.
+
+A feature without a template update ships dark. If you're unsure whether a template update is needed, it is.
+
+---
+
 ## Questions
 
 Open a GitHub issue or message the cortextOS community channel.


### PR DESCRIPTION
## Summary

Adds two process-level guardrails for feature contributions:

1. **CONTRIBUTING.md** — new "Agent Awareness Standard" section appended before the Questions footer. Every feature PR must verify that new commands, hooks, or skills have a corresponding template update. A feature without a template update ships dark.

2. **`.github/PULL_REQUEST_TEMPLATE.md`** — new file. GitHub auto-populates PR descriptions from this template. Includes standard fields (summary, test plan) plus two checklist items:
   - **Agent Awareness**: did you update `templates/*/CLAUDE.md`?
   - **Migration Parity**: will existing agents get this change on restart?

## Test plan

- [x] CONTRIBUTING.md renders correctly with the new section
- [x] `.github/PULL_REQUEST_TEMPLATE.md` is valid markdown
- [ ] Open a test PR and verify GitHub auto-populates the description from the template

## Checklist

- [x] No build/test impact (docs only)
- [x] No new secrets or credentials committed
- [x] **Agent Awareness:** N/A (this IS the awareness standard)
- [x] **Migration Parity:** N/A (docs only)