### PR TITLE
fix(pty): preserve Windows path-expansion env vars in agent PTY

### DIFF
--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -303,7 +303,14 @@ export class AgentPTY {
     const keepVars = [
       'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
       'TMPDIR', 'TEMP', 'TMP', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY',
-      'NODE_PATH', 'COMSPEC', 'SystemRoot', 'USERPROFILE',
+      'NODE_PATH', 'COMSPEC', 'USERPROFILE',
+      // Windows path-expansion essentials. Stripping these causes phantom
+      // %SystemDrive% directories from inherited Search Indexer processes
+      // and Unity batchmode UPM IPC crashes (path.join(undefined,...)).
+      'SystemDrive', 'SystemRoot', 'windir',
+      'APPDATA', 'LOCALAPPDATA', 'ProgramData', 'ALLUSERSPROFILE',
+      'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
+      'HOMEDRIVE', 'HOMEPATH', 'PUBLIC',
     ];
     for (const key of keepVars) {
       if (process.env[key]) {


### PR DESCRIPTION
## Summary

The `keepVars` allowlist in `AgentPTY.getBaseEnv()` strips essential Windows path-expansion env vars when building the agent PTY environment. Inherited Windows processes (Search Indexer, Unity UPM IPC, COM-driven shell ops) see empty values and either crash on `path.join(undefined, ...)` or write to literal-string `%SystemDrive%` paths relative to CWD.

This PR adds the missing vars to the allowlist. Purely additive — nothing removed, no behaviour change for non-Windows platforms.

## Symptoms this resolves

1. **Phantom `%SystemDrive%/ProgramData/Microsoft/Windows/Caches/` directories** appearing in agent CWDs on Windows. Reproduced in two independent agent dirs running cortextos on Windows 11. Cache files (`cversions.2.db`, several GUID-named `.ver*.db`) match the Windows Property System / IFilter content-version cache layout — `SearchProtocolHost.exe` / `SearchIndexer.exe` resolves the literal `%SystemDrive%` prefix relative to CWD when the variable is empty.

2. **Unity batchmode UPM IPC crashes** when launching Unity from a bash subprocess inside a cortextos agent. The "Unity blocked by Defender" error message is misleading — the real cause is `path.join(undefined, ...)` inside Unity's UPM child process, with `undefined` coming from `process.env.APPDATA` / `LOCALAPPDATA` being missing.

Both classes have one root cause: `AgentPTY.getBaseEnv()` keeping `SystemRoot` but not `SystemDrive`, and skipping `APPDATA`/`LOCALAPPDATA`/`ProgramData` entirely.

## Change

`src/pty/agent-pty.ts` — `keepVars` array in `getBaseEnv()`:

```diff
     const keepVars = [
       'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
       'TMPDIR', 'TEMP', 'TMP', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY',
-      'NODE_PATH', 'COMSPEC', 'SystemRoot', 'USERPROFILE',
+      'NODE_PATH', 'COMSPEC', 'USERPROFILE',
+      // Windows path-expansion essentials. Stripping these causes phantom
+      // %SystemDrive% directories from inherited Search Indexer processes
+      // and Unity batchmode UPM IPC crashes (path.join(undefined,...)).
+      'SystemDrive', 'SystemRoot', 'windir',
+      'APPDATA', 'LOCALAPPDATA', 'ProgramData', 'ALLUSERSPROFILE',
+      'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
+      'HOMEDRIVE', 'HOMEPATH', 'PUBLIC',
     ];
```

`SystemRoot` is retained — the new line block reorganises rather than removes. All added vars are standard Windows path constants present in the parent daemon's `process.env`. No new secrets exposed; these are public OS paths.

## Test plan

- [x] `npm run build` — TypeScript clean (CJS build success in 118ms; all hooks + cli + daemon emitted).
- [x] `npm test` — 675/708 tests pass on this branch. **Note for reviewers:** the 33 failures are pre-existing on `main` and are not introduced by this change. Verified via baseline run: `git stash && npm test` on `main` produced the identical 33-failure / 675-pass split. Failures are localised to `dashboard/src/lib/__tests__/sync.test.ts` and 6 other dashboard test files; none touch `src/pty/`.
- [x] Manual verification: with the patch applied, restart an agent and confirm `echo $SystemDrive` returns `C:`, `echo $APPDATA` returns the user's roaming path. No new `%SystemDrive%/` dirs created in agent CWD.
- [ ] Optional follow-up: a unit test asserting the Windows env-var subset is present in the PTY environment when running on `platform() === 'win32'`. Happy to add in this PR if reviewers want it; left out of the initial diff to keep the change minimal.

## Risk

Low. Additive-only change. The vars are standard Windows constants; not adding them was the bug. Non-Windows platforms unaffected (`process.env[key]` returns `undefined` → skipped by the existing falsy check at line 332).

## Out-of-scope

This PR does **not** touch the `claude.cmd` / `claude.exe` resolution logic (`resolveClaudeOnWindows`) or the UTF-8 locale block, both of which are addressed by separate Windows-support work. This change is orthogonal — a missing-allowlist gap that affects inherited child processes regardless of which Claude binary launches.
