### PR TITLE
feat(dashboard): multi-select skill install with portal overlay

### DIFF
--- a/dashboard/src/components/skills/skill-card.tsx
+++ b/dashboard/src/components/skills/skill-card.tsx
@@ -1,10 +1,14 @@
 'use client';
 
-import { useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { ChevronDownIcon } from 'lucide-react';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/components/ui/select';
+import { Checkbox } from '@/components/ui/checkbox';
+import { cn } from '@/lib/utils';
+
 interface SkillInfo {
   slug: string;
   name: string;
@@ -21,17 +25,76 @@ interface SkillCardProps {
 
 export function SkillCard({ skill, agents, onRefresh }: SkillCardProps) {
   const [loading, setLoading] = useState(false);
-  const [selectedAgent, setSelectedAgent] = useState<string>('');
+  const [selected, setSelected] = useState<Set<string>>(new Set());
+  const [open, setOpen] = useState(false);
   const [error, setError] = useState('');
+  const [mounted, setMounted] = useState(false);
+  const [panelRect, setPanelRect] = useState<{ top: number; left: number; width: number } | null>(null);
+  const triggerRef = useRef<HTMLButtonElement | null>(null);
+  const panelRef = useRef<HTMLDivElement | null>(null);
 
-  async function handleInstall() {
-    if (!selectedAgent) {
-      setError('Select an agent first');
-      return;
+  const selectableAgents = agents.filter(
+    (a) => !skill.installedFor.includes(`${a.org}/${a.name}`),
+  );
+  const allSelected =
+    selectableAgents.length > 0 &&
+    selectableAgents.every((a) => selected.has(`${a.org}/${a.name}`));
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useLayoutEffect(() => {
+    if (!open) return;
+    function updateRect() {
+      const el = triggerRef.current;
+      if (!el) return;
+      const r = el.getBoundingClientRect();
+      setPanelRect({ top: r.bottom + 4, left: r.left, width: r.width });
     }
-    const [org, agent] = selectedAgent.split('/');
-    setLoading(true);
-    setError('');
+    updateRect();
+    window.addEventListener('resize', updateRect);
+    window.addEventListener('scroll', updateRect, true);
+    return () => {
+      window.removeEventListener('resize', updateRect);
+      window.removeEventListener('scroll', updateRect, true);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    function onDocClick(e: MouseEvent) {
+      const t = e.target as Node;
+      if (triggerRef.current?.contains(t)) return;
+      if (panelRef.current?.contains(t)) return;
+      setOpen(false);
+    }
+    document.addEventListener('mousedown', onDocClick);
+    return () => document.removeEventListener('mousedown', onDocClick);
+  }, [open]);
+
+  function toggleOne(key: string) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  function toggleAll() {
+    setSelected((prev) => {
+      if (
+        selectableAgents.length > 0 &&
+        selectableAgents.every((a) => prev.has(`${a.org}/${a.name}`))
+      ) {
+        return new Set();
+      }
+      return new Set(selectableAgents.map((a) => `${a.org}/${a.name}`));
+    });
+  }
+
+  async function installOne(org: string, agent: string): Promise<string | null> {
     const res = await fetch('/api/skills', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -39,8 +102,32 @@ export function SkillCard({ skill, agents, onRefresh }: SkillCardProps) {
     });
     if (!res.ok) {
       const data = await res.json().catch(() => ({}));
-      setError(data.error ?? 'Install failed');
+      return data.error ?? 'Install failed';
     }
+    return null;
+  }
+
+  async function handleInstall() {
+    if (selected.size === 0) {
+      setError('Select at least one agent');
+      return;
+    }
+    setLoading(true);
+    setError('');
+
+    const targets = Array.from(selected).map((k) => {
+      const [org, agent] = k.split('/');
+      return { org, agent };
+    });
+    const results = await Promise.all(
+      targets.map((t) => installOne(t.org, t.agent)),
+    );
+    const failures = results.filter((r): r is string => r !== null);
+    if (failures.length > 0) {
+      setError(`${failures.length} failed: ${failures[0]}`);
+    }
+
+    setSelected(new Set());
     setLoading(false);
     onRefresh();
   }
@@ -61,6 +148,13 @@ export function SkillCard({ skill, agents, onRefresh }: SkillCardProps) {
     setLoading(false);
     onRefresh();
   }
+
+  const triggerLabel =
+    selected.size === 0
+      ? 'Select agents...'
+      : selected.size === 1
+        ? Array.from(selected)[0]
+        : `${selected.size} agents selected`;
 
   return (
     <Card>
@@ -103,26 +197,80 @@ export function SkillCard({ skill, agents, onRefresh }: SkillCardProps) {
       <CardFooter>
         <div className="flex w-full flex-col gap-2">
           <div className="flex items-center gap-2">
-            <Select value={selectedAgent} onValueChange={(v) => setSelectedAgent(v ?? '')}>
-              <SelectTrigger className="flex-1">
-                <SelectValue placeholder="Select agent..." />
-              </SelectTrigger>
-              <SelectContent>
-                {agents.map((a) => {
-                  const key = `${a.org}/${a.name}`;
-                  const alreadyInstalled = skill.installedFor.includes(key);
-                  return (
-                    <SelectItem key={key} value={key} disabled={alreadyInstalled}>
-                      {key}{alreadyInstalled ? ' (installed)' : ''}
-                    </SelectItem>
-                  );
-                })}
-              </SelectContent>
-            </Select>
+            <div className="flex-1">
+              <button
+                ref={triggerRef}
+                type="button"
+                onClick={() => setOpen((o) => !o)}
+                aria-expanded={open}
+                aria-haspopup="listbox"
+                className="flex h-8 w-full items-center justify-between gap-1.5 rounded-lg border border-input bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors outline-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 dark:bg-input/30 dark:hover:bg-input/50"
+              >
+                <span className={cn('truncate text-left', selected.size === 0 && 'text-muted-foreground')}>
+                  {triggerLabel}
+                </span>
+                <ChevronDownIcon className="size-4 shrink-0 text-muted-foreground" />
+              </button>
+              {open && mounted && panelRect && createPortal(
+                <div
+                  ref={panelRef}
+                  role="listbox"
+                  style={{
+                    position: 'fixed',
+                    top: panelRect.top,
+                    left: panelRect.left,
+                    width: panelRect.width,
+                  }}
+                  className="z-[100] max-h-64 overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10"
+                >
+                  <label
+                    className={cn(
+                      'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-sm hover:bg-accent hover:text-accent-foreground',
+                      selectableAgents.length === 0 && 'cursor-not-allowed opacity-50',
+                    )}
+                  >
+                    <Checkbox
+                      checked={allSelected}
+                      disabled={selectableAgents.length === 0}
+                      onCheckedChange={() => toggleAll()}
+                    />
+                    <span className="font-medium">Select all</span>
+                    <span className="ml-auto text-xs text-muted-foreground">
+                      {selectableAgents.length} available
+                    </span>
+                  </label>
+                  <div className="pointer-events-none my-1 h-px bg-border" />
+                  {agents.map((a) => {
+                    const key = `${a.org}/${a.name}`;
+                    const alreadyInstalled = skill.installedFor.includes(key);
+                    return (
+                      <label
+                        key={key}
+                        className={cn(
+                          'flex cursor-pointer items-center gap-2 rounded-md px-1.5 py-1 text-sm hover:bg-accent hover:text-accent-foreground',
+                          alreadyInstalled && 'cursor-not-allowed opacity-50 hover:bg-transparent hover:text-inherit',
+                        )}
+                      >
+                        <Checkbox
+                          checked={selected.has(key)}
+                          disabled={alreadyInstalled}
+                          onCheckedChange={() => toggleOne(key)}
+                        />
+                        <span className="truncate">{key}</span>
+                        {alreadyInstalled && (
+                          <span className="ml-auto text-xs text-muted-foreground">installed</span>
+                        )}
+                      </label>
+                    );
+                  })}
+                </div>,
+                document.body,
+              )}
+            </div>
             <Button
               size="sm"
               onClick={handleInstall}
-              disabled={loading || !selectedAgent}
+              disabled={loading || selected.size === 0}
             >
               Install
             </Button>


### PR DESCRIPTION
## Summary
- Replaces the single-select agent dropdown on skill cards with a checkbox list so you can install a skill to multiple agents in one click.
- Adds a **Select all** toggle at the top of the panel (selects every not-yet-installed agent on first click, clears all on second click). Checkboxes are on the left of each row.
- Portals the panel to `document.body` with fixed positioning so it overlays neighboring cards instead of being clipped by `Card`'s `overflow-hidden`.
- Install button fans out parallel `POST /api/skills` requests for every checked agent; no API changes.

## Test plan
- [x] `tsc --noEmit` passes in `dashboard/`
- [x] Playwright QA against the live dashboard: panel top-most at its bounding box (no clip), Select all toggles 0↔N, individual checkboxes toggle independently
- [ ] Manual smoke test: pick 2 agents and click Install; confirm both get the skill in `~/.cortextos/<instance>/orgs/<org>/agents/<agent>/skills/<slug>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)