### PR TITLE
feat(daemon): add telegram_polling config flag to suppress poller on specialist agents

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -293,8 +293,10 @@ export class AgentManager {
       }).catch(() => { /* non-fatal */ });
     }
 
-    // Start Telegram poller if credentials are available
-    if (telegramApi && chatId) {
+    // Start Telegram poller if credentials are available and not explicitly disabled.
+    // Set telegram_polling: false in config.json to prevent a specialist agent from
+    // running its own poller (only the designated orchestrator agent should poll).
+    if (telegramApi && chatId && config.telegram_polling !== false) {
       const stateDir = join(this.ctxRoot, 'state', name);
       const poller = new TelegramPoller(telegramApi, stateDir);
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -181,6 +181,14 @@ export interface AgentConfig {
    * continuity, and exit handling.
    */
   runtime?: 'claude-code' | 'hermes';
+  /**
+   * Whether this agent runs a Telegram poller. Defaults to true when absent
+   * (preserves existing behaviour). Set to false on specialist agents that
+   * should not own a Telegram bot — only the designated orchestrator agent
+   * should poll. Requires BOT_TOKEN + CHAT_ID to already be unset or the
+   * poller will be skipped regardless.
+   */
+  telegram_polling?: boolean;
 }
 
 export interface CronEntry {


### PR DESCRIPTION
## Summary

Per AGENT-ETIQUETTE, only the designated orchestrator agent should own the Telegram interface. Specialist agents that have a `BOT_TOKEN` configured (e.g. for slash-command registration) would previously also start a full inbound poller, generating unnecessary `getUpdates` traffic and timeout noise.

- Add `telegram_polling?: boolean` to `AgentConfig`
- When `false`, the poller is skipped even if `BOT_TOKEN` + `CHAT_ID` are both present
- Defaults to `true` when absent — **no breaking change** to existing deployments
- Slash-command registration is unaffected (guarded separately by `if (telegramApi && botToken)`)

## Usage

Specialist agents opt out via `config.json`:
```json
{
  "telegram_polling": false
}
```

## Changes

- `src/types/index.ts` — add `telegram_polling?: boolean` field with JSDoc to `AgentConfig`
- `src/daemon/agent-manager.ts` — add `config.telegram_polling !== false` guard to poller startup (line ~297)

**2 files changed, 12 insertions(+), 2 deletions(-)**

## Test plan

- [ ] Agent with `telegram_polling: false` + valid `BOT_TOKEN`/`CHAT_ID` → no poller starts, no `getUpdates` calls
- [ ] Agent with `telegram_polling: true` (explicit) → poller starts as before
- [ ] Agent with `telegram_polling` absent → poller starts as before (backwards compat)
- [ ] Slash-command registration still works when `telegram_polling: false`

## Context

Filed against issue observed in taylorgroup cortextOS fleet where 4 specialist agents were running pollers unnecessarily, generating repeated `getUpdates` timeout errors in daemon logs. Relates to AGENT-ETIQUETTE rule: "only boss sends Telegram to user."

> **Draft** — opened by devops infra agent for upstream maintainer review. Do not merge without human sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)