### PR TITLE
fix(test): use relative timestamps in channels route test

### DIFF
--- a/dashboard/src/app/api/comms/__tests__/routes.test.ts
+++ b/dashboard/src/app/api/comms/__tests__/routes.test.ts
@@ -123,9 +123,11 @@ describe('GET /api/comms/feed', () => {
 // ---------------------------------------------------------------------------
 describe('GET /api/comms/channels', () => {
   it('groups messages by pair and reports last-message metadata', async () => {
+    const t1 = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString();
+    const t2 = new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString();
     writeHistory([
-      { id: 'm1', from: 'boris', to: 'nick', priority: 'normal', timestamp: '2026-04-15T09:00:00Z', text: 'hi', reply_to: null },
-      { id: 'm2', from: 'nick', to: 'boris', priority: 'normal', timestamp: '2026-04-15T10:00:00Z', text: 'reply', reply_to: null },
+      { id: 'm1', from: 'boris', to: 'nick', priority: 'normal', timestamp: t1, text: 'hi', reply_to: null },
+      { id: 'm2', from: 'nick', to: 'boris', priority: 'normal', timestamp: t2, text: 'reply', reply_to: null },
     ]);
 
     const res = await channels.GET(makeRequest('/api/comms/channels'));


### PR DESCRIPTION
## Summary

Unblocks CI for every open PR by fixing the aged-out hardcoded timestamps in the channels route test.

The test hardcoded `2026-04-15T09:00:00Z` / `2026-04-15T10:00:00Z`. The `/api/comms/channels` route filters messages by a 7-day archive window — once ~1 week passed since Apr 15, those messages aged out of the window and the test asserting `expect(channels).toHaveLength(1)` started returning `[]` (length 0).

This turns every PR's CI red on the Unit Tests check, even for unrelated changes (PR #223 hit it tonight).

## Fix

Use relative timestamps (`Date.now() - 2h` / `Date.now() - 1h`) so the test is time-invariant.

## Provenance

Cherry-picked from `ae8c13bc048eb711c0a58f9f023dde626b9dd931` which already lives on several feature branches (`fix/boot-cron-restore-skip-cloud-prompt`, `test/combined-fixes`) but was never landed directly on `main`. Since those branches are still open PRs, the simplest path is this dedicated one-commit PR.

## Test plan

- [ ] CI green on Unit Tests
- [ ] After merge, every in-flight PR's CI also goes green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>