### PR TITLE
fix(telegram): switch to HTML parse mode — eliminates silent content drops

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -958,7 +958,6 @@ busCommand
     const api = new TelegramAPI(botToken);
     try {
       let sentMessageId = 0;
-      let parseFallbackReason: string | null = null;
       if (opts.image) {
         const result = await api.sendPhoto(chatId, opts.image, message);
         sentMessageId = result?.result?.message_id ?? 0;
@@ -967,10 +966,7 @@ busCommand
         sentMessageId = result?.result?.message_id ?? 0;
       } else {
         const result = await api.sendMessage(chatId, message, undefined, {
-          parseMode: opts.plainText ? null : 'Markdown',
-          onParseFallback: (reason) => {
-            parseFallbackReason = reason;
-          },
+          parseMode: opts.plainText ? null : 'HTML',
         });
         sentMessageId = result?.result?.message_id ?? 0;
       }
@@ -979,9 +975,7 @@ busCommand
       const env = resolveEnv();
       if (env.agentName && env.ctxRoot) {
         logOutboundMessage(env.ctxRoot, env.agentName, chatId, message, sentMessageId, {
-          parseMode: opts.plainText ? 'none' : 'markdown',
-          parseFallback: parseFallbackReason !== null,
-          parseFallbackReason: parseFallbackReason ?? undefined,
+          parseMode: opts.plainText ? 'none' : 'html',
         });
         cacheLastSent(env.ctxRoot, env.agentName, chatId, message);
         // Auto-emit activity event so dashboard sees every Telegram send,

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -18,68 +18,105 @@ export class TelegramAPI {
   }
 
   /**
-   * Strip MarkdownV2-style backslash escapes that Telegram Markdown v1 doesn't support.
-   * In v1, only *, _, `, [ are special. Everything else should not be backslash-escaped.
+   * Convert a Markdown-flavored string to Telegram HTML.
+   *
+   * Why HTML instead of Markdown v1: Telegram Markdown v1 silently drops
+   * content when it encounters an unclosed or unrecognised entity (backtick
+   * spans containing `--flags`, `$` before numbers, `_` inside filenames,
+   * etc.). HTML parse mode rejects the whole message with an explicit error
+   * instead — no silent data loss.
+   *
+   * Processing order (matters — do not reorder):
+   *   1. HTML-escape & < > in raw text (& first, then < >). Backticks, *,
+   *      _ are not HTML-special so they survive intact for step 2+.
+   *   2. Fenced code blocks (``` ... ```) → <pre><code>...</code></pre>
+   *   3. Inline code (`...`) → <code>...</code>
+   *   4. Bold (*...*) → <b>...</b>
+   *   5. Italic (_..._) — word-boundary aware to avoid snake_case false positives
+   *
+   * Pass `plainText: true` to skip conversion (just HTML-escape and send raw).
    */
-  private sanitizeMarkdown(text: string): string {
-    // Remove backslash before any char that isn't a Markdown v1 special char or newline
-    return text.replace(/\\([^_*`\[\n])/g, '$1');
+  private markdownToHtml(text: string, plainText = false): string {
+    // Step 1: HTML-escape (& must be first to avoid double-escaping)
+    let html = text
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;');
+
+    if (plainText) return html;
+
+    // Step 2: Fenced code blocks — multiline, processed before inline `
+    html = html.replace(/```(?:\w*\n?)?([\s\S]*?)```/g, (_, code) =>
+      `<pre><code>${code.trimEnd()}</code></pre>`,
+    );
+
+    // Step 3: Inline code — single backtick, no newlines inside
+    html = html.replace(/`([^`\n]+)`/g, '<code>$1</code>');
+
+    // Step 4: Bold — *text* (no newlines, greedy-avoided)
+    html = html.replace(/\*([^*\n]+)\*/g, '<b>$1</b>');
+
+    // Step 5: Italic — _text_ with word-boundary guard (no newlines)
+    html = html.replace(/(?<![_\w])_([^_\n]+)_(?![_\w])/g, '<i>$1</i>');
+
+    return html;
   }
 
   /**
-   * Send a text message. Splits long messages at 4096 chars.
+   * Split HTML text into chunks at paragraph/newline boundaries to avoid
+   * breaking mid-entity. Falls back to hard split only if a single line
+   * exceeds maxLen.
+   */
+  private splitHtml(text: string, maxLen: number): string[] {
+    if (text.length <= maxLen) return [text];
+
+    const chunks: string[] = [];
+    let remaining = text;
+    while (remaining.length > maxLen) {
+      const window = remaining.slice(0, maxLen);
+      // Prefer splitting at a paragraph break (\n\n), then a newline
+      let splitAt = window.lastIndexOf('\n\n');
+      if (splitAt > 0) {
+        splitAt += 2; // include the double-newline in the preceding chunk
+      } else {
+        splitAt = window.lastIndexOf('\n');
+        if (splitAt > 0) splitAt += 1;
+        else splitAt = maxLen; // no newline — hard split as last resort
+      }
+      chunks.push(remaining.slice(0, splitAt));
+      remaining = remaining.slice(splitAt);
+    }
+    if (remaining.length > 0) chunks.push(remaining);
+    return chunks;
+  }
+
+  /**
+   * Send a text message. Converts Markdown to HTML and sends with
+   * `parse_mode: "HTML"`. HTML mode never silently drops content — bad
+   * markup produces an explicit API error rather than invisible text.
    *
-   * Markdown parse behavior:
+   * Pass `{ parseMode: null }` to send plain text (no formatting, no
+   * conversion). Useful for raw log output or user-supplied text that
+   * should not be interpreted as Markdown.
    *
-   * - By default, each chunk is sent with `parse_mode: "Markdown"` (Telegram
-   *   v1 Markdown). If the Telegram API rejects the chunk with a
-   *   "can't parse entities" error — usually because the text contains an
-   *   unescaped `_`, `*`, backtick, or `[` that Telegram interprets as the
-   *   start of an entity it cannot close — sendMessage catches the error,
-   *   logs a one-line stderr warning, and automatically RETRIES that chunk
-   *   ONCE with `parse_mode` omitted (plain text). This is the safety net
-   *   for agents generating natural prose that happens to look like bad
-   *   markdown. If the retry also fails, the error is rethrown so callers
-   *   still see real failures.
-   *
-   * - Callers who KNOW their message contains unescaped special characters
-   *   can opt out of parsing entirely by passing `{ parseMode: null }`.
-   *   This skips the first Markdown attempt, avoids the retry roundtrip,
-   *   and suppresses the warning. Useful for `cortextos bus send-telegram
-   *   --plain-text` and any agent message known to carry literal code,
-   *   error output, or user-supplied text.
-   *
-   * - Other error classes (401 bad_token, 400 chat_not_found, 403
-   *   bot_recipient, network failures) do NOT trigger the retry. Only
-   *   parse-entity failures are recoverable here — everything else is a
-   *   real config problem that callers need to see.
+   * Long messages are split at paragraph/newline boundaries (not raw char
+   * offsets) so formatting entities are never cut mid-span.
    */
   async sendMessage(
     chatId: string | number,
     text: string,
     replyMarkup?: object,
     opts?: {
-      parseMode?: 'Markdown' | null;
+      parseMode?: 'HTML' | null;
       onParseFallback?: (reason: string) => void;
     },
   ): Promise<any> {
-    const sanitized = this.sanitizeMarkdown(text);
-    // Rate limit: 1 message per second per chat
+    const plainText = opts?.parseMode === null;
+    const html = this.markdownToHtml(text, plainText);
+
     await this.rateLimit(String(chatId));
 
-    const requestedParseMode: 'Markdown' | null = opts?.parseMode === null ? null : 'Markdown';
-
-    // Split long messages. Always produces at least one chunk (even if the
-    // input is empty, which preserves the old behavior of POSTing once).
-    const maxLen = 4096;
-    const chunks: string[] = [];
-    if (sanitized.length <= maxLen) {
-      chunks.push(sanitized);
-    } else {
-      for (let i = 0; i < sanitized.length; i += maxLen) {
-        chunks.push(sanitized.slice(i, i + maxLen));
-      }
-    }
+    const chunks = this.splitHtml(html, 4096);
 
     let lastResult: any;
     for (let i = 0; i < chunks.length; i++) {
@@ -88,31 +125,21 @@ export class TelegramAPI {
       lastResult = await this.sendChunk(
         chatId,
         chunk,
-        requestedParseMode,
+        plainText ? null : 'HTML',
         isLastChunk ? replyMarkup : undefined,
-        (reason) => {
-          // Default observability: one-line stderr warning, plus forward to
-          // the caller's hook if they supplied one (outbound log augmentation
-          // uses this path).
-          console.warn(`[telegram] parse-mode fallback for chat ${chatId}: ${reason}`);
-          opts?.onParseFallback?.(reason);
-        },
       );
     }
     return lastResult;
   }
 
   /**
-   * Send a single chunk with the given parse mode, with a one-shot retry
-   * on parse-entity failures. Extracted so the multi-chunk path can reuse
-   * the same retry logic without duplicating the try/catch.
+   * Send a single chunk with the given parse mode.
    */
   private async sendChunk(
     chatId: string | number,
     text: string,
-    parseMode: 'Markdown' | null,
+    parseMode: 'HTML' | null,
     replyMarkup: object | undefined,
-    onFallback: (reason: string) => void,
   ): Promise<any> {
     const basePayload: Record<string, unknown> = {
       chat_id: chatId,
@@ -120,27 +147,15 @@ export class TelegramAPI {
       ...(replyMarkup ? { reply_markup: replyMarkup } : {}),
     };
 
-    // First attempt: honor the caller's requested parse mode.
-    const firstPayload =
+    const payload =
       parseMode === null ? basePayload : { ...basePayload, parse_mode: parseMode };
 
     try {
-      return await this.post('sendMessage', firstPayload);
+      return await this.post('sendMessage', payload);
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err);
-      // Only retry for Telegram parse-entity errors. Any other failure
-      // (401, 400, 403, network) must surface to the caller unchanged.
-      if (parseMode !== null && /can'?t parse entities|parse entit/i.test(msg)) {
-        onFallback(msg);
-        // Retry with parse_mode omitted (plain text).
-        return await this.post('sendMessage', basePayload);
-      }
       // self_chat safety net: a 403 "bots can't send messages to bots" at
-      // sendMessage time means CHAT_ID likely equals the bot's own user id
-      // (pasted from the BOT_TOKEN prefix during setup). Emit a one-time
-      // diagnostic per chat_id per process so operators see a clear pointer
-      // even when the agent was provisioned before the config-time probe
-      // (validateCredentials) landed. Does NOT change throw behavior.
+      // sendMessage time means CHAT_ID likely equals the bot's own user id.
+      const msg = err instanceof Error ? err.message : String(err);
       if (/bots can'?t send messages to bots/i.test(msg)) {
         const key = String(chatId);
         if (!this.warnedSelfChat.has(key)) {

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -33,6 +33,7 @@ export class TelegramAPI {
    *   3. Inline code (`...`) → <code>...</code>
    *   4. Bold (*...*) → <b>...</b>
    *   5. Italic (_..._) — word-boundary aware to avoid snake_case false positives
+   *   6. Links ([text](url)) → <a href="url">text</a>
    *
    * Pass `plainText: true` to skip conversion (just HTML-escape and send raw).
    */
@@ -58,6 +59,9 @@ export class TelegramAPI {
 
     // Step 5: Italic — _text_ with word-boundary guard (no newlines)
     html = html.replace(/(?<![_\w])_([^_\n]+)_(?![_\w])/g, '<i>$1</i>');
+
+    // Step 6: Links — [text](url). URL may contain HTML-escaped & (&amp;) which is fine.
+    html = html.replace(/\[([^\]]+)\]\((https?:\/\/[^)]+)\)/g, '<a href="$2">$1</a>');
 
     return html;
   }

--- a/src/telegram/logging.ts
+++ b/src/telegram/logging.ts
@@ -39,9 +39,6 @@ export function logOutboundMessage(
   // stays unchanged for callers that pass nothing (backwards compat).
   const meta: Record<string, unknown> = {};
   if (metadata?.parseMode !== undefined) meta.parse_mode = metadata.parseMode;
-  if (metadata?.parseFallback !== undefined) meta.parse_fallback = metadata.parseFallback;
-  if (metadata?.parseFallbackReason !== undefined)
-    meta.parse_fallback_reason = metadata.parseFallbackReason;
 
   const entry = JSON.stringify({
     timestamp: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),

--- a/src/telegram/logging.ts
+++ b/src/telegram/logging.ts
@@ -12,18 +12,12 @@ import { join, dirname } from 'path';
  * Fields are all optional so existing callers that pass nothing still
  * produce the same JSONL shape as before this extension.
  *
- * - `parseMode`: which parse_mode the first send attempt used. "markdown"
- *   for the default path, "none" when the caller used --plain-text.
- * - `parseFallback`: true iff the first attempt failed with a Telegram
- *   parse-entities error and sendMessage retried with parse_mode omitted.
- * - `parseFallbackReason`: the Telegram error description that triggered
- *   the fallback, when present. Useful for auditing which agents keep
- *   generating bad markdown so we can target them for hardening.
+ * - `parseMode`: which parse_mode the first send attempt used. "html"
+ *   for the default path (Markdown-to-HTML conversion), "none" when the
+ *   caller used --plain-text.
  */
 export interface OutboundLogMetadata {
-  parseMode?: 'markdown' | 'none';
-  parseFallback?: boolean;
-  parseFallbackReason?: string;
+  parseMode?: 'html' | 'none';
 }
 
 /**

--- a/tests/unit/telegram/send-message.test.ts
+++ b/tests/unit/telegram/send-message.test.ts
@@ -49,13 +49,8 @@ afterEach(() => {
   console.warn = originalWarn;
 });
 
-// Strip out the mandatory rate-limit delay so the test suite stays fast.
-// sendMessage() calls rateLimit() which sleeps 0-1000ms per send. Since we
-// only make small test messages the per-chat memory happens not to trip the
-// limit after the first call, but the first call still takes ~0ms.
-
-describe('TelegramAPI.sendMessage parse-mode retry', () => {
-  it('happy path: well-formed markdown sends once with parse_mode=Markdown, no retry, no warning', async () => {
+describe('TelegramAPI.sendMessage HTML mode', () => {
+  it('sends with parse_mode=HTML by default', async () => {
     queue({ status: 200, body: { ok: true, result: { message_id: 111 } } });
 
     const api = new TelegramAPI('111:AAA');
@@ -64,82 +59,72 @@ describe('TelegramAPI.sendMessage parse-mode retry', () => {
     expect(result?.result?.message_id).toBe(111);
     expect(callLog).toHaveLength(1);
     expect(callLog[0].url).toContain('/sendMessage');
-    expect(callLog[0].body.parse_mode).toBe('Markdown');
-    expect(callLog[0].body.text).toBe('hello world');
+    expect(callLog[0].body.parse_mode).toBe('HTML');
     expect(warnLog).toHaveLength(0);
   });
 
-  it('parse-entity error triggers one-shot retry with parse_mode omitted', async () => {
-    // First call: Telegram parse failure. Second call: success.
-    queue({
-      status: 400,
-      body: {
-        ok: false,
-        error_code: 400,
-        description: "Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 42",
-      },
-    });
-    queue({ status: 200, body: { ok: true, result: { message_id: 222 } } });
-
-    const fallbackReasons: string[] = [];
+  it('converts *bold* to <b>bold</b>', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
     const api = new TelegramAPI('111:AAA');
-    const result = await api.sendMessage('chat1', 'prose with a dangling _underscore', undefined, {
-      onParseFallback: (reason) => fallbackReasons.push(reason),
-    });
-
-    expect(result?.result?.message_id).toBe(222);
-    expect(callLog).toHaveLength(2);
-    // First attempt used Markdown:
-    expect(callLog[0].body.parse_mode).toBe('Markdown');
-    // Retry attempt has NO parse_mode field:
-    expect(callLog[1].body).not.toHaveProperty('parse_mode');
-    // Same chat_id and text on both attempts:
-    expect(callLog[1].body.chat_id).toBe('chat1');
-    expect(callLog[1].body.text).toBe('prose with a dangling _underscore');
-    // Exactly one warning emitted, plus the caller's hook fired once:
-    expect(warnLog).toHaveLength(1);
-    expect(warnLog[0]).toMatch(/parse-mode fallback for chat chat1/);
-    expect(fallbackReasons).toHaveLength(1);
-    expect(fallbackReasons[0]).toMatch(/can'?t parse entities/i);
+    await api.sendMessage('chat1', '*hello world*');
+    expect(callLog[0].body.text).toBe('<b>hello world</b>');
   });
 
-  it('parse-entity error AND retry also fails: sendMessage rethrows, no infinite loop', async () => {
-    queue({
-      status: 400,
-      body: { ok: false, error_code: 400, description: "Bad Request: can't parse entities" },
-    });
-    queue({
-      status: 500,
-      body: { ok: false, error_code: 500, description: 'Internal Server Error' },
-    });
-
+  it('converts `inline code` to <code>inline code</code>', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
     const api = new TelegramAPI('111:AAA');
-    await expect(api.sendMessage('chat1', 'bad text')).rejects.toThrow(/Internal Server Error/);
-
-    // Exactly 2 calls — the initial attempt and one retry. Never more.
-    expect(callLog).toHaveLength(2);
-    // Warning was still emitted before the retry attempt (observability).
-    expect(warnLog).toHaveLength(1);
+    await api.sendMessage('chat1', 'run `--runtime` flag');
+    expect(callLog[0].body.text).toBe('run <code>--runtime</code> flag');
   });
 
-  it('non-parse error (401 unauthorized) does NOT trigger retry, fails fast', async () => {
+  it('converts fenced code blocks to <pre><code>', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', '```\nnpm install\n```');
+    expect(callLog[0].body.text).toContain('<pre><code>');
+    expect(callLog[0].body.text).toContain('npm install');
+    expect(callLog[0].body.text).toContain('</code></pre>');
+  });
+
+  it('HTML-escapes & < > in raw text', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', 'cost is $100 & more <info>');
+    expect(callLog[0].body.text).toBe('cost is $100 &amp; more &lt;info&gt;');
+  });
+
+  it('$ signs and numbers are not dropped', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', '$50 budget at $100 hard-block');
+    expect(callLog[0].body.text).toBe('$50 budget at $100 hard-block');
+  });
+
+  it('underscores in filenames/flags are not dropped', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', 'file_name.ts and CTX_ROOT env');
+    // snake_case should NOT be converted to italic
+    expect(callLog[0].body.text).toBe('file_name.ts and CTX_ROOT env');
+  });
+
+  it('non-parse error (401 unauthorized) fails fast, no retry', async () => {
     queue({ status: 401, body: { ok: false, error_code: 401, description: 'Unauthorized' } });
 
     const api = new TelegramAPI('999:BAD');
     await expect(api.sendMessage('chat1', 'test')).rejects.toThrow(/Unauthorized/);
 
-    // Only ONE call — 401 is not recoverable via parse-mode removal.
     expect(callLog).toHaveLength(1);
     expect(warnLog).toHaveLength(0);
   });
 
-  it('opt-in plain-text mode: first call has no parse_mode, no retry, no warning', async () => {
+  it('opt-in plain-text mode: no parse_mode field, no Markdown conversion', async () => {
     queue({ status: 200, body: { ok: true, result: { message_id: 333 } } });
 
     const api = new TelegramAPI('111:AAA');
     const result = await api.sendMessage(
       'chat1',
-      'literal _underscores_ and *asterisks* all over',
+      '*not bold* `not code`',
       undefined,
       { parseMode: null },
     );
@@ -147,91 +132,53 @@ describe('TelegramAPI.sendMessage parse-mode retry', () => {
     expect(result?.result?.message_id).toBe(333);
     expect(callLog).toHaveLength(1);
     expect(callLog[0].body).not.toHaveProperty('parse_mode');
+    // Content is HTML-escaped but not Markdown-converted
+    expect(callLog[0].body.text).toBe('*not bold* `not code`');
     expect(warnLog).toHaveLength(0);
   });
 
-  it('opt-in plain-text mode does NOT retry even if Telegram returns a parse-like error string', async () => {
-    // Edge case: if the caller is in plain-text mode and Telegram still
-    // returns an error that mentions "parse entities" (shouldn't happen
-    // in practice but guards the logic), we must NOT retry — there's no
-    // further parse_mode to strip.
-    queue({
-      status: 400,
-      body: { ok: false, error_code: 400, description: "Bad Request: can't parse entities (weird edge case)" },
-    });
-
-    const api = new TelegramAPI('111:AAA');
-    await expect(
-      api.sendMessage('chat1', 'weird', undefined, { parseMode: null }),
-    ).rejects.toThrow(/parse entities/);
-
-    expect(callLog).toHaveLength(1);
-    expect(warnLog).toHaveLength(0);
-  });
-
-  it('chunked long messages: every chunk respects parseMode=null when opted in', async () => {
-    // 9000-char message → 3 chunks at 4096-char boundary.
-    const longText = 'x'.repeat(9000);
+  it('chunked long messages: splits at newline boundaries, not raw char offsets', async () => {
+    // Build a message with clear paragraph structure so we can verify split point
+    const para = 'x'.repeat(2000) + '\n\n';
+    const longText = para + para + 'z'.repeat(500); // ~4500 chars total
     queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
     queue({ status: 200, body: { ok: true, result: { message_id: 2 } } });
-    queue({ status: 200, body: { ok: true, result: { message_id: 3 } } });
 
     const api = new TelegramAPI('111:AAA');
     const result = await api.sendMessage('chat1', longText, undefined, { parseMode: null });
 
-    expect(callLog).toHaveLength(3);
+    expect(callLog).toHaveLength(2);
+    // Verify the split happened at a newline (first chunk ends with \n\n or similar)
+    expect(callLog[0].body.text.endsWith('\n\n') || callLog[0].body.text.endsWith('\n')).toBe(true);
+    expect(result?.result?.message_id).toBe(2);
+  });
+
+  it('chunked long messages: all chunks use parse_mode=HTML when not plain-text', async () => {
+    const longText = 'a'.repeat(5000);
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    queue({ status: 200, body: { ok: true, result: { message_id: 2 } } });
+
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', longText);
+
+    expect(callLog).toHaveLength(2);
+    for (const call of callLog) {
+      expect(call.body.parse_mode).toBe('HTML');
+    }
+  });
+
+  it('chunked long messages: all chunks omit parse_mode when plain-text', async () => {
+    const longText = 'b'.repeat(5000);
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    queue({ status: 200, body: { ok: true, result: { message_id: 2 } } });
+
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', longText, undefined, { parseMode: null });
+
+    expect(callLog).toHaveLength(2);
     for (const call of callLog) {
       expect(call.body).not.toHaveProperty('parse_mode');
     }
-    // Result is the last chunk's response (backwards-compatible with the
-    // pre-patch behavior).
-    expect(result?.result?.message_id).toBe(3);
-  });
-
-  it('chunked long messages: parse error on chunk 2 triggers retry for that chunk only', async () => {
-    const longText = 'y'.repeat(9000);
-    // chunk 1 ok, chunk 2 parse-fails then ok, chunk 3 ok.
-    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
-    queue({
-      status: 400,
-      body: { ok: false, error_code: 400, description: "Bad Request: can't parse entities" },
-    });
-    queue({ status: 200, body: { ok: true, result: { message_id: 2 } } });
-    queue({ status: 200, body: { ok: true, result: { message_id: 3 } } });
-
-    const api = new TelegramAPI('111:AAA');
-    const result = await api.sendMessage('chat1', longText);
-
-    // 4 total calls: chunk1, chunk2-fail, chunk2-retry, chunk3
-    expect(callLog).toHaveLength(4);
-    expect(callLog[0].body.parse_mode).toBe('Markdown');
-    expect(callLog[1].body.parse_mode).toBe('Markdown');
-    expect(callLog[2].body).not.toHaveProperty('parse_mode'); // retry chunk 2
-    expect(callLog[3].body.parse_mode).toBe('Markdown'); // chunk 3 still Markdown
-    expect(result?.result?.message_id).toBe(3);
-    // One warning for the one fallback.
-    expect(warnLog).toHaveLength(1);
-  });
-
-  it('onParseFallback hook is called exactly once per fallback with the Telegram error message', async () => {
-    queue({
-      status: 400,
-      body: {
-        ok: false,
-        error_code: 400,
-        description: "Bad Request: can't parse entities at byte 99",
-      },
-    });
-    queue({ status: 200, body: { ok: true, result: { message_id: 5 } } });
-
-    const reasons: string[] = [];
-    const api = new TelegramAPI('111:AAA');
-    await api.sendMessage('chat1', 'bad', undefined, {
-      onParseFallback: (r) => reasons.push(r),
-    });
-
-    expect(reasons).toHaveLength(1);
-    expect(reasons[0]).toContain("can't parse entities at byte 99");
   });
 });
 

--- a/tests/unit/telegram/send-message.test.ts
+++ b/tests/unit/telegram/send-message.test.ts
@@ -100,6 +100,13 @@ describe('TelegramAPI.sendMessage HTML mode', () => {
     expect(callLog[0].body.text).toBe('$50 budget at $100 hard-block');
   });
 
+  it('converts [text](url) to <a href="url">text</a>', async () => {
+    queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
+    const api = new TelegramAPI('111:AAA');
+    await api.sendMessage('chat1', 'check [the docs](https://example.com/docs)');
+    expect(callLog[0].body.text).toBe('check <a href="https://example.com/docs">the docs</a>');
+  });
+
   it('underscores in filenames/flags are not dropped', async () => {
     queue({ status: 200, body: { ok: true, result: { message_id: 1 } } });
     const api = new TelegramAPI('111:AAA');


### PR DESCRIPTION
Fixes #179

## Problem

Telegram Markdown v1 silently drops text when it hits a parse error. Backtick spans containing `--flags`, `$` near numbers, `_` in filenames/env vars — any of these can cause Telegram to eat the text without any error. The user sees "Right now only takes , not ." instead of "Right now only takes `--model`, not `--runtime`."

Two compounding bugs:
1. The message chunker split at raw 4096-char offsets, sometimes cutting mid-backtick-span — the resulting malformed chunks were silently dropped
2. Telegram Markdown v1 itself is fragile with many real-world content patterns

## Fix

Switch the entire send layer from Markdown v1 to HTML parse mode:

- **HTML never silently drops** — a bad tag produces an explicit API error, not invisible text
- Added `markdownToHtml()` converter in `TelegramAPI`: `*bold*` → `<b>`, `` `code` `` → `<code>`, fenced blocks → `<pre><code>`, `_italic_` (word-boundary aware), `& < >` → HTML entities
- Fixed chunking: splits at paragraph/newline boundaries, not raw char offsets
- Removed Markdown parse-entity retry fallback (no longer needed)

## What agents need to change

Nothing. Agents already write `*bold*`, `` `code` ``, `_italic_` — the converter handles it transparently. Plain-text mode (`parseMode: null`) still works.

## Test plan

- [x] 17 tests covering conversion, HTML escaping, chunking, self_chat safety net — all pass
- [x] Full suite: 637/637 pass
- [x] `npm run build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)