### PR TITLE
feat(daemon): cron-list mismatch detection — Hook 2, closes 7-day silent cliff

### DIFF
--- a/src/bus/cron-list.ts
+++ b/src/bus/cron-list.ts
@@ -1,0 +1,106 @@
+/**
+ * Daemon-side mirror of the agent's live CronList output (cron-list.json).
+ *
+ * The agent dumps its current CronList tool result here on every heartbeat
+ * via `cortextos bus update-cron-list` (stdin JSON). The daemon polls this
+ * file and compares against config.json's `crons[]` to detect crons that
+ * have silently dropped out of the active session — typically because of
+ * the 7-day CronCreate auto-expiry, an unobserved restart, or compaction.
+ *
+ * On mismatch, the daemon injects a forced-recreate nudge so the agent
+ * recreates the cron via CronCreate before the gap-detector's 2x-interval
+ * threshold has had time to elapse (which on a weekly cron is 14 days of
+ * silent failure — unacceptable).
+ *
+ * Storage: state/<agent>/cron-list.json (same dir as cron-state.json).
+ */
+
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+
+export interface CronListEntry {
+  /** The cron's logical name as it appears in config.json. */
+  name: string;
+  /** The verbatim prompt the cron fires (matched against config.json on agent dump). */
+  prompt: string;
+}
+
+interface CronListFile {
+  updated_at: string;
+  crons: CronListEntry[];
+}
+
+function cronListPath(stateDir: string): string {
+  return join(stateDir, 'cron-list.json');
+}
+
+/**
+ * Atomically write the agent's current CronList contents.
+ * Called by `cortextos bus update-cron-list` (stdin JSON).
+ */
+export function writeCronList(stateDir: string, crons: CronListEntry[]): void {
+  ensureDir(stateDir);
+  const payload: CronListFile = {
+    updated_at: new Date().toISOString(),
+    crons,
+  };
+  atomicWriteSync(cronListPath(stateDir), JSON.stringify(payload, null, 2) + '\n');
+}
+
+/**
+ * Read the agent's last-dumped CronList. Returns null when the file is
+ * missing, malformed, or older than `maxAgeMs` (stale dumps may not reflect
+ * the current session — caller skips mismatch detection in that case).
+ */
+export function readCronList(
+  stateDir: string,
+  maxAgeMs: number,
+): CronListFile | null {
+  const filePath = cronListPath(stateDir);
+  if (!existsSync(filePath)) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(filePath, 'utf-8'));
+  } catch {
+    return null;
+  }
+  if (
+    !parsed ||
+    typeof parsed !== 'object' ||
+    !Array.isArray((parsed as CronListFile).crons) ||
+    typeof (parsed as CronListFile).updated_at !== 'string'
+  ) {
+    return null;
+  }
+  const file = parsed as CronListFile;
+  const updatedAtMs = Date.parse(file.updated_at);
+  if (isNaN(updatedAtMs)) return null;
+  if (Date.now() - updatedAtMs > maxAgeMs) return null;
+  return file;
+}
+
+/**
+ * Compute which configured crons are missing from the agent's last
+ * CronList dump. Match by name first, fall back to prompt equality so
+ * a renamed-but-still-running cron isn't falsely flagged.
+ *
+ * Pure function — no I/O — so the daemon polling loop and unit tests
+ * share the same implementation.
+ */
+export function findMissingCrons(
+  configCrons: Array<{ name: string; prompt: string; type?: string }>,
+  liveCrons: CronListEntry[],
+): Array<{ name: string; prompt: string }> {
+  const liveByName = new Set(liveCrons.map(c => c.name));
+  const livePrompts = new Set(liveCrons.map(c => c.prompt));
+  const missing: Array<{ name: string; prompt: string }> = [];
+  for (const cfg of configCrons) {
+    if (cfg.type === 'once' || cfg.type === 'disabled') continue;
+    if (!cfg.prompt) continue;
+    if (liveByName.has(cfg.name)) continue;
+    if (livePrompts.has(cfg.prompt)) continue;
+    missing.push({ name: cfg.name, prompt: cfg.prompt });
+  }
+  return missing;
+}

--- a/src/bus/cron-state.ts
+++ b/src/bus/cron-state.ts
@@ -95,6 +95,41 @@ export function parseDurationMs(interval: string): number {
 }
 
 /**
+ * Convert a duration interval ("4h", "30m", "1d", "1w") into a 5-field cron
+ * expression. Returns null when the interval doesn't cleanly fit a recurring
+ * cron slot (e.g. "7m" leaves uneven gaps; "5w" has no clean weekly form).
+ *
+ * Mirrors the rounding rules in the /loop skill so daemon-injected nudges can
+ * give the agent a CronCreate-ready expression instead of a /loop command
+ * (which prompts AskUserQuestion for ≥60-minute intervals).
+ */
+export function intervalToCronExpression(interval: string): string | null {
+  const match = /^(\d+)(m|h|d|w)$/.exec(interval.trim());
+  if (!match) return null;
+  const n = parseInt(match[1], 10);
+  if (n <= 0) return null;
+  const unit = match[2];
+
+  if (unit === 'm') {
+    if (n <= 59) return 60 % n === 0 ? `*/${n} * * * *` : null;
+    if (n % 60 !== 0) return null;
+    const hours = n / 60;
+    return hours <= 23 && 24 % hours === 0 ? `0 */${hours} * * *` : null;
+  }
+  if (unit === 'h') {
+    if (n <= 23) return 24 % n === 0 ? `0 */${n} * * *` : null;
+    return null;
+  }
+  if (unit === 'd') {
+    return n >= 1 ? `0 0 */${n} * *` : null;
+  }
+  if (unit === 'w') {
+    return n === 1 ? '0 0 * * 0' : null;
+  }
+  return null;
+}
+
+/**
  * Estimate the minimum expected firing interval for a 5-field cron expression.
  * Handles common patterns (every-N-minutes, every-N-hours, daily) without an
  * external library. Returns a conservative 48h fallback for anything else.

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -15,6 +15,7 @@ import { collectMetrics, parseUsageOutput, storeUsageData, checkUpstream, collec
 import { createApproval, updateApproval } from '../bus/approval.js';
 import { createReminder, listReminders, ackReminder, pruneReminders } from '../bus/reminders.js';
 import { updateCronFire } from '../bus/cron-state.js';
+import { writeCronList, type CronListEntry } from '../bus/cron-list.js';
 import { queryKnowledgeBase, ingestKnowledgeBase, ensureKBDirs } from '../bus/knowledge-base.js';
 import { checkUsageApi, refreshOAuthToken, rotateOAuth, loadAccounts, ALERT_5H, ALERT_7D } from '../bus/oauth.js';
 import { resolvePaths } from '../utils/paths.js';
@@ -1782,6 +1783,48 @@ busCommand
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
     updateCronFire(paths.stateDir, cronName, opts.interval);
     console.log(`Recorded fire for cron "${cronName}"`);
+  });
+
+busCommand
+  .command('update-cron-list')
+  .description('Mirror the agent\'s current CronList output to state/<agent>/cron-list.json. Reads JSON array of {name, prompt} from stdin or --json. Used by the daemon to detect crons that have silently dropped out (closes the 7-day CronCreate auto-expiry cliff before gap accumulation).')
+  .option('--json <json>', 'CronList JSON array (alternative to stdin)')
+  .action(async (opts: { json?: string }) => {
+    const env = resolveEnv();
+    const paths = resolvePaths(env.agentName, env.instanceId, env.org);
+
+    let raw = opts.json;
+    if (!raw) {
+      raw = await new Promise<string>((resolve, reject) => {
+        const chunks: Buffer[] = [];
+        process.stdin.on('data', (c) => chunks.push(c));
+        process.stdin.on('end', () => resolve(Buffer.concat(chunks).toString('utf-8')));
+        process.stdin.on('error', reject);
+      });
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw.trim() || '[]');
+    } catch (err) {
+      console.error(`Error: invalid JSON: ${err}`);
+      process.exit(1);
+    }
+    if (!Array.isArray(parsed)) {
+      console.error('Error: expected a JSON array of {name, prompt} objects');
+      process.exit(1);
+    }
+
+    const entries: CronListEntry[] = [];
+    for (const item of parsed) {
+      if (!item || typeof item !== 'object') continue;
+      const obj = item as Record<string, unknown>;
+      if (typeof obj.name !== 'string' || typeof obj.prompt !== 'string') continue;
+      entries.push({ name: obj.name, prompt: obj.prompt });
+    }
+
+    writeCronList(paths.stateDir, entries);
+    console.log(`Wrote cron-list.json (${entries.length} entries)`);
   });
 
 busCommand

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -277,6 +277,13 @@ export class AgentManager {
     // and nudges the agent if any cron has been silent >2x its expected interval.
     agentProcess.scheduleGapDetection();
 
+    // Schedule background cron-list mismatch detection: polls cron-list.json
+    // (the agent's last-dumped CronList output) every 10 min and injects a
+    // forced-recreate nudge when a cron in config.json is missing from the
+    // live list — catches the 7-day CronCreate auto-expiry cliff before the
+    // gap detector's 2x-interval threshold has had time to elapse.
+    agentProcess.scheduleCronListMismatchDetection();
+
     // Start fast checker in background
     checker.start().catch(err => {
       console.error(`[${name}] Fast checker error:`, err);

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -9,6 +9,7 @@ import { ensureDir } from '../utils/atomic.js';
 import { writeCortextosEnv } from '../utils/env.js';
 import { getOverdueReminders } from '../bus/reminders.js';
 import { readCronState, parseDurationMs, cronExpressionMinIntervalMs, intervalToCronExpression } from '../bus/cron-state.js';
+import { readCronList, findMissingCrons } from '../bus/cron-list.js';
 import { resolvePaths } from '../utils/paths.js';
 
 type LogFn = (msg: string) => void;
@@ -742,6 +743,84 @@ export class AgentProcess {
     this.runGapDetectionLoop(monitorable, generation, loopStartedAt).catch(err => {
       this.log(`Cron gap detection failed (non-fatal): ${err}`);
     });
+  }
+
+  /**
+   * Starts a background loop that detects crons present in config.json but
+   * missing from the agent's last-dumped CronList output. Catches the case
+   * where a cron silently drops off (7-day CronCreate auto-expiry, an
+   * unobserved restart, or compaction) BEFORE the gap-detection 2x-interval
+   * threshold has had time to elapse — on a weekly cron that is otherwise
+   * 14 days of silent failure.
+   *
+   * Fire-and-forget: errors are logged but never propagated.
+   */
+  scheduleCronListMismatchDetection(): void {
+    const crons = this.config.crons;
+    if (!crons || crons.length === 0) return;
+
+    const generation = this.lifecycleGeneration;
+    this.runCronListMismatchLoop(generation).catch(err => {
+      this.log(`Cron-list mismatch detection failed (non-fatal): ${err}`);
+    });
+  }
+
+  private async runCronListMismatchLoop(generation: number): Promise<void> {
+    const POLL_MS = 10 * 60 * 1000;       // poll every 10 minutes
+    const STALE_MAX_AGE_MS = 60 * 60 * 1000; // skip dumps older than 1h
+
+    const stateDir = join(this.env.ctxRoot, 'state', this.name);
+    let warnedMissingFile = false;
+
+    // Initial wait — give the agent time to boot and dump its first CronList
+    // (heartbeat fires the dump on every cycle; first dump may not arrive
+    // until the first heartbeat after startup).
+    await sleep(POLL_MS);
+
+    while (true) {
+      if (generation !== this.lifecycleGeneration || this.status !== 'running') return;
+
+      const liveList = readCronList(stateDir, STALE_MAX_AGE_MS);
+      if (!liveList) {
+        // null covers: missing file, malformed JSON, stale (>1h). Log the
+        // missing-file case once so a never-dumping agent surfaces visibly,
+        // then skip until the next heartbeat refreshes the file.
+        if (!warnedMissingFile) {
+          this.log('Cron-list mismatch: cron-list.json missing or stale — agent has not dumped CronList yet (or it is >1h old). Skipping until next heartbeat.');
+          warnedMissingFile = true;
+        }
+        await sleep(POLL_MS);
+        continue;
+      }
+      warnedMissingFile = false;
+
+      const configCrons = (this.config.crons ?? []).map(c => ({
+        name: c.name,
+        prompt: c.prompt,
+        type: c.type,
+      }));
+      const missing = findMissingCrons(configCrons, liveList.crons);
+
+      for (const cfg of missing) {
+        const cronDef = this.config.crons!.find(c => c.name === cfg.name);
+        if (!cronDef) continue;
+        const cronExpr = cronDef.cron
+          ?? (cronDef.interval ? intervalToCronExpression(cronDef.interval) : null);
+        const recreateHint = cronExpr
+          ? `Recreate it NOW with CronCreate (do NOT use /loop): cron="${cronExpr}", recurring=true, prompt=${JSON.stringify(cronDef.prompt)}.`
+          : `Recreate it NOW from config.json — interval "${cronDef.interval ?? 'unknown'}" cannot be expressed as a clean cron, so use /loop with the verbatim prompt from config.json.`;
+        const nudge = `[SYSTEM] Cron "${cfg.name}" is in config.json but missing from your last CronList dump (likely silently dropped via 7-day auto-expiry). ${recreateHint}`;
+
+        this.log(`Mismatch nudge: ${cfg.name} missing from live CronList`);
+        if (this.pty && this.status === 'running') {
+          injectMessage((data) => this.pty?.write(data), nudge);
+          // Stagger so back-to-back missing-cron injections don't spike context.
+          await sleep(30_000);
+        }
+      }
+
+      await sleep(POLL_MS);
+    }
   }
 
   private async runGapDetectionLoop(

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -8,7 +8,7 @@ import { MessageDedup, injectMessage } from '../pty/inject.js';
 import { ensureDir } from '../utils/atomic.js';
 import { writeCortextosEnv } from '../utils/env.js';
 import { getOverdueReminders } from '../bus/reminders.js';
-import { readCronState, parseDurationMs, cronExpressionMinIntervalMs } from '../bus/cron-state.js';
+import { readCronState, parseDurationMs, cronExpressionMinIntervalMs, intervalToCronExpression } from '../bus/cron-state.js';
 import { resolvePaths } from '../utils/paths.js';
 
 type LogFn = (msg: string) => void;
@@ -724,9 +724,12 @@ export class AgentProcess {
     const crons = this.config.crons;
     if (!crons || crons.length === 0) return;
 
-    // Monitor recurring crons with either a parseable interval or a cron expression
+    // Monitor recurring crons with either a parseable interval or a cron expression.
+    // Skip entries with missing prompts (malformed config) so the gap nudge can always
+    // include CronCreate-ready instructions.
     const monitorable = crons.filter(c => {
       if (c.type === 'once' || c.type === 'disabled') return false;
+      if (!c.prompt || typeof c.prompt !== 'string') return false;
       if (c.interval && !isNaN(parseDurationMs(c.interval))) return true;
       if (c.cron) return true;
       return false;
@@ -742,7 +745,7 @@ export class AgentProcess {
   }
 
   private async runGapDetectionLoop(
-    crons: Array<{ name: string; interval?: string; cron?: string }>,
+    crons: Array<{ name: string; interval?: string; cron?: string; prompt: string }>,
     generation: number,
     loopStartedAt: number,
   ): Promise<void> {
@@ -784,9 +787,11 @@ export class AgentProcess {
         if (gapMs > threshold) {
           const gapMin = Math.round(gapMs / 60_000);
           const expectedMin = Math.round(intervalMs / 60_000);
-          const restoreHint = cronDef.interval
-            ? `If missing, restore it from config.json: /loop ${cronDef.interval} <cron prompt>.`
-            : `If missing, restore it from config.json using the cron expression in your config.`;
+          const cronExpr = cronDef.cron
+            ?? (cronDef.interval ? intervalToCronExpression(cronDef.interval) : null);
+          const restoreHint = cronExpr
+            ? `If missing, recreate it directly with CronCreate (do NOT use /loop, which prompts for confirmation on long intervals): cron="${cronExpr}", recurring=true, prompt=${JSON.stringify(cronDef.prompt)}.`
+            : `If missing, recreate it from config.json — interval "${cronDef.interval ?? 'unknown'}" can't be expressed as a clean cron, so use /loop with the verbatim prompt from config.json.`;
           const nudge = `[SYSTEM] Cron gap detected for "${cronDef.name}": last fired ${gapMin} minutes ago (expected every ${expectedMin} minutes). Run CronList to verify the cron is still active. ${restoreHint}`;
 
           this.log(`Gap nudge: ${cronDef.name} silent ${gapMin}min (threshold: ${Math.round(threshold / 60_000)}min)`);

--- a/templates/agent/HEARTBEAT.md
+++ b/templates/agent/HEARTBEAT.md
@@ -11,6 +11,28 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+## Step 1b: Cron survival check + dump live CronList (CRITICAL — closes the 7-day silent cliff)
+
+CronCreate auto-expires after 7 days. Without this check, crons silently disappear and the agent goes DEAD until something nudges it. The daemon also polls `state/<agent>/cron-list.json` (your last dump) and injects a forced-recreate nudge when a cron in `config.json` is missing from your live list — so this dump every heartbeat is what closes the silent cliff.
+
+1. Call `CronList`. Cross-reference each live entry against `config.json`'s `crons[]` by prompt text.
+2. For ANY cron in `config.json` not in the live `CronList` output, recreate it with `CronCreate` using the **cron expression** (or interval converted to a cron expression) and the verbatim `prompt` from `config.json`. Do NOT use `/loop` — for intervals ≥60 minutes it pops `AskUserQuestion`, which you cannot answer in this context.
+3. Dump the live CronList to `cron-list.json` as a JSON array of `{name, prompt}` objects (one per live cron). Match each live entry's prompt back to a `config.json` name where possible; pass the verbatim prompt either way:
+
+```bash
+# Replace the inline array with the actual CronList contents you just observed.
+echo '[{"name":"<config-name>","prompt":"<verbatim cron prompt>"},...]' \
+  | cortextos bus update-cron-list
+```
+
+Log any recreation:
+
+```bash
+cortextos bus log-event action cron_recreated info --meta '{"agent":"'$CTX_AGENT_NAME'","cron":"<name>"}'
+```
+
+If `cron-list.json` is not refreshed for >1h, the daemon's mismatch detector skips silently — so don't miss this step.
+
 ## Step 2: Sweep inbox for un-ACK'd messages
 
 Messages arrive in real time via the fast-checker daemon — you don't need to poll for them. This step is a safety sweep for anything that wasn't ACK'd (e.g. a crash mid-processing).

--- a/templates/analyst/HEARTBEAT.md
+++ b/templates/analyst/HEARTBEAT.md
@@ -11,6 +11,28 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+## Step 1b: Cron survival check + dump live CronList (CRITICAL — closes the 7-day silent cliff)
+
+CronCreate auto-expires after 7 days. Without this check, crons silently disappear and the agent goes DEAD until something nudges it. The daemon also polls `state/<agent>/cron-list.json` (your last dump) and injects a forced-recreate nudge when a cron in `config.json` is missing from your live list — so this dump every heartbeat is what closes the silent cliff.
+
+1. Call `CronList`. Cross-reference each live entry against `config.json`'s `crons[]` by prompt text.
+2. For ANY cron in `config.json` not in the live `CronList` output, recreate it with `CronCreate` using the **cron expression** (or interval converted to a cron expression) and the verbatim `prompt` from `config.json`. Do NOT use `/loop` — for intervals ≥60 minutes it pops `AskUserQuestion`, which you cannot answer in this context.
+3. Dump the live CronList to `cron-list.json` as a JSON array of `{name, prompt}` objects (one per live cron). Match each live entry's prompt back to a `config.json` name where possible; pass the verbatim prompt either way:
+
+```bash
+# Replace the inline array with the actual CronList contents you just observed.
+echo '[{"name":"<config-name>","prompt":"<verbatim cron prompt>"},...]' \
+  | cortextos bus update-cron-list
+```
+
+Log any recreation:
+
+```bash
+cortextos bus log-event action cron_recreated info --meta '{"agent":"'$CTX_AGENT_NAME'","cron":"<name>"}'
+```
+
+If `cron-list.json` is not refreshed for >1h, the daemon's mismatch detector skips silently — so don't miss this step.
+
 ## Step 2: Check inbox
 
 ```bash

--- a/templates/hermes/HEARTBEAT.md
+++ b/templates/hermes/HEARTBEAT.md
@@ -11,6 +11,28 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+## Step 1b: Cron survival check + dump live CronList (CRITICAL — closes the 7-day silent cliff)
+
+CronCreate auto-expires after 7 days. Without this check, crons silently disappear and the agent goes DEAD until something nudges it. The daemon also polls `state/<agent>/cron-list.json` (your last dump) and injects a forced-recreate nudge when a cron in `config.json` is missing from your live list — so this dump every heartbeat is what closes the silent cliff.
+
+1. Call `CronList`. Cross-reference each live entry against `config.json`'s `crons[]` by prompt text.
+2. For ANY cron in `config.json` not in the live `CronList` output, recreate it with `CronCreate` using the **cron expression** (or interval converted to a cron expression) and the verbatim `prompt` from `config.json`. Do NOT use `/loop` — for intervals ≥60 minutes it pops `AskUserQuestion`, which you cannot answer in this context.
+3. Dump the live CronList to `cron-list.json` as a JSON array of `{name, prompt}` objects (one per live cron). Match each live entry's prompt back to a `config.json` name where possible; pass the verbatim prompt either way:
+
+```bash
+# Replace the inline array with the actual CronList contents you just observed.
+echo '[{"name":"<config-name>","prompt":"<verbatim cron prompt>"},...]' \
+  | cortextos bus update-cron-list
+```
+
+Log any recreation:
+
+```bash
+cortextos bus log-event action cron_recreated info --meta '{"agent":"'$CTX_AGENT_NAME'","cron":"<name>"}'
+```
+
+If `cron-list.json` is not refreshed for >1h, the daemon's mismatch detector skips silently — so don't miss this step.
+
 ## Step 2: Check inbox
 
 ```bash

--- a/templates/orchestrator/HEARTBEAT.md
+++ b/templates/orchestrator/HEARTBEAT.md
@@ -11,6 +11,28 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+## Step 1b: Cron survival check + dump live CronList (CRITICAL — closes the 7-day silent cliff)
+
+CronCreate auto-expires after 7 days. Without this check, crons silently disappear and the agent goes DEAD until something nudges it. The daemon also polls `state/<agent>/cron-list.json` (your last dump) and injects a forced-recreate nudge when a cron in `config.json` is missing from your live list — so this dump every heartbeat is what closes the silent cliff.
+
+1. Call `CronList`. Cross-reference each live entry against `config.json`'s `crons[]` by prompt text.
+2. For ANY cron in `config.json` not in the live `CronList` output, recreate it with `CronCreate` using the **cron expression** (or interval converted to a cron expression) and the verbatim `prompt` from `config.json`. Do NOT use `/loop` — for intervals ≥60 minutes it pops `AskUserQuestion`, which you cannot answer in this context.
+3. Dump the live CronList to `cron-list.json` as a JSON array of `{name, prompt}` objects (one per live cron). Match each live entry's prompt back to a `config.json` name where possible; pass the verbatim prompt either way:
+
+```bash
+# Replace the inline array with the actual CronList contents you just observed.
+echo '[{"name":"<config-name>","prompt":"<verbatim cron prompt>"},...]' \
+  | cortextos bus update-cron-list
+```
+
+Log any recreation:
+
+```bash
+cortextos bus log-event action cron_recreated info --meta '{"agent":"'$CTX_AGENT_NAME'","cron":"<name>"}'
+```
+
+If `cron-list.json` is not refreshed for >1h, the daemon's mismatch detector skips silently — so don't miss this step.
+
 ## Step 2: Sweep inbox for un-ACK'd messages
 
 Messages arrive in real time via the fast-checker daemon — you don't need to poll for them. This step is a safety sweep for anything that wasn't ACK'd (e.g. a crash mid-processing).

--- a/tests/unit/bus/cron-list.test.ts
+++ b/tests/unit/bus/cron-list.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  writeCronList,
+  readCronList,
+  findMissingCrons,
+  type CronListEntry,
+} from '../../../src/bus/cron-list';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'cron-list-test-'));
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
+});
+
+const ONE_HOUR_MS = 60 * 60 * 1000;
+
+describe('writeCronList + readCronList', () => {
+  it('round-trips a non-empty list', () => {
+    writeCronList(tmpDir, [
+      { name: 'heartbeat', prompt: 'Read HEARTBEAT.md and...' },
+      { name: 'autoresearch', prompt: 'Run autoresearch loop...' },
+    ]);
+    const file = readCronList(tmpDir, ONE_HOUR_MS);
+    expect(file).not.toBeNull();
+    expect(file!.crons).toHaveLength(2);
+    expect(file!.crons[0].name).toBe('heartbeat');
+    expect(file!.crons[1].prompt).toBe('Run autoresearch loop...');
+    expect(Date.parse(file!.updated_at)).not.toBeNaN();
+  });
+
+  it('round-trips an empty list', () => {
+    writeCronList(tmpDir, []);
+    const file = readCronList(tmpDir, ONE_HOUR_MS);
+    expect(file).not.toBeNull();
+    expect(file!.crons).toEqual([]);
+  });
+});
+
+describe('readCronList', () => {
+  it('returns null when file is missing', () => {
+    expect(readCronList(tmpDir, ONE_HOUR_MS)).toBeNull();
+  });
+
+  it('returns null when JSON is malformed', () => {
+    writeFileSync(join(tmpDir, 'cron-list.json'), '{ not valid', 'utf-8');
+    expect(readCronList(tmpDir, ONE_HOUR_MS)).toBeNull();
+  });
+
+  it('returns null when crons field is missing', () => {
+    writeFileSync(
+      join(tmpDir, 'cron-list.json'),
+      JSON.stringify({ updated_at: new Date().toISOString() }),
+      'utf-8',
+    );
+    expect(readCronList(tmpDir, ONE_HOUR_MS)).toBeNull();
+  });
+
+  it('returns null when updated_at is unparseable', () => {
+    writeFileSync(
+      join(tmpDir, 'cron-list.json'),
+      JSON.stringify({ updated_at: 'not-a-date', crons: [] }),
+      'utf-8',
+    );
+    expect(readCronList(tmpDir, ONE_HOUR_MS)).toBeNull();
+  });
+
+  it('returns null when file is older than maxAgeMs', () => {
+    const tenSecondsAgo = new Date(Date.now() - 10_000).toISOString();
+    writeFileSync(
+      join(tmpDir, 'cron-list.json'),
+      JSON.stringify({ updated_at: tenSecondsAgo, crons: [] }),
+      'utf-8',
+    );
+    expect(readCronList(tmpDir, 5_000)).toBeNull();
+    expect(readCronList(tmpDir, 60_000)).not.toBeNull();
+  });
+});
+
+describe('findMissingCrons', () => {
+  const live: CronListEntry[] = [
+    { name: 'heartbeat', prompt: 'Read HEARTBEAT.md...' },
+    { name: 'autoresearch', prompt: 'Run autoresearch...' },
+  ];
+
+  it('returns empty when every config cron is in the live list (by name)', () => {
+    const cfg = [
+      { name: 'heartbeat', prompt: 'Read HEARTBEAT.md...' },
+      { name: 'autoresearch', prompt: 'Run autoresearch...' },
+    ];
+    expect(findMissingCrons(cfg, live)).toEqual([]);
+  });
+
+  it('matches by prompt when the name has drifted', () => {
+    const cfg = [
+      { name: 'heartbeat-v2', prompt: 'Read HEARTBEAT.md...' },
+    ];
+    expect(findMissingCrons(cfg, live)).toEqual([]);
+  });
+
+  it('flags a config cron with no matching name or prompt', () => {
+    const cfg = [
+      { name: 'experiment-ecom-shipped', prompt: 'Run the experiment loop' },
+    ];
+    expect(findMissingCrons(cfg, live)).toEqual([
+      { name: 'experiment-ecom-shipped', prompt: 'Run the experiment loop' },
+    ]);
+  });
+
+  it('returns multiple missing entries when several are absent', () => {
+    const cfg = [
+      { name: 'heartbeat', prompt: 'Read HEARTBEAT.md...' },
+      { name: 'experiment-a', prompt: 'A' },
+      { name: 'experiment-b', prompt: 'B' },
+    ];
+    expect(findMissingCrons(cfg, live)).toEqual([
+      { name: 'experiment-a', prompt: 'A' },
+      { name: 'experiment-b', prompt: 'B' },
+    ]);
+  });
+
+  it('skips disabled crons', () => {
+    const cfg = [
+      { name: 'old-experiment', prompt: 'old', type: 'disabled' },
+    ];
+    expect(findMissingCrons(cfg, live)).toEqual([]);
+  });
+
+  it('skips one-shot crons', () => {
+    const cfg = [
+      { name: 'one-shot', prompt: 'fire once', type: 'once' },
+    ];
+    expect(findMissingCrons(cfg, live)).toEqual([]);
+  });
+
+  it('skips entries with no prompt (malformed config)', () => {
+    const cfg = [
+      { name: 'malformed', prompt: '' },
+    ];
+    expect(findMissingCrons(cfg, live)).toEqual([]);
+  });
+
+  it('returns empty when both config and live are empty', () => {
+    expect(findMissingCrons([], [])).toEqual([]);
+  });
+});

--- a/tests/unit/bus/cron-state.test.ts
+++ b/tests/unit/bus/cron-state.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { updateCronFire, readCronState, parseDurationMs } from '../../../src/bus/cron-state';
+import { updateCronFire, readCronState, parseDurationMs, intervalToCronExpression } from '../../../src/bus/cron-state';
 
 let tmpDir: string;
 
@@ -44,6 +44,60 @@ describe('parseDurationMs', () => {
   it('returns NaN for unknown unit', () => {
     expect(parseDurationMs('5y')).toBeNaN();
     expect(parseDurationMs('10s')).toBeNaN();
+  });
+});
+
+describe('intervalToCronExpression', () => {
+  it('converts sub-hour minute intervals that divide 60', () => {
+    expect(intervalToCronExpression('5m')).toBe('*/5 * * * *');
+    expect(intervalToCronExpression('15m')).toBe('*/15 * * * *');
+    expect(intervalToCronExpression('30m')).toBe('*/30 * * * *');
+  });
+
+  it('returns null for minute intervals that do not divide 60 cleanly', () => {
+    expect(intervalToCronExpression('7m')).toBeNull();
+    expect(intervalToCronExpression('45m')).toBeNull();
+  });
+
+  it('converts whole-hour minute intervals when hours divide 24', () => {
+    expect(intervalToCronExpression('60m')).toBe('0 */1 * * *');
+    expect(intervalToCronExpression('120m')).toBe('0 */2 * * *');
+    expect(intervalToCronExpression('240m')).toBe('0 */4 * * *');
+  });
+
+  it('returns null for whole-hour minute intervals that do not divide 24', () => {
+    expect(intervalToCronExpression('300m')).toBeNull(); // 5 hours doesn't divide 24
+    expect(intervalToCronExpression('420m')).toBeNull(); // 7 hours
+  });
+
+  it('converts hour intervals that divide 24', () => {
+    expect(intervalToCronExpression('1h')).toBe('0 */1 * * *');
+    expect(intervalToCronExpression('4h')).toBe('0 */4 * * *');
+    expect(intervalToCronExpression('12h')).toBe('0 */12 * * *');
+  });
+
+  it('returns null for hour intervals that do not divide 24', () => {
+    expect(intervalToCronExpression('5h')).toBeNull();
+    expect(intervalToCronExpression('7h')).toBeNull();
+    expect(intervalToCronExpression('25h')).toBeNull();
+  });
+
+  it('converts day intervals', () => {
+    expect(intervalToCronExpression('1d')).toBe('0 0 */1 * *');
+    expect(intervalToCronExpression('7d')).toBe('0 0 */7 * *');
+  });
+
+  it('converts 1w only', () => {
+    expect(intervalToCronExpression('1w')).toBe('0 0 * * 0');
+    expect(intervalToCronExpression('2w')).toBeNull();
+  });
+
+  it('returns null for malformed or unsupported intervals', () => {
+    expect(intervalToCronExpression('')).toBeNull();
+    expect(intervalToCronExpression('5y')).toBeNull();
+    expect(intervalToCronExpression('abc')).toBeNull();
+    expect(intervalToCronExpression('0h')).toBeNull();
+    expect(intervalToCronExpression('0 8 * * *')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- Daemon now detects crons that have silently dropped out of the agent's live `CronList` and injects a forced-recreate nudge **before** the existing gap detector's 2x-interval threshold elapses (which on a weekly cron is 14 days of silent failure).
- New CLI `cortextos bus update-cron-list` lets the agent mirror its `CronList` output to `state/<agent>/cron-list.json` every heartbeat.
- Step 1b added to all four heartbeat templates so new agents adopt the dump-then-detect protocol automatically.

## Why

Closes the 7-day `CronCreate` auto-expiry cliff at the earliest possible signal: the moment a cron disappears from `CronList`, not 2x the interval later. PR #299 closed the related symptom (gap-nudge text recommending `/loop` on long intervals); this PR closes the larger silent-failure class itself.

## How it works

1. **Agent dump** (heartbeat step 1b): agent calls `CronList`, builds a JSON array of `{name, prompt}` matching live entries against `config.json`, pipes via `cortextos bus update-cron-list`. CLI atomic-writes to `state/<agent>/cron-list.json` with `{updated_at, crons[]}`.
2. **Daemon poll** (`scheduleCronListMismatchDetection`): every 10 min, daemon reads `cron-list.json`, computes which `config.json` crons are missing from the live dump (via `findMissingCrons` — matches by name, falls back to prompt equality so renames don't false-positive).
3. **Forced-recreate nudge**: for each missing cron, daemon injects `[SYSTEM] Cron \"X\" is in config.json but missing from your last CronList dump (likely silently dropped via 7-day auto-expiry). Recreate it NOW with CronCreate (do NOT use /loop): cron=\"…\", recurring=true, prompt=…`. Reuses #299's `intervalToCronExpression` for the cron-expression conversion.
4. **Edge handling**: file missing → warn-once + skip; >1h stale → skip + wait next heartbeat; malformed JSON → skip. No false positives if the agent never dumps.

## Implementation

- `src/bus/cron-list.ts`: `writeCronList` / `readCronList` / `findMissingCrons` (pure function so daemon loop and unit tests share impl).
- `src/cli/bus.ts`: `update-cron-list` command (stdin or `--json`).
- `src/daemon/agent-process.ts`: `scheduleCronListMismatchDetection` + `runCronListMismatchLoop`.
- `src/daemon/agent-manager.ts`: kicks off mismatch detection alongside gap detection on agent start.
- `templates/{agent,analyst,orchestrator,hermes}/HEARTBEAT.md`: Step 1b. Live per-agent `HEARTBEAT.md` files are patched separately by the orchestrator agent per propagation policy.

## Dependency

Builds on **PR #299** (improved gap nudge + `intervalToCronExpression`). Needs a clean rebase if #299 lands second; conflicts are trivial.

## Test plan

- [x] 15 new unit tests (`tests/unit/bus/cron-list.test.ts`): round-trip, missing/malformed/stale handling, mismatch detection by name + by prompt, edge cases (disabled / once / no-prompt configs).
- [x] `npm run build` clean.
- [x] `npm test` — 751/751 pass.
- [ ] Smoke: stage a `cron-list.json` missing one config cron, observe forced-recreate nudge in agent PTY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)