### PR TITLE
fix(bus): reduce observability noise across heartbeats, events, and experiments

### DIFF
--- a/src/bus/event.ts
+++ b/src/bus/event.ts
@@ -1,7 +1,7 @@
-import { appendFileSync } from 'fs';
+import { appendFileSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import type { EventCategory, EventSeverity, BusPaths } from '../types/index.js';
-import { ensureDir } from '../utils/atomic.js';
+import type { EventCategory, EventSeverity, BusPaths, Heartbeat } from '../types/index.js';
+import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
 import { randomString } from '../utils/random.js';
 import { validateEventCategory, validateEventSeverity, isValidJson } from '../utils/validate.js';
 
@@ -10,6 +10,15 @@ import { validateEventCategory, validateEventSeverity, isValidJson } from '../ut
  * Identical to bash log-event.sh format.
  *
  * Events are stored at: {analyticsDir}/events/{agent}/{YYYY-MM-DD}.jsonl
+ *
+ * Side-effect: if this agent has an existing heartbeat.json, refresh its
+ * `last_heartbeat` timestamp. Activity is liveness — if the agent is
+ * logging events, it is by definition alive, so the stale-heartbeat
+ * monitor should not page on it. Other fields (status, mode, etc.) are
+ * preserved from the last explicit update-heartbeat call. Best-effort:
+ * a failing heartbeat refresh never blocks the event write itself.
+ * If no heartbeat file exists yet we do nothing — the first
+ * update-heartbeat call creates it with full field values.
  */
 export function logEvent(
   paths: BusPaths,
@@ -54,4 +63,25 @@ export function logEvent(
   });
 
   appendFileSync(join(eventsDir, `${today}.jsonl`), eventLine + '\n', 'utf-8');
+
+  // Refresh heartbeat timestamp as a side-effect. See doc comment above.
+  refreshHeartbeatTimestamp(paths, timestamp);
+}
+
+/**
+ * Bump the `last_heartbeat` timestamp on the existing heartbeat.json,
+ * preserving every other field. No-op when the file does not exist yet
+ * or when any step fails — event writes are the authoritative record
+ * and must never be blocked by heartbeat housekeeping.
+ */
+function refreshHeartbeatTimestamp(paths: BusPaths, timestamp: string): void {
+  try {
+    const hbPath = join(paths.stateDir, 'heartbeat.json');
+    if (!existsSync(hbPath)) return;
+    const hb = JSON.parse(readFileSync(hbPath, 'utf-8')) as Heartbeat;
+    hb.last_heartbeat = timestamp;
+    atomicWriteSync(hbPath, JSON.stringify(hb));
+  } catch {
+    // Best-effort — event already persisted, heartbeat refresh is secondary.
+  }
 }

--- a/src/bus/experiment.ts
+++ b/src/bus/experiment.ts
@@ -139,6 +139,14 @@ function saveConfig(agentDir: string, config: ExperimentConfig): void {
 
 /**
  * Create a new experiment proposal.
+ *
+ * Fields with no explicit option fall back to the matching cycle in
+ * `experiments/config.json` (same metric + same agent) before using the
+ * static default. The autoresearch skill registers its measurement method,
+ * direction, window, and surface once in the cycle config; with the cycle
+ * fallback, repeat experiments on that metric stop losing the measurement
+ * description because the agent forgot to pass --measurement.
+ * Explicit options always win over the cycle so ad-hoc overrides still work.
  */
 export function createExperiment(
   agentDir: string,
@@ -151,15 +159,17 @@ export function createExperiment(
   const rand = randomString(5);
   const id = `exp_${epoch}_${rand}`;
 
+  const cycleDefaults = findCycleDefaults(agentDir, agentName, metric);
+
   const experiment: Experiment = {
     id,
     agent: agentName,
     metric,
     hypothesis,
-    surface: options?.surface || '',
-    direction: options?.direction || 'higher',
-    window: options?.window || '24h',
-    measurement: options?.measurement || '',
+    surface: options?.surface ?? cycleDefaults.surface ?? '',
+    direction: options?.direction ?? cycleDefaults.direction ?? 'higher',
+    window: options?.window ?? cycleDefaults.window ?? '24h',
+    measurement: options?.measurement ?? cycleDefaults.measurement ?? '',
     status: 'proposed',
     baseline_value: 0,
     result_value: null,
@@ -176,6 +186,35 @@ export function createExperiment(
   saveExperiment(agentDir, experiment);
 
   return id;
+}
+
+/**
+ * Look up cycle-level defaults for a new experiment on the given metric.
+ * Matches a cycle by metric + agent. Returns an empty object if no cycle
+ * is configured — createExperiment then falls through to its static
+ * defaults. Best-effort: any config-read error returns empty so the
+ * experiment create path never breaks on malformed config.
+ */
+function findCycleDefaults(
+  agentDir: string,
+  agentName: string,
+  metric: string,
+): Partial<Pick<ExperimentCreateOptions, 'surface' | 'direction' | 'window' | 'measurement'>> {
+  try {
+    const config = loadConfig(agentDir);
+    const cycle = config.cycles?.find(
+      (c) => c.metric === metric && c.agent === agentName,
+    );
+    if (!cycle) return {};
+    return {
+      surface: cycle.surface || undefined,
+      direction: cycle.direction || undefined,
+      window: cycle.window || undefined,
+      measurement: cycle.measurement || undefined,
+    };
+  } catch {
+    return {};
+  }
 }
 
 /**

--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -4,6 +4,7 @@ import type { Task, Priority, TaskStatus, BusPaths, StaleTaskReport, ArchiveRepo
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
 import { randomDigits } from '../utils/random.js';
 import { validatePriority } from '../utils/validate.js';
+import { logEvent } from './event.js';
 
 /**
  * Create a new task. Identical JSON format to bash create-task.sh.
@@ -440,6 +441,12 @@ export function claimTask(
  * Matches bash complete-task.sh behavior, with the cross-org fallback from
  * findTaskFile so an assignee in one org can complete a task filed by an
  * orchestrator in a sibling org.
+ *
+ * Side-effect: emits a `task/task_completed` event on the activity feed so
+ * completions are visible on the dashboard without agents having to follow
+ * every complete-task call with a separate log-event. The event is written
+ * best-effort — a failing event write never unblocks task completion from
+ * persisting to disk.
  */
 export function completeTask(
   paths: BusPaths,
@@ -454,11 +461,13 @@ export function completeTask(
   }
   let prevStatus: TaskStatus | undefined;
   let assignee: string | undefined;
+  let taskOrg: string = '';
   try {
     const content = readFileSync(filePath, 'utf-8');
     const task: Task = JSON.parse(content);
     prevStatus = task.status;
     assignee = task.assigned_to;
+    taskOrg = task.org || '';
     task.status = 'completed';
     task.updated_at = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
     task.completed_at = task.updated_at;
@@ -470,6 +479,18 @@ export function completeTask(
     throw new Error(`Task ${taskId} complete failed: ${err}`);
   }
   appendTaskAudit(paths, taskId, { event: 'complete', agent: assignee || 'unknown', from: prevStatus, to: 'completed', note: result });
+
+  // Activity-feed event. Best-effort — the task is already persisted.
+  if (assignee) {
+    try {
+      logEvent(paths, assignee, taskOrg, 'task', 'task_completed', 'info', {
+        task_id: taskId,
+        ...(result ? { result } : {}),
+      });
+    } catch {
+      // Never let observability break task completion.
+    }
+  }
 }
 
 /**

--- a/tests/sprint3-experiments.test.ts
+++ b/tests/sprint3-experiments.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { existsSync, readFileSync, mkdirSync, rmSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -62,6 +62,112 @@ describe('Sprint 3: Experiment Framework', () => {
       expect(exp.surface).toBe('experiments/surfaces/bounce/current.md');
       expect(exp.direction).toBe('lower');
       expect(exp.window).toBe('48h');
+    });
+
+    it('inherits measurement/direction/window/surface from a matching cycle in config.json', () => {
+      // Write an experiments/config.json with a cycle for this metric.
+      mkdirSync(join(testDir, 'experiments'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'experiments', 'config.json'),
+        JSON.stringify({
+          cycles: [
+            {
+              name: 'retention-cycle',
+              agent: 'testbot',
+              metric: 'retention',
+              metric_type: 'quantitative',
+              surface: 'experiments/surfaces/retention/current.md',
+              direction: 'higher',
+              window: '7d',
+              measurement: 'count(distinct users_returning_in_7d) / count(distinct signups)',
+              loop_interval: '7d',
+              enabled: true,
+              created_by: 'testbot',
+              created_at: '2026-04-01T00:00:00Z',
+            },
+          ],
+        }),
+      );
+
+      const id = createExperiment(testDir, 'testbot', 'retention', 'Better onboarding improves retention');
+
+      const exp = JSON.parse(
+        readFileSync(join(testDir, 'experiments', 'history', `${id}.json`), 'utf-8').trim(),
+      );
+      expect(exp.measurement).toBe('count(distinct users_returning_in_7d) / count(distinct signups)');
+      expect(exp.surface).toBe('experiments/surfaces/retention/current.md');
+      expect(exp.window).toBe('7d');
+      expect(exp.direction).toBe('higher');
+    });
+
+    it('explicit options win over matching-cycle defaults', () => {
+      mkdirSync(join(testDir, 'experiments'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'experiments', 'config.json'),
+        JSON.stringify({
+          cycles: [
+            {
+              name: 'ctr-cycle',
+              agent: 'testbot',
+              metric: 'ctr',
+              direction: 'higher',
+              window: '24h',
+              measurement: 'clicks / impressions',
+              surface: 'default-surface.md',
+              enabled: true,
+              created_by: 'testbot',
+              created_at: '2026-04-01T00:00:00Z',
+              metric_type: 'quantitative',
+              loop_interval: '24h',
+            },
+          ],
+        }),
+      );
+
+      const id = createExperiment(testDir, 'testbot', 'ctr', 'test', {
+        direction: 'lower',
+        measurement: 'custom-override',
+      });
+      const exp = JSON.parse(
+        readFileSync(join(testDir, 'experiments', 'history', `${id}.json`), 'utf-8').trim(),
+      );
+      expect(exp.direction).toBe('lower'); // overrode cycle
+      expect(exp.measurement).toBe('custom-override'); // overrode cycle
+      expect(exp.window).toBe('24h'); // inherited from cycle
+      expect(exp.surface).toBe('default-surface.md'); // inherited from cycle
+    });
+
+    it('falls through to static defaults when no matching cycle exists', () => {
+      mkdirSync(join(testDir, 'experiments'), { recursive: true });
+      writeFileSync(
+        join(testDir, 'experiments', 'config.json'),
+        JSON.stringify({
+          cycles: [
+            {
+              name: 'other-metric-cycle',
+              agent: 'testbot',
+              metric: 'different_metric',
+              direction: 'higher',
+              window: '7d',
+              measurement: 'irrelevant',
+              surface: '',
+              enabled: true,
+              created_by: 'testbot',
+              created_at: '2026-04-01T00:00:00Z',
+              metric_type: 'quantitative',
+              loop_interval: '7d',
+            },
+          ],
+        }),
+      );
+
+      const id = createExperiment(testDir, 'testbot', 'unrelated_metric', 'test');
+      const exp = JSON.parse(
+        readFileSync(join(testDir, 'experiments', 'history', `${id}.json`), 'utf-8').trim(),
+      );
+      expect(exp.measurement).toBe('');
+      expect(exp.direction).toBe('higher'); // static default
+      expect(exp.window).toBe('24h'); // static default
     });
   });
 

--- a/tests/unit/bus/event.test.ts
+++ b/tests/unit/bus/event.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { logEvent } from '../../../src/bus/event';
+import type { BusPaths, Heartbeat } from '../../../src/types';
+
+/**
+ * Tests for the heartbeat-refresh side-effect on logEvent. The data
+ * point that motivated this behavior: 76.4% of fleet activity events
+ * landed while the agent's heartbeat was >5min stale — every event
+ * implies the agent is alive, so the stale-monitor should never fire
+ * on an agent that is actively logging activity.
+ */
+describe('Bus events', () => {
+  let testDir: string;
+  let paths: BusPaths;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-event-test-'));
+    paths = {
+      ctxRoot: testDir,
+      inbox: join(testDir, 'inbox', 'spark'),
+      inflight: join(testDir, 'inflight', 'spark'),
+      processed: join(testDir, 'processed', 'spark'),
+      logDir: join(testDir, 'logs', 'spark'),
+      stateDir: join(testDir, 'state', 'spark'),
+      taskDir: join(testDir, 'tasks'),
+      approvalDir: join(testDir, 'approvals'),
+      analyticsDir: join(testDir, 'analytics'),
+      heartbeatDir: join(testDir, 'heartbeats'),
+    };
+    mkdirSync(paths.stateDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('logEvent appends a JSONL entry to the daily events file', () => {
+    logEvent(paths, 'spark', 'eros-os', 'action', 'test_event', 'info', { foo: 'bar' });
+
+    const today = new Date().toISOString().split('T')[0];
+    const eventFile = join(paths.analyticsDir, 'events', 'spark', `${today}.jsonl`);
+    expect(existsSync(eventFile)).toBe(true);
+
+    const entries = readFileSync(eventFile, 'utf-8').trim().split('\n').map((l) => JSON.parse(l));
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      agent: 'spark',
+      org: 'eros-os',
+      category: 'action',
+      event: 'test_event',
+      severity: 'info',
+      metadata: { foo: 'bar' },
+    });
+  });
+
+  describe('heartbeat refresh side-effect', () => {
+    it('bumps last_heartbeat on an existing heartbeat.json without overwriting other fields', async () => {
+      const oldHeartbeat: Heartbeat = {
+        agent: 'spark',
+        org: 'eros-os',
+        status: 'online',
+        current_task: 'fix/log-event-refreshes-heartbeat',
+        mode: 'day',
+        last_heartbeat: '2026-04-23T12:00:00Z',
+        loop_interval: '4h',
+      };
+      writeFileSync(join(paths.stateDir, 'heartbeat.json'), JSON.stringify(oldHeartbeat));
+
+      // Let one millisecond tick so the new timestamp is strictly newer.
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      logEvent(paths, 'spark', 'eros-os', 'action', 'activity_tick', 'info');
+
+      const refreshed = JSON.parse(
+        readFileSync(join(paths.stateDir, 'heartbeat.json'), 'utf-8'),
+      ) as Heartbeat;
+
+      // Timestamp bumped…
+      expect(new Date(refreshed.last_heartbeat).getTime()).toBeGreaterThan(
+        new Date(oldHeartbeat.last_heartbeat).getTime(),
+      );
+      // …other fields preserved intact.
+      expect(refreshed.status).toBe('online');
+      expect(refreshed.current_task).toBe('fix/log-event-refreshes-heartbeat');
+      expect(refreshed.mode).toBe('day');
+      expect(refreshed.loop_interval).toBe('4h');
+      expect(refreshed.agent).toBe('spark');
+      expect(refreshed.org).toBe('eros-os');
+    });
+
+    it('is a no-op when no heartbeat.json exists yet', () => {
+      // Fresh agent — no heartbeat file written yet.
+      expect(existsSync(join(paths.stateDir, 'heartbeat.json'))).toBe(false);
+
+      logEvent(paths, 'spark', 'eros-os', 'action', 'first_boot', 'info');
+
+      // Still no heartbeat file — refresh is a no-op when nothing exists.
+      expect(existsSync(join(paths.stateDir, 'heartbeat.json'))).toBe(false);
+
+      // But the event itself was written.
+      const today = new Date().toISOString().split('T')[0];
+      const eventFile = join(paths.analyticsDir, 'events', 'spark', `${today}.jsonl`);
+      expect(existsSync(eventFile)).toBe(true);
+    });
+
+    it('never blocks event persistence when the heartbeat refresh fails', () => {
+      // Write a corrupt heartbeat.json to exercise the error path.
+      writeFileSync(join(paths.stateDir, 'heartbeat.json'), '{not valid json');
+
+      // Must not throw.
+      expect(() =>
+        logEvent(paths, 'spark', 'eros-os', 'action', 'after_corrupt_hb', 'info'),
+      ).not.toThrow();
+
+      // Event still written.
+      const today = new Date().toISOString().split('T')[0];
+      const eventFile = join(paths.analyticsDir, 'events', 'spark', `${today}.jsonl`);
+      const entries = readFileSync(eventFile, 'utf-8').trim().split('\n');
+      expect(entries).toHaveLength(1);
+    });
+  });
+});

--- a/tests/unit/bus/task.test.ts
+++ b/tests/unit/bus/task.test.ts
@@ -82,6 +82,32 @@ describe('Task Management', () => {
       expect(content.completed_at).toBeTruthy();
       expect(content.result).toBe('Landing page done, committed at abc123');
     });
+
+    it('emits a task/task_completed activity event for the assignee', () => {
+      const taskId = createTask(paths, 'paul', 'acme', 'Complete-event task', {
+        assignee: 'boris',
+      });
+      completeTask(paths, taskId, 'shipped');
+
+      // Event file: <analyticsDir>/events/boris/<YYYY-MM-DD>.jsonl
+      const today = new Date().toISOString().split('T')[0];
+      const eventFile = join(paths.analyticsDir, 'events', 'boris', `${today}.jsonl`);
+      expect(existsSync(eventFile)).toBe(true);
+
+      const events = readFileSync(eventFile, 'utf-8')
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line));
+      const completedEvents = events.filter((e) => e.event === 'task_completed');
+      expect(completedEvents).toHaveLength(1);
+      const evt = completedEvents[0];
+      expect(evt.agent).toBe('boris');
+      expect(evt.org).toBe('acme');
+      expect(evt.category).toBe('task');
+      expect(evt.severity).toBe('info');
+      expect(evt.metadata.task_id).toBe(taskId);
+      expect(evt.metadata.result).toBe('shipped');
+    });
   });
 
   describe('listTasks', () => {


### PR DESCRIPTION
## Summary
Three framework fixes that all surfaced from the same fleet telemetry dump (`orgs/eros-os/agents/finance/memory/2026-04-24_heartbeat_divergence.csv`): activity was happening while agents looked stale to the monitor, and experiments were losing their measurement description on every iteration.

## 1. `logEvent` refreshes the agent's heartbeat timestamp
**Problem:** 76.4% of fleet activity events landed while the heartbeat was >5min stale. Activity is liveness — if an agent is writing events, the stale-heartbeat monitor should not page on it. We were generating noise instead of measuring real downtime.

**Fix:** New helper `refreshHeartbeatTimestamp` in `src/bus/event.ts` bumps `last_heartbeat` on the existing `heartbeat.json` and preserves every other field (status, current_task, mode, loop_interval). No-op when no heartbeat file exists yet; fully best-effort so a failing heartbeat write never blocks the event write itself. Zero changes required on the agent side.

## 2. `completeTask` emits a `task/task_completed` activity event
**Problem:** Previous pattern required agents to follow every `bus complete-task` with a separate `bus log-event task task_completed`. Half the time the log-event call was forgotten and the dashboard feed missed the completion.

**Fix:** The event is now emitted from inside `completeTask` (src/bus/task.ts), so any caller (CLI today, programmatic tomorrow) gets the behavior. Attribution uses the task's `assigned_to` + `org`.

## 3. `createExperiment` inherits from the matching cycle
**Problem:** When the autoresearch skill ran repeat experiments on the same metric, `measurement` kept coming through blank because the agent forgot `--measurement` on the re-run. The cycle config in `experiments/config.json` already holds the canonical measurement method.

**Fix:** New helper `findCycleDefaults` in `src/bus/experiment.ts` looks up the cycle for the same metric + agent and fills in `measurement`, `direction`, `window`, and `surface` when they aren't passed explicitly. Explicit options still win so ad-hoc overrides continue to work.

## Test plan
- [x] `npm test` — 678 tests pass across 47 files
- [x] `npm run build` clean
- [x] 3 new test suites cover each fix:
  - `tests/unit/bus/event.test.ts` — heartbeat refresh side-effect + corrupt-heartbeat resilience + no-op when no heartbeat file
  - `tests/unit/bus/task.test.ts` — task_completed event emission with correct agent/org/metadata
  - `tests/sprint3-experiments.test.ts` — cycle inheritance + explicit-option override + fallthrough to static defaults

🤖 Generated with [Claude Code](https://claude.com/claude-code)