### PR TITLE
fix(scripts): auto-install dashboard deps before vitest

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",
+    "pretest": "node scripts/ensure-dashboard-deps.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "typecheck": "tsc --noEmit",

--- a/scripts/ensure-dashboard-deps.mjs
+++ b/scripts/ensure-dashboard-deps.mjs
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+// Ensures dashboard/node_modules exists before running tests.
+//
+// vitest.config.ts includes `dashboard/src/**/__tests__/**/*.test.ts` in
+// the root test suite. Those tests import from dashboard/node_modules
+// (better-sqlite3, next/server, etc.), which the root `npm install` does
+// NOT populate. CI installs them in a separate step
+// (`npm ci --prefix dashboard`); this script keeps local `npm test` in
+// sync so a fresh clone + `npm install` + `npm test` passes without the
+// contributor having to know about the two-package-lockfile layout.
+
+import { existsSync } from 'node:fs';
+import { execSync } from 'node:child_process';
+
+if (!existsSync('dashboard/node_modules')) {
+  console.log('[ensure-dashboard-deps] dashboard/node_modules missing — installing …');
+  execSync('npm install --prefix dashboard', { stdio: 'inherit' });
+}


### PR DESCRIPTION
## Problem

On a fresh clone, `npm install && npm test` fails with 2 import-error suites:

```
 FAIL  dashboard/src/lib/__tests__/sync.test.ts
Error: Cannot find package 'better-sqlite3' imported from
/Users/…/cortextos/dashboard/src/lib/db.ts

 FAIL  dashboard/src/app/api/comms/__tests__/routes.test.ts
Error: Cannot find package 'next/server' imported from
/Users/…/cortextos/dashboard/src/app/api/comms/__tests__/routes.test.ts

 Test Files  2 failed | 41 passed (43)
      Tests  604 passed | 17 skipped (621)
```

Root cause: `vitest.config.ts` includes `dashboard/src/**/__tests__/**/*.test.ts` in the root test suite (with `@` → `dashboard/src` alias), and those tests import from `dashboard/node_modules/` (`better-sqlite3`, `next/server`, etc.). But root `npm install` installs daemon deps only; `dashboard/node_modules/` is populated separately — `.github/workflows/ci.yml` does it as a second step (`npm ci --prefix dashboard`) before `npm test`, but no equivalent runs locally.

This also trips the `pre-push` hook installed by `scripts/setup-hooks.sh`, which calls `npm test`; new contributors hit a failing push on their first attempt.

## Fix

Add a `pretest` script that ensures `dashboard/node_modules/` exists, mirroring what CI does. `scripts/ensure-dashboard-deps.mjs` installs only if the directory is missing, so repeat `npm test` runs are no-ops.

```diff
-    "test": "vitest run",
+    "pretest": "node scripts/ensure-dashboard-deps.mjs",
+    "test": "vitest run",
```

No new dependencies, no change to daemon/CLI install surface — the extra install only runs on first `npm test` after a fresh clone.

## Verification

Clean-room test — delete `dashboard/node_modules` and run `npm test`:

**Before this PR:**
```
 Test Files  2 failed | 41 passed (43)
      Tests  604 passed | 17 skipped (621)
```

**After this PR:**
```
> cortextos@0.1.1 pretest
> node scripts/ensure-dashboard-deps.mjs

[ensure-dashboard-deps] dashboard/node_modules missing — installing …
added 830 packages, and audited 831 packages in 8s

> cortextos@0.1.1 test
> vitest run

 Test Files  43 passed (43)
      Tests  632 passed (632)
```

Second run confirms no-op when deps are present:
```
> cortextos@0.1.1 pretest
> node scripts/ensure-dashboard-deps.mjs
> cortextos@0.1.1 test
> vitest run

 Test Files  43 passed (43)
      Tests  632 passed (632)
```

## Alternatives considered

- `postinstall` on root → installs dashboard deps even for CLI-only users (slower default install).
- Shell one-liner (`[ -d dashboard/node_modules ] || …`) → not cross-platform.
- Update `pre-push` hook only → doesn't help contributors who run `npm test` directly.
- Add ensure call to `test`, `test:watch`, `test:playwright` individually → possible follow-up; this PR fixes the reported break (`npm test`) with the minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)