### PR TITLE
fix(daemon): guard PTY write callbacks against null to prevent daemon crash

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -266,7 +266,7 @@ export class AgentProcess {
       return false;
     }
 
-    injectMessage((data) => this.pty!.write(data), content);
+    injectMessage((data) => this.pty?.write(data), content);
     return true;
   }
 
@@ -780,7 +780,7 @@ export class AgentProcess {
 
           this.log(`Gap nudge: ${cronDef.name} silent ${gapMin}min (threshold: ${Math.round(threshold / 60_000)}min)`);
           if (this.pty && this.status === 'running') {
-            injectMessage((data) => this.pty!.write(data), nudge);
+            injectMessage((data) => this.pty?.write(data), nudge);
             // Stagger: wait between nudges so the agent can process each one
             // before the next arrives. Without this, N simultaneous stale crons
             // fire N back-to-back injections, spiking context and triggering
@@ -856,7 +856,7 @@ export class AgentProcess {
 
     this.log(`Injecting cron verification (expecting: ${cronList})`);
     if (this.pty) {
-      injectMessage((data) => this.pty!.write(data), verifyPrompt);
+      injectMessage((data) => this.pty?.write(data), verifyPrompt);
     }
   }
 }


### PR DESCRIPTION
## Summary

- Replaces `this.pty!.write(data)` with `this.pty?.write(data)` at all 3 injectMessage call sites in agent-process.ts
- Prevents TypeError crash when a 300ms delayed Enter keypress fires after the PTY is already destroyed

## Root cause

`injectMessage` in inject.ts fires a `setTimeout(() => write(KEYS.ENTER), 300)`. The write callback was `(data) => this.pty!.write(data)`. If the agent exits in that 300ms window, `this.pty` is null and the non-null assertion throws:

```
TypeError: Cannot read properties of null (reading 'write')
```

This is an unhandled exception that crashes the entire daemon process. PM2 auto-restarts the daemon, which stops and restarts every agent simultaneously. With agents already at high context in `--continue` mode, this triggers the context-thrashing loop — the rapid restart storm.

Observed: 226 daemon crashes in ~15 minutes on 2026-04-20, causing all agents to rapid-restart in sync.

## Fix

`this.pty?.write(data)` — optional chain silently no-ops if PTY is gone. The Enter keypress is lost (inconsequential) but the daemon stays alive.

Fixed at 3 sites: `injectMessage()`, gap nudge injection, cron verification injection.

## Test plan

- [x] `npm run build` — clean
- [x] `npm test` — 670/670 pass
- [ ] Manually verify: no more daemon crashes on agent exit during injection window

🤖 Generated with [Claude Code](https://claude.com/claude-code)