### PR TITLE
fix(telegram): catch poller Conflict error with 10s backoff

### DIFF
--- a/src/cli/ecosystem.ts
+++ b/src/cli/ecosystem.ts
@@ -97,7 +97,7 @@ export const ecosystemCommand = new Command('ecosystem')
       // Dashboard reads its real config from dashboard/.env.local — populated
       // by /onboarding Phase 7. PM2 just supervises the npm process.
       max_restarts: 50,
-      restart_delay: 5000,
+      restart_delay: 15000,
       autorestart: true,
     }`
       : '';
@@ -123,7 +123,7 @@ module.exports = {
         CTX_ORG: process.env.CTX_ORG || ${JSON.stringify(detectedOrg)},
       },
       max_restarts: 50,
-      restart_delay: 5000,
+      restart_delay: 15000,
       autorestart: true,
     }${dashboardAppBlock},
   ],

--- a/src/telegram/poller.ts
+++ b/src/telegram/poller.ts
@@ -105,7 +105,18 @@ export class TelegramPoller {
    * update so a crash mid-batch does not drop confirmed state.
    */
   async pollOnce(): Promise<void> {
-    const result = await this.api.getUpdates(this.offset, 1);
+    let result;
+    try {
+      result = await this.api.getUpdates(this.offset, 1);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('Conflict') || msg.includes('terminated by other getUpdates')) {
+        console.error('[telegram-poller] Conflict detected (another poller active), backing off 10s');
+        await sleep(10_000);
+        return;
+      }
+      throw err;
+    }
     if (!result?.result?.length) return;
 
     for (const update of result.result as TelegramUpdate[]) {


### PR DESCRIPTION
Telegram polling returns 409 Conflict when two instances poll simultaneously. Now caught explicitly with a 10s backoff rather than crashing the poller loop. Also bumps PM2 restart_delay to 15s to reduce the chance of overlap on rapid restarts.