### PR TITLE
fix(telegram): validate BOT_TOKEN and CHAT_ID at add-agent and setup time

### DIFF
--- a/src/cli/enable-agent.ts
+++ b/src/cli/enable-agent.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { IPCClient } from '../daemon/ipc-server.js';
+import { TelegramAPI, formatValidateError } from '../telegram/api.js';
 
 /**
  * BUG-035 fix: discover the cortextOS framework root without depending on
@@ -179,6 +180,44 @@ export const enableAgentCommand = new Command('enable')
       console.error(`Error: .env for agent "${agent}" is missing required values: ${missing.join(', ')}`);
       console.error(`Edit ${agentEnvPath} and set BOT_TOKEN and CHAT_ID before enabling.`);
       process.exit(1);
+    }
+
+    // self-chat trap preflight: validate BOT_TOKEN + CHAT_ID against the live
+    // Telegram API before registering. Catches bad tokens, unreachable chats,
+    // bot-recipient configs, and the self_chat trap (CHAT_ID == bot's own
+    // user id) BEFORE the agent boots up on a silently broken config. Without
+    // this, the first real sendMessage call fails with a cryptic 401/400/403
+    // buried in the agent's stdout log, and the dashboard happily shows the
+    // agent as alive.
+    //
+    // Hard-fails on config-level reasons (bad_token, chat_not_found,
+    // bot_recipient, self_chat). Warns but does not block on transient
+    // reasons (network_error, rate_limited) so offline enable and burst
+    // enables during the morning cascade still succeed.
+    try {
+      const telegramApi = new TelegramAPI(env.BOT_TOKEN);
+      const validation = await telegramApi.validateCredentials(env.CHAT_ID);
+      if (validation.ok) {
+        const label = validation.chatTitle ? ` (${validation.chatTitle})` : '';
+        console.log(
+          `Telegram validated: bot=@${validation.botUsername} chat=${env.CHAT_ID} type=${validation.chatType}${label}`,
+        );
+      } else if (validation.reason === 'network_error' || validation.reason === 'rate_limited') {
+        console.error(`Warning: could not verify Telegram credentials (${validation.reason}).`);
+        console.error(`  ${formatValidateError(validation)}`);
+        console.error('  Continuing anyway — re-run enable after connectivity is restored to confirm.');
+      } else {
+        console.error(`Error: Telegram credentials for agent "${agent}" failed validation.`);
+        console.error(`  ${formatValidateError(validation)}`);
+        console.error(`  Edit ${agentEnvPath} and re-run: cortextos enable ${agent}`);
+        process.exit(1);
+      }
+    } catch (err) {
+      // Defensive: validateCredentials should never throw, but if it does,
+      // fall through with a warning rather than blocking enable on a bug in
+      // the validator itself.
+      console.error(`Warning: Telegram credential validation crashed: ${err instanceof Error ? err.message : String(err)}`);
+      console.error('  Continuing enable. Investigate the validator if this recurs.');
     }
 
     const agents = readEnabledAgents(options.instance);

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -14,6 +14,7 @@ import { existsSync, writeFileSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { spawnSync } from 'child_process';
+import { TelegramAPI, formatValidateError } from '../telegram/api.js';
 
 function rl(): Interface {
   return createInterface({ input: process.stdin, output: process.stdout });
@@ -101,6 +102,67 @@ function fetchChatId(botToken: string): string {
   }
   console.log('  Could not auto-detect chat ID.');
   return '';
+}
+
+/**
+ * Probe a BOT_TOKEN + CHAT_ID pair against the live Telegram API before
+ * writing the .env to disk. Interactively prompts the user to re-enter the
+ * chat id on a hard failure (bad_token is not recoverable here — they need
+ * to fix the token outside the wizard and re-run setup).
+ *
+ * Returns the validated chat id (possibly re-entered) on success, or null
+ * if the user gave up. Network errors and rate limits print a WARNING and
+ * continue with the original chat id — the enable preflight will re-probe
+ * once connectivity is restored.
+ */
+async function validateTelegramCredsInteractive(
+  iface: Interface,
+  botToken: string,
+  initialChatId: string,
+  label: string,
+): Promise<string | null> {
+  let chatId = initialChatId;
+  // Allow up to 3 re-entry attempts before giving up.
+  for (let attempt = 0; attempt < 3; attempt++) {
+    const api = new TelegramAPI(botToken);
+    let result;
+    try {
+      result = await api.validateCredentials(chatId);
+    } catch (err) {
+      console.log(`  Warning: Telegram validator crashed: ${err instanceof Error ? err.message : String(err)}. Writing .env anyway.`);
+      return chatId;
+    }
+
+    if (result.ok) {
+      const titleHint = result.chatTitle ? ` (${result.chatTitle})` : '';
+      console.log(`  Validated ${label}: bot=@${result.botUsername} chat=${chatId} type=${result.chatType}${titleHint}`);
+      return chatId;
+    }
+
+    if (result.reason === 'network_error' || result.reason === 'rate_limited') {
+      console.log(`  Warning: ${formatValidateError(result)}`);
+      console.log('  Writing .env with unvalidated values. Re-run cortextos enable later to confirm.');
+      return chatId;
+    }
+
+    console.log(`  Validation failed: ${formatValidateError(result)}`);
+
+    if (result.reason === 'bad_token') {
+      // Can't recover from a bad token inside the wizard loop — the user
+      // needs to fix the token at @BotFather and re-run setup. Bail.
+      console.log('  Re-run cortextos setup after fixing the bot token.');
+      return null;
+    }
+
+    const answer = await ask(iface, `  Enter a different chat_id for ${label} (or blank to give up): `);
+    if (!answer) {
+      console.log('  Giving up on validation. No .env will be written for this agent.');
+      return null;
+    }
+    chatId = answer;
+  }
+  console.log(`  Too many failed attempts — giving up on ${label}.`);
+  return null;
 }
 
 function validateAgentName(name: string): boolean {
@@ -228,6 +290,22 @@ export const setupCommand = new Command('setup')
       orchChatId = await askRequired(iface, '  Enter your Telegram chat ID manually: ', 'Chat ID is required.');
     }
 
+    // self-chat trap preflight: validate credentials against the live Telegram API
+    // BEFORE writing .env. Catches bad tokens, unreachable chats, bot
+    // recipients, and the self_chat trap (CHAT_ID == bot's own user id).
+    const validatedOrchChatId = await validateTelegramCredsInteractive(
+      iface,
+      orchToken,
+      orchChatId,
+      `orchestrator ${orchName}`,
+    );
+    if (!validatedOrchChatId) {
+      console.error('\n  Cannot continue without validated orchestrator credentials.');
+      iface.close();
+      process.exit(1);
+    }
+    orchChatId = validatedOrchChatId;
+
     // Create orchestrator agent
     const addOrchOk = runCli(
       projectRoot,
@@ -299,6 +377,19 @@ export const setupCommand = new Command('setup')
       if (!agentChatId) {
         agentChatId = await askRequired(iface, `  Enter chat ID for ${agentName} manually: `, 'Chat ID is required.');
       }
+
+      // self-chat trap preflight (see validateTelegramCredsInteractive above).
+      const validatedAgentChatId = await validateTelegramCredsInteractive(
+        iface,
+        agentToken,
+        agentChatId,
+        `agent ${agentName}`,
+      );
+      if (!validatedAgentChatId) {
+        console.log(`  Skipping ${agentName} — fix the credentials and re-run cortextos setup or cortextos enable ${agentName}.`);
+        continue;
+      }
+      agentChatId = validatedAgentChatId;
 
       const addOk = runCli(
         projectRoot,

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -6,6 +6,80 @@
 import { existsSync, readFileSync } from 'fs';
 import { basename } from 'path';
 
+/**
+ * Result of TelegramAPI.validateCredentials. Tagged union so callers can
+ * key targeted error messages off the `reason` discriminant.
+ *
+ * ok=false reasons:
+ *  - bad_token: 401 from getMe; BOT_TOKEN is invalid or revoked
+ *  - chat_not_found: 400 from getChat; CHAT_ID is not reachable by this bot
+ *    (most commonly: the user never sent /start to the bot)
+ *  - bot_recipient: getChat succeeded but the recipient is a bot (type=private
+ *    && is_bot=true), or Telegram returned the 403 "bots can't send messages
+ *    to bots" error at probe time. Bots cannot message bots.
+ *  - self_chat: CHAT_ID matches the bot's OWN user id (getMe.id). This is the
+ *    self-chat trap: someone pasted the BOT_TOKEN prefix into CHAT_ID. Caught without
+ *    needing a sendMessage probe — getMe alone is enough.
+ *  - network_error: fetch() threw — DNS, timeout, or offline. Callers should
+ *    treat as WARNING, not hard-fail.
+ *  - rate_limited: 429 from the Telegram API. Callers should treat as WARNING,
+ *    not hard-fail (retry later).
+ */
+export type ValidateCredentialsResult =
+  | {
+      ok: true;
+      botUsername: string;
+      botId: number;
+      chatType: string;
+      chatTitle?: string;
+    }
+  | {
+      ok: false;
+      reason:
+        | 'bad_token'
+        | 'chat_not_found'
+        | 'bot_recipient'
+        | 'self_chat'
+        | 'network_error'
+        | 'rate_limited';
+      detail: string;
+    };
+
+/**
+ * Format a human-readable error message for a failed ValidateCredentialsResult.
+ * Single source of truth for the CLI-facing error strings so setup.ts and
+ * enable-agent.ts stay in sync. Never leaks BOT_TOKEN (not even a prefix).
+ */
+export function formatValidateError(result: Extract<ValidateCredentialsResult, { ok: false }>): string {
+  switch (result.reason) {
+    case 'bad_token':
+      return 'BOT_TOKEN is invalid or revoked. Telegram returned 401 Unauthorized. Check the token in your .env against @BotFather.';
+    case 'chat_not_found':
+      return (
+        `CHAT_ID ${result.detail} was not found by the bot. ` +
+        'The most common cause: the user has never sent /start to the bot. ' +
+        'Open Telegram, send /start to your bot, then retry.'
+      );
+    case 'bot_recipient':
+      return (
+        `CHAT_ID ${result.detail} resolves to a bot, not a user. ` +
+        'A Telegram bot cannot message another bot. ' +
+        'Confirm this is a real user chat_id, not a bot user id.'
+      );
+    case 'self_chat':
+      return (
+        `CHAT_ID (${result.detail}) matches the bot's own user ID. ` +
+        'You likely pasted the BOT_TOKEN prefix instead of your real chat_id. ' +
+        'To get your real chat_id: send /start to the bot in Telegram, then visit ' +
+        'https://api.telegram.org/bot<TOKEN>/getUpdates and look for result[-1].message.chat.id.'
+      );
+    case 'network_error':
+      return `Could not reach the Telegram API: ${result.detail}. Check connectivity and retry.`;
+    case 'rate_limited':
+      return `Telegram API rate-limited the validation probe (${result.detail}). Retry in a few seconds.`;
+  }
+}
+
 export class TelegramAPI {
   private baseUrl: string;
   private lastSendTime: Map<string, number> = new Map();
@@ -287,6 +361,147 @@ export class TelegramAPI {
       timeout,
       allowed_updates: ['message', 'callback_query', 'message_reaction'],
     });
+  }
+
+  /**
+   * Get info about the bot itself (getMe). Throws on Telegram API error.
+   * Primarily used by validateCredentials() to confirm the BOT_TOKEN is
+   * valid and to look up the bot's own user id for the self_chat check.
+   */
+  async getMe(): Promise<any> {
+    return this.post('getMe', {});
+  }
+
+  /**
+   * Get info about a chat (getChat). Throws on Telegram API error.
+   * Used by validateCredentials() to confirm the chat_id is reachable
+   * and to inspect the chat type + is_bot flag.
+   */
+  async getChat(chatId: string | number): Promise<any> {
+    return this.post('getChat', { chat_id: chatId });
+  }
+
+  /**
+   * Race a promise against a timeout. Used by validateCredentials() so a
+   * network partition cannot hang `cortextos enable` or `cortextos setup`
+   * indefinitely. The underlying fetch keeps running in the background
+   * after the timeout, but that is acceptable for a one-off probe.
+   */
+  private async withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+      timer = setTimeout(
+        () => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s`)),
+        ms,
+      );
+    });
+    try {
+      return await Promise.race([promise, timeout]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Probe whether this bot + chat_id combination is actually usable for
+   * sending messages, without attempting a send. Catches the classes of
+   * silent-broken-config that used to surface only at first real send:
+   *
+   *   1. bad_token — BOT_TOKEN is invalid or revoked (401 from getMe)
+   *   2. chat_not_found — CHAT_ID was never opened with this bot (400)
+   *   3. bot_recipient — CHAT_ID resolves to another bot (403 at send time,
+   *      or getChat returns type=private is_bot=true)
+   *   4. self_chat — CHAT_ID equals getMe.id, meaning someone pasted the
+   *      BOT_TOKEN prefix into CHAT_ID (the "self_chat trap")
+   *   5. network_error — fetch itself failed; caller should treat as WARN
+   *   6. rate_limited — 429 from Telegram; caller should treat as WARN
+   *
+   * Never sends a real message. Only two API calls: getMe and getChat.
+   * Both are free operations on the Telegram side.
+   */
+  async validateCredentials(chatId: string | number): Promise<ValidateCredentialsResult> {
+    // Normalize chatId to a string for comparisons; Telegram accepts either.
+    const chatIdStr = String(chatId).trim();
+    if (!chatIdStr) {
+      return { ok: false, reason: 'chat_not_found', detail: '(empty)' };
+    }
+
+    // Validation probes are bounded at 10s per call so a network partition
+    // cannot hang `cortextos enable` or `cortextos setup` indefinitely.
+    const TIMEOUT_MS = 10_000;
+
+    // Step 1: getMe — validates the token AND gives us the bot's user id
+    // for the self_chat check.
+    let me: any;
+    try {
+      me = await this.withTimeout(this.getMe(), TIMEOUT_MS, 'Telegram API request');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/Unauthorized|401/i.test(msg)) {
+        return { ok: false, reason: 'bad_token', detail: msg };
+      }
+      if (/Too Many Requests|429/i.test(msg)) {
+        return { ok: false, reason: 'rate_limited', detail: msg };
+      }
+      // Any other error at the getMe step is a network-level failure
+      // (fetch threw, DNS died, etc.) rather than a credential problem.
+      if (/Telegram API error/.test(msg)) {
+        // The API replied but with an unrecognized error shape. Treat as
+        // bad_token conservatively — it's the most common cause.
+        return { ok: false, reason: 'bad_token', detail: msg };
+      }
+      return { ok: false, reason: 'network_error', detail: msg };
+    }
+
+    const botId: number | undefined = me?.result?.id;
+    const botUsername: string = me?.result?.username ?? '(unknown)';
+
+    // Step 2: the self_chat check. If CHAT_ID matches the bot's own user id,
+    // no further probing is needed — the config is broken no matter what
+    // getChat would return. This catches the self-chat trap before any additional
+    // API calls.
+    if (botId !== undefined && String(botId) === chatIdStr) {
+      return { ok: false, reason: 'self_chat', detail: chatIdStr };
+    }
+
+    // Step 3: getChat — confirms the chat is reachable by this bot and
+    // lets us inspect type + is_bot.
+    let chat: any;
+    try {
+      chat = await this.withTimeout(this.getChat(chatIdStr), TIMEOUT_MS, 'Telegram API request');
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      if (/chat not found|Bad Request/i.test(msg)) {
+        return { ok: false, reason: 'chat_not_found', detail: chatIdStr };
+      }
+      if (/bots can.?t send messages to bots|Forbidden/i.test(msg)) {
+        return { ok: false, reason: 'bot_recipient', detail: chatIdStr };
+      }
+      if (/Too Many Requests|429/i.test(msg)) {
+        return { ok: false, reason: 'rate_limited', detail: msg };
+      }
+      if (/Telegram API error/.test(msg)) {
+        return { ok: false, reason: 'chat_not_found', detail: chatIdStr };
+      }
+      return { ok: false, reason: 'network_error', detail: msg };
+    }
+
+    const chatType: string = chat?.result?.type ?? '(unknown)';
+    const chatIsBot: boolean = chatType === 'private' && chat?.result?.is_bot === true;
+    const chatTitle: string | undefined =
+      chat?.result?.title ?? chat?.result?.first_name ?? chat?.result?.username;
+
+    if (chatIsBot) {
+      return { ok: false, reason: 'bot_recipient', detail: chatIdStr };
+    }
+
+    return {
+      ok: true,
+      botUsername,
+      botId: botId ?? 0,
+      chatType,
+      chatTitle,
+    };
   }
 
   /**

--- a/tests/unit/telegram/api.test.ts
+++ b/tests/unit/telegram/api.test.ts
@@ -1,6 +1,9 @@
-import { describe, it, expect, afterEach, vi } from 'vitest';
-import { TelegramAPI } from '../../../src/telegram/api';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { TelegramAPI, formatValidateError } from '../../../src/telegram/api';
 
+// ---------------------------------------------------------------------------
+// Fetch timeout tests (from main — pre-existing)
+// ---------------------------------------------------------------------------
 describe('TelegramAPI fetch timeout', () => {
   const originalFetch = globalThis.fetch;
 
@@ -36,5 +39,287 @@ describe('TelegramAPI fetch timeout', () => {
     const api = new TelegramAPI('123:TEST');
     const res = await api.getUpdates(0, 1);
     expect(res.ok).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateCredentials tests (from pr-58)
+// Minimal fetch mock — each test queues up 1 or 2 responses (one for getMe,
+// optionally one for getChat) and asserts the resulting ValidateCredentialsResult.
+// ---------------------------------------------------------------------------
+type MockResponse = { status: number; body: any } | { throws: Error };
+
+let responseQueue: MockResponse[] = [];
+let callLog: Array<{ url: string; body: any }> = [];
+
+function queue(response: MockResponse): void {
+  responseQueue.push(response);
+}
+
+describe('TelegramAPI.validateCredentials', () => {
+  beforeEach(() => {
+    responseQueue = [];
+    callLog = [];
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init: RequestInit) => {
+      const body = init?.body ? JSON.parse(String(init.body)) : {};
+      callLog.push({ url, body });
+      const next = responseQueue.shift();
+      if (!next) {
+        throw new Error('fetch called with no queued response');
+      }
+      if ('throws' in next) {
+        throw next.throws;
+      }
+      return {
+        ok: next.status === 200,
+        status: next.status,
+        json: async () => next.body,
+      } as any;
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('happy path: valid token + reachable user chat returns ok=true', async () => {
+    queue({ status: 200, body: { ok: true, result: { id: 111, username: 'my_test_bot' } } });
+    queue({
+      status: 200,
+      body: { ok: true, result: { id: 222, type: 'private', first_name: 'Alice', is_bot: false } },
+    });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.validateCredentials('222');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.botId).toBe(111);
+      expect(result.botUsername).toBe('my_test_bot');
+      expect(result.chatType).toBe('private');
+      expect(result.chatTitle).toBe('Alice');
+    }
+    expect(callLog[0].url).toContain('/getMe');
+    expect(callLog[1].url).toContain('/getChat');
+    expect(callLog[1].body.chat_id).toBe('222');
+  });
+
+  it('bad_token: getMe returns 401 -> reason=bad_token', async () => {
+    queue({ status: 401, body: { ok: false, error_code: 401, description: 'Unauthorized' } });
+
+    const api = new TelegramAPI('999:BAD');
+    const result = await api.validateCredentials('222');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('bad_token');
+    }
+    // Critical: error message must not leak any part of the token.
+    if (!result.ok) {
+      const msg = formatValidateError(result);
+      expect(msg).not.toContain('999');
+      expect(msg).not.toContain('BAD');
+      expect(msg).toMatch(/401 Unauthorized/);
+    }
+    // Must NOT have attempted getChat once getMe failed.
+    expect(callLog).toHaveLength(1);
+    expect(callLog[0].url).toContain('/getMe');
+  });
+
+  it('self_chat: CHAT_ID equals getMe.id -> reason=self_chat (no getChat call)', async () => {
+    queue({ status: 200, body: { ok: true, result: { id: 1234567890, username: 'self_chat_test_bot' } } });
+
+    const api = new TelegramAPI('1234567890:AAF3-rr');
+    const result = await api.validateCredentials('1234567890');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('self_chat');
+      expect(result.detail).toBe('1234567890');
+      const msg = formatValidateError(result);
+      // The error message must name the trap, point at the fix, and NOT
+      // leak any part of the token.
+      expect(msg).toContain('1234567890');
+      expect(msg).toContain('BOT_TOKEN prefix');
+      expect(msg).toContain('/start');
+      expect(msg).toContain('getUpdates');
+      expect(msg).not.toContain('AAF3');
+    }
+    // self_chat is caught after getMe alone — getChat must not have been called.
+    expect(callLog).toHaveLength(1);
+  });
+
+  it('chat_not_found: getChat returns 400 -> reason=chat_not_found', async () => {
+    queue({ status: 200, body: { ok: true, result: { id: 111, username: 'my_test_bot' } } });
+    queue({ status: 400, body: { ok: false, error_code: 400, description: 'Bad Request: chat not found' } });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.validateCredentials('222');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('chat_not_found');
+      expect(result.detail).toBe('222');
+      const msg = formatValidateError(result);
+      expect(msg).toContain('222');
+      expect(msg).toContain('/start');
+    }
+    expect(callLog).toHaveLength(2);
+  });
+
+  it('bot_recipient: getChat returns a bot user -> reason=bot_recipient', async () => {
+    queue({ status: 200, body: { ok: true, result: { id: 111, username: 'my_test_bot' } } });
+    queue({
+      status: 200,
+      body: { ok: true, result: { id: 333, type: 'private', username: 'other_bot', is_bot: true } },
+    });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.validateCredentials('333');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('bot_recipient');
+      const msg = formatValidateError(result);
+      expect(msg).toContain('333');
+      expect(msg).toContain('bot');
+    }
+    expect(callLog).toHaveLength(2);
+  });
+
+  it('bot_recipient: getChat throws 403 "bots cant send messages to bots" -> reason=bot_recipient', async () => {
+    queue({ status: 200, body: { ok: true, result: { id: 111, username: 'my_test_bot' } } });
+    queue({
+      status: 403,
+      body: { ok: false, error_code: 403, description: "Forbidden: bots can't send messages to bots" },
+    });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.validateCredentials('333');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('bot_recipient');
+    }
+  });
+
+  it('network_error: fetch throws -> reason=network_error (caller treats as WARN)', async () => {
+    queue({ throws: new Error('getaddrinfo ENOTFOUND api.telegram.org') });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.validateCredentials('222');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('network_error');
+      expect(result.detail).toContain('ENOTFOUND');
+      const msg = formatValidateError(result);
+      expect(msg).toMatch(/Telegram API/i);
+    }
+  });
+
+  it('rate_limited: getMe 429 -> reason=rate_limited', async () => {
+    queue({
+      status: 429,
+      body: { ok: false, error_code: 429, description: 'Too Many Requests: retry after 5' },
+    });
+
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.validateCredentials('222');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('rate_limited');
+    }
+  });
+
+  it('timeout: fetch never resolves -> reason=network_error with "timed out" detail', async () => {
+    // Queue nothing — fetch will just hang. Then advance fake timers past 10s
+    // and assert the validator bails with network_error.
+    vi.useFakeTimers();
+    try {
+      // Override the stubbed fetch to return a never-resolving promise.
+      vi.stubGlobal('fetch', vi.fn(() => new Promise(() => { /* never resolves */ })));
+
+      const api = new TelegramAPI('111:AAA');
+      const pending = api.validateCredentials('222');
+
+      // Advance fake timers past the 10s withTimeout cap. The internal
+      // setTimeout in withTimeout rejects, validateCredentials catches,
+      // returns network_error.
+      await vi.advanceTimersByTimeAsync(10_500);
+
+      const result = await pending;
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.reason).toBe('network_error');
+        expect(result.detail).toMatch(/timed out after 10s/);
+      }
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('empty chat_id: reason=chat_not_found with no API calls', async () => {
+    // Note: this must NOT call fetch at all, so queue nothing.
+    const api = new TelegramAPI('111:AAA');
+    const result = await api.validateCredentials('');
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.reason).toBe('chat_not_found');
+    }
+    expect(callLog).toHaveLength(0);
+  });
+});
+
+describe('formatValidateError', () => {
+  it('bad_token: does not leak token or detail in user-facing text', () => {
+    const msg = formatValidateError({
+      ok: false,
+      reason: 'bad_token',
+      detail: 'Telegram API error: Unauthorized TOKEN_SECRET_123',
+    });
+    expect(msg).not.toContain('TOKEN_SECRET_123');
+    expect(msg).toMatch(/invalid or revoked/);
+  });
+
+  it('self_chat: message includes concrete fix instructions', () => {
+    const msg = formatValidateError({ ok: false, reason: 'self_chat', detail: '1234567890' });
+    expect(msg).toContain('1234567890');
+    expect(msg).toContain('BOT_TOKEN prefix');
+    expect(msg).toContain('/start');
+    expect(msg).toContain('getUpdates');
+  });
+
+  it('chat_not_found: suggests /start', () => {
+    const msg = formatValidateError({ ok: false, reason: 'chat_not_found', detail: '222' });
+    expect(msg).toContain('222');
+    expect(msg).toContain('/start');
+  });
+
+  it('bot_recipient: explains the user-vs-bot distinction', () => {
+    const msg = formatValidateError({ ok: false, reason: 'bot_recipient', detail: '333' });
+    expect(msg).toMatch(/bot/i);
+    expect(msg).toMatch(/user/i);
+    expect(msg).toContain('333');
+  });
+
+  it('network_error: includes the underlying detail', () => {
+    const msg = formatValidateError({
+      ok: false,
+      reason: 'network_error',
+      detail: 'ENOTFOUND api.telegram.org',
+    });
+    expect(msg).toContain('ENOTFOUND');
+  });
+
+  it('rate_limited: mentions retry', () => {
+    const msg = formatValidateError({
+      ok: false,
+      reason: 'rate_limited',
+      detail: 'Too Many Requests: retry after 5',
+    });
+    expect(msg).toMatch(/retry/i);
   });
 });


### PR DESCRIPTION
## Summary

Supersedes #58 (ClintMoody's original PR) with a clean rebase onto current `main` (which now contains #223 + #217 + #210 + #181 + #184 + #226 + #197 + #196 from today's stability wave). The original #58 branch was 9 days out of date and wouldn't rebase cleanly due to massive drift; this PR cherry-picks the single validation commit (`be1947b`) cleanly on top, preserving **ClintMoody as commit author**.

Original PR: #58 (close-with-reference once this merges)
Commit author preserved: `@ClintMoody <ClintMoody@users.noreply.github.com>`

## What this fixes

An agent can currently boot on silently broken Telegram credentials and look healthy in the dashboard while every inbound/outbound message fails in the background. Four distinct failure modes all pass the existing presence-check in `cortextos enable`:

1. **bad_token** — BOT_TOKEN malformed/revoked (401 on any API call)
2. **chat_not_found** — CHAT_ID valid shape but user never `/start`'d the bot (400)
3. **bot_recipient** — CHAT_ID resolves to another bot, not a user (403)
4. **self_chat** — CHAT_ID pasted from BOT_TOKEN prefix by mistake (first segment of `123456789:AAEfg...` ≡ bot's own user id). Same 403 as bot_recipient but operator-recognizable.

Before: first real `sendMessage` fails, error buries in agent stdout, dashboard shows agent alive. After: `enable` + `setup` probe Telegram API upfront and error loudly with specific root cause + fix instructions.

## Implementation

- New `TelegramAPI.validateCredentials(chatId)` method — returns tagged-union `ValidateCredentialsResult`.
- New `formatValidateError(result)` helper — single source of human-readable error strings. Never leaks any BOT_TOKEN prefix or content.
- Integrated into `src/cli/enable-agent.ts` (+39) and `src/cli/setup.ts` (+91).
- Hard-fails on config-level reasons (bad_token, chat_not_found, bot_recipient, self_chat).
- **Warns but continues** on transient reasons (network_error, rate_limited) so offline enable + morning-cascade burst enables still succeed.

## Tests

- 18 new unit tests in `tests/unit/telegram/api.test.ts`:
  - 10 validateCredentials tests covering all 4 failure modes + happy path + timeout + rate-limited + empty chat_id + network error
  - 6 formatValidateError tests checking error-message content (token-leakage guards, fix-instruction quality)
  - 2 preserved fetch-timeout tests from prior PRs on main
- Conflict-free cherry-pick: only test-file needed manual merge (both-added with main's existing fetch-timeout tests — merged additively).

## Live validation on a real production agent (cortext-designer)

Ran 5 scenarios end-to-end on live fleet:

| Scenario | Behavior |
|---|---|
| Valid creds | ✅ `Telegram validated: bot=@bebeebooboo_bot chat=... type=private (James)` |
| bad_token (fake 999:FAKE) | ✅ Blocks: `BOT_TOKEN is invalid or revoked. Telegram returned 401 Unauthorized...` — token NOT leaked |
| self_chat (CHAT_ID = bot user id) | ✅ Blocks: `CHAT_ID (X) matches the bot's own user ID. You likely pasted the BOT_TOKEN prefix...` with exact fix instructions (`/start` + `getUpdates` URL) |
| chat_not_found (valid token, unreachable chat) | ✅ Blocks: `CHAT_ID X was not found by the bot. The most common cause: the user has never sent /start...` |
| Empty CHAT_ID | ✅ Fails fast on pre-check before API call |

All 18 unit tests pass. Typecheck clean. Build clean.

## Co-authoring preserved

Original commit `be1947b` authored by ClintMoody — cherry-picked verbatim, only conflict (both-added test file) resolved additively. Commit author attribution remains intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>