### PR TITLE
fix(metrics): exclude info/warning severity from errors_today count

### DIFF
--- a/src/bus/metrics.ts
+++ b/src/bus/metrics.ts
@@ -74,6 +74,29 @@ export interface RegisterCommandsResult {
 
 // --- collectMetrics ---
 
+/**
+ * Decide whether a single JSONL event line should be counted as an error
+ * for the daily errors_today metric. Returns false on malformed JSON
+ * rather than throwing — bad lines should not break the report.
+ *
+ * An event qualifies only when BOTH:
+ *   - category === 'error', AND
+ *   - severity ∈ {'error', 'critical'}
+ * 'warning' is intentionally not counted toward errors_today; it has its
+ * own meaning in the severity ladder. 'info' events with category=error
+ * (the original false-positive class) are filtered out here.
+ */
+function isErrorEvent(line: string): boolean {
+  let evt: { category?: unknown; severity?: unknown };
+  try {
+    evt = JSON.parse(line);
+  } catch {
+    return false;
+  }
+  if (evt.category !== 'error') return false;
+  return evt.severity === 'error' || evt.severity === 'critical';
+}
+
 export function collectMetrics(ctxRoot: string, org?: string): MetricsReport {
   const timestamp = new Date().toISOString();
   const today = timestamp.split('T')[0];
@@ -130,7 +153,14 @@ export function collectMetrics(ctxRoot: string, org?: string): MetricsReport {
     }
     totalCompleted += completed;
 
-    // Count errors today from event logs
+    // Count errors today from event logs.
+    // Both category AND severity must match — early agents emitted
+    // category=error events at severity=info for things like
+    // `gap_detector_false_positive` (Frank had 7 of these in a single day,
+    // all classified as "errors" by the previous substring check). Filter
+    // on parsed JSON to skip false positives that happen to contain
+    // `"category":"error"` inside a metadata payload, and only count
+    // events where severity is genuinely error-level.
     let errorsToday = 0;
     const eventPaths = [
       join(ctxRoot, 'analytics', 'events', agent, `${today}.jsonl`),
@@ -142,7 +172,7 @@ export function collectMetrics(ctxRoot: string, org?: string): MetricsReport {
       if (existsSync(eventFile)) {
         try {
           const lines = readFileSync(eventFile, 'utf-8').split('\n').filter(Boolean);
-          errorsToday += lines.filter(l => l.includes('"category":"error"')).length;
+          errorsToday += lines.filter(line => isErrorEvent(line)).length;
         } catch { /* skip */ }
       }
     }

--- a/tests/sprint5-metrics.test.ts
+++ b/tests/sprint5-metrics.test.ts
@@ -112,7 +112,7 @@ describe('Sprint 5: Observability & Metrics', () => {
       expect(existsSync(join(ctxRoot, 'analytics', 'reports', 'latest.json'))).toBe(true);
     });
 
-    it('counts errors from event logs', () => {
+    it('counts errors from event logs (severity-filtered)', () => {
       writeFileSync(join(ctxRoot, 'config', 'enabled-agents.json'), JSON.stringify({ bot1: { enabled: true } }), 'utf-8');
       mkdirSync(join(ctxRoot, 'state', 'bot1'), { recursive: true });
 
@@ -120,13 +120,100 @@ describe('Sprint 5: Observability & Metrics', () => {
       const eventDir = join(ctxRoot, 'analytics', 'events', 'bot1');
       mkdirSync(eventDir, { recursive: true });
       writeFileSync(join(eventDir, `${today}.jsonl`), [
-        '{"category":"error","event":"crash"}',
-        '{"category":"info","event":"heartbeat"}',
-        '{"category":"error","event":"timeout"}',
+        '{"category":"error","event":"crash","severity":"error"}',
+        '{"category":"info","event":"heartbeat","severity":"info"}',
+        '{"category":"error","event":"timeout","severity":"error"}',
       ].join('\n'), 'utf-8');
 
       const report = collectMetrics(ctxRoot);
       expect(report.agents.bot1.errors_today).toBe(2);
+    });
+
+    it('does NOT count info-severity events even when category=error (Frank false-positive case)', () => {
+      writeFileSync(join(ctxRoot, 'config', 'enabled-agents.json'), JSON.stringify({ bot1: { enabled: true } }), 'utf-8');
+      mkdirSync(join(ctxRoot, 'state', 'bot1'), { recursive: true });
+
+      const today = new Date().toISOString().split('T')[0];
+      const eventDir = join(ctxRoot, 'analytics', 'events', 'bot1');
+      mkdirSync(eventDir, { recursive: true });
+      // The exact pattern that polluted Frank's metrics: 7 info-severity
+      // gap_detector_false_positive events emitted under category=error.
+      const lines: string[] = [];
+      for (let i = 0; i < 7; i++) {
+        lines.push(`{"category":"error","event":"gap_detector_false_positive","severity":"info","metadata":{"i":${i}}}`);
+      }
+      // Plus one real error
+      lines.push('{"category":"error","event":"actual_failure","severity":"error"}');
+      writeFileSync(join(eventDir, `${today}.jsonl`), lines.join('\n'), 'utf-8');
+
+      const report = collectMetrics(ctxRoot);
+      expect(report.agents.bot1.errors_today).toBe(1);
+    });
+
+    it('counts critical-severity events as errors', () => {
+      writeFileSync(join(ctxRoot, 'config', 'enabled-agents.json'), JSON.stringify({ bot1: { enabled: true } }), 'utf-8');
+      mkdirSync(join(ctxRoot, 'state', 'bot1'), { recursive: true });
+
+      const today = new Date().toISOString().split('T')[0];
+      const eventDir = join(ctxRoot, 'analytics', 'events', 'bot1');
+      mkdirSync(eventDir, { recursive: true });
+      writeFileSync(join(eventDir, `${today}.jsonl`), [
+        '{"category":"error","event":"oom","severity":"critical"}',
+        '{"category":"error","event":"crash","severity":"error"}',
+      ].join('\n'), 'utf-8');
+
+      const report = collectMetrics(ctxRoot);
+      expect(report.agents.bot1.errors_today).toBe(2);
+    });
+
+    it('does NOT count warning-severity category=error events', () => {
+      writeFileSync(join(ctxRoot, 'config', 'enabled-agents.json'), JSON.stringify({ bot1: { enabled: true } }), 'utf-8');
+      mkdirSync(join(ctxRoot, 'state', 'bot1'), { recursive: true });
+
+      const today = new Date().toISOString().split('T')[0];
+      const eventDir = join(ctxRoot, 'analytics', 'events', 'bot1');
+      mkdirSync(eventDir, { recursive: true });
+      writeFileSync(join(eventDir, `${today}.jsonl`), [
+        '{"category":"error","event":"degraded","severity":"warning"}',
+      ].join('\n'), 'utf-8');
+
+      const report = collectMetrics(ctxRoot);
+      expect(report.agents.bot1.errors_today).toBe(0);
+    });
+
+    it('ignores false positives where "category":"error" appears inside a metadata payload', () => {
+      writeFileSync(join(ctxRoot, 'config', 'enabled-agents.json'), JSON.stringify({ bot1: { enabled: true } }), 'utf-8');
+      mkdirSync(join(ctxRoot, 'state', 'bot1'), { recursive: true });
+
+      const today = new Date().toISOString().split('T')[0];
+      const eventDir = join(ctxRoot, 'analytics', 'events', 'bot1');
+      mkdirSync(eventDir, { recursive: true });
+      // The substring `"category":"error"` is embedded in metadata, but the
+      // actual top-level category is 'task'. The previous substring check
+      // would have miscounted this; the parsed-JSON path correctly skips it.
+      writeFileSync(join(eventDir, `${today}.jsonl`), [
+        '{"category":"task","event":"taxonomy","severity":"info","metadata":{"taxonomy":"\\"category\\":\\"error\\""}}',
+      ].join('\n'), 'utf-8');
+
+      const report = collectMetrics(ctxRoot);
+      expect(report.agents.bot1.errors_today).toBe(0);
+    });
+
+    it('skips malformed JSON lines without crashing', () => {
+      writeFileSync(join(ctxRoot, 'config', 'enabled-agents.json'), JSON.stringify({ bot1: { enabled: true } }), 'utf-8');
+      mkdirSync(join(ctxRoot, 'state', 'bot1'), { recursive: true });
+
+      const today = new Date().toISOString().split('T')[0];
+      const eventDir = join(ctxRoot, 'analytics', 'events', 'bot1');
+      mkdirSync(eventDir, { recursive: true });
+      writeFileSync(join(eventDir, `${today}.jsonl`), [
+        '{"category":"error","event":"real","severity":"error"}',
+        'not-valid-json-at-all',
+        '{broken json',
+      ].join('\n'), 'utf-8');
+
+      const report = collectMetrics(ctxRoot);
+      expect(report.agents.bot1.errors_today).toBe(1);
     });
   });
 


### PR DESCRIPTION
## Summary

The metrics collector counted every event with \`category=error\` regardless of its \`severity\` field. Frank's daily report showed 7 "errors" that were all \`info\`-severity \`gap_detector_false_positive\` events — so the dashboard was screaming about a healthy agent.

## Fix

**1. Filter on severity.** \`errors_today\` now counts only events where \`severity\` is \`error\` or \`critical\`. \`info\`-severity (the original false-positive class) and \`warning\`-severity events are excluded. Warnings have their own meaning in the severity ladder; including them in a field literally named \`errors_today\` is misleading.

**2. Parse JSON instead of substring matching.** The previous \`line.includes('"category":"error"')\` would also match payloads where that substring appeared inside metadata (escape-stuffed JSON, taxonomy values, etc.) — false positives in the opposite direction. The parsed-JSON path correctly inspects only the top-level \`category\` and \`severity\` fields. Malformed lines are skipped, not thrown.

## Test plan

- [x] \`npm test\` — 713 tests pass across 47 files
- [x] \`npm run build\` clean
- [x] 5 new test cases on top of the existing one cover: the exact 7-info-severity Frank case (counted as 0+1=1, not 8), critical severity counted, warning severity excluded, metadata-stuffed substring false positive ignored, malformed JSON survived

🤖 Generated with [Claude Code](https://claude.com/claude-code)