### PR TITLE
fix(daemon): guard worker PTY null-write + add crash visibility

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -24,7 +24,26 @@ module.exports = {
         CTX_FRAMEWORK_ROOT: FRAMEWORK_ROOT,
         CTX_PROJECT_ROOT: PROJECT_ROOT,
         CTX_ORG: CTX_ORG,
+        // Debug-only: set to '1' to enable SIGUSR2 signal → controlled
+        // uncaughtException for testing the crash-visibility path
+        // (.daemon-crashed markers + crash-loop operator Telegram alert).
+        // Leave '0' in production; enable temporarily to reproduce crash
+        // paths during development. `kill -SIGUSR2 $(pm2 pid cortextos-daemon)`
+        // then watch the operator chat for "🚨 CRITICAL: daemon crash-looping"
+        // after 3 crashes in 15 min.
+        CTX_DEBUG_ALLOW_CRASH_TRIGGER: '0',
       },
+      // max_restarts + restart_delay is the ultimate crash-storm circuit
+      // breaker. If the daemon dies 10 times faster than 5s apart, PM2
+      // gives up — the fleet goes fully dead, requiring a manual
+      // `pm2 restart cortextos-daemon`. That is intentional: storm
+      // protection > fleet uptime during a pathological crash loop.
+      // The daemon's uncaughtException handler (src/daemon/index.ts)
+      // fires a Telegram alert to the operator at 3+ crashes in 15 min —
+      // well before this circuit trips. Do NOT raise these values without
+      // also strengthening the upstream fix; the 2026-04-22 storm is a
+      // reminder that unchecked auto-restart amplifies one bug into a
+      // fleet-wide outage.
       max_restarts: 10,
       restart_delay: 5000,
       autorestart: true,

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,9 +1,212 @@
 import { AgentManager } from './agent-manager.js';
 import { IPCServer } from './ipc-server.js';
-import { writeFileSync, existsSync, chmodSync } from 'fs';
+import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
+import { spawnSync } from 'child_process';
 import { join } from 'path';
 import { homedir } from 'os';
 import { ensureDir } from '../utils/atomic.js';
+
+// ---------------------------------------------------------------------------
+// Crash handling: turn silent daemon deaths into attributable, observable
+// events. Three responsibilities:
+//   1. Write a .daemon-crashed marker per agent — hook-crash-alert.ts uses
+//      this on the next session boot to emit "🚨 daemon crashed" instead of
+//      the misleading "🚨 agent crashed" default.
+//   2. Maintain a small crash-history JSON so we can detect crash-loops.
+//   3. On ≥3 crashes in 15 min, send ONE Telegram alert to the operator chat
+//      (with a 30-min cooldown). PM2's max_restarts: 10 is the final
+//      circuit breaker; our alert fires before the fleet goes fully dead.
+// Context: root cause of 2026-04-22 restart storm was unguarded this.pty!
+// in worker-process.ts:93 — PR #196 fixed 3 sister sites but missed this
+// one. The inject.ts try/catch + worker-process ?. land the structural fix;
+// this module is the visibility layer.
+// ---------------------------------------------------------------------------
+
+export interface CrashEvent { ts: string; err: string; }
+export interface CrashHistory { crashes: CrashEvent[]; lastAlertAt?: string; }
+
+export const CRASH_HISTORY_MAX = 20;
+export const CRASH_LOOP_WINDOW_MS = 15 * 60 * 1000;    // 15 min detection window
+export const CRASH_LOOP_THRESHOLD = 3;                  // 3 crashes trips the alert
+export const CRASH_LOOP_COOLDOWN_MS = 30 * 60 * 1000;   // 30 min between alerts
+const TELEGRAM_SEND_TIMEOUT_MS = 3000;           // bounded — we're crashing
+
+export function crashHistoryPath(ctxRoot: string): string {
+  return join(ctxRoot, 'state', '.daemon-crash-history.json');
+}
+
+export function readCrashHistory(ctxRoot: string): CrashHistory {
+  const p = crashHistoryPath(ctxRoot);
+  if (!existsSync(p)) return { crashes: [] };
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf-8')) as CrashHistory;
+    return { crashes: parsed.crashes ?? [], lastAlertAt: parsed.lastAlertAt };
+  } catch {
+    return { crashes: [] };
+  }
+}
+
+export function writeCrashHistory(ctxRoot: string, history: CrashHistory): void {
+  try {
+    ensureDir(join(ctxRoot, 'state'));
+    writeFileSync(crashHistoryPath(ctxRoot), JSON.stringify(history, null, 2), 'utf-8');
+  } catch {
+    // disk full / permission issue — don't block exit
+    console.error('[daemon] Failed to persist crash history (non-fatal)');
+  }
+}
+
+export function recordCrash(ctxRoot: string, errStr: string): CrashHistory {
+  const history = readCrashHistory(ctxRoot);
+  history.crashes.push({ ts: new Date().toISOString(), err: errStr.slice(0, 2000) });
+  if (history.crashes.length > CRASH_HISTORY_MAX) {
+    history.crashes = history.crashes.slice(-CRASH_HISTORY_MAX);
+  }
+  writeCrashHistory(ctxRoot, history);
+  return history;
+}
+
+export function shouldSendCrashLoopAlert(history: CrashHistory): boolean {
+  const now = Date.now();
+  const windowStart = now - CRASH_LOOP_WINDOW_MS;
+  const recent = history.crashes.filter(c => Date.parse(c.ts) >= windowStart).length;
+  if (recent < CRASH_LOOP_THRESHOLD) return false;
+  if (history.lastAlertAt) {
+    const cooldownEnd = Date.parse(history.lastAlertAt) + CRASH_LOOP_COOLDOWN_MS;
+    if (now < cooldownEnd) return false;
+  }
+  return true;
+}
+
+export function countRecentCrashes(history: CrashHistory): number {
+  const windowStart = Date.now() - CRASH_LOOP_WINDOW_MS;
+  return history.crashes.filter(c => Date.parse(c.ts) >= windowStart).length;
+}
+
+export function writeDaemonCrashedMarkers(ctxRoot: string): void {
+  // Scan state/ for per-agent dirs (each agent has state/<name>/ created
+  // by AgentProcess). Writing here parallels the .daemon-stop marker path
+  // in agent-manager.ts:stopAll — lets hook-crash-alert.ts distinguish
+  // crash from planned stop. Each write is independently try/catch'd so
+  // a single bad agent dir can't block the exit path.
+  const stateDir = join(ctxRoot, 'state');
+  if (!existsSync(stateDir)) return;
+  let names: string[];
+  try {
+    names = readdirSync(stateDir, { withFileTypes: true })
+      .filter(d => d.isDirectory())
+      .map(d => d.name);
+  } catch { return; }
+  const ts = new Date().toISOString();
+  for (const name of names) {
+    try {
+      writeFileSync(join(stateDir, name, '.daemon-crashed'), ts, 'utf-8');
+    } catch { /* swallow per-agent */ }
+  }
+}
+
+function getOperatorChatCreds(frameworkRoot: string): { chatId: string; botToken: string } | null {
+  // Priority 1: explicit operator env (recommended for production).
+  const envChat = process.env.CTX_OPERATOR_CHAT_ID;
+  const envToken = process.env.CTX_OPERATOR_BOT_TOKEN;
+  if (envChat && envToken && /^\d+:[A-Za-z0-9_-]+$/.test(envToken)) {
+    return { chatId: envChat, botToken: envToken };
+  }
+  // Priority 2: fall back to the first agent's .env. Good enough for
+  // small single-operator installs — alert still lands SOMEWHERE visible.
+  try {
+    const orgsRoot = join(frameworkRoot, 'orgs');
+    if (!existsSync(orgsRoot)) return null;
+    const orgs = readdirSync(orgsRoot, { withFileTypes: true }).filter(d => d.isDirectory());
+    for (const org of orgs) {
+      const agentsRoot = join(orgsRoot, org.name, 'agents');
+      if (!existsSync(agentsRoot)) continue;
+      const agents = readdirSync(agentsRoot, { withFileTypes: true }).filter(d => d.isDirectory());
+      for (const a of agents) {
+        const envFile = join(agentsRoot, a.name, '.env');
+        if (!existsSync(envFile)) continue;
+        try {
+          const content = readFileSync(envFile, 'utf-8');
+          const tokenMatch = content.match(/^BOT_TOKEN=(.+)$/m);
+          const chatMatch = content.match(/^CHAT_ID=(.+)$/m);
+          if (!tokenMatch || !chatMatch) continue;
+          const botToken = tokenMatch[1].trim();
+          const chatId = envChat || chatMatch[1].trim();
+          if (/^\d+:[A-Za-z0-9_-]+$/.test(botToken)) {
+            return { chatId, botToken };
+          }
+        } catch { /* skip this agent */ }
+      }
+    }
+  } catch { /* fall through */ }
+  return null;
+}
+
+function sendCrashLoopAlertBestEffort(
+  frameworkRoot: string,
+  crashCount: number,
+  errStr: string,
+): boolean {
+  const creds = getOperatorChatCreds(frameworkRoot);
+  if (!creds) {
+    console.error('[daemon] Crash-loop alert: no operator chat configured ' +
+      '(set CTX_OPERATOR_CHAT_ID + CTX_OPERATOR_BOT_TOKEN, or ensure at least one agent .env exists)');
+    return false;
+  }
+  const message =
+    `🚨 CRITICAL: cortextos daemon is crash-looping\n` +
+    `${crashCount} crashes in 15 minutes\n` +
+    `Last error: ${errStr.slice(0, 500)}\n` +
+    `Next alert in 30 min if the pattern continues.`;
+  try {
+    const r = spawnSync('curl', [
+      '-s', '--max-time', '3',
+      '-X', 'POST',
+      `https://api.telegram.org/bot${creds.botToken}/sendMessage`,
+      '-d', `chat_id=${creds.chatId}`,
+      '--data-urlencode', `text=${message}`,
+    ], { timeout: TELEGRAM_SEND_TIMEOUT_MS, stdio: 'pipe' });
+    if (r.status === 0) {
+      console.error('[daemon] Crash-loop alert sent to operator chat');
+      return true;
+    }
+    console.error('[daemon] Crash-loop alert send failed (non-fatal)');
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Shared fatal-error handler for both uncaughtException and
+ * unhandledRejection. Performs marker writes + crash recording + optional
+ * telegram alert, then optionally exits. Stays fully synchronous so it
+ * finishes before Node's default crash behavior triggers.
+ */
+function handleFatal(
+  tag: 'uncaughtException' | 'unhandledRejection',
+  err: unknown,
+  ctxRoot: string,
+  frameworkRoot: string,
+  doExit: boolean,
+): void {
+  const errStr = err instanceof Error ? (err.stack || err.message) : String(err);
+  console.error(`[daemon] FATAL ${tag} — exiting for PM2 respawn`);
+  console.error(errStr);
+
+  writeDaemonCrashedMarkers(ctxRoot);
+  const history = recordCrash(ctxRoot, errStr);
+
+  if (shouldSendCrashLoopAlert(history)) {
+    const recent = countRecentCrashes(history);
+    if (sendCrashLoopAlertBestEffort(frameworkRoot, recent, errStr)) {
+      history.lastAlertAt = new Date().toISOString();
+      writeCrashHistory(ctxRoot, history);
+    }
+  }
+
+  if (doExit) process.exit(1);
+}
 
 /**
  * cortextOS Daemon - single process managing all agents.
@@ -99,6 +302,32 @@ class Daemon {
 
     process.on('SIGINT', handleSignal);
     process.on('SIGTERM', handleSignal);
+
+    // Global fatal-error handlers. uncaughtException exits for PM2 respawn.
+    // unhandledRejection logs + records but does not exit (rejected promises
+    // shouldn't be fatal by default; matches Node 15+ behavior without
+    // adopting the new strict default). Both paths write .daemon-crashed
+    // markers and increment the crash-loop counter.
+    const ctxRootForHandler = this.ctxRoot;
+    const frameworkRootForHandler = frameworkRoot;
+    process.on('uncaughtException', (err) => {
+      handleFatal('uncaughtException', err, ctxRootForHandler, frameworkRootForHandler, true);
+    });
+    process.on('unhandledRejection', (reason) => {
+      handleFatal('unhandledRejection', reason, ctxRootForHandler, frameworkRootForHandler, false);
+    });
+    console.log('[daemon] Fatal-error handlers registered (uncaughtException + unhandledRejection)');
+
+    // Debug-only: SIGUSR2 induces a controlled uncaughtException for
+    // live crash-path verification. Off in production unless
+    // CTX_DEBUG_ALLOW_CRASH_TRIGGER=1 is explicitly set. See docs/debugging.md.
+    if (process.env.CTX_DEBUG_ALLOW_CRASH_TRIGGER === '1') {
+      process.on('SIGUSR2', () => {
+        console.error('[daemon] SIGUSR2 received — inducing test crash (CTX_DEBUG_ALLOW_CRASH_TRIGGER=1)');
+        throw new Error('Simulated daemon crash via SIGUSR2 (test harness)');
+      });
+      console.log('[daemon] SIGUSR2 crash trigger ENABLED (debug mode)');
+    }
 
     // Fallback cleanup on exit (belt-and-suspenders for Windows)
     process.on('exit', () => {

--- a/src/daemon/worker-process.ts
+++ b/src/daemon/worker-process.ts
@@ -90,7 +90,7 @@ export class WorkerProcess {
    */
   inject(text: string): boolean {
     if (!this.pty || this.status !== 'running') return false;
-    injectMessage((data) => this.pty!.write(data), text);
+    injectMessage((data) => this.pty?.write(data), text);
     return true;
   }
 

--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -122,6 +122,10 @@ async function main(): Promise<void> {
     { file: '.user-restart', type: 'user-restart' },
     { file: '.user-disable', type: 'user-disable' },
     { file: '.user-stop', type: 'user-stop' },
+    // .daemon-crashed wins over .daemon-stop when both are present — a crash
+    // during shutdown is the more important signal. Written by the daemon's
+    // uncaughtException handler in src/daemon/index.ts.
+    { file: '.daemon-crashed', type: 'daemon-crashed' },
     { file: '.daemon-stop', type: 'daemon-stop' },
   ];
 
@@ -217,6 +221,16 @@ async function main(): Promise<void> {
     case 'daemon-stop':
       message = `🛑 ${agentName} stopped (daemon shutdown).`;
       if (reason) message += ` (${reason})`;
+      break;
+    case 'daemon-crashed':
+      // Deliberately NOT suppressed during quiet hours — a daemon crash at
+      // 3am is genuinely worth waking for (historically it has preceded
+      // fleet-wide restart storms). Crash-loop alerts from the daemon
+      // itself add operator-level urgency; this is the per-agent variant
+      // that replaces the misleading "🚨 agent crashed" message users
+      // were getting on every daemon respawn.
+      message = `🚨 ${agentName} — daemon crashed, session was interrupted. Resuming.`;
+      if (reason) message += `\nCrash time: ${reason}`;
       break;
     case 'rate-limited':
       message = `⏳ ${agentName} paused — Anthropic rate limit hit. Will resume when the window resets.`;

--- a/src/pty/inject.ts
+++ b/src/pty/inject.ts
@@ -79,8 +79,23 @@ export function injectMessage(
     write(PASTE_END);
   }
 
-  // Send Enter after a short delay to submit the pasted content
-  setTimeout(() => write(KEYS.ENTER), enterDelay);
+  // Send Enter after a short delay to submit the pasted content.
+  // Why the try/catch: the write callback captures `this.pty` (or similar
+  // nullable PTY handle) via closure in callers. If the PTY is torn down
+  // during the enterDelay window — e.g. hard-restart IPC kills the child —
+  // the callback will read `null.write` and throw. Swallowing here keeps
+  // the daemon process alive; the dropped Enter is the acceptable cost.
+  // Root cause: PR #196 fixed three this.pty! callers in agent-process.ts
+  // but missed worker-process.ts:93. This try/catch is the structural fix
+  // that covers every present and future caller.
+  setTimeout(() => {
+    try {
+      write(KEYS.ENTER);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      console.warn(`[inject] deferred Enter failed (pty likely torn down): ${msg}`);
+    }
+  }, enterDelay);
 }
 
 /**

--- a/tests/unit/daemon/crash-handlers.test.ts
+++ b/tests/unit/daemon/crash-handlers.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  crashHistoryPath,
+  readCrashHistory,
+  writeCrashHistory,
+  recordCrash,
+  shouldSendCrashLoopAlert,
+  countRecentCrashes,
+  writeDaemonCrashedMarkers,
+  CRASH_HISTORY_MAX,
+  CRASH_LOOP_THRESHOLD,
+  CRASH_LOOP_COOLDOWN_MS,
+  CrashHistory,
+} from '../../../src/daemon/index';
+
+// Regression guard for the 2026-04-22 restart storm visibility work. These
+// helpers are what let the daemon attribute a crash to itself (not to a
+// random agent) and page the operator at 3+ crashes in 15min.
+
+function mkCtxRoot(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'cortextos-crash-'));
+  mkdirSync(join(dir, 'state'), { recursive: true });
+  return dir;
+}
+
+describe('crash history persistence', () => {
+  let ctxRoot: string;
+
+  beforeEach(() => { ctxRoot = mkCtxRoot(); });
+  afterEach(() => { rmSync(ctxRoot, { recursive: true, force: true }); });
+
+  it('returns empty history when no file exists', () => {
+    const h = readCrashHistory(ctxRoot);
+    expect(h.crashes).toEqual([]);
+    expect(h.lastAlertAt).toBeUndefined();
+  });
+
+  it('returns empty history on corrupt JSON', () => {
+    writeFileSync(crashHistoryPath(ctxRoot), 'not valid json{{{', 'utf-8');
+    const h = readCrashHistory(ctxRoot);
+    expect(h.crashes).toEqual([]);
+  });
+
+  it('round-trips write → read', () => {
+    const original: CrashHistory = {
+      crashes: [{ ts: '2026-04-23T01:00:00.000Z', err: 'err1' }],
+      lastAlertAt: '2026-04-23T01:05:00.000Z',
+    };
+    writeCrashHistory(ctxRoot, original);
+    expect(readCrashHistory(ctxRoot)).toEqual(original);
+  });
+
+  it('recordCrash appends and caps at CRASH_HISTORY_MAX', () => {
+    for (let i = 0; i < CRASH_HISTORY_MAX + 5; i++) {
+      recordCrash(ctxRoot, `crash ${i}`);
+    }
+    const h = readCrashHistory(ctxRoot);
+    expect(h.crashes.length).toBe(CRASH_HISTORY_MAX);
+    // Oldest entries trimmed — last crash should be "crash 24" (MAX+5-1)
+    expect(h.crashes[h.crashes.length - 1].err).toContain(`crash ${CRASH_HISTORY_MAX + 4}`);
+  });
+
+  it('recordCrash truncates very long error strings', () => {
+    const huge = 'x'.repeat(5000);
+    recordCrash(ctxRoot, huge);
+    const h = readCrashHistory(ctxRoot);
+    expect(h.crashes[0].err.length).toBeLessThanOrEqual(2000);
+  });
+});
+
+describe('shouldSendCrashLoopAlert', () => {
+  const now = Date.now();
+  const minAgo = (n: number) => new Date(now - n * 60_000).toISOString();
+
+  it('returns false below threshold', () => {
+    const h: CrashHistory = {
+      crashes: [
+        { ts: minAgo(1), err: 'a' },
+        { ts: minAgo(2), err: 'b' },
+      ],
+    };
+    expect(shouldSendCrashLoopAlert(h)).toBe(false);
+  });
+
+  it('returns true at exactly threshold within window', () => {
+    const h: CrashHistory = {
+      crashes: Array.from({ length: CRASH_LOOP_THRESHOLD }, (_, i) => ({
+        ts: minAgo(i + 1),
+        err: `crash${i}`,
+      })),
+    };
+    expect(shouldSendCrashLoopAlert(h)).toBe(true);
+  });
+
+  it('ignores crashes older than the 15min window', () => {
+    const h: CrashHistory = {
+      crashes: [
+        { ts: minAgo(20), err: 'old1' },
+        { ts: minAgo(18), err: 'old2' },
+        { ts: minAgo(16), err: 'old3' },
+        { ts: minAgo(2), err: 'recent1' },
+      ],
+    };
+    // Only 1 recent — below threshold
+    expect(shouldSendCrashLoopAlert(h)).toBe(false);
+  });
+
+  it('respects 30-min cooldown after previous alert', () => {
+    const h: CrashHistory = {
+      crashes: Array.from({ length: CRASH_LOOP_THRESHOLD + 1 }, (_, i) => ({
+        ts: minAgo(i + 1),
+        err: `crash${i}`,
+      })),
+      lastAlertAt: new Date(now - 10 * 60_000).toISOString(), // 10 min ago
+    };
+    expect(shouldSendCrashLoopAlert(h)).toBe(false);
+  });
+
+  it('fires again once cooldown expires', () => {
+    const h: CrashHistory = {
+      crashes: Array.from({ length: CRASH_LOOP_THRESHOLD }, (_, i) => ({
+        ts: minAgo(i + 1),
+        err: `crash${i}`,
+      })),
+      lastAlertAt: new Date(now - CRASH_LOOP_COOLDOWN_MS - 60_000).toISOString(),
+    };
+    expect(shouldSendCrashLoopAlert(h)).toBe(true);
+  });
+});
+
+describe('countRecentCrashes', () => {
+  const now = Date.now();
+  it('counts only crashes inside the 15min window', () => {
+    const h: CrashHistory = {
+      crashes: [
+        { ts: new Date(now - 20 * 60_000).toISOString(), err: 'old' },
+        { ts: new Date(now - 10 * 60_000).toISOString(), err: 'inside1' },
+        { ts: new Date(now - 5 * 60_000).toISOString(), err: 'inside2' },
+        { ts: new Date(now - 16 * 60_000).toISOString(), err: 'just-outside' },
+      ],
+    };
+    expect(countRecentCrashes(h)).toBe(2);
+  });
+});
+
+describe('writeDaemonCrashedMarkers', () => {
+  let ctxRoot: string;
+
+  beforeEach(() => {
+    ctxRoot = mkCtxRoot();
+    mkdirSync(join(ctxRoot, 'state', 'boris'), { recursive: true });
+    mkdirSync(join(ctxRoot, 'state', 'donna'), { recursive: true });
+    mkdirSync(join(ctxRoot, 'state', 'nick'), { recursive: true });
+  });
+  afterEach(() => { rmSync(ctxRoot, { recursive: true, force: true }); });
+
+  it('writes a .daemon-crashed marker in each per-agent state dir', () => {
+    writeDaemonCrashedMarkers(ctxRoot);
+    for (const name of ['boris', 'donna', 'nick']) {
+      const marker = join(ctxRoot, 'state', name, '.daemon-crashed');
+      expect(existsSync(marker)).toBe(true);
+      // ISO timestamp
+      expect(readFileSync(marker, 'utf-8')).toMatch(/\d{4}-\d{2}-\d{2}T/);
+    }
+  });
+
+  it('skips gracefully when state dir is missing', () => {
+    const empty = mkdtempSync(join(tmpdir(), 'cortextos-empty-'));
+    expect(() => writeDaemonCrashedMarkers(empty)).not.toThrow();
+    rmSync(empty, { recursive: true, force: true });
+  });
+
+  it('overwrites existing marker with newer timestamp', () => {
+    writeFileSync(join(ctxRoot, 'state', 'boris', '.daemon-crashed'), 'OLD', 'utf-8');
+    writeDaemonCrashedMarkers(ctxRoot);
+    const content = readFileSync(join(ctxRoot, 'state', 'boris', '.daemon-crashed'), 'utf-8');
+    expect(content).not.toBe('OLD');
+    expect(content).toMatch(/\d{4}-\d{2}-\d{2}T/);
+  });
+});

--- a/tests/unit/pty/inject.test.ts
+++ b/tests/unit/pty/inject.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { MessageDedup, KEYS } from '../../../src/pty/inject';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MessageDedup, KEYS, injectMessage } from '../../../src/pty/inject';
 
 describe('MessageDedup', () => {
   it('detects duplicate content', () => {
@@ -32,5 +32,62 @@ describe('KEYS', () => {
     expect(KEYS.DOWN).toBe('\x1b[B');
     expect(KEYS.UP).toBe('\x1b[A');
     expect(KEYS.SPACE).toBe(' ');
+  });
+});
+
+describe('injectMessage — deferred Enter crash safety', () => {
+  // Regression guard for the 2026-04-22 storm. worker-process.ts:93 passed
+  // an unsafe `this.pty!.write` callback; when PTY was torn down during the
+  // 300ms enterDelay window the setTimeout fired null.write → uncaught
+  // TypeError → daemon crash. The fix wraps the deferred write in try/catch.
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    warnSpy.mockRestore();
+  });
+
+  it('swallows throw from the deferred Enter callback without crashing', () => {
+    const writes: string[] = [];
+    // Caller's write is "safe" during the synchronous paste but starts
+    // throwing by the time the deferred Enter fires — simulates PTY teardown.
+    let ptyAlive = true;
+    const write = (data: string) => {
+      if (!ptyAlive) throw new TypeError("Cannot read properties of null (reading 'write')");
+      writes.push(data);
+    };
+
+    // Synchronous calls (paste markers + content) should succeed.
+    expect(() => injectMessage(write, 'hello', 300)).not.toThrow();
+    expect(writes.length).toBeGreaterThan(0);
+
+    // PTY dies before the 300ms Enter timeout fires.
+    ptyAlive = false;
+
+    // Advancing the clock invokes the deferred callback. Must NOT propagate.
+    expect(() => vi.advanceTimersByTime(300)).not.toThrow();
+
+    // The warn path in inject.ts confirms the catch branch ran.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toMatch(/deferred Enter failed/);
+  });
+
+  it('sends Enter normally when the PTY stays alive', () => {
+    const writes: string[] = [];
+    const write = (data: string) => { writes.push(data); };
+
+    injectMessage(write, 'hi', 300);
+    const writesBeforeTimer = writes.length;
+    vi.advanceTimersByTime(300);
+
+    // Exactly one new write — the ENTER keystroke — and no warn.
+    expect(writes.length).toBe(writesBeforeTimer + 1);
+    expect(writes[writes.length - 1]).toBe(KEYS.ENTER);
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary

- Fixes the 2026-04-22 fleet-wide restart storm by closing the unguarded `this.pty!.write` site PR #196 missed (`src/daemon/worker-process.ts:93`), plus a structural try/catch in `pty/inject.ts` so the whole class is dead.
- Adds a crash-visibility layer so future daemon deaths are **attributable** (`.daemon-crashed` markers → new `🚨 daemon crashed` hook variant), **observable** (`state/.daemon-crash-history.json` with source-mapped stacks), and **storm-surfaced** (operator Telegram alert at 3 crashes in 15 min, 30-min cooldown).
- Documents `max_restarts: 10` as the **intentional** final circuit breaker — storm protection > fleet uptime during pathological loops.

## Root cause of the 2026-04-22 storm

```
TypeError: Cannot read properties of null (reading 'write')
    at process.<anonymous> (src/daemon/worker-process.ts:93)
    at Timeout._onTimeout (src/pty/inject.ts:83)
```

`worker-process.ts:93`:
```typescript
injectMessage((data) => this.pty!.write(data), text);
```

TypeScript's `!` erases at runtime, so the compiled callback is `this.pty.write(data)`. `inject.ts:83` schedules a 300ms `setTimeout` to submit the Enter keystroke. If the worker PTY is torn down in that window (e.g. terminate-worker during an inject), the callback fires `null.write` → unhandled TypeError → daemon crashes → PM2 respawns → `discoverAndStart()` → same race on the next cycle → **5-iteration storm** until manually rolled back.

PR #196 fixed the **three** identical sites in `agent-process.ts`. This is the **fourth** site — `grep -rn 'this\.pty!' src/` now returns zero.

## Why it fired tonight specifically

The `test/combined-fixes` branch being tested included **PR #217** (hard-restart IPC). Before #217, `cortextos bus hard-restart` was a no-op (issue #202) — PTYs rarely got torn down in the 300ms inject window. With #217 active, hard-restart actually kills the PTY → the latent race fires reliably → storm.

This PR **must land before #217 merges** or the storm recurs.

## Changes (5 edits, 2 test files; ~523 lines added, 6 removed)

### 1. `src/daemon/worker-process.ts:93` — one character
```diff
- injectMessage((data) => this.pty!.write(data), text);
+ injectMessage((data) => this.pty?.write(data), text);
```

### 2. `src/pty/inject.ts:83` — structural safety net
Wrap the deferred Enter `setTimeout` in try/catch. Makes the crash class unreachable from any caller, present or future. Warn-logs the dropped keystroke instead of crashing the daemon.

### 3. `src/daemon/index.ts` — `uncaughtException` + `unhandledRejection` handlers (~230 lines)
- `uncaughtException`: logs `[daemon] FATAL uncaughtException — exiting for PM2 respawn` with full stack, writes `.daemon-crashed` markers into every agent's state dir, records to `state/.daemon-crash-history.json` (capped at 20), fires operator Telegram alert at 3 crashes in 15 min (30-min cooldown), exits(1) for PM2 respawn.
- `unhandledRejection`: same tracking, logs only, does not exit (Node 15+ non-strict default).
- Debug: `CTX_DEBUG_ALLOW_CRASH_TRIGGER=1` registers a `SIGUSR2` handler that throws a synthetic exception — enables live verification of the crash-visibility path.
- Operator creds: `CTX_OPERATOR_CHAT_ID` + `CTX_OPERATOR_BOT_TOKEN` env vars (recommended for production); falls back to first agent's `.env` `BOT_TOKEN`/`CHAT_ID` for small installs.

### 4. `src/hooks/hook-crash-alert.ts` — new `daemon-crashed` variant
```
🚨 <agent> — daemon crashed, session was interrupted. Resuming.
Crash time: 2026-04-23T13:53:21.598Z
```
Deliberately NOT suppressed during quiet hours — daemon crash at 3am historically preceded fleet-wide storms.

### 5. `ecosystem.config.js` — documentation + debug env slot
- Comment block explaining `max_restarts: 10` + `restart_delay: 5000` as intentional circuit breaker; do not raise.
- `CTX_DEBUG_ALLOW_CRASH_TRIGGER: '0'` env slot, documented.

## Tests

- `tests/unit/pty/inject.test.ts` (+2): deferred-callback swallow path; normal-path no-warn.
- `tests/unit/daemon/crash-handlers.test.ts` (new, 14 tests): round-trip persistence, threshold detection, 30-min cooldown, truncation, window math, multi-agent marker writing, graceful failure on disk errors.

**Full suite**: 658 passed (was 642), 17 skipped, zero regressions. Typecheck clean.

## Live verification (production fleet, 2026-04-23 UTC)

- **Exact storm reproduction**: `cortextos spawn-worker ... && cortextos inject-worker ... && cortextos terminate-worker ...` within 100ms. Pre-fix this crashed the daemon; post-fix zero errors, daemon uptime grew normally.
- **Phase C.1 (single SIGUSR2)**: daemon exits cleanly with FATAL log + source-mapped stack, 12 `.daemon-crashed` markers written, `crash-history.json` created with ISO timestamp, PM2 respawns cleanly. Manual hook fire emitted the new `🚨 daemon crashed` Telegram variant for a target agent — verified by the user.
- **Phase C.2 (3 SIGUSR2 in <3min)**: crash-history accumulates `1→2→3`; on the 3rd crash, operator Telegram alert fires exactly once, `lastAlertAt` set. Unit test verifies the 30-min cooldown (skipped live to avoid noise).
- **Passive 11+ hours on live fleet**: zero new `TypeError: Cannot read properties of null` entries in the error log. All existing ones are pre-existing from the earlier storm (before this PR deployed).

## Coordination with in-flight PRs

- **#217 `fix/hard-restart-ipc-missing`** — **this PR must land first**. They're coupled: #217 makes the worker-inject race fire reliably, this PR makes that safe.
- **#206/#207** — unrelated surfaces; no conflict.

## Out of scope (deferred to follow-up PRs)

- **#218** fast-checker regex false-positive on `[1m]` config (Robert Sahakyan)
- **#132/#202** Tier 3 handoff on auto-compact failure (fixed by #217)
- **#34/#151** heartbeat watchdog dead-zone coordination (needs single design doc first — community PRs #149/#159/#65/#189 overlap)
- Broken `cron-state.json` tracking (agents never instructed to call `bus update-cron-fire`)
- SessionEnd hook not auto-dispatching after daemon-initiated PTY shutdown
- Sonnet weekly-limit interactive modal freezing agents silently

Full finding list in the session's bug-findings log; each will be filed as individual tracking issues after this ships.

## Test plan

- [ ] Reviewer: `grep -rn 'this\.pty!' src/` returns zero hits
- [ ] Reviewer: `npm run typecheck` clean
- [ ] Reviewer: `npm test` → 658+ passing, zero new failures
- [ ] Reviewer: `npm run build && node dist/daemon.js` boots an isolated daemon cleanly
- [ ] Reviewer: `CTX_DEBUG_ALLOW_CRASH_TRIGGER=1 node dist/daemon.js` + `kill -SIGUSR2 <pid>` → FATAL log + exit(1), crash-history written

🤖 Generated with [Claude Code](https://claude.com/claude-code)