### PR TITLE
feat(templates): add orchestrator heartbeat summary pattern to agent template

### DIFF
--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -109,6 +109,24 @@ Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages 
 
 ---
 
+## Orchestrator Heartbeat Summary
+
+On every 4h heartbeat cycle, send your orchestrator a brief status summary. Three lines is enough:
+
+```bash
+cortextos bus send-message <orchestrator> normal 'Heartbeat:
+- Completed: <what finished since last heartbeat>
+- Blocked: <anything waiting on external input>
+- Waiting: <tasks in queue or pending approval>'
+```
+
+**Rules:**
+- Send this every heartbeat cycle, not just when something changes
+- Do NOT route routine task details through the orchestrator to the user — the user contacts you directly
+- Only escalate to the orchestrator when you need a decision, a handoff, or are genuinely blocked
+
+---
+
 ## Crons
 
 Defined in `config.json` under `crons` array. Set up once per session via `/loop`.


### PR DESCRIPTION
## Summary

- Adds an **Orchestrator Heartbeat Summary** section to `templates/agent/CLAUDE.md`
- Every 4h heartbeat cycle, agents send their orchestrator a brief 3-line status: completed / blocked / waiting
- Establishes comms boundary: routine details stay agent↔user direct, orchestrator only receives decisions, handoffs, and genuine blockers

## Why

Without this pattern, agents either over-report (routing everything through the orchestrator) or under-report (orchestrator has no visibility into fleet status). This gives orchestrators consistent heartbeat visibility without creating a bottleneck.

## Change

One new section, ~15 lines, in the agent template. Zero changes to code or tests.

## Test plan

- [ ] Read `templates/agent/CLAUDE.md` and verify the new section reads clearly
- [ ] Verify existing agent sessions can adopt the pattern without a restart (it is behavioral, not structural)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)