### PR TITLE
fix(daemon): stagger gap nudges + guard duplicate cron verification (#182)

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -43,6 +43,9 @@ export class AgentProcess {
   // from an old PTY can race past stopRequested and trigger crash recovery on
   // the new agent.
   private lifecycleGeneration: number = 0;
+  // Guard: only one cron verification waiter in-flight per agent at a time.
+  // Rapid --continue restarts must not stack duplicate waiters. (Issue #182)
+  private cronVerificationPending: boolean = false;
   // BUG-011 fix: stop() awaits this promise (resolved by the onExit handler in start())
   // to guarantee the PTY exit has fired before stopping=false is reset. Without
   // this, the exit handler can fire after stopping=false and trigger spurious
@@ -626,12 +629,20 @@ export class AgentProcess {
       .map(c => c.name);
     if (recurringNames.length === 0) return;
 
+    // Dedup: only one waiter in-flight per agent. Rapid --continue restarts
+    // would otherwise stack multiple concurrent waiters. (Issue #182)
+    if (this.cronVerificationPending) {
+      this.log('Cron verification already pending — skipping duplicate');
+      return;
+    }
+
     const generation = this.lifecycleGeneration;
 
     // Run in background — don't block startup
-    this.verifyCronsAfterIdle(recurringNames, generation).catch(err => {
-      this.log(`Cron verification failed (non-fatal): ${err}`);
-    });
+    this.cronVerificationPending = true;
+    this.verifyCronsAfterIdle(recurringNames, generation)
+      .catch(err => { this.log(`Cron verification failed (non-fatal): ${err}`); })
+      .finally(() => { this.cronVerificationPending = false; });
   }
 
   /**
@@ -705,6 +716,11 @@ export class AgentProcess {
           this.log(`Gap nudge: ${cronDef.name} silent ${gapMin}min (threshold: ${Math.round(threshold / 60_000)}min)`);
           if (this.pty && this.status === 'running') {
             injectMessage((data) => this.pty!.write(data), nudge);
+            // Stagger: wait between nudges so the agent can process each one
+            // before the next arrives. Without this, N simultaneous stale crons
+            // fire N back-to-back injections, spiking context and triggering
+            // ctx-watchdog restarts. (Issue #182)
+            await sleep(30_000);
           }
         }
       }
@@ -729,9 +745,10 @@ export class AgentProcess {
       }
     } catch { /* ignore */ }
 
-    // Wait up to 10 minutes for the agent to finish its startup turn.
-    // Poll every 15s. Bail if the agent stopped or a new lifecycle started.
-    const maxWaitMs = 10 * 60 * 1000;
+    // Wait up to 30 minutes for the agent to finish its startup turn.
+    // 10 min was too short — agents busy processing gap nudge bursts would
+    // never go idle in time and the verification would silently drop. (Issue #182)
+    const maxWaitMs = 30 * 60 * 1000;
     const pollMs = 15_000;
     const startTime = Date.now();
     let foundIdle = false;


### PR DESCRIPTION
## Summary

Fixes two bugs that compound into restart storms when multiple crons are stale simultaneously after a daemon restart (issue #182).

- **Bug 1 — Gap nudge burst:** `runGapDetectionLoop` fired all stale-cron nudges back-to-back in a tight `for` loop. N simultaneous nudges → N rapid Claude turns → context spike → ctx-watchdog force-restart. Fixed by adding a 30s sleep between nudge injections.

- **Bug 2 — Verification timeout:** `verifyCronsAfterIdle` gave up after 10 minutes if the agent was busy (e.g. processing the nudge burst), silently dropping the cron recovery check. Fixed by extending `maxWaitMs` to 30 minutes and adding a `cronVerificationPending` guard so rapid `--continue` restarts don't stack duplicate waiters.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 634 tests pass (`npm test`)
- [ ] Manually verify: restart daemon with 3+ agents that have aligned cron intervals — confirm gap nudges fire with ~30s gaps between them, not as a burst
- [ ] Confirm: no "Cron verification: timed out" log lines appear for agents with active startup turns under 30 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)