### PR TITLE
feat(bus): hooks framework — Day-1 stub + Day-2 per-handler wiring + telemetry

### DIFF
--- a/src/bus/hooks.ts
+++ b/src/bus/hooks.ts
@@ -264,6 +264,7 @@ export async function dispatchHook(hook: HookEntry, event: Event): Promise<void>
     'hook_fire';
 
   emitHookBusEvent(eventName, {
+    ...(result.meta ?? {}),
     hook_id: hook.id,
     handler_type: hook.handler_type,
     event_id: event.id,
@@ -271,7 +272,6 @@ export async function dispatchHook(hook: HookEntry, event: Event): Promise<void>
     event_type: event.event,
     source_agent: event.agent,
     outcome: result.reason ?? `${result.action}_no_reason`,
-    ...(result.meta ?? {}),
   });
 }
 

--- a/src/bus/hooks.ts
+++ b/src/bus/hooks.ts
@@ -1,0 +1,343 @@
+// added 2026-04-29 by collie via dane dispatch — RFC #15 minimal stub; dispatcher wiring pending Aussie/Codex Thu execution
+//
+// Bus hook framework — registry loader, event matcher, dispatcher stub.
+// Schema lives at orgs/<org>/hooks.json. Per RFC #15 §4, this file is the
+// in-process surface that fast-checker will eventually call on every logged
+// event. Today nothing is wired — loadHookRegistry + matchHooks return data,
+// dispatchHook only logs the would-be invocation.
+
+import { existsSync, readFileSync, appendFileSync, mkdirSync } from 'fs';
+import { join, dirname } from 'path';
+import { execFile } from 'child_process';
+import type { Event, EventCategory, EventSeverity } from '../types/index.js';
+
+// ── Schema types — mirror RFC #15 §4 ─────────────────────────────────────────
+
+export type HandlerType = 'log_event' | 'send_message' | 'bash' | 'webhook';
+
+/**
+ * Pattern that an Event must match for a hook to fire.
+ * Matching is partial — only the fields present in the pattern are checked.
+ * `metadata` keys (when present) require deep equality on the listed keys only.
+ */
+export interface HookPattern {
+  category?: EventCategory;
+  type?: string;
+  severity?: EventSeverity;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Handler payload. Shape varies by HandlerType but is a flat object at the
+ * registry level — the dispatcher narrows by `handler_type` at runtime.
+ */
+export interface Handler {
+  category?: EventCategory;
+  type?: string;
+  severity?: EventSeverity;
+  meta?: Record<string, unknown>;
+  to?: string;
+  priority?: 'urgent' | 'high' | 'normal' | 'low';
+  template?: string;
+  command?: string;
+  url?: string;
+}
+
+export interface HookEntry {
+  id: string;
+  event_pattern: HookPattern;
+  handler_type: HandlerType;
+  handler: Handler;
+  agent_filter?: string[];
+  priority: number;
+  enabled: boolean;
+  notes?: string;
+}
+
+export interface HookRegistry {
+  schema_version: string;
+  comment?: string;
+  hooks: HookEntry[];
+}
+
+const EMPTY_REGISTRY: HookRegistry = { schema_version: '0.1', hooks: [] };
+
+// added 2026-04-29 by collie via dane dispatch — Day-2 per-handler wiring: handler-result contract
+/**
+ * Result a handler can return to influence which bus event the dispatcher emits.
+ *
+ * - `fire` → handler ran (or implicitly accepts); dispatcher emits `hook_fire`.
+ * - `block` → handler refused the action this hook was invoked for; dispatcher emits `hook_block`.
+ * - `escalate` → handler bumped severity / re-routed to a higher-priority surface; dispatcher emits `hook_escalate`.
+ *
+ * `reason` is a short slug intended to slot into the bus event meta `outcome` field.
+ * `meta` is merged into the bus event meta, never used to override the dispatcher's own bookkeeping fields.
+ */
+export interface HandlerResult {
+  action: 'fire' | 'block' | 'escalate';
+  reason?: string;
+  meta?: Record<string, unknown>;
+}
+
+/**
+ * Synchronous or async handler function. Returns a HandlerResult, or undefined/void
+ * for the implicit "fire" default. Throws are caught by the dispatcher and treated
+ * as `{action: 'block', reason: 'handler_threw'}` so a buggy handler never breaks the loop.
+ */
+export type HandlerFn = (
+  hook: HookEntry,
+  event: Event,
+) => Promise<HandlerResult | void | undefined> | HandlerResult | void | undefined;
+
+// added 2026-04-29 by collie via dane dispatch — Day-2 per-handler wiring: in-process handler registry.
+// Day-1 stub had a single static `dispatchHook` that always logged-and-fired. Day-2 lets callers
+// (Codex Thu / Aussie's Day-3 wiring / future skill-side handlers) register handler implementations
+// per HandlerType. If no handler is registered for a hook's handler_type, dispatcher falls back to
+// the Day-1 stub behavior (log + emit `hook_fire`). This is backwards-compatible.
+const _handlerRegistry: Map<HandlerType, HandlerFn> = new Map();
+
+/**
+ * Register a handler function for a given HandlerType. Replaces any existing handler.
+ * Returns the previous handler (if any) so callers can chain or restore.
+ */
+export function registerHandler(type: HandlerType, fn: HandlerFn): HandlerFn | undefined {
+  const prev = _handlerRegistry.get(type);
+  _handlerRegistry.set(type, fn);
+  return prev;
+}
+
+/**
+ * Remove all registered handlers. Intended for tests + setup-teardown blocks.
+ */
+export function clearHandlerRegistry(): void {
+  _handlerRegistry.clear();
+}
+
+/**
+ * Look up a registered handler. Internal — exported for tests only.
+ */
+export function _getRegisteredHandler(type: HandlerType): HandlerFn | undefined {
+  return _handlerRegistry.get(type);
+}
+
+// ── Registry loading ─────────────────────────────────────────────────────────
+
+/**
+ * Read orgs/<org>/hooks.json and return its parsed contents.
+ *
+ * Per RFC #15 §9 fail-open default: a missing file or malformed JSON returns
+ * an empty registry, never throws. The caller is fast-checker, which must
+ * never crash on registry errors.
+ *
+ * @param orgPath Absolute path to the org directory (e.g. /Users/.../orgs/ascendops).
+ */
+export function loadHookRegistry(orgPath: string): HookRegistry {
+  const file = join(orgPath, 'hooks.json');
+  if (!existsSync(file)) {
+    return EMPTY_REGISTRY;
+  }
+  try {
+    const raw = readFileSync(file, 'utf-8');
+    const parsed = JSON.parse(raw) as Partial<HookRegistry>;
+    if (!parsed || !Array.isArray(parsed.hooks)) {
+      logRegistryWarn(orgPath, `hooks.json is missing 'hooks' array`);
+      return EMPTY_REGISTRY;
+    }
+    return {
+      schema_version: parsed.schema_version ?? '0.1',
+      comment: parsed.comment,
+      hooks: parsed.hooks,
+    };
+  } catch (err) {
+    logRegistryWarn(orgPath, `hooks.json parse error: ${(err as Error).message}`);
+    return EMPTY_REGISTRY;
+  }
+}
+
+// ── Event matching ───────────────────────────────────────────────────────────
+
+/**
+ * Filter the registry to hooks that should fire for this event.
+ *
+ * Match rules:
+ * - `enabled` must be true.
+ * - `agent_filter` empty/missing matches all agents; otherwise must include `agentName`.
+ * - `event_pattern.category` (if present) must equal `event.category`.
+ * - `event_pattern.type` (if present) must equal `event.event` (note: registry
+ *   uses `type` while the Event object uses `event` — bridged here).
+ * - `event_pattern.severity` (if present) must equal `event.severity`.
+ * - `event_pattern.metadata` (if present) — every key/value must deep-match
+ *   `event.metadata` (extra keys on the event are OK).
+ *
+ * Result is sorted by `priority` descending (highest first).
+ */
+export function matchHooks(
+  registry: HookRegistry,
+  event: Event,
+  agentName: string,
+): HookEntry[] {
+  const matched = registry.hooks.filter((hook) => {
+    if (!hook.enabled) return false;
+
+    const filter = hook.agent_filter;
+    if (filter && filter.length > 0 && !filter.includes(agentName)) return false;
+
+    const pattern = hook.event_pattern;
+    if (pattern.category !== undefined && pattern.category !== event.category) return false;
+    if (pattern.type !== undefined && pattern.type !== event.event) return false;
+    if (pattern.severity !== undefined && pattern.severity !== event.severity) return false;
+
+    if (pattern.metadata) {
+      for (const [key, value] of Object.entries(pattern.metadata)) {
+        if (!deepEqual(event.metadata?.[key], value)) return false;
+      }
+    }
+
+    return true;
+  });
+
+  return matched.sort((a, b) => b.priority - a.priority);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== 'object' || typeof b !== 'object' || a === null || b === null) {
+    return false;
+  }
+  const keysA = Object.keys(a as Record<string, unknown>);
+  const keysB = Object.keys(b as Record<string, unknown>);
+  if (keysA.length !== keysB.length) return false;
+  return keysA.every((key) =>
+    deepEqual(
+      (a as Record<string, unknown>)[key],
+      (b as Record<string, unknown>)[key],
+    ),
+  );
+}
+
+// ── Dispatch (STUB) ──────────────────────────────────────────────────────────
+
+/**
+ * Dispatch a matched hook against an event.
+ *
+ * Day-1 (stub): no handlers registered → logged-and-fired.
+ * Day-2 (this commit): handlers may be registered via `registerHandler(type, fn)`.
+ *   Their HandlerResult drives which bus event fires:
+ *     - `{action: 'fire'}` (or undefined return) → emits `hook_fire`
+ *     - `{action: 'block', reason}` → emits `hook_block`
+ *     - `{action: 'escalate', reason}` → emits `hook_escalate`
+ *   A handler that throws is caught and treated as `block` with `reason: 'handler_threw: <msg>'`.
+ *
+ * Day-3+ (Codex Thu): the per-HandlerType built-in implementations
+ * (log_event / send_message / bash / webhook) register themselves at module
+ * init using this same `registerHandler` API. No further dispatcher changes.
+ */
+export async function dispatchHook(hook: HookEntry, event: Event): Promise<void> {
+  // Always write the local activity-log line (Day-1 behavior) for postmortem/audit.
+  logHookAttempt(hook, event);
+
+  // added 2026-04-29 by collie via dane dispatch — Day-2 per-handler wiring: result-driven emit
+  const handler = _handlerRegistry.get(hook.handler_type);
+  let result: HandlerResult;
+  if (!handler) {
+    // No handler registered for this type — Day-1 stub semantic: implicit fire.
+    result = { action: 'fire', reason: 'no_handler_registered' };
+  } else {
+    try {
+      const ret = await handler(hook, event);
+      if (!ret) {
+        // undefined / void → implicit fire (backwards-compatible default per Dane spec)
+        result = { action: 'fire', reason: 'implicit_default' };
+      } else {
+        result = ret;
+      }
+    } catch (err) {
+      // Buggy handler must never break the dispatcher loop. Treat throw as block.
+      const msg = err instanceof Error ? err.message : String(err);
+      result = { action: 'block', reason: `handler_threw: ${msg.slice(0, 120)}` };
+    }
+  }
+
+  const eventName: HookEmitName =
+    result.action === 'block' ? 'hook_block' :
+    result.action === 'escalate' ? 'hook_escalate' :
+    'hook_fire';
+
+  emitHookBusEvent(eventName, {
+    hook_id: hook.id,
+    handler_type: hook.handler_type,
+    event_id: event.id,
+    event_category: event.category,
+    event_type: event.event,
+    source_agent: event.agent,
+    outcome: result.reason ?? `${result.action}_no_reason`,
+    ...(result.meta ?? {}),
+  });
+}
+
+// ── Logging helpers (best-effort, never throw) ───────────────────────────────
+
+function logHookAttempt(hook: HookEntry, event: Event): void {
+  const line = JSON.stringify({
+    ts: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    kind: 'hook_attempt',  // Day-2: no longer a stub — real result-driven emit follows in dispatchHook
+    hook_id: hook.id,
+    handler_type: hook.handler_type,
+    event_id: event.id,
+    event_category: event.category,
+    event_type: event.event,
+    agent: event.agent,
+  });
+  appendActivityLine(event.agent, line);
+  // Day-2 (2026-04-29): bus event is now emitted by dispatchHook AFTER the handler returns,
+  // so the bus-event taxonomy reflects the real action (fire/block/escalate). The local
+  // activity-log line above stays for postmortem/audit — it records every attempt regardless.
+}
+
+// added 2026-04-29 by collie via dane dispatch — Task 1: queryable hook telemetry via cortextos bus log-event
+// Best-effort: never throws, never blocks the dispatcher loop. Events go to the canonical
+// per-agent JSONL at <analyticsDir>/events/<agent>/<YYYY-MM-DD>.jsonl so they show up in
+// the same surface as task_completed, agent_message_sent, etc.
+//
+// Emit names follow Aussie's 8:10p test report taxonomy:
+//   - hook_fire     — a hook matched + its dispatch was attempted (today: stub-logged only)
+//   - hook_block    — a hook matched + actively blocked the calling action (gate said NO)
+//   - hook_escalate — a hook matched + raised severity / re-routed (future use; not emitted by current code paths)
+type HookEmitName = 'hook_fire' | 'hook_block' | 'hook_escalate';
+function emitHookBusEvent(name: HookEmitName, meta: Record<string, unknown>): void {
+  try {
+    execFile(
+      'cortextos',
+      ['bus', 'log-event', 'action', name, 'info', '--meta', JSON.stringify(meta)],
+      { timeout: 5_000 },
+      () => { /* fire-and-forget */ },
+    );
+  } catch {
+    // best-effort: never propagate logging failures
+  }
+}
+
+function logRegistryWarn(orgPath: string, reason: string): void {
+  const line = JSON.stringify({
+    ts: new Date().toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    kind: 'hook_registry_warn',
+    org_path: orgPath,
+    reason,
+  });
+  appendActivityLine('shared', line);
+}
+
+function appendActivityLine(scope: string, line: string): void {
+  try {
+    const dir = join(process.env.CTX_ROOT ?? '', 'logs', scope);
+    mkdirSync(dir, { recursive: true });
+    appendFileSync(join(dir, 'hooks.log'), `${line}\n`, 'utf-8');
+  } catch {
+    // best-effort: never throw from a hook-side log path
+  }
+}
+
+// Silence unused-import tsc warnings for symbols reserved for the upcoming
+// dispatcher implementation (handler dispatch will use `dirname` to resolve
+// relative paths in bash-handler templates per RFC #15 §5).
+void dirname;

--- a/tests/unit/bus/hooks.test.ts
+++ b/tests/unit/bus/hooks.test.ts
@@ -234,6 +234,36 @@ describe('src/bus/hooks — Day-2 per-handler wiring', () => {
       expect(e?.meta.handler_type).toBe('log_event');
       expect(e?.meta.event_id).toBe('evt-meta');
     });
+
+    it('handler meta cannot override dispatcher bookkeeping fields', async () => {
+      registerHandler('log_event', (): HandlerResult => ({
+        action: 'fire',
+        reason: 'meta_override_check',
+        meta: {
+          hook_id: 'OVERRIDE_ATTEMPT',
+          handler_type: 'OVERRIDE_ATTEMPT',
+          event_id: 'OVERRIDE_ATTEMPT',
+          event_category: 'OVERRIDE_ATTEMPT',
+          event_type: 'OVERRIDE_ATTEMPT',
+          source_agent: 'OVERRIDE_ATTEMPT',
+          outcome: 'OVERRIDE_ATTEMPT',
+          extra_handler_field: 'kept',
+        },
+      }));
+      await dispatchHook(
+        makeHook({ id: 'h-real', handler_type: 'log_event' }),
+        makeEvent({ id: 'evt-real', agent: 'real-agent', category: 'action', event: 'real_event' }),
+      );
+      const e = lastEmittedEvent();
+      expect(e?.meta.hook_id).toBe('h-real');
+      expect(e?.meta.handler_type).toBe('log_event');
+      expect(e?.meta.event_id).toBe('evt-real');
+      expect(e?.meta.event_category).toBe('action');
+      expect(e?.meta.event_type).toBe('real_event');
+      expect(e?.meta.source_agent).toBe('real-agent');
+      expect(e?.meta.outcome).toBe('meta_override_check');
+      expect(e?.meta.extra_handler_field).toBe('kept');
+    });
   });
 
   describe('handler registry', () => {

--- a/tests/unit/bus/hooks.test.ts
+++ b/tests/unit/bus/hooks.test.ts
@@ -1,0 +1,257 @@
+// added 2026-04-29 by collie via dane dispatch — RFC #15 Day-2 per-handler wiring tests.
+// Covers HandlerResult-driven dispatch (fire / block / escalate / undefined / throw) and
+// the basic loadHookRegistry + matchHooks paths so a regression in either surface is caught.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { Event } from '../../../src/types/index';
+
+// Capture every execFile invocation so we can assert which bus event was emitted.
+// The dispatcher uses execFile('cortextos', ['bus', 'log-event', 'action', <name>, 'info', '--meta', <json>])
+// fire-and-forget — we intercept before it spawns anything.
+const execFileCalls: Array<{ cmd: string; args: string[] }> = [];
+vi.mock('child_process', () => ({
+  execFile: (cmd: string, args: string[], _opts: unknown, cb?: () => void) => {
+    execFileCalls.push({ cmd, args: [...args] });
+    if (typeof cb === 'function') cb();
+    return { unref: () => {} };
+  },
+}));
+
+// Imported AFTER vi.mock so the mocked execFile is in effect.
+import {
+  loadHookRegistry,
+  matchHooks,
+  dispatchHook,
+  registerHandler,
+  clearHandlerRegistry,
+  _getRegisteredHandler,
+  type HookEntry,
+  type HandlerResult,
+} from '../../../src/bus/hooks';
+
+function makeEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'evt-1',
+    agent: 'collie',
+    org: 'ascendops',
+    timestamp: '2026-04-29T20:00:00Z',
+    category: 'action',
+    event: 'pm_meld_completed',
+    severity: 'info',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function makeHook(overrides: Partial<HookEntry> = {}): HookEntry {
+  return {
+    id: 'h1',
+    event_pattern: { category: 'action', type: 'pm_meld_completed' },
+    handler_type: 'log_event',
+    handler: { category: 'action', type: 'demo', severity: 'info', meta: {} },
+    agent_filter: [],
+    priority: 100,
+    enabled: true,
+    ...overrides,
+  };
+}
+
+// Helper: read the meta JSON from the most recent execFile call.
+function lastEmittedEvent(): { name: string; meta: Record<string, unknown> } | null {
+  if (execFileCalls.length === 0) return null;
+  const args = execFileCalls[execFileCalls.length - 1].args;
+  // shape: [bus, log-event, action, <name>, info, --meta, <json>]
+  const name = args[3];
+  const metaIdx = args.indexOf('--meta');
+  const meta = metaIdx >= 0 && metaIdx + 1 < args.length ? JSON.parse(args[metaIdx + 1]) : {};
+  return { name, meta };
+}
+
+describe('src/bus/hooks — Day-2 per-handler wiring', () => {
+  beforeEach(() => {
+    execFileCalls.length = 0;
+    clearHandlerRegistry();
+  });
+
+  describe('loadHookRegistry', () => {
+    let tmp: string;
+
+    beforeEach(() => { tmp = mkdtempSync(join(tmpdir(), 'cx-hooks-')); });
+    afterEach(() => { rmSync(tmp, { recursive: true, force: true }); });
+
+    it('returns empty registry when hooks.json is missing', () => {
+      const reg = loadHookRegistry(tmp);
+      expect(reg.hooks).toEqual([]);
+      expect(reg.schema_version).toBe('0.1');
+    });
+
+    it('returns empty registry on malformed JSON (fail-open)', () => {
+      writeFileSync(join(tmp, 'hooks.json'), '{not json');
+      const reg = loadHookRegistry(tmp);
+      expect(reg.hooks).toEqual([]);
+    });
+
+    it('parses a valid registry', () => {
+      const valid = {
+        schema_version: '1.0',
+        hooks: [makeHook({ id: 'a' }), makeHook({ id: 'b' })],
+      };
+      writeFileSync(join(tmp, 'hooks.json'), JSON.stringify(valid));
+      const reg = loadHookRegistry(tmp);
+      expect(reg.hooks).toHaveLength(2);
+      expect(reg.hooks.map(h => h.id)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('matchHooks', () => {
+    it('matches enabled hooks by category + type', () => {
+      const reg = { schema_version: '1.0', hooks: [makeHook({ id: 'a' })] };
+      const matched = matchHooks(reg, makeEvent(), 'collie');
+      expect(matched).toHaveLength(1);
+      expect(matched[0].id).toBe('a');
+    });
+
+    it('skips disabled hooks', () => {
+      const reg = { schema_version: '1.0', hooks: [makeHook({ id: 'a', enabled: false })] };
+      expect(matchHooks(reg, makeEvent(), 'collie')).toHaveLength(0);
+    });
+
+    it('respects agent_filter', () => {
+      const reg = { schema_version: '1.0', hooks: [makeHook({ id: 'a', agent_filter: ['blue'] })] };
+      expect(matchHooks(reg, makeEvent({ agent: 'collie' }), 'collie')).toHaveLength(0);
+      expect(matchHooks(reg, makeEvent({ agent: 'blue' }), 'blue')).toHaveLength(1);
+    });
+
+    it('sorts matches by priority descending', () => {
+      const reg = {
+        schema_version: '1.0',
+        hooks: [makeHook({ id: 'a', priority: 10 }), makeHook({ id: 'b', priority: 100 })],
+      };
+      const matched = matchHooks(reg, makeEvent(), 'collie');
+      expect(matched.map(h => h.id)).toEqual(['b', 'a']);
+    });
+
+    it('matches metadata deeply (extra event keys allowed)', () => {
+      const reg = {
+        schema_version: '1.0',
+        hooks: [makeHook({
+          id: 'a',
+          event_pattern: { category: 'action', type: 'pm_meld_completed', metadata: { tech: 'carlos' } },
+        })],
+      };
+      expect(matchHooks(reg, makeEvent({ metadata: { tech: 'carlos', meld: 12345 } }), 'collie'))
+        .toHaveLength(1);
+      expect(matchHooks(reg, makeEvent({ metadata: { tech: 'silvano' } }), 'collie'))
+        .toHaveLength(0);
+    });
+  });
+
+  describe('dispatchHook — Day-2 result-driven emit', () => {
+    it('falls back to hook_fire (no_handler_registered) when no handler is registered', async () => {
+      await dispatchHook(makeHook(), makeEvent());
+      const e = lastEmittedEvent();
+      expect(e?.name).toBe('hook_fire');
+      expect(e?.meta.outcome).toBe('no_handler_registered');
+    });
+
+    it('emits hook_fire (implicit_default) when handler returns undefined', async () => {
+      registerHandler('log_event', () => undefined);
+      await dispatchHook(makeHook(), makeEvent());
+      const e = lastEmittedEvent();
+      expect(e?.name).toBe('hook_fire');
+      expect(e?.meta.outcome).toBe('implicit_default');
+    });
+
+    it('emits hook_fire with custom meta when handler returns {action:fire, meta}', async () => {
+      registerHandler('log_event', (): HandlerResult => ({
+        action: 'fire',
+        reason: 'handler_ran',
+        meta: { processed_meld_id: 12345 },
+      }));
+      await dispatchHook(makeHook(), makeEvent());
+      const e = lastEmittedEvent();
+      expect(e?.name).toBe('hook_fire');
+      expect(e?.meta.outcome).toBe('handler_ran');
+      expect(e?.meta.processed_meld_id).toBe(12345);
+    });
+
+    it('emits hook_block when handler returns {action:block}', async () => {
+      registerHandler('log_event', (): HandlerResult => ({
+        action: 'block',
+        reason: 'guardrail_triggered',
+      }));
+      await dispatchHook(makeHook(), makeEvent());
+      const e = lastEmittedEvent();
+      expect(e?.name).toBe('hook_block');
+      expect(e?.meta.outcome).toBe('guardrail_triggered');
+    });
+
+    it('emits hook_escalate when handler returns {action:escalate}', async () => {
+      registerHandler('log_event', (): HandlerResult => ({
+        action: 'escalate',
+        reason: 'severity_upgraded_to_critical',
+      }));
+      await dispatchHook(makeHook(), makeEvent());
+      const e = lastEmittedEvent();
+      expect(e?.name).toBe('hook_escalate');
+      expect(e?.meta.outcome).toBe('severity_upgraded_to_critical');
+    });
+
+    it('treats handler throw as hook_block with handler_threw reason', async () => {
+      registerHandler('log_event', () => {
+        throw new Error('intentional fault for test');
+      });
+      await dispatchHook(makeHook(), makeEvent());
+      const e = lastEmittedEvent();
+      expect(e?.name).toBe('hook_block');
+      expect(typeof e?.meta.outcome).toBe('string');
+      expect(String(e?.meta.outcome)).toContain('handler_threw');
+      expect(String(e?.meta.outcome)).toContain('intentional fault');
+    });
+
+    it('awaits async handlers and routes their result correctly', async () => {
+      registerHandler('log_event', async (): Promise<HandlerResult> => {
+        await new Promise(r => setTimeout(r, 1));
+        return { action: 'block', reason: 'async_block' };
+      });
+      await dispatchHook(makeHook(), makeEvent());
+      const e = lastEmittedEvent();
+      expect(e?.name).toBe('hook_block');
+      expect(e?.meta.outcome).toBe('async_block');
+    });
+
+    it('always carries hook_id, handler_type, event_id in the meta payload', async () => {
+      registerHandler('log_event', (): HandlerResult => ({ action: 'fire', reason: 'check_meta' }));
+      await dispatchHook(
+        makeHook({ id: 'h-meta', handler_type: 'log_event' }),
+        makeEvent({ id: 'evt-meta' }),
+      );
+      const e = lastEmittedEvent();
+      expect(e?.meta.hook_id).toBe('h-meta');
+      expect(e?.meta.handler_type).toBe('log_event');
+      expect(e?.meta.event_id).toBe('evt-meta');
+    });
+  });
+
+  describe('handler registry', () => {
+    it('registerHandler replaces existing handler and returns the prior one', () => {
+      const fnA = () => undefined;
+      const fnB = () => undefined;
+      expect(registerHandler('log_event', fnA)).toBeUndefined();
+      const prev = registerHandler('log_event', fnB);
+      expect(prev).toBe(fnA);
+      expect(_getRegisteredHandler('log_event')).toBe(fnB);
+    });
+
+    it('clearHandlerRegistry removes all registrations', () => {
+      registerHandler('log_event', () => undefined);
+      registerHandler('bash', () => undefined);
+      clearHandlerRegistry();
+      expect(_getRegisteredHandler('log_event')).toBeUndefined();
+      expect(_getRegisteredHandler('bash')).toBeUndefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an extensible bus-side hooks framework that lets handlers register against hook types and return structured results (`fire` / `block` / `escalate`) for downstream observability + safety. Includes the bus event emit pipeline (`hook_fire` / `hook_block` / `hook_escalate`) so test harnesses and dashboards can count hook outcomes cleanly.

Designed in three phases:
- **Day-1 (stub):** dispatcher exists, treats every attempt as `hook_fire` with `outcome=no_handler_registered`. No handler refusal capability.
- **Day-2 (this PR's added wiring):** `HandlerResult` contract, in-process registry (`registerHandler` / `clearHandlerRegistry` / `_getRegisteredHandler`), dispatcher routes results to the correct event taxonomy. Throws caught as `block(handler_threw)`. Backwards-compat: undefined return = fire, empty registry = Day-1 stub semantic.
- **Day-3 (follow-up PR):** built-in handler implementations (bash spawn / send_message / log_event / webhook fetch) wired against the same `registerHandler` API.

## What changed

- New `src/bus/hooks.ts` — exports:
  - `HandlerResult` type: `{ action: 'fire' | 'block' | 'escalate', reason?: string, meta?: Record<string, unknown> }`
  - `HandlerFn` type: sync-or-async, returns `HandlerResult | void`
  - `registerHandler(type, fn)` / `clearHandlerRegistry()` / `_getRegisteredHandler(type)`
  - `dispatchHook(type, eventMeta)` — routes via registered handler, catches throws as block, emits the right bus event
  - `emitHookBusEvent(eventName, meta)` — fire-and-forget execFile to `cortextos bus log-event`
  - `loadHookRegistry()` / `matchHooks()` — config-driven hook routing
- New `tests/unit/bus/hooks.test.ts` — 18 tests covering: loadHookRegistry (missing file fail-open, malformed JSON fail-open, valid parse), matchHooks (enabled/disabled/agent_filter own+cross, priority sort, metadata deep-match), dispatchHook (no-handler/undefined/fire-with-meta/block/escalate/throw/async/bookkeeping-fields-always-present), registry CRUD.

## Test plan

- [x] 18 new unit tests, all passing
- [x] `npm run build` clean
- [x] TypeScript no errors (`npx tsc --noEmit` clean)
- [x] Backwards-compat verified: empty registry produces same Day-1 stub behavior as before

## Follow-up

A separate PR will land the built-in handler scaffolds. Day-3 dispatch logic for bash_spawn / send_message / webhook_fetch is intentionally deferred — log_event handler is fully implemented in the follow-up.

## Risk / rollback

Risk: low. New file + tests only. No production dispatcher exists yet for the live handler path; this is enabling infrastructure.
Rollback: `git revert <merge-commit>`.
