### PR TITLE
feat(daemon): 3-tier model cost routing (haiku/sonnet/opus) for agents

### DIFF
--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
+import { resolveModel } from '../utils/model-tiers.js';
 import { OutputBuffer } from './output-buffer.js';
 
 // node-pty types
@@ -210,8 +211,9 @@ export class AgentPTY {
 
     args.push('--dangerously-skip-permissions');
 
-    if (this.config.model) {
-      args.push('--model', this.config.model);
+    const model = resolveModel(this.config);
+    if (model) {
+      args.push('--model', model);
     }
 
     // Local override pattern (feat #20): concatenate {agentDir}/local/*.md files

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -158,6 +158,17 @@ export interface AgentConfig {
   max_session_seconds?: number;
   max_crashes_per_day?: number;
   model?: string;
+  /**
+   * Cost tier for model routing: 'haiku' | 'sonnet' | 'opus'.
+   * Ignored when `model` is set (explicit model takes precedence).
+   * Resolved to a concrete model ID via model_tiers (or DEFAULT_MODEL_TIERS).
+   */
+  tier?: 'haiku' | 'sonnet' | 'opus';
+  /**
+   * Per-agent overrides for the tier→model ID mapping.
+   * Merges on top of DEFAULT_MODEL_TIERS — only specify the tiers you want to override.
+   */
+  model_tiers?: { haiku?: string; sonnet?: string; opus?: string };
   working_directory?: string;
   enabled?: boolean;
   crons?: CronEntry[];

--- a/src/utils/model-tiers.ts
+++ b/src/utils/model-tiers.ts
@@ -1,0 +1,72 @@
+/**
+ * model-tiers.ts — 3-tier model cost routing for cortextOS agents.
+ *
+ * Agents can be assigned a cost tier ('haiku', 'sonnet', or 'opus') instead
+ * of a hard-coded model string. The tier is resolved to a concrete model ID
+ * at spawn time using DEFAULT_MODEL_TIERS (or an agent-level override).
+ *
+ * Precedence (highest to lowest):
+ *   1. config.model          — explicit model string, bypasses tier routing
+ *   2. config.tier           — maps to config.model_tiers or DEFAULT_MODEL_TIERS
+ *   3. (no model set)        — Claude Code uses its own default
+ *
+ * This lets operators:
+ *   - Assign lightweight agents (cron checkers, notifiers) to 'haiku' for cost savings
+ *   - Keep knowledge-work agents on 'sonnet' (default)
+ *   - Reserve 'opus' for orchestrators or complex reasoning tasks
+ *   - Upgrade all agents to a new model generation by bumping DEFAULT_MODEL_TIERS
+ *     in one place rather than editing every config.json
+ */
+
+import type { AgentConfig } from '../types/index.js';
+
+/** The three cost tiers available for model routing. */
+export type ModelTier = 'haiku' | 'sonnet' | 'opus';
+
+/** Maps each tier to a concrete Anthropic model ID. */
+export type ModelTiers = Record<ModelTier, string>;
+
+/**
+ * Current Anthropic model IDs for each tier.
+ * Update this when new model generations ship.
+ */
+export const DEFAULT_MODEL_TIERS: ModelTiers = {
+  haiku: 'claude-haiku-4-5-20251001',
+  sonnet: 'claude-sonnet-4-6',
+  opus: 'claude-opus-4-6',
+};
+
+/**
+ * Resolve the model to pass to `--model` for a given agent config.
+ *
+ * Returns undefined if neither `model` nor `tier` is set, letting Claude Code
+ * use its own default.
+ *
+ * @param config        The agent's loaded configuration.
+ * @param defaultTiers  Optional override for the default tier→model mapping.
+ *                      Useful in tests or when the operator wants to pin tiers
+ *                      at the framework level without editing each agent config.
+ */
+export function resolveModel(
+  config: AgentConfig,
+  defaultTiers: ModelTiers = DEFAULT_MODEL_TIERS,
+): string | undefined {
+  // Explicit model string takes priority — backwards-compatible with existing configs.
+  if (config.model) return config.model;
+
+  // Tier-based routing: merge per-agent overrides on top of defaults.
+  if (config.tier) {
+    let tiers: ModelTiers = defaultTiers;
+    if (config.model_tiers) {
+      // Filter out undefined values before merging so that an explicitly-undefined
+      // override (e.g. model_tiers: { haiku: undefined }) does not shadow the default.
+      const overrides = Object.fromEntries(
+        Object.entries(config.model_tiers).filter(([, v]) => v !== undefined),
+      ) as Partial<ModelTiers>;
+      tiers = { ...defaultTiers, ...overrides };
+    }
+    return tiers[config.tier];
+  }
+
+  return undefined;
+}

--- a/templates/agent/config.json
+++ b/templates/agent/config.json
@@ -4,6 +4,7 @@
   "startup_delay": 0,
   "max_session_seconds": 255600,
   "max_crashes_per_day": 10,
+  "tier": "sonnet",
   "working_directory": "",
   "timezone": "",
   "crons": [

--- a/templates/analyst/config.json
+++ b/templates/analyst/config.json
@@ -4,6 +4,7 @@
   "startup_delay": 0,
   "max_session_seconds": 255600,
   "max_crashes_per_day": 10,
+  "tier": "sonnet",
   "working_directory": "",
   "timezone": "",
   "day_mode_start": "",

--- a/templates/orchestrator/config.json
+++ b/templates/orchestrator/config.json
@@ -4,6 +4,7 @@
   "startup_delay": 0,
   "max_session_seconds": 255600,
   "max_crashes_per_day": 10,
+  "tier": "sonnet",
   "working_directory": "",
   "timezone": "",
   "day_mode_start": "",

--- a/tests/unit/utils/model-tiers.test.ts
+++ b/tests/unit/utils/model-tiers.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_MODEL_TIERS,
+  resolveModel,
+} from '../../../src/utils/model-tiers';
+import type { AgentConfig } from '../../../src/types/index';
+
+describe('DEFAULT_MODEL_TIERS', () => {
+  it('defines all three tiers', () => {
+    expect(DEFAULT_MODEL_TIERS.haiku).toBeDefined();
+    expect(DEFAULT_MODEL_TIERS.sonnet).toBeDefined();
+    expect(DEFAULT_MODEL_TIERS.opus).toBeDefined();
+  });
+
+  it('uses non-empty model IDs', () => {
+    for (const id of Object.values(DEFAULT_MODEL_TIERS)) {
+      expect(typeof id).toBe('string');
+      expect(id.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('resolveModel', () => {
+  const base: AgentConfig = {};
+
+  it('returns undefined when neither model nor tier is set', () => {
+    expect(resolveModel(base)).toBeUndefined();
+  });
+
+  it('returns the explicit model string when set', () => {
+    expect(resolveModel({ ...base, model: 'claude-custom-model' })).toBe('claude-custom-model');
+  });
+
+  it('explicit model takes priority over tier', () => {
+    expect(resolveModel({ ...base, model: 'explicit', tier: 'opus' })).toBe('explicit');
+  });
+
+  it('resolves haiku tier to correct model ID', () => {
+    expect(resolveModel({ ...base, tier: 'haiku' })).toBe(DEFAULT_MODEL_TIERS.haiku);
+  });
+
+  it('resolves sonnet tier to correct model ID', () => {
+    expect(resolveModel({ ...base, tier: 'sonnet' })).toBe(DEFAULT_MODEL_TIERS.sonnet);
+  });
+
+  it('resolves opus tier to correct model ID', () => {
+    expect(resolveModel({ ...base, tier: 'opus' })).toBe(DEFAULT_MODEL_TIERS.opus);
+  });
+
+  it('per-agent model_tiers override merges with defaults', () => {
+    const config: AgentConfig = {
+      tier: 'haiku',
+      model_tiers: { haiku: 'claude-haiku-custom' },
+    };
+    expect(resolveModel(config)).toBe('claude-haiku-custom');
+  });
+
+  it('per-agent model_tiers override does not affect other tiers', () => {
+    const config: AgentConfig = {
+      tier: 'sonnet',
+      model_tiers: { haiku: 'claude-haiku-custom' },
+    };
+    expect(resolveModel(config)).toBe(DEFAULT_MODEL_TIERS.sonnet);
+  });
+
+  it('accepts a custom defaultTiers argument', () => {
+    const custom = { haiku: 'h', sonnet: 's', opus: 'o' };
+    expect(resolveModel({ ...base, tier: 'opus' }, custom)).toBe('o');
+  });
+
+  it('per-agent model_tiers merges on top of custom defaultTiers', () => {
+    const custom = { haiku: 'h', sonnet: 's', opus: 'o' };
+    const config: AgentConfig = {
+      tier: 'opus',
+      model_tiers: { opus: 'o-override' },
+    };
+    expect(resolveModel(config, custom)).toBe('o-override');
+  });
+
+  it('undefined model_tiers values do not shadow defaults', () => {
+    // model_tiers: { haiku: undefined } should NOT overwrite DEFAULT_MODEL_TIERS.haiku
+    const config: AgentConfig = {
+      tier: 'haiku',
+      model_tiers: { haiku: undefined },
+    };
+    expect(resolveModel(config)).toBe(DEFAULT_MODEL_TIERS.haiku);
+  });
+});


### PR DESCRIPTION
- New src/utils/model-tiers.ts: ModelTier type, DEFAULT_MODEL_TIERS constant
  (maps tier names to current Anthropic model IDs), and resolveModel() helper
  with explicit-model-takes-priority semantics for backward compat.
- AgentConfig gains optional tier ('haiku'|'sonnet'|'opus') and model_tiers
  (per-agent override map) fields.
- agent-pty.ts uses resolveModel(config) instead of raw config.model.
- Template configs default to tier: "sonnet"; operators change a single field
  to move a lightweight agent to haiku or an orchestrator to opus.
- Codex fix: undefined values in model_tiers overrides are filtered before
  merging so they cannot silently shadow DEFAULT_MODEL_TIERS entries.
- 13 new unit tests covering all tier/model/override precedence combinations.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

