### PR TITLE
fix(daemon): skip type=disabled cron entries in gap detector and verification

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -622,7 +622,7 @@ export class AgentProcess {
     if (!crons || crons.length === 0) return;
 
     const recurringNames = crons
-      .filter(c => c.type !== 'once')
+      .filter(c => c.type !== 'once' && c.type !== 'disabled')
       .map(c => c.name);
     if (recurringNames.length === 0) return;
 
@@ -647,7 +647,7 @@ export class AgentProcess {
 
     // Only monitor recurring crons with a parseable interval (skip cron expressions)
     const monitorable = crons.filter(
-      c => c.type !== 'once' && c.interval && !isNaN(parseDurationMs(c.interval)),
+      c => c.type !== 'once' && c.type !== 'disabled' && c.interval && !isNaN(parseDurationMs(c.interval)),
     );
     if (monitorable.length === 0) return;
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -183,7 +183,7 @@ export interface CronEntry {
   prompt: string;
   /** "recurring" (default) restores on every session start.
    *  "once" restores only if fire_at is still in the future; deleted after firing. */
-  type?: 'recurring' | 'once';
+  type?: 'recurring' | 'once' | 'disabled';
 }
 
 export interface OrgContext {

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -271,6 +271,26 @@ describe('AgentProcess - cron auto-verification', () => {
     expect(mockInjectMessage).not.toHaveBeenCalled();
   });
 
+  it('scheduleCronVerification() is a no-op when config has only disabled crons', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {
+      crons: [{ name: 'paused-job', type: 'disabled' as const, interval: '1h', prompt: 'test' }],
+    });
+    await ap.start();
+    ap.scheduleCronVerification();
+    await new Promise(r => setTimeout(r, 100));
+    expect(mockInjectMessage).not.toHaveBeenCalled();
+  });
+
+  it('scheduleGapDetection() is a no-op when config has only disabled crons', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {
+      crons: [{ name: 'paused-job', type: 'disabled' as const, interval: '1h', prompt: 'test' }],
+    });
+    await ap.start();
+    ap.scheduleGapDetection();
+    await new Promise(r => setTimeout(r, 100));
+    expect(mockInjectMessage).not.toHaveBeenCalled();
+  });
+
   it('scheduleCronVerification() schedules verification when config has recurring crons', async () => {
     const ap = new AgentProcess('alice', mockEnv, {
       crons: [


### PR DESCRIPTION
## Summary

- Cron entries with `type=disabled` in `config.json` were passing through the `scheduleGapDetection()` and `scheduleCronVerification()` filter expressions, which only excluded `type=once`
- This caused gap-nudge messages to fire every 10 minutes for intentionally disabled crons
- Fix adds `c.type !== 'disabled'` to both filter sites and `'disabled'` to the `CronEntry` type union
- Two regression tests added alongside the existing `type=once` no-op tests

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 752/752 pass (2 new tests added)
- [x] Existing `scheduleCronVerification()` once no-op test still passes
- [x] New: `scheduleCronVerification()` is a no-op for disabled crons
- [x] New: `scheduleGapDetection()` is a no-op for disabled crons

🤖 Generated with [Claude Code](https://claude.com/claude-code)