### PR TITLE
feat(hooks): PreToolUse loop detection — repetition and ping-pong blocking

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1820,6 +1820,11 @@ busCommand
   .description('Stop hook: writes last_idle.flag timestamp so fast-checker knows agent finished its turn')
   .action(() => runHook('hook-idle-flag'));
 
+busCommand
+  .command('hook-loop-detector')
+  .description('PreToolUse hook: detects and blocks repeated tool loops (repetition and ping-pong patterns)')
+  .action(() => runHook('hook-loop-detector'));
+
 // --- OAuth token rotation commands ---
 
 busCommand

--- a/src/hooks/hook-loop-detector.ts
+++ b/src/hooks/hook-loop-detector.ts
@@ -1,0 +1,261 @@
+/**
+ * hook-loop-detector.ts — PreToolUse hook: detects and blocks repeated tool loops.
+ *
+ * Ports the two-strategy detection algorithm from desplega-ai/agent-swarm into
+ * a cortextOS PreToolUse hook.
+ *
+ * Detection strategies:
+ *   1. Repetition — the same (tool, args-hash) pair appears ≥ REPETITION_BLOCK
+ *      times in the last HISTORY_SIZE calls.
+ *   2. Ping-pong — two tools alternate and together dominate ≥ 80% of the last
+ *      PINGPONG_WINDOW calls.
+ *
+ * On detection the hook writes a block decision to stdout and exits 0.
+ * All other paths exit 0 silently so the tool call proceeds.
+ *
+ * State: {ctxRoot}/state/{agentName}/loop-detector.json
+ * Cleared automatically when it exceeds HISTORY_SIZE entries (sliding window).
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { createHash } from 'crypto';
+import { readStdin, parseHookInput } from './index.js';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Rolling history window size. */
+export const HISTORY_SIZE = 30;
+
+/** Block repetition loops after this many identical (tool, args-hash) calls. */
+export const REPETITION_BLOCK = 15;
+
+/** Window size for ping-pong pattern analysis. */
+export const PINGPONG_WINDOW = 12;
+
+/** Block ping-pong loops after this many alternating-pair calls in the window. */
+export const PINGPONG_BLOCK = 14;
+
+/** Fraction of PINGPONG_WINDOW the two dominant tools must occupy to trigger. */
+export const PINGPONG_DOMINANCE = 0.8;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ToolCallRecord {
+  toolName: string;
+  argsHash: string;
+  ts: number; // epoch ms
+}
+
+export interface LoopDetectorState {
+  history: ToolCallRecord[];
+}
+
+// ---------------------------------------------------------------------------
+// Args hashing
+// ---------------------------------------------------------------------------
+
+/**
+ * Recursively sort object keys for deterministic JSON serialisation.
+ * Arrays are left in their original order (order matters for array args).
+ */
+function sortObjectKeys(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(sortObjectKeys);
+  const obj = value as Record<string, unknown>;
+  return Object.keys(obj)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, k) => {
+      acc[k] = sortObjectKeys(obj[k]);
+      return acc;
+    }, {});
+}
+
+/**
+ * Produce a collision-resistant hash string for the tool input arguments.
+ * Uses sorted JSON serialisation so {a:1, b:2} === {b:2, a:1}.
+ * Returns an empty string for null/undefined inputs.
+ *
+ * SHA-256 (first 16 hex chars) is used to avoid the false-positive repetition
+ * blocks that a 32-bit djb2 hash would produce from collisions.
+ */
+export function hashArgs(toolInput: unknown): string {
+  if (toolInput === null || toolInput === undefined) return '';
+  try {
+    const normalized = JSON.stringify(sortObjectKeys(toolInput));
+    return createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  } catch {
+    return '';
+  }
+}
+
+// ---------------------------------------------------------------------------
+// State persistence
+// ---------------------------------------------------------------------------
+
+function statePath(stateDir: string): string {
+  return join(stateDir, 'loop-detector.json');
+}
+
+export function loadState(stateDir: string): LoopDetectorState {
+  const p = statePath(stateDir);
+  if (!existsSync(p)) return { history: [] };
+  try {
+    const raw = readFileSync(p, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<LoopDetectorState>;
+    const rawHistory = Array.isArray(parsed.history) ? parsed.history : [];
+    // Filter out corrupt/partial records so countRepetitions and detectPingPong
+    // never throw on missing fields (Bug-1 fix).
+    const history: ToolCallRecord[] = rawHistory.filter(
+      (r): r is ToolCallRecord =>
+        r !== null &&
+        typeof r === 'object' &&
+        typeof (r as ToolCallRecord).toolName === 'string' &&
+        typeof (r as ToolCallRecord).argsHash === 'string' &&
+        typeof (r as ToolCallRecord).ts === 'number',
+    );
+    return { history };
+  } catch {
+    return { history: [] };
+  }
+}
+
+function saveState(stateDir: string, state: LoopDetectorState): void {
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(statePath(stateDir), JSON.stringify(state, null, 2) + '\n', 'utf-8');
+  } catch {
+    // Best-effort — never throw from a hook
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Detection algorithms
+// ---------------------------------------------------------------------------
+
+/**
+ * Repetition detection: count how many times the same (toolName, argsHash)
+ * pair appears in the last HISTORY_SIZE records.
+ * Returns the count.
+ */
+export function countRepetitions(
+  history: ToolCallRecord[],
+  toolName: string,
+  argsHash: string,
+): number {
+  return history.filter(r => r.toolName === toolName && r.argsHash === argsHash).length;
+}
+
+/**
+ * Ping-pong detection (two-phase):
+ *
+ * Phase 1 — Identify the pair using the last PINGPONG_WINDOW records.
+ *   Two tools must together occupy ≥ PINGPONG_DOMINANCE of that window.
+ *
+ * Phase 2 — Count alternations across the FULL history.
+ *   We use the window only to establish WHICH pair is oscillating; the
+ *   alternation count is measured over all history so that PINGPONG_BLOCK (14)
+ *   is reachable (max alternations in a 12-call window is only 11).
+ *
+ * Returns { count, tools } where count is total alternations between the pair
+ * in the full history, or { count: 0, tools: null } if no pair is found.
+ */
+export function detectPingPong(history: ToolCallRecord[]): {
+  count: number;
+  tools: [string, string] | null;
+} {
+  if (history.length < PINGPONG_WINDOW) return { count: 0, tools: null };
+
+  // Phase 1: identify dominant pair from the recent window
+  const window = history.slice(-PINGPONG_WINDOW);
+  const freq: Record<string, number> = {};
+  for (const r of window) {
+    freq[r.toolName] = (freq[r.toolName] ?? 0) + 1;
+  }
+
+  const sorted = Object.entries(freq).sort((a, b) => b[1] - a[1]);
+  if (sorted.length < 2) return { count: 0, tools: null };
+
+  const [topTool, topCount] = sorted[0];
+  const [secondTool, secondCount] = sorted[1];
+  const combinedFraction = (topCount + secondCount) / PINGPONG_WINDOW;
+
+  if (combinedFraction < PINGPONG_DOMINANCE) return { count: 0, tools: null };
+
+  // Phase 2: count alternations between the pair across the FULL history
+  const pairSet = new Set([topTool, secondTool]);
+  const pairCalls = history.filter(r => pairSet.has(r.toolName));
+  let alternations = 0;
+  for (let i = 1; i < pairCalls.length; i++) {
+    if (pairCalls[i].toolName !== pairCalls[i - 1].toolName) {
+      alternations++;
+    }
+  }
+
+  return {
+    count: alternations,
+    tools: [topTool, secondTool],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook output
+// ---------------------------------------------------------------------------
+
+function blockCall(reason: string): void {
+  const output = { decision: 'block', reason };
+  process.stdout.write(JSON.stringify(output) + '\n');
+  process.exit(0);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  const input = await readStdin();
+  const { tool_name, tool_input } = parseHookInput(input);
+
+  const agentName = process.env.CTX_AGENT_NAME || '';
+  const ctxRoot = process.env.CTX_ROOT || join(homedir(), '.cortextos', 'default');
+  const stateDir = join(ctxRoot, 'state', agentName);
+
+  const state = loadState(stateDir);
+  const argsHash = hashArgs(tool_input);
+
+  // Append current call to history (before threshold checks so the blocking
+  // call is counted — prevents "block at 15, record nothing, retry forever")
+  state.history.push({ toolName: tool_name, argsHash, ts: Date.now() });
+  // Trim to sliding window
+  if (state.history.length > HISTORY_SIZE) {
+    state.history = state.history.slice(-HISTORY_SIZE);
+  }
+  saveState(stateDir, state);
+
+  // --- Strategy 1: Repetition ---
+  const reps = countRepetitions(state.history, tool_name, argsHash);
+  if (reps >= REPETITION_BLOCK) {
+    blockCall(
+      `Tool loop detected: "${tool_name}" called ${reps} times with identical arguments in the last ${HISTORY_SIZE} calls. Stop repeating this action and try a fundamentally different approach.`,
+    );
+    return;
+  }
+
+  // --- Strategy 2: Ping-pong ---
+  const pp = detectPingPong(state.history);
+  if (pp.count >= PINGPONG_BLOCK && pp.tools) {
+    blockCall(
+      `Tool loop detected: "${pp.tools[0]}" and "${pp.tools[1]}" are alternating repeatedly (${pp.count} alternations in the last ${state.history.length} calls). Stop this back-and-forth pattern and try a fundamentally different approach.`,
+    );
+    return;
+  }
+
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -39,6 +39,15 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-loop-detector",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -39,6 +39,15 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-loop-detector",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/templates/orchestrator/.claude/settings.json
+++ b/templates/orchestrator/.claude/settings.json
@@ -39,6 +39,15 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-loop-detector",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/tests/unit/hooks/loop-detector.test.ts
+++ b/tests/unit/hooks/loop-detector.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  HISTORY_SIZE,
+  REPETITION_BLOCK,
+  PINGPONG_WINDOW,
+  PINGPONG_BLOCK,
+  hashArgs,
+  countRepetitions,
+  detectPingPong,
+  loadState,
+  type ToolCallRecord,
+} from '../../../src/hooks/hook-loop-detector';
+
+// ---------------------------------------------------------------------------
+// hashArgs
+// ---------------------------------------------------------------------------
+
+describe('hashArgs', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(hashArgs(null)).toBe('');
+    expect(hashArgs(undefined)).toBe('');
+  });
+
+  it('returns a non-empty hex string for an object', () => {
+    const h = hashArgs({ file_path: '/tmp/foo', content: 'bar' });
+    expect(h).toMatch(/^[0-9a-f]+$/);
+    expect(h.length).toBeGreaterThan(0);
+  });
+
+  it('is order-independent for object keys', () => {
+    const a = hashArgs({ file_path: '/tmp/foo', old_string: 'x', new_string: 'y' });
+    const b = hashArgs({ new_string: 'y', old_string: 'x', file_path: '/tmp/foo' });
+    expect(a).toBe(b);
+  });
+
+  it('produces different hashes for different values', () => {
+    const a = hashArgs({ file_path: '/tmp/a' });
+    const b = hashArgs({ file_path: '/tmp/b' });
+    expect(a).not.toBe(b);
+  });
+
+  it('preserves array order', () => {
+    const a = hashArgs({ items: [1, 2, 3] });
+    const b = hashArgs({ items: [3, 2, 1] });
+    expect(a).not.toBe(b);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// countRepetitions
+// ---------------------------------------------------------------------------
+
+describe('countRepetitions', () => {
+  const makeRecord = (toolName: string, argsHash: string): ToolCallRecord => ({
+    toolName,
+    argsHash,
+    ts: Date.now(),
+  });
+
+  it('returns 0 for empty history', () => {
+    expect(countRepetitions([], 'Read', 'abc')).toBe(0);
+  });
+
+  it('counts exact matches', () => {
+    const history = [
+      makeRecord('Read', 'abc'),
+      makeRecord('Read', 'abc'),
+      makeRecord('Edit', 'abc'),
+      makeRecord('Read', 'def'),
+    ];
+    expect(countRepetitions(history, 'Read', 'abc')).toBe(2);
+  });
+
+  it('requires both tool name and args hash to match', () => {
+    const history = [makeRecord('Read', 'abc'), makeRecord('Edit', 'abc')];
+    expect(countRepetitions(history, 'Read', 'abc')).toBe(1);
+    expect(countRepetitions(history, 'Edit', 'abc')).toBe(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// detectPingPong
+// ---------------------------------------------------------------------------
+
+describe('detectPingPong', () => {
+  const makeRecord = (toolName: string): ToolCallRecord => ({
+    toolName,
+    argsHash: hashArgs({ tool: toolName }),
+    ts: Date.now(),
+  });
+
+  it('returns 0 for history shorter than PINGPONG_WINDOW', () => {
+    const short = Array.from({ length: PINGPONG_WINDOW - 1 }, () => makeRecord('Read'));
+    expect(detectPingPong(short).count).toBe(0);
+  });
+
+  it('returns 0 when no two tools dominate the window', () => {
+    // 4 different tools spread evenly — no pair dominates 80%
+    const tools = ['Read', 'Write', 'Grep', 'Bash', 'Edit', 'Glob', 'WebFetch', 'WebSearch', 'Read', 'Write', 'Grep', 'Bash'];
+    const history = tools.map(makeRecord);
+    expect(detectPingPong(history).count).toBe(0);
+  });
+
+  it('detects a clean A/B alternation pattern', () => {
+    // PINGPONG_WINDOW alternating Read/Edit = PINGPONG_WINDOW-1 alternations
+    const alternating = Array.from({ length: PINGPONG_WINDOW }, (_, i) =>
+      makeRecord(i % 2 === 0 ? 'Read' : 'Edit'),
+    );
+    const result = detectPingPong(alternating);
+    expect(result.count).toBeGreaterThan(0);
+    expect(result.tools).not.toBeNull();
+    expect(result.tools).toContain('Read');
+    expect(result.tools).toContain('Edit');
+  });
+
+  it('does not detect when same tool fills the window (no alternation)', () => {
+    // All Read — no ping-pong
+    const monotone = Array.from({ length: PINGPONG_WINDOW }, () => makeRecord('Read'));
+    expect(detectPingPong(monotone).count).toBe(0);
+  });
+
+  it('uses the last PINGPONG_WINDOW records to identify the pair', () => {
+    // Build HISTORY_SIZE records with varied tools, then append a clean alternating window
+    const noise = Array.from({ length: HISTORY_SIZE - PINGPONG_WINDOW }, () =>
+      makeRecord('Glob'),
+    );
+    const alternating = Array.from({ length: PINGPONG_WINDOW }, (_, i) =>
+      makeRecord(i % 2 === 0 ? 'Read' : 'Edit'),
+    );
+    const history = [...noise, ...alternating];
+    const result = detectPingPong(history);
+    expect(result.count).toBeGreaterThan(0);
+  });
+
+  it('counts alternations across the full history (not just the window)', () => {
+    // Build HISTORY_SIZE alternating Read/Edit entries so alternation count
+    // spans the full history — necessary for PINGPONG_BLOCK (14) to be reachable
+    // since max alternations in PINGPONG_WINDOW (12) alone is only 11.
+    const fullAlternating = Array.from({ length: HISTORY_SIZE }, (_, i) =>
+      makeRecord(i % 2 === 0 ? 'Read' : 'Edit'),
+    );
+    const result = detectPingPong(fullAlternating);
+    // Full alternation across 30 records gives 29 alternations — well above PINGPONG_BLOCK
+    expect(result.count).toBeGreaterThanOrEqual(PINGPONG_BLOCK);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// loadState
+// ---------------------------------------------------------------------------
+
+describe('loadState', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'loop-detector-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty history when state file does not exist', () => {
+    const state = loadState(tmpDir);
+    expect(state.history).toEqual([]);
+  });
+
+  it('filters out corrupt records on load (Bug-1 fix)', () => {
+    const stateFile = join(tmpDir, 'loop-detector.json');
+    const corrupt = {
+      history: [
+        { toolName: 'Read', argsHash: 'abc', ts: 1000 }, // valid
+        { toolName: null, argsHash: 'def', ts: 2000 },   // null toolName — corrupt
+        { toolName: 'Edit', argsHash: 789, ts: 3000 },   // argsHash not string — corrupt
+        { toolName: 'Grep' },                             // missing argsHash and ts — corrupt
+        { toolName: 'Bash', argsHash: 'xyz', ts: 5000 }, // valid
+      ],
+    };
+    writeFileSync(stateFile, JSON.stringify(corrupt), 'utf-8');
+    const state = loadState(tmpDir);
+    expect(state.history).toHaveLength(2);
+    expect(state.history[0].toolName).toBe('Read');
+    expect(state.history[1].toolName).toBe('Bash');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Threshold sanity
+// ---------------------------------------------------------------------------
+
+describe('threshold constants', () => {
+  it('HISTORY_SIZE >= REPETITION_BLOCK', () => {
+    expect(HISTORY_SIZE).toBeGreaterThanOrEqual(REPETITION_BLOCK);
+  });
+
+  it('PINGPONG_WINDOW <= HISTORY_SIZE', () => {
+    expect(PINGPONG_WINDOW).toBeLessThanOrEqual(HISTORY_SIZE);
+  });
+
+  it('PINGPONG_BLOCK > PINGPONG_WINDOW (alternations counted across full history)', () => {
+    // The block threshold is checked against the FULL history alternation count,
+    // not just the PINGPONG_WINDOW, so it can exceed the window size. This is
+    // intentional — without this, the max reachable alternation count in a
+    // 12-call window is only 11, making a threshold of 14 unreachable.
+    expect(PINGPONG_BLOCK).toBeGreaterThan(PINGPONG_WINDOW);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
     'hooks/hook-context-status': 'src/hooks/hook-context-status.ts',
+    'hooks/hook-loop-detector': 'src/hooks/hook-loop-detector.ts',
   },
   format: ['cjs'],
   target: 'node20',


### PR DESCRIPTION
Adds a PreToolUse hook that detects when the agent is repeating identical tool calls (repetition loop) or alternating between two calls (ping-pong loop). Uses SHA-256 hashing to fingerprint args and a 30-call sliding window for detection. On detection the hook writes {"decision":"block","reason":"..."} to stdout — Claude Code blocks the tool and shows the reason to the agent. Registered as cortextos bus hook-loop-detector and added to all three template settings.json files.