### PR TITLE
fix(daemon): pass handoff doc on Tier 3 force-restart + elevate pickup message priority

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -473,8 +473,11 @@ export class AgentProcess {
     const deliverablesBlock = this.buildDeliverablesBlock();
     const handoffBlock = this.consumeHandoffBlock();
     const isHandoffRestart = handoffBlock.length > 0;
+    // HANDOFF UX: the pickup message MUST be the first action after reading the handoff doc —
+    // before cron restoration, before heartbeat, before anything else. Placing this instruction
+    // immediately after the handoffBlock in the prompt ensures it is not buried.
     const handoffUxOverride = isHandoffRestart
-      ? ' HANDOFF UX: This is a context handoff restart — your memory is intact via the handoff doc. Do NOT send "Booting up... one moment" (skip AGENTS.md step 1 entirely). After restoring crons and reading the handoff, send ONE brief conversational message that picks up naturally — e.g. "back — [what you were just working on]". No cron IDs, no status report, no cold-boot phrasing.'
+      ? ' HANDOFF UX: This is a context handoff restart — your memory is intact via the handoff doc. CRITICAL: The VERY FIRST thing you must do after reading the handoff document is send ONE brief conversational Telegram message that picks up naturally — e.g. "back — [what you were just working on]". Do this BEFORE restoring crons, BEFORE running heartbeat, BEFORE anything else. No cron IDs, no status report, no cold-boot phrasing. Do NOT send "Booting up... one moment" (skip AGENTS.md step 1 entirely).'
       : '';
     const onlineMessage = isHandoffRestart
       ? ''

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -1012,6 +1012,27 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     this.ctxCircuitRestarts.push(now);
     this.saveCtxCircuit();
 
+    // If the agent wrote a handoff doc in the last 15 minutes but didn't get to call
+    // hard-restart --handoff-doc (e.g. Tier 3 force-restart cut it short), pick it up
+    // so the new session still receives handoff context.
+    try {
+      const handoffsDir = join(this.agent.getAgentDir(), 'memory', 'handoffs');
+      if (existsSync(handoffsDir)) {
+        const cutoff = now - 15 * 60_000;
+        const recent = readdirSync(handoffsDir)
+          .filter(f => f.startsWith('handoff-') && f.endsWith('.md'))
+          .map(f => ({ f, mtime: statSync(join(handoffsDir, f)).mtimeMs }))
+          .filter(({ mtime }) => mtime >= cutoff)
+          .sort((a, b) => b.mtime - a.mtime);
+        if (recent.length > 0) {
+          const docPath = join(handoffsDir, recent[0].f);
+          const markerPath = join(this.paths.stateDir, '.handoff-doc-path');
+          writeFileSync(markerPath, docPath, 'utf-8');
+          this.log(`Tier 3 restart: found recent handoff doc, writing marker → ${docPath}`);
+        }
+      }
+    } catch { /* non-fatal — proceed without handoff context */ }
+
     // Reset per-session context state for the new session
     this.ctxHandoffFiredAt = 0;
     this.ctxHandoffDeadlineAt = 0;


### PR DESCRIPTION
## Summary

- **Fix 1 (Tier 3 handoff doc passthrough):** `forceContextRestart()` in `fast-checker.ts` now scans `memory/handoffs/` for a doc written in the last 15 minutes before calling `hardRestart()`. If found, writes `.handoff-doc-path` so the new session receives full handoff context even when Tier 3 fires before the agent could voluntarily call `hard-restart --handoff-doc`.
- **Fix 2 (pickup message order):** `handoffUxOverride` in `agent-process.ts` now marks the Telegram pickup message as `CRITICAL` and explicitly orders it **before** cron restoration, heartbeat, and all other boot steps — preventing it from being buried and skipped.

## Root cause

Tier 3 force-restarts were silently dropping handoff context: the agent had written the doc but hadn't reached the `hard-restart --handoff-doc` call. Fix 1 recovers it. Fix 2 closes a separate UX gap where the pickup message was consistently skipped because the instruction appeared after 12 other boot steps.

## Test plan

- [ ] Build passes (`npm run build`)
- [ ] All 670 tests pass (`npm test`)
- [ ] Trigger a Tier 3 restart on a live agent and confirm new session reads handoff doc
- [ ] Confirm first action after handoff restart is the pickup Telegram message

🤖 Generated with [Claude Code](https://claude.com/claude-code)