### PR TITLE
fix(bus): hard-restart now sends IPC restart-agent to terminate the session

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -628,7 +628,7 @@ busCommand
   .description('Plan a hard restart (fresh session, no --continue)')
   .option('--reason <why>', 'Reason for restart')
   .option('--handoff-doc <path>', 'Path to handoff document to inject into next session boot prompt')
-  .action((opts: { reason?: string; handoffDoc?: string }) => {
+  .action(async (opts: { reason?: string; handoffDoc?: string }) => {
     const { writeFileSync: fsWrite, existsSync: fsExists, mkdirSync: fsMkdir } = require('fs');
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
@@ -637,7 +637,22 @@ busCommand
       fsMkdir(paths.stateDir, { recursive: true });
       fsWrite(join(paths.stateDir, '.handoff-doc-path'), opts.handoffDoc + '\n', 'utf-8');
     }
-    console.log('Hard restart planned');
+    // Send IPC restart-agent so the daemon terminates and restarts this session
+    // immediately. Without this the session keeps running — .force-fresh is only
+    // consumed on the NEXT restart, which never comes unless the daemon is notified.
+    const ipc = new IPCClient(env.instanceId);
+    const daemonRunning = await ipc.isDaemonRunning();
+    if (daemonRunning) {
+      const resp = await ipc.send({ type: 'restart-agent', agent: env.agentName, source: 'cortextos bus hard-restart' });
+      if (resp.success) {
+        console.log(`Hard restart triggered for ${env.agentName} — fresh session incoming`);
+      } else {
+        console.error(`Daemon restart failed: ${resp.error}`);
+        process.exit(1);
+      }
+    } else {
+      console.log('Hard restart planned (daemon not running — will take effect on next start)');
+    }
   });
 
 busCommand

--- a/tests/unit/bus/system.test.ts
+++ b/tests/unit/bus/system.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
-import { selfRestart, autoCommit, checkGoalStaleness, postActivity } from '../../../src/bus/system';
+import { selfRestart, hardRestart, autoCommit, checkGoalStaleness, postActivity } from '../../../src/bus/system';
 import type { BusPaths } from '../../../src/types';
 
 function makePaths(testDir: string, agent: string = 'test-agent'): BusPaths {
@@ -58,6 +58,25 @@ describe('Bus System', () => {
       const logPath = join(paths.logDir, 'restarts.log');
       const logContent = readFileSync(logPath, 'utf-8');
       expect(logContent).toContain('SELF-RESTART: no reason specified');
+    });
+  });
+
+  describe('hardRestart', () => {
+    it('creates .force-fresh and .restart-planned markers', () => {
+      const paths = makePaths(testDir);
+      hardRestart(paths, 'test-agent', 'context handoff');
+
+      expect(existsSync(join(paths.stateDir, '.force-fresh'))).toBe(true);
+      expect(existsSync(join(paths.stateDir, '.restart-planned'))).toBe(true);
+      const logContent = readFileSync(join(paths.logDir, 'restarts.log'), 'utf-8');
+      expect(logContent).toContain('HARD-RESTART: context handoff');
+    });
+
+    it('uses default reason when none provided', () => {
+      const paths = makePaths(testDir);
+      hardRestart(paths, 'test-agent');
+      const logContent = readFileSync(join(paths.logDir, 'restarts.log'), 'utf-8');
+      expect(logContent).toContain('HARD-RESTART: no reason specified');
     });
   });
 


### PR DESCRIPTION
## Summary

`cortextos bus hard-restart` was writing `.force-fresh` and `.restart-planned` marker files but never notifying the daemon, so the current Claude session kept running indefinitely. `.force-fresh` is only consumed on the NEXT restart — which never comes unless something triggers a restart.

**Root cause:** `self-restart` sends `IPC restart-agent` to the daemon (line ~613). `hard-restart` did not — it just wrote markers and printed "Hard restart planned", leaving the session alive.

**Symptom:** Heartbeat gets stuck at "restarting" indefinitely. Sentinel has to nudge to unstick. Flagged twice today by data agent.

**Fix:** Add IPC `restart-agent` send to `hard-restart`, matching the existing pattern in `self-restart`. When daemon is not running, falls back gracefully with a clear message.

## Test plan
- [x] `npm run build` — clean
- [x] `npx vitest run tests/unit/bus/system.test.ts` → 22/22 pass (2 new hardRestart tests)
- [x] Full `npm test` → 676/676 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)