### PR TITLE
fix(daemon): pre-arm .force-fresh at Tier 2 handoff to break --continue restart storm

### DIFF
--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -979,6 +979,13 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       const handoffPrompt = `[CONTEXT HANDOFF REQUIRED] Context is at ${Math.round(effectivePct)}%. Write a handoff document to memory/handoffs/handoff-${ts}.md with these sections: ## Current Tasks, ## Next Actions, ## Active Crons, ## Key Context, ## Files Modified This Session. Then run: cortextos bus hard-restart --reason "context handoff at ${Math.round(effectivePct)}%" --handoff-doc <absolute path to the handoff doc you just wrote>. Do this NOW before the context window is exhausted.`;
       this.agent.injectMessage(handoffPrompt);
       this.log(`Handoff prompt injected at ${Math.round(effectivePct)}%`);
+      // Pre-arm .force-fresh so the next restart is always a clean fresh session.
+      // If the agent cooperates and calls hard-restart, it also writes .force-fresh — no-op.
+      // If context exhausts naturally before the agent acts, .force-fresh is already set,
+      // preventing a --continue restart that would loop at the same high context level.
+      try {
+        writeFileSync(join(this.paths.stateDir, '.force-fresh'), '');
+      } catch { /* non-fatal */ }
     }
   }
 


### PR DESCRIPTION
## Summary

- Writes `.force-fresh` immediately when the context handoff prompt is injected (Tier 2)
- Guarantees the next restart is always a fresh session, whether the agent cooperates or context exhausts naturally
- If the agent successfully calls `hard-restart`, it also writes `.force-fresh` — no double effect

## Root cause

When context hits the handoff threshold the daemon injects a prompt asking the agent to write a handoff doc and call `hard-restart`. But if the agent runs out of context *before* completing that call, the session exits cleanly (code 0) and `shouldContinue()` returns true — restarting in `--continue` mode at the same ~77-81% context level. The watchdog fires again immediately, injects another handoff prompt, the agent exhausts context again... restart storm.

Observed: sentinel + donna cycling 77% → 78% → 78% → 79% → 81% repeatedly on Apr 20 2026. The existing Tier 3 deadline (5min force-fresh) eventually broke the loop, but not before 1500+ rapid exits.

## Fix

One line: write `.force-fresh` right after injecting the handoff prompt. From that point on, the next `start()` call skips `--continue` regardless of what the agent does.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 670/670 pass
- [ ] Manually verify: induce a high-context restart, confirm next session starts in fresh mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)