### PR TITLE
feat(templates): add orchestrator heartbeat summary pattern

### DIFF
--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -109,6 +109,24 @@ Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages 
 
 ---
 
+## Orchestrator Heartbeat Summary
+
+On every 4h heartbeat cycle, send your orchestrator a brief status summary. Three lines is enough:
+
+```bash
+cortextos bus send-message <orchestrator> normal 'Heartbeat:
+- Completed: <what finished since last heartbeat>
+- Blocked: <anything waiting on external input>
+- Waiting: <tasks in queue or pending approval>'
+```
+
+**Rules:**
+- Send this every heartbeat cycle, not just when something changes
+- Do NOT route routine task details through the orchestrator to the user — the user contacts you directly
+- Only escalate to the orchestrator when you need a decision, a handoff, or are genuinely blocked
+
+---
+
 ## Crons
 
 Defined in `config.json` under `crons` array. Set up once per session via `/loop`.


### PR DESCRIPTION
## Summary

Adds the canonical orchestrator heartbeat-summary pattern (completed / blocked / waiting) as a template fragment so new orchestrator-class agents pick it up out of the box.

Every 4h heartbeat, agents send their orchestrator a brief summary of completed work, blocked items, and what they are waiting on. Establishes a clear comms boundary: routine details stay between agent and user, orchestrator only sees decisions, handoffs, and blockers.

## What changed

- `templates/agent/CLAUDE.md` — adds the orchestrator heartbeat summary pattern documentation (+18 lines).

## Test plan

- [x] No code path changes
- [x] Template renders correctly via the agent boot path

## Risk / rollback

Risk: very low. Documentation/template only.
Rollback: `git revert <merge-commit>`.
