### PR TITLE
feat: agentmemory MCP + session-restore hook

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1820,6 +1820,16 @@ busCommand
   .description('Stop hook: writes last_idle.flag timestamp so fast-checker knows agent finished its turn')
   .action(() => runHook('hook-idle-flag'));
 
+busCommand
+  .command('hook-extract-facts')
+  .description('PreCompact hook: extracts and stores session summary as structured fact entry for cross-session memory')
+  .action(() => runHook('hook-extract-facts'));
+
+busCommand
+  .command('hook-session-restore')
+  .description('SessionStart hook: injects the most recent compaction snapshot as additionalContext to restore working state')
+  .action(() => runHook('hook-session-restore'));
+
 // --- OAuth token rotation commands ---
 
 busCommand

--- a/src/hooks/hook-session-restore.ts
+++ b/src/hooks/hook-session-restore.ts
@@ -1,0 +1,117 @@
+/**
+ * hook-session-restore.ts — SessionStart hook.
+ *
+ * Injects the most recent compaction snapshot into the new session as
+ * `additionalContext`. This restores working state automatically after a
+ * context compaction without requiring the agent to explicitly call
+ * `recall-facts` — the context arrives before the agent's first turn.
+ *
+ * Design:
+ * - Reads the last N fact entries written by hook-extract-facts (PreCompact).
+ * - Formats the most recent summary as a compact context block.
+ * - Returns `{"additionalContext": "..."}` so Claude Code injects it.
+ * - Silent on any error — never blocks session start.
+ *
+ * Registered in settings.json under "SessionStart".
+ * Compatible with agentmemory MCP: this hook handles short-term compaction
+ * restore; agentmemory provides long-term semantic search across many sessions.
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { loadEnv, readStdin } from './index.js';
+
+interface FactEntry {
+  ts: string;
+  session_id: string;
+  agent: string;
+  org: string;
+  source: string;
+  summary: string;
+  keywords: string[];
+}
+
+interface SessionStartPayload {
+  session_id?: string;
+  source?: string; // 'startup' | 'resume' | 'compact'
+}
+
+const MAX_SUMMARY_CHARS = 3000;
+const MAX_AGE_HOURS = 6;
+
+async function main(): Promise<void> {
+  try {
+    const raw = await readStdin();
+    let payload: SessionStartPayload = {};
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      // Non-JSON input — proceed with defaults
+    }
+
+    // On fresh startup (not a resume/compact), no restore needed
+    if (payload.source === 'startup') {
+      process.exit(0);
+    }
+
+    const env = loadEnv();
+    const factsDir = join(env.ctxRoot, 'state', env.agentName, 'memory', 'facts');
+
+    const entries: FactEntry[] = [];
+    for (let d = 0; d < 2; d++) {
+      const date = new Date(Date.now() - d * 24 * 60 * 60 * 1000);
+      const dateStr = date.toISOString().slice(0, 10);
+      const factsFile = join(factsDir, `${dateStr}.jsonl`);
+      if (!existsSync(factsFile)) continue;
+      try {
+        const lines = readFileSync(factsFile, 'utf-8').split('\n').filter(l => l.trim());
+        for (const line of lines) {
+          try {
+            const entry = JSON.parse(line) as FactEntry;
+            if (entry.source === 'precompact' && entry.summary) {
+              entries.push(entry);
+            }
+          } catch { /* skip corrupt lines */ }
+        }
+      } catch { /* skip unreadable files */ }
+    }
+
+    if (entries.length === 0) {
+      process.exit(0);
+    }
+
+    // Use the most recent entry
+    const latest = entries[entries.length - 1];
+
+    // Skip if the snapshot is too old (agent probably had a clean restart)
+    const ageMs = Date.now() - new Date(latest.ts).getTime();
+    if (ageMs > MAX_AGE_HOURS * 60 * 60 * 1000) {
+      process.exit(0);
+    }
+
+    const ts = latest.ts.replace('T', ' ').replace('Z', ' UTC').slice(0, 16);
+    const summary = latest.summary.slice(0, MAX_SUMMARY_CHARS);
+    const keywordsLine = latest.keywords.length > 0
+      ? `\nKey topics: ${latest.keywords.slice(0, 8).join(', ')}`
+      : '';
+
+    const additionalContext = [
+      `## Context from Previous Session`,
+      ``,
+      `_Snapshot taken at ${ts} (before context compaction)_`,
+      keywordsLine,
+      ``,
+      summary,
+    ].filter(line => line !== null).join('\n');
+
+    const output = { additionalContext };
+    process.stdout.write(JSON.stringify(output) + '\n');
+    process.exit(0);
+
+  } catch {
+    // Never fail — session start must not be blocked
+    process.exit(0);
+  }
+}
+
+main().catch(() => process.exit(0));

--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -49,6 +49,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-session-restore",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "Stop": [
       {
         "hooks": [

--- a/templates/agent/.mcp.json
+++ b/templates/agent/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["-y", "agentmemory-mcp"],
+      "env": {
+        "TOKEN_BUDGET": "2000",
+        "AGENTMEMORY_TOOLS": "core"
+      }
+    }
+  }
+}

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -49,6 +49,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-session-restore",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/templates/analyst/.mcp.json
+++ b/templates/analyst/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["-y", "agentmemory-mcp"],
+      "env": {
+        "TOKEN_BUDGET": "2000",
+        "AGENTMEMORY_TOOLS": "core"
+      }
+    }
+  }
+}

--- a/templates/orchestrator/.claude/settings.json
+++ b/templates/orchestrator/.claude/settings.json
@@ -49,6 +49,17 @@
         ]
       }
     ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-session-restore",
+            "timeout": 5
+          }
+        ]
+      }
+    ],
     "SessionEnd": [
       {
         "hooks": [

--- a/templates/orchestrator/.mcp.json
+++ b/templates/orchestrator/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "agentmemory": {
+      "command": "npx",
+      "args": ["-y", "agentmemory-mcp"],
+      "env": {
+        "TOKEN_BUDGET": "2000",
+        "AGENTMEMORY_TOOLS": "core"
+      }
+    }
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
     'hooks/hook-context-status': 'src/hooks/hook-context-status.ts',
+    'hooks/hook-session-restore': 'src/hooks/hook-session-restore.ts',
   },
   format: ['cjs'],
   target: 'node20',


### PR DESCRIPTION
Integrates two memory improvements into all agent templates:

1. **agentmemory MCP**: Adds `.mcp.json` to all three templates (agent, orchestrator, analyst) with `agentmemory-mcp` configured via npx, TOKEN_BUDGET=2000, AGENTMEMORY_TOOLS=core (7 semantic tools: recall, save, search, etc.). Local SQLite + BM25 + vector embeddings, zero external services.

2. **hook-session-restore**: New SessionStart hook that injects the most recent PreCompact snapshot as `additionalContext` before the agent's first turn on every session resume. Restores working state automatically — no explicit recall-facts call needed after a compaction. Guards: only fires on resume/compact source, skips if snapshot >6h old.

Registered in all three template settings.json under SessionStart. Build entry added to tsup.config.ts. CLI commands `cortextos bus hook-session-restore` and `cortextos bus hook-extract-facts` registered in bus.ts.

**Test plan**: All 688 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)