### PR TITLE
fix(task): widen random suffix from 3 to 6 digits to prevent ID collision

### DIFF
--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -38,7 +38,7 @@ export function createTask(
   validatePriority(priority);
 
   const epoch = Date.now();
-  const rand = randomDigits(3);
+  const rand = randomDigits(6);
   const taskId = `task_${epoch}_${rand}`;
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
 

--- a/tests/unit/bus/task.test.ts
+++ b/tests/unit/bus/task.test.ts
@@ -37,7 +37,7 @@ describe('Task Management', () => {
         priority: 'high',
       });
 
-      expect(taskId).toMatch(/^task_\d+_\d{3}$/);
+      expect(taskId).toMatch(/^task_\d+_\d{6}$/);
 
       const content = JSON.parse(readFileSync(join(paths.taskDir, `${taskId}.json`), 'utf-8'));
 


### PR DESCRIPTION
## Summary

Task IDs were colliding under high task-creation rates. Suffix was 3 digits = 1000-value space; with batch dispatches this hit collisions. Widening to 6 digits = 1M-value space brings collision probability to negligible.

## What changed

- Task ID format `task_<timestamp>_<3-digit-suffix>` → `task_<timestamp>_<6-digit-suffix>`.
- Doc comment updated to match.

## Test plan

- [x] Existing task tests pass (39/39 in `tests/unit/bus/task.test.ts`)
- [x] `npx tsc --noEmit` clean
- [x] Manual verification of new ID format

## Risk / rollback

Risk: low. ID format change only; existing IDs still parse correctly.
Rollback: `git revert <merge-commit>`.
