### PR TITLE
feat(telegram): ack inbound user messages with 👍 + typing indicator

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -12,6 +12,7 @@ import { logInboundMessage, cacheLastSent, logOutboundMessage, buildRecentHistor
 import { collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
 import { stripControlChars } from '../utils/validate.js';
 import { processMediaMessage } from '../telegram/media.js';
+import { ackTelegramReceipt } from '../telegram/receipt-ack.js';
 
 type LogFn = (msg: string) => void;
 
@@ -298,6 +299,11 @@ export class AgentManager {
       const stateDir = join(this.ctxRoot, 'state', name);
       const poller = new TelegramPoller(telegramApi, stateDir);
 
+      // Per-bot set of message_ids we've already 👍'd. Lives for the agent's
+      // lifetime so Telegram redeliveries after a handler exception don't
+      // trigger a second reaction API call.
+      const ackedMessageIds = new Set<number>();
+
       poller.onMessage((msg) => {
         // ALLOWED_USER gate: if configured, ignore messages from other users.
         // Use numeric comparison to avoid string coercion issues.
@@ -313,6 +319,11 @@ export class AgentManager {
         const msgChatId = msg.chat?.id;
         const effectiveChatId = msgChatId ?? chatId ?? '';
         const stateDir = join(this.ctxRoot, 'state', name);
+
+        // Acknowledge receipt immediately — 👍 + typing indicator. Runs before
+        // dedup and media download so the user sees the ack within ~1s of
+        // sending, even when downstream processing is slow. Fire-and-forget.
+        ackTelegramReceipt(telegramApi, effectiveChatId, msg.message_id, ackedMessageIds, log);
 
         // Log inbound message to JSONL
         logInboundMessage(this.ctxRoot, name, {

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -308,6 +308,24 @@ export class TelegramAPI {
   }
 
   /**
+   * React to a message with a single emoji. Passing an empty emoji (or an
+   * empty reactions array) clears any prior reaction. Used by the daemon to
+   * ack inbound user messages the moment they arrive, before the agent has
+   * begun processing — the user sees 👍 within ~1s of sending.
+   */
+  async setMessageReaction(
+    chatId: string | number,
+    messageId: number,
+    emoji: string = '👍',
+  ): Promise<any> {
+    return this.post('setMessageReaction', {
+      chat_id: chatId,
+      message_id: messageId,
+      reaction: emoji ? [{ type: 'emoji', emoji }] : [],
+    });
+  }
+
+  /**
    * Get file info for downloading.
    */
   async getFile(fileId: string): Promise<any> {

--- a/src/telegram/receipt-ack.ts
+++ b/src/telegram/receipt-ack.ts
@@ -1,0 +1,57 @@
+/**
+ * Receipt acknowledgement for inbound user Telegram messages.
+ *
+ * Called immediately after an update passes the allowed-user gate, before any
+ * media download, dedup check, or PTY injection. The user sees 👍 and a
+ * `typing…` indicator within ~1 second of sending — long before the agent
+ * finishes processing.
+ *
+ * Both Telegram calls are fire-and-forget: a failure here must never block
+ * message delivery. Errors are logged and swallowed.
+ *
+ * Per-message dedup: Telegram may redeliver an update if the downstream
+ * handler throws (see TelegramPoller.pollOnce). Without a local guard we
+ * would react on every redelivery — wasteful API calls and log noise.
+ * The `ackedMessageIds` set is caller-owned so it persists across poll
+ * cycles for the same bot; we bound its size at 1000 entries (FIFO-ish)
+ * to prevent unbounded memory growth on a long-running daemon.
+ */
+
+import type { TelegramAPI } from './api.js';
+
+type LogFn = (msg: string) => void;
+
+const MAX_ACKED_IDS = 1000;
+const TRIM_TARGET = 900;
+
+export function ackTelegramReceipt(
+  api: TelegramAPI | undefined,
+  chatId: string | number | undefined,
+  messageId: number | undefined,
+  ackedMessageIds: Set<number>,
+  log: LogFn,
+): void {
+  if (!api || chatId === undefined || chatId === '' || !messageId) return;
+  if (ackedMessageIds.has(messageId)) return;
+
+  ackedMessageIds.add(messageId);
+  // Bounded cleanup: Set iteration order is insertion order, so dropping the
+  // oldest N entries keeps the most recent message_ids ack-guarded.
+  if (ackedMessageIds.size > MAX_ACKED_IDS) {
+    const toDrop = ackedMessageIds.size - TRIM_TARGET;
+    const iter = ackedMessageIds.values();
+    for (let i = 0; i < toDrop; i++) {
+      const next = iter.next();
+      if (next.done) break;
+      ackedMessageIds.delete(next.value);
+    }
+  }
+
+  api.setMessageReaction(chatId, messageId, '👍').catch((err) => {
+    log(`setMessageReaction failed for msg ${messageId}: ${err}`);
+  });
+  api.sendChatAction(chatId, 'typing').catch(() => {
+    // sendChatAction is best-effort; indicator auto-expires ~5s so a miss
+    // is visually harmless.
+  });
+}

--- a/tests/unit/telegram/api.test.ts
+++ b/tests/unit/telegram/api.test.ts
@@ -38,3 +38,57 @@ describe('TelegramAPI fetch timeout', () => {
     expect(res.ok).toBe(true);
   });
 });
+
+describe('TelegramAPI.setMessageReaction', () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    vi.restoreAllMocks();
+  });
+
+  it('posts to setMessageReaction with the 👍 emoji by default', async () => {
+    const calls: Array<{ url: string; body: any }> = [];
+    globalThis.fetch = vi.fn(async (url: string, init: any) => {
+      calls.push({ url, body: JSON.parse(String(init.body)) });
+      return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+    }) as any;
+
+    const api = new TelegramAPI('123:TEST');
+    const res = await api.setMessageReaction(42, 999);
+
+    expect(res.ok).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toMatch(/\/setMessageReaction$/);
+    expect(calls[0].body).toEqual({
+      chat_id: 42,
+      message_id: 999,
+      reaction: [{ type: 'emoji', emoji: '👍' }],
+    });
+  });
+
+  it('sends an empty reaction array when emoji is empty (clears reaction)', async () => {
+    const calls: Array<{ body: any }> = [];
+    globalThis.fetch = vi.fn(async (_url: string, init: any) => {
+      calls.push({ body: JSON.parse(String(init.body)) });
+      return new Response(JSON.stringify({ ok: true, result: true }), { status: 200 });
+    }) as any;
+
+    const api = new TelegramAPI('123:TEST');
+    await api.setMessageReaction('42', 999, '');
+
+    expect(calls[0].body).toEqual({
+      chat_id: '42',
+      message_id: 999,
+      reaction: [],
+    });
+  });
+
+  it('throws a Telegram API error when the response is not ok', async () => {
+    globalThis.fetch = vi.fn(async () =>
+      new Response(JSON.stringify({ ok: false, description: 'REACTION_INVALID' }), { status: 400 }),
+    ) as any;
+
+    const api = new TelegramAPI('123:TEST');
+    await expect(api.setMessageReaction(42, 1, '🎉')).rejects.toThrow(/REACTION_INVALID/);
+  });
+});


### PR DESCRIPTION
## Summary
- Daemon reacts with 👍 and fires `sendChatAction('typing')` the moment an inbound user Telegram message passes the ALLOWED_USER gate — before dedup, media download, or PTY injection, so users see an ack within ~1s regardless of downstream latency.
- New `TelegramAPI.setMessageReaction` helper (empty emoji clears); new `src/telegram/receipt-ack.ts` holds the fire-and-forget logic plus a per-bot `Set<number>` of already-ack'd message_ids, bounded at 1000 entries, so Telegram redeliveries after a handler exception don't double-react.
- Wired into `AgentManager.onMessage` after the ALLOWED_USER gate so bot messages and unauthorized senders are skipped. Both API calls are fire-and-forget — failures are logged but never block message processing.

## Why
When an agent is busy (processing media, generating a response, or just slow on a cold cache), users today get no signal that their message arrived at all. A 👍 + typing indicator within ~1s is a cheap, ubiquitous UX fix.

## Test plan
- [x] `npm run build` — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npm test` — 691/691 passing, including 3 new unit tests covering default emoji payload shape, empty-emoji clears reaction, and API error propagation
- [ ] Manual: send a message to a running agent's bot; 👍 + typing indicator should appear within ~1s
- [ ] Manual: verify re-sending the same `message_id` (simulated redelivery) does not trigger a second reaction API call
- [ ] Reactions may need to be enabled per-bot via @BotFather before they appear in clients — flagging for ops

🤖 Generated with [Claude Code](https://claude.com/claude-code)