### PR TITLE
fix(daemon): improve gap nudge with CronCreate hint — closes /loop AskUserQuestion silent fail

### DIFF
--- a/src/bus/cron-state.ts
+++ b/src/bus/cron-state.ts
@@ -95,6 +95,41 @@ export function parseDurationMs(interval: string): number {
 }
 
 /**
+ * Convert a duration interval ("4h", "30m", "1d", "1w") into a 5-field cron
+ * expression. Returns null when the interval doesn't cleanly fit a recurring
+ * cron slot (e.g. "7m" leaves uneven gaps; "5w" has no clean weekly form).
+ *
+ * Mirrors the rounding rules in the /loop skill so daemon-injected nudges can
+ * give the agent a CronCreate-ready expression instead of a /loop command
+ * (which prompts AskUserQuestion for ≥60-minute intervals).
+ */
+export function intervalToCronExpression(interval: string): string | null {
+  const match = /^(\d+)(m|h|d|w)$/.exec(interval.trim());
+  if (!match) return null;
+  const n = parseInt(match[1], 10);
+  if (n <= 0) return null;
+  const unit = match[2];
+
+  if (unit === 'm') {
+    if (n <= 59) return 60 % n === 0 ? `*/${n} * * * *` : null;
+    if (n % 60 !== 0) return null;
+    const hours = n / 60;
+    return hours <= 23 && 24 % hours === 0 ? `0 */${hours} * * *` : null;
+  }
+  if (unit === 'h') {
+    if (n <= 23) return 24 % n === 0 ? `0 */${n} * * *` : null;
+    return null;
+  }
+  if (unit === 'd') {
+    return n >= 1 ? `0 0 */${n} * *` : null;
+  }
+  if (unit === 'w') {
+    return n === 1 ? '0 0 * * 0' : null;
+  }
+  return null;
+}
+
+/**
  * Estimate the minimum expected firing interval for a 5-field cron expression.
  * Handles common patterns (every-N-minutes, every-N-hours, daily) without an
  * external library. Returns a conservative 48h fallback for anything else.

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -8,7 +8,7 @@ import { MessageDedup, injectMessage } from '../pty/inject.js';
 import { ensureDir } from '../utils/atomic.js';
 import { writeCortextosEnv } from '../utils/env.js';
 import { getOverdueReminders } from '../bus/reminders.js';
-import { readCronState, parseDurationMs, cronExpressionMinIntervalMs } from '../bus/cron-state.js';
+import { readCronState, parseDurationMs, cronExpressionMinIntervalMs, intervalToCronExpression } from '../bus/cron-state.js';
 import { resolvePaths } from '../utils/paths.js';
 
 type LogFn = (msg: string) => void;
@@ -724,9 +724,12 @@ export class AgentProcess {
     const crons = this.config.crons;
     if (!crons || crons.length === 0) return;
 
-    // Monitor recurring crons with either a parseable interval or a cron expression
+    // Monitor recurring crons with either a parseable interval or a cron expression.
+    // Skip entries with missing prompts (malformed config) so the gap nudge can always
+    // include CronCreate-ready instructions.
     const monitorable = crons.filter(c => {
       if (c.type === 'once' || c.type === 'disabled') return false;
+      if (!c.prompt || typeof c.prompt !== 'string') return false;
       if (c.interval && !isNaN(parseDurationMs(c.interval))) return true;
       if (c.cron) return true;
       return false;
@@ -742,7 +745,7 @@ export class AgentProcess {
   }
 
   private async runGapDetectionLoop(
-    crons: Array<{ name: string; interval?: string; cron?: string }>,
+    crons: Array<{ name: string; interval?: string; cron?: string; prompt: string }>,
     generation: number,
     loopStartedAt: number,
   ): Promise<void> {
@@ -784,9 +787,11 @@ export class AgentProcess {
         if (gapMs > threshold) {
           const gapMin = Math.round(gapMs / 60_000);
           const expectedMin = Math.round(intervalMs / 60_000);
-          const restoreHint = cronDef.interval
-            ? `If missing, restore it from config.json: /loop ${cronDef.interval} <cron prompt>.`
-            : `If missing, restore it from config.json using the cron expression in your config.`;
+          const cronExpr = cronDef.cron
+            ?? (cronDef.interval ? intervalToCronExpression(cronDef.interval) : null);
+          const restoreHint = cronExpr
+            ? `If missing, recreate it directly with CronCreate (do NOT use /loop, which prompts for confirmation on long intervals): cron="${cronExpr}", recurring=true, prompt=${JSON.stringify(cronDef.prompt)}.`
+            : `If missing, recreate it from config.json — interval "${cronDef.interval ?? 'unknown'}" can't be expressed as a clean cron, so use /loop with the verbatim prompt from config.json.`;
           const nudge = `[SYSTEM] Cron gap detected for "${cronDef.name}": last fired ${gapMin} minutes ago (expected every ${expectedMin} minutes). Run CronList to verify the cron is still active. ${restoreHint}`;
 
           this.log(`Gap nudge: ${cronDef.name} silent ${gapMin}min (threshold: ${Math.round(threshold / 60_000)}min)`);

--- a/tests/unit/bus/cron-state.test.ts
+++ b/tests/unit/bus/cron-state.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { updateCronFire, readCronState, parseDurationMs } from '../../../src/bus/cron-state';
+import { updateCronFire, readCronState, parseDurationMs, intervalToCronExpression } from '../../../src/bus/cron-state';
 
 let tmpDir: string;
 
@@ -44,6 +44,60 @@ describe('parseDurationMs', () => {
   it('returns NaN for unknown unit', () => {
     expect(parseDurationMs('5y')).toBeNaN();
     expect(parseDurationMs('10s')).toBeNaN();
+  });
+});
+
+describe('intervalToCronExpression', () => {
+  it('converts sub-hour minute intervals that divide 60', () => {
+    expect(intervalToCronExpression('5m')).toBe('*/5 * * * *');
+    expect(intervalToCronExpression('15m')).toBe('*/15 * * * *');
+    expect(intervalToCronExpression('30m')).toBe('*/30 * * * *');
+  });
+
+  it('returns null for minute intervals that do not divide 60 cleanly', () => {
+    expect(intervalToCronExpression('7m')).toBeNull();
+    expect(intervalToCronExpression('45m')).toBeNull();
+  });
+
+  it('converts whole-hour minute intervals when hours divide 24', () => {
+    expect(intervalToCronExpression('60m')).toBe('0 */1 * * *');
+    expect(intervalToCronExpression('120m')).toBe('0 */2 * * *');
+    expect(intervalToCronExpression('240m')).toBe('0 */4 * * *');
+  });
+
+  it('returns null for whole-hour minute intervals that do not divide 24', () => {
+    expect(intervalToCronExpression('300m')).toBeNull(); // 5 hours doesn't divide 24
+    expect(intervalToCronExpression('420m')).toBeNull(); // 7 hours
+  });
+
+  it('converts hour intervals that divide 24', () => {
+    expect(intervalToCronExpression('1h')).toBe('0 */1 * * *');
+    expect(intervalToCronExpression('4h')).toBe('0 */4 * * *');
+    expect(intervalToCronExpression('12h')).toBe('0 */12 * * *');
+  });
+
+  it('returns null for hour intervals that do not divide 24', () => {
+    expect(intervalToCronExpression('5h')).toBeNull();
+    expect(intervalToCronExpression('7h')).toBeNull();
+    expect(intervalToCronExpression('25h')).toBeNull();
+  });
+
+  it('converts day intervals', () => {
+    expect(intervalToCronExpression('1d')).toBe('0 0 */1 * *');
+    expect(intervalToCronExpression('7d')).toBe('0 0 */7 * *');
+  });
+
+  it('converts 1w only', () => {
+    expect(intervalToCronExpression('1w')).toBe('0 0 * * 0');
+    expect(intervalToCronExpression('2w')).toBeNull();
+  });
+
+  it('returns null for malformed or unsupported intervals', () => {
+    expect(intervalToCronExpression('')).toBeNull();
+    expect(intervalToCronExpression('5y')).toBeNull();
+    expect(intervalToCronExpression('abc')).toBeNull();
+    expect(intervalToCronExpression('0h')).toBeNull();
+    expect(intervalToCronExpression('0 8 * * *')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Daemon's gap-detection nudge now embeds a clean cron expression + the verbatim prompt from `config.json`, so the agent can recreate a missing cron via `CronCreate` directly.
- Closes the silent failure mode where intervals ≥60 min triggered `/loop`'s `AskUserQuestion` confirmation that the agent can't answer.
- Falls back to the old `/loop` instruction (with a note to use the verbatim prompt) when the interval can't be expressed as a clean cron (e.g. `7m`, `5h`, `2w`).

## Why

CronCreate auto-expires entries after 7 days. When an interval-based cron drops off, the previous nudge said "run /loop 4h <cron prompt>" — but `/loop` for ≥60 min intervals pops `AskUserQuestion`, which the agent has no way to answer in a cron-injected nudge context. Result: nudge fires, agent reads it, can't act, cron stays missing.

This change makes the nudge actionable in all cases where the interval is convertible.

## Implementation

- `intervalToCronExpression(interval)` added to `src/bus/cron-state.ts`. Mirrors `/loop`'s rounding rules: only emits expressions for intervals that cleanly divide their unit (e.g. `5m → */5 * * * *`, `4h → 0 */4 * * *`, `1d → 0 0 */1 * *`, `1w → 0 0 * * 0`); returns `null` otherwise.
- `runGapDetectionLoop` signature widened to include `prompt`. `monitorable` filter now requires a valid `prompt` string so the nudge is always actionable.
- New nudge text: when convertible, instructs `CronCreate` directly with `cron`, `recurring=true`, and a JSON-quoted `prompt`. Otherwise falls back to a `/loop` hint that explicitly tells the agent to copy the verbatim prompt from `config.json`.

## Test plan

- [x] 9 new unit tests for `intervalToCronExpression` (clean intervals, non-divisible cases, all units, malformed input)
- [x] `npm run build` clean
- [x] `npm test` — 748/748 pass (was 739, +9 new)
- [ ] Smoke: simulate stale cron-state.json, observe new nudge text in agent PTY

## Scope note

Pragmatic Option A: improves the existing nudge surface without daemon-side cron self-recreate (CronCreate is a Claude Code session-only tool — the daemon can't call it). Hook 1 (PR #298, agent-crash → bus alert) and Hook 3 (approval → Telegram) are separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)