### PR TITLE
fix: add reason string to .force-fresh pre-arm

### DIFF
--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -984,7 +984,7 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       // If context exhausts naturally before the agent acts, .force-fresh is already set,
       // preventing a --continue restart that would loop at the same high context level.
       try {
-        writeFileSync(join(this.paths.stateDir, '.force-fresh'), '');
+        writeFileSync(join(this.paths.stateDir, '.force-fresh'), 'tier2-prearm\n', 'utf-8');
       } catch { /* non-fatal */ }
     }
   }


### PR DESCRIPTION
Adds diagnostic reason string to the .force-fresh pre-arm write that fires at Tier 2 context threshold (79%).

**Changes**: Writes 'tier2-prearm\n' instead of empty string, consistent with other .force-fresh write sites like forceContextRestart() and hardRestart().

**Test plan**: All 688 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)