### PR TITLE
Hook 1: agent_crashed -> alert chief + analyst

### DIFF
--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -17,6 +17,7 @@
 import { existsSync, readFileSync, writeFileSync, appendFileSync, unlinkSync, mkdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { execFile } from 'child_process';
 
 const DEDUP_WINDOW_MS = 10 * 60 * 1000;         // 10 minutes
 const QUIET_HOUR_START_LA = 22;                 // 22:00 America/Los_Angeles
@@ -74,6 +75,54 @@ function detectRateLimitInLog(logPath: string): boolean {
     );
   } catch {
     return false;
+  }
+}
+
+/**
+ * Read max_crashes_per_day from the agent's config.json. Returns null if the
+ * file is missing, malformed, or the field is not a number — caller treats
+ * null as "no limit configured" so a missing config never blocks the alert.
+ */
+export function readMaxCrashesPerDay(agentDir: string | undefined): number | null {
+  if (!agentDir) return null;
+  try {
+    const cfg = JSON.parse(readFileSync(join(agentDir, 'config.json'), 'utf-8')) as Record<string, unknown>;
+    return typeof cfg.max_crashes_per_day === 'number' ? cfg.max_crashes_per_day : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Send a crash notification via `cortextos bus send-message` to the listed
+ * recipient agents. Best-effort: failures are swallowed so an alert miss never
+ * cascades into a hook crash.
+ */
+export function notifyAgents(opts: {
+  agentName: string;
+  endType: string;
+  reason: string;
+  lastTask: string;
+  crashCount: number;
+  restartAttempted: boolean;
+  recipients: string[];
+}): void {
+  const body = [
+    `agent=${opts.agentName} crashed (type=${opts.endType})`,
+    `reason: ${opts.reason || 'none'}`,
+    `last status: ${opts.lastTask || 'unknown'}`,
+    `crashes today: ${opts.crashCount}`,
+    `restart attempted: ${opts.restartAttempted ? 'yes' : 'no (max_crashes_per_day reached)'}`,
+  ].join('\n');
+  for (const target of opts.recipients) {
+    try {
+      execFile(
+        'cortextos',
+        ['bus', 'send-message', target, 'high', body],
+        { timeout: 10_000 },
+        () => { /* fire-and-forget */ },
+      );
+    } catch { /* best-effort, never throw */ }
   }
 }
 
@@ -167,6 +216,15 @@ async function main(): Promise<void> {
     try {
       writeFileSync(countFile, `${today}:${crashCount}`, 'utf-8');
     } catch { /* ignore */ }
+  } else if (endType === 'daemon-crashed') {
+    // Read-only: surface today's count to chief/analyst without mutating it.
+    try {
+      const data = readFileSync(countFile, 'utf-8').trim();
+      const [date, count] = data.split(':');
+      crashCount = date === today ? parseInt(count, 10) : 0;
+    } catch {
+      crashCount = 0;
+    }
   }
 
   // Read last heartbeat for context
@@ -251,6 +309,25 @@ async function main(): Promise<void> {
         body: JSON.stringify({ chat_id: chatId, text: message }),
       });
     } catch { /* ignore send failures */ }
+  }
+
+  // Real-crash agent alerts: notify chief + analyst on crash and daemon-crashed
+  // so silent failures get visibility on the bus, not just on Telegram. Gated
+  // by the same dedup window as the Telegram send (handled above), and skipped
+  // for clean exits / planned restarts / rate-limit pauses.
+  if (endType === 'crash' || endType === 'daemon-crashed') {
+    const agentDir = process.env.CTX_AGENT_DIR || process.cwd();
+    const maxCrashes = readMaxCrashesPerDay(agentDir);
+    const restartAttempted = maxCrashes === null || crashCount < maxCrashes;
+    notifyAgents({
+      agentName,
+      endType,
+      reason,
+      lastTask,
+      crashCount,
+      restartAttempted,
+      recipients: ['chief', 'analyst'],
+    });
   }
 }
 

--- a/tests/unit/hooks/hook-crash-alert.test.ts
+++ b/tests/unit/hooks/hook-crash-alert.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const execFileMock = vi.fn();
+vi.mock('child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+}));
+
+import { readMaxCrashesPerDay, notifyAgents } from '../../../src/hooks/hook-crash-alert';
+
+describe('readMaxCrashesPerDay', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('returns null when agentDir is undefined', () => {
+    expect(readMaxCrashesPerDay(undefined)).toBeNull();
+  });
+
+  it('returns null when config.json is missing', () => {
+    expect(readMaxCrashesPerDay(tmp)).toBeNull();
+  });
+
+  it('returns null when config.json is malformed', () => {
+    writeFileSync(join(tmp, 'config.json'), '{ not valid json', 'utf-8');
+    expect(readMaxCrashesPerDay(tmp)).toBeNull();
+  });
+
+  it('returns null when max_crashes_per_day is missing', () => {
+    writeFileSync(join(tmp, 'config.json'), JSON.stringify({ agent_name: 'x' }), 'utf-8');
+    expect(readMaxCrashesPerDay(tmp)).toBeNull();
+  });
+
+  it('returns the configured number when present', () => {
+    writeFileSync(join(tmp, 'config.json'), JSON.stringify({ max_crashes_per_day: 10 }), 'utf-8');
+    expect(readMaxCrashesPerDay(tmp)).toBe(10);
+  });
+
+  it('returns null when max_crashes_per_day is not a number', () => {
+    writeFileSync(join(tmp, 'config.json'), JSON.stringify({ max_crashes_per_day: 'ten' }), 'utf-8');
+    expect(readMaxCrashesPerDay(tmp)).toBeNull();
+  });
+});
+
+describe('notifyAgents', () => {
+  beforeEach(() => {
+    execFileMock.mockReset();
+  });
+
+  it('sends one bus send-message per recipient', () => {
+    notifyAgents({
+      agentName: 'dev',
+      endType: 'crash',
+      reason: 'uncaught exception',
+      lastTask: 'building hooks',
+      crashCount: 2,
+      restartAttempted: true,
+      recipients: ['chief', 'analyst'],
+    });
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses cortextos bus send-message with priority high', () => {
+    notifyAgents({
+      agentName: 'dev',
+      endType: 'crash',
+      reason: 'r',
+      lastTask: 't',
+      crashCount: 1,
+      restartAttempted: true,
+      recipients: ['chief'],
+    });
+    const [cmd, args] = execFileMock.mock.calls[0];
+    expect(cmd).toBe('cortextos');
+    expect(args.slice(0, 4)).toEqual(['bus', 'send-message', 'chief', 'high']);
+  });
+
+  it('body includes all required fields', () => {
+    notifyAgents({
+      agentName: 'dev',
+      endType: 'daemon-crashed',
+      reason: 'PTY null write',
+      lastTask: 'idle',
+      crashCount: 3,
+      restartAttempted: false,
+      recipients: ['analyst'],
+    });
+    const body: string = execFileMock.mock.calls[0][1][4];
+    expect(body).toContain('agent=dev');
+    expect(body).toContain('type=daemon-crashed');
+    expect(body).toContain('reason: PTY null write');
+    expect(body).toContain('last status: idle');
+    expect(body).toContain('crashes today: 3');
+    expect(body).toContain('restart attempted: no');
+  });
+
+  it('marks restart attempted yes when crashCount under limit', () => {
+    notifyAgents({
+      agentName: 'dev',
+      endType: 'crash',
+      reason: '',
+      lastTask: '',
+      crashCount: 1,
+      restartAttempted: true,
+      recipients: ['chief'],
+    });
+    expect(execFileMock.mock.calls[0][1][4]).toContain('restart attempted: yes');
+  });
+
+  it('uses fallback strings when reason and lastTask are empty', () => {
+    notifyAgents({
+      agentName: 'dev',
+      endType: 'crash',
+      reason: '',
+      lastTask: '',
+      crashCount: 1,
+      restartAttempted: true,
+      recipients: ['chief'],
+    });
+    const body: string = execFileMock.mock.calls[0][1][4];
+    expect(body).toContain('reason: none');
+    expect(body).toContain('last status: unknown');
+  });
+
+  it('does not throw when execFile throws synchronously', () => {
+    execFileMock.mockImplementationOnce(() => { throw new Error('exec failed'); });
+    expect(() => notifyAgents({
+      agentName: 'dev',
+      endType: 'crash',
+      reason: '',
+      lastTask: '',
+      crashCount: 1,
+      restartAttempted: true,
+      recipients: ['chief', 'analyst'],
+    })).not.toThrow();
+    // Second recipient still attempted
+    expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
## Summary

- Closes the silent-failure gap exposed by chief's 29h outage — chief and analyst now learn about real crashes via the bus, not just via a Telegram poll.
- Edits `src/hooks/hook-crash-alert.ts` (the existing SessionEnd hook) to fan out a `cortextos bus send-message` to chief + analyst on the `crash` and `daemon-crashed` end types only. Clean exits, planned restarts, user-initiated stops, and rate-limit pauses do not notify.
- Reuses the existing 10-minute dedup window so a crash loop does not flood the bus inbox.
- Best-effort `max_crashes_per_day` read from the agent's `config.json` to set `restart_attempted: yes/no` in the body. A missing or malformed config is treated as no-limit so the alert still fires.

## Why this scope (Pragmatic A)

Per the in-flight scope discussion, the bus-hooks framework merged in #272 is built but not yet wired (`matchHooks` / `dispatchHook` are never called by `logEvent` or fast-checker, and no `HandlerType` implementations are registered). Wiring the framework end-to-end is a separate strategic decision; meanwhile the silent-failure gap is real and time-sensitive (the 29h chief outage). This PR ships the pain-relief through the existing SessionEnd hook surface — same visible behavior to operators, no framework dependency.

Hook 2 (cron expiry auto-recreate) and Hook 3 (approval Telegram ping) follow as separate PRs.

Cobi-authorized via analyst (msg `1777802706627-analyst-z4qsj`).

## Test plan

- [x] Type-check clean (`npm run build`)
- [x] 12 new unit tests in `tests/unit/hooks/hook-crash-alert.test.ts` — covers `readMaxCrashesPerDay` edge cases (missing / malformed / non-numeric `max_crashes_per_day`) and `notifyAgents` body content, recipient fan-out, synchronous-throw resilience
- [x] Full suite passes locally (739 / 739)
- [ ] Sandbox crash validation by analyst — controlled crash on a sandbox agent, verify chief + analyst receive the bus message with the expected fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)