### PR TITLE
fix(cli): invert 1M-context default for new agents — opt-in 200K fallback

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -119,10 +119,12 @@ export const addAgentCommand = new Command('add-agent')
         'CHAT_ID=',
         '',
         '# Claude Code v2.1.111+ gives Sonnet 4.6 a 1M context window by default.',
-        '# Without "extra usage" billing enabled, compaction fails at 100% ctx.',
-        '# Keep this for Sonnet and Haiku agents. Remove it for Opus agents on Max/Team/Enterprise',
-        '# (Opus 1M context is included in those plans and does not need the billing gate).',
-        'CLAUDE_CODE_DISABLE_1M_CONTEXT=true',
+        '# On plans WITHOUT "extra usage" billing, compaction fails at 100% ctx with:',
+        '#   "Extra usage is required for 1M context"',
+        '# If you see that error on a Sonnet or Haiku agent, uncomment the line below',
+        '# to revert to the standard 200K window.',
+        '# (Opus on Max / Team / Enterprise includes 1M natively — leave this commented.)',
+        '# CLAUDE_CODE_DISABLE_1M_CONTEXT=true',
         '',
       ].join('\n'), 'utf-8');
       chmodSync(envPath, 0o600); // credentials — owner read/write only


### PR DESCRIPTION
## Summary

`cortextos add-agent` currently writes `CLAUDE_CODE_DISABLE_1M_CONTEXT=true` into every new agent `.env` by default. That caps new agents at Claude Code's 200K window — even on plans where 1M is included natively (Opus on Max / Team / Enterprise). Users have to know to manually delete the line after every add-agent to get the context their plan already provides.

This inverts the default: the line is written commented-out, with an inline comment explaining when to uncomment it. The 200K fallback is still one edit away for users who need it.

## Test plan

- [x] Existing test suite passes (670/670)
- [x] `cortextos add-agent` on a fresh agent writes the new commented default
- [x] Existing agents with `CLAUDE_CODE_DISABLE_1M_CONTEXT=true` unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
