### PR TITLE
fix(bus): ping requesting agent's bot on createApproval (closes 50h+ stall)

### DIFF
--- a/src/bus/approval.ts
+++ b/src/bus/approval.ts
@@ -1,9 +1,11 @@
-import { readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import type { Approval, ApprovalCategory, ApprovalStatus, BusPaths } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+import { parseEnvFile } from '../utils/env.js';
 import { randomString } from '../utils/random.js';
 import { validateApprovalCategory } from '../utils/validate.js';
+import { TelegramAPI } from '../telegram/api.js';
 import { sendMessage } from './message.js';
 import { postActivity } from './system.js';
 
@@ -96,6 +98,68 @@ function postApprovalToActivityChannel(
 }
 
 /**
+ * Best-effort: ping the requesting agent's own Telegram chat (the operator's
+ * 1:1 conversation with the agent's bot) when a new approval is created.
+ * The activity-channel post handles "Approve / Deny" inline routing for the
+ * operator-via-orchestrator UX, but operators on a per-agent bot would
+ * otherwise miss approvals entirely — that's the source of the observed
+ * 50h+ Repo-B-style stalls. This pings them on the bot they're actually
+ * watching so they can hop to the orchestrator chat or dashboard to act.
+ *
+ * Reads BOT_TOKEN + CHAT_ID from `<agentDir>/.env`. Skips silently with a
+ * single warn line when either is missing — approvals from a bot-less
+ * agent (e.g. a hermes runtime, or pre-onboarding) must still succeed.
+ *
+ * Errors from the network round-trip are suppressed: a Telegram outage
+ * must not block approval creation.
+ */
+function pingAgentChatId(
+  agentDir: string | undefined,
+  approvalId: string,
+  title: string,
+  category: ApprovalCategory,
+  agentName: string,
+  context: string | undefined,
+): Promise<void> {
+  if (!agentDir) {
+    console.warn(
+      `[approval] No agentDir available for ${approvalId} — skipping agent-bot Telegram ping.`,
+    );
+    return Promise.resolve();
+  }
+  const envPath = join(agentDir, '.env');
+  if (!existsSync(envPath)) {
+    return Promise.resolve();
+  }
+  const env = parseEnvFile(envPath);
+  const botToken = env.BOT_TOKEN;
+  const chatId = env.CHAT_ID;
+  if (!botToken || !chatId) {
+    console.warn(
+      `[approval] BOT_TOKEN or CHAT_ID missing in ${envPath} — skipping agent-bot Telegram ping for ${approvalId}.`,
+    );
+    return Promise.resolve();
+  }
+
+  const lines = [
+    `🔔 Approval needed: ${title}`,
+    `Category: ${category}`,
+    `Requested by: ${agentName}`,
+  ];
+  if (context) {
+    lines.push('', context);
+  }
+  lines.push('', `id: ${approvalId}`);
+  lines.push('', 'Approve via the orchestrator chat (Approve/Deny buttons) or the dashboard.');
+  const message = lines.join('\n');
+
+  const api = new TelegramAPI(botToken);
+  return api.sendMessage(chatId, message, undefined, { parseMode: null })
+    .then(() => undefined)
+    .catch(() => undefined); // Telegram outage must not fail approval creation.
+}
+
+/**
  * Create an approval request.
  * Identical to bash create-approval.sh format.
  *
@@ -119,6 +183,7 @@ export async function createApproval(
   category: ApprovalCategory,
   context?: string,
   frameworkRoot?: string,
+  agentDir?: string,
 ): Promise<string> {
   validateApprovalCategory(category);
 
@@ -153,6 +218,12 @@ export async function createApproval(
   // via the orchestrator's activity-channel poller (see
   // daemon/agent-manager.ts).
   await postApprovalToActivityChannel(paths, org, approvalId, title, category, agentName, context, frameworkRoot);
+
+  // Best-effort ping to the requesting agent's own Telegram bot (the
+  // operator's 1:1 conversation with the agent). Closes the gap where
+  // operators not in the activity channel would miss approvals entirely
+  // (the 50h+ Repo-B-style stall). Errors suppressed — see helper.
+  await pingAgentChatId(agentDir, approvalId, title, category, agentName, context);
 
   return approvalId;
 }

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -722,6 +722,7 @@ busCommand
         'other',
         `Experiment ID: ${id}\nMetric: ${metric}\nHypothesis: ${hypothesis}`,
         env.frameworkRoot,
+        env.agentDir,
       );
       console.log(`approval_required: ${approvalId}`);
     }
@@ -1035,7 +1036,7 @@ busCommand
     // orgDir resolves to where activity-channel.env actually lives (the
     // framework repo path, NOT the runtime state path — see
     // src/bus/approval.ts:postApprovalToActivityChannel for the history).
-    const id = await createApproval(paths, env.agentName, env.org, title, category as ApprovalCategory, context || '', env.frameworkRoot);
+    const id = await createApproval(paths, env.agentName, env.org, title, category as ApprovalCategory, context || '', env.frameworkRoot, env.agentDir);
     console.log(id);
   });
 

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -131,7 +131,7 @@ export function writeCortextosEnv(agentDir: string, env: CtxEnv): void {
  *   - Inline ` #` comments on unquoted values
  * Lines with no `=` are skipped.
  */
-function parseEnvFile(filePath: string): Record<string, string> {
+export function parseEnvFile(filePath: string): Record<string, string> {
   const result: Record<string, string> = {};
   try {
     const content = readFileSync(filePath, 'utf-8');

--- a/tests/unit/bus/approval.test.ts
+++ b/tests/unit/bus/approval.test.ts
@@ -10,7 +10,22 @@ vi.mock('../../../src/bus/message', () => ({
   sendMessage: vi.fn(),
 }));
 
-import { mkdtempSync, rmSync, readdirSync, readFileSync, existsSync } from 'fs';
+// Mock TelegramAPI so the agent-bot ping is observable without hitting the
+// network. Constructor records the bot token; sendMessage records its call.
+const telegramSendMessageSpy = vi.fn().mockResolvedValue({ result: { message_id: 1 } });
+const telegramConstructorSpy = vi.fn();
+vi.mock('../../../src/telegram/api', () => ({
+  TelegramAPI: class {
+    constructor(token: string) {
+      telegramConstructorSpy(token);
+    }
+    sendMessage(...args: unknown[]) {
+      return telegramSendMessageSpy(...args);
+    }
+  },
+}));
+
+import { mkdtempSync, rmSync, readdirSync, readFileSync, existsSync, writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { createApproval, updateApproval, listPendingApprovals } from '../../../src/bus/approval';
@@ -46,6 +61,9 @@ beforeEach(() => {
   paths = mkPaths(testDir);
   postActivitySpy.mockClear();
   postActivitySpy.mockResolvedValue(true);
+  telegramSendMessageSpy.mockClear();
+  telegramSendMessageSpy.mockResolvedValue({ result: { message_id: 1 } });
+  telegramConstructorSpy.mockClear();
   delete process.env.CTX_FRAMEWORK_ROOT;
 });
 
@@ -229,6 +247,149 @@ describe('createApproval', () => {
     const id = await createApprovalPromise;
     expect(createApprovalResolved).toBe(true);
     expect(id).toMatch(/^approval_\d+_[a-zA-Z0-9]+$/);
+  });
+});
+
+describe('createApproval — agent-bot Telegram ping (closes 50h+ Repo-B-style stall)', () => {
+  // The activity-channel post handles the operator-via-orchestrator UX
+  // (Approve/Deny inline buttons), but operators on a per-agent bot would
+  // otherwise miss approvals entirely. createApproval also pings the
+  // requesting agent's own .env BOT_TOKEN+CHAT_ID so those operators see
+  // it on the bot they're actually watching.
+  function writeAgentEnv(agentDir: string, vars: Record<string, string>): void {
+    mkdirSync(agentDir, { recursive: true });
+    const lines = Object.entries(vars).map(([k, v]) => `${k}=${v}`);
+    writeFileSync(join(agentDir, '.env'), lines.join('\n') + '\n');
+  }
+
+  it('pings the agent bot when agentDir/.env/BOT_TOKEN/CHAT_ID are all present', async () => {
+    const agentDir = join(testDir, 'agent-with-bot');
+    writeAgentEnv(agentDir, { BOT_TOKEN: 'test-token-123', CHAT_ID: '987654321' });
+
+    const id = await createApproval(
+      paths,
+      'alice',
+      'TestOrg',
+      'Deploy to prod',
+      'deployment',
+      'rationale here',
+      frameworkRoot,
+      agentDir,
+    );
+
+    expect(telegramConstructorSpy).toHaveBeenCalledWith('test-token-123');
+    expect(telegramSendMessageSpy).toHaveBeenCalledTimes(1);
+    const [chatId, message, , opts] = telegramSendMessageSpy.mock.calls[0] as [
+      string,
+      string,
+      unknown,
+      { parseMode: string | null },
+    ];
+    expect(chatId).toBe('987654321');
+    expect(String(message)).toContain('Deploy to prod');
+    expect(String(message)).toContain('deployment');
+    expect(String(message)).toContain('alice');
+    expect(String(message)).toContain(id);
+    expect(String(message)).toContain('rationale here');
+    // Plain text — must NOT trip Telegram's HTML/Markdown parser on
+    // arbitrary approval titles. parseMode: null sends as plain text.
+    expect(opts.parseMode).toBeNull();
+  });
+
+  it('skips with a warn when agentDir is not provided', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const id = await createApproval(paths, 'alice', 'TestOrg', 'No agentDir', 'deployment', undefined, frameworkRoot);
+
+    expect(telegramSendMessageSpy).not.toHaveBeenCalled();
+    const warnCalls = warnSpy.mock.calls.map((c) => c.join(' '));
+    expect(warnCalls.some((w) => w.includes('[approval]') && w.includes('No agentDir') && w.includes(id))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('skips silently when the agent .env file is missing (bot-less agent)', async () => {
+    // A hermes runtime or pre-onboarding agent has no .env yet. Approval
+    // creation must still succeed without a noisy warn — this is the
+    // expected steady state, not a misconfiguration.
+    const agentDir = join(testDir, 'bot-less-agent');
+    mkdirSync(agentDir, { recursive: true });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await createApproval(paths, 'alice', 'TestOrg', 'No env', 'deployment', undefined, frameworkRoot, agentDir);
+
+    expect(telegramSendMessageSpy).not.toHaveBeenCalled();
+    // No agent-bot warn for this case (the missing-keys case below DOES warn).
+    const warnCalls = warnSpy.mock.calls.map((c) => c.join(' '));
+    expect(warnCalls.some((w) => w.includes('agent-bot Telegram ping') || w.includes('BOT_TOKEN or CHAT_ID missing'))).toBe(
+      false,
+    );
+    warnSpy.mockRestore();
+  });
+
+  it('skips with a warn when BOT_TOKEN is missing from .env', async () => {
+    const agentDir = join(testDir, 'agent-missing-token');
+    writeAgentEnv(agentDir, { CHAT_ID: '987654321' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const id = await createApproval(paths, 'alice', 'TestOrg', 'Missing token', 'deployment', undefined, frameworkRoot, agentDir);
+
+    expect(telegramSendMessageSpy).not.toHaveBeenCalled();
+    const warnCalls = warnSpy.mock.calls.map((c) => c.join(' '));
+    expect(warnCalls.some((w) => w.includes('BOT_TOKEN or CHAT_ID missing') && w.includes(id))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('skips with a warn when CHAT_ID is missing from .env', async () => {
+    const agentDir = join(testDir, 'agent-missing-chat');
+    writeAgentEnv(agentDir, { BOT_TOKEN: 'test-token-123' });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const id = await createApproval(paths, 'alice', 'TestOrg', 'Missing chat', 'deployment', undefined, frameworkRoot, agentDir);
+
+    expect(telegramSendMessageSpy).not.toHaveBeenCalled();
+    const warnCalls = warnSpy.mock.calls.map((c) => c.join(' '));
+    expect(warnCalls.some((w) => w.includes('BOT_TOKEN or CHAT_ID missing') && w.includes(id))).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('approval creation succeeds even when the Telegram ping rejects (errors suppressed)', async () => {
+    // Telegram outage must NEVER block approval creation. The activity
+    // channel is best-effort, so is the agent-bot ping.
+    const agentDir = join(testDir, 'agent-tg-down');
+    writeAgentEnv(agentDir, { BOT_TOKEN: 'test-token-123', CHAT_ID: '987654321' });
+    telegramSendMessageSpy.mockRejectedValueOnce(new Error('telegram unreachable'));
+
+    const id = await createApproval(paths, 'alice', 'TestOrg', 'Telegram down', 'deployment', undefined, frameworkRoot, agentDir);
+
+    const pendingFile = join(paths.approvalDir, 'pending', `${id}.json`);
+    expect(existsSync(pendingFile)).toBe(true);
+  });
+
+  it('message body includes title, category, agent, id, context, and the orchestrator-chat hint', async () => {
+    const agentDir = join(testDir, 'agent-body-test');
+    writeAgentEnv(agentDir, { BOT_TOKEN: 'test-token-123', CHAT_ID: '987654321' });
+
+    const id = await createApproval(
+      paths,
+      'bob',
+      'TestOrg',
+      'Body shape test',
+      'other',
+      'detailed context paragraph',
+      frameworkRoot,
+      agentDir,
+    );
+
+    const [, message] = telegramSendMessageSpy.mock.calls[0] as [string, string, unknown, unknown];
+    const text = String(message);
+    expect(text).toContain('Body shape test');
+    expect(text).toContain('other');
+    expect(text).toContain('bob');
+    expect(text).toContain(id);
+    expect(text).toContain('detailed context paragraph');
+    // The ping must point operators at the action surface — they cannot
+    // act from the per-agent bot, so the body tells them where to go.
+    expect(text).toMatch(/orchestrator|dashboard/i);
   });
 });
 


### PR DESCRIPTION
## Summary
- `createApproval` now pings the requesting agent's own Telegram bot (reads `BOT_TOKEN`+`CHAT_ID` from `<agentDir>/.env`) alongside the activity-channel post.
- Closes the 50h+ Repo-B-style stall: operators on per-agent bots (the common shape) previously missed approvals entirely.
- Errors and missing-config skip silently with a single warn — Telegram outage and bot-less agents (hermes runtime, pre-onboarding) must never block approval creation.

## Why
The activity-channel post handles the operator-via-orchestrator UX (Approve/Deny inline buttons). But the typical deployment has the operator watching a per-agent bot and not the activity channel. Without this ping, that operator only learns about the approval if they happen to open the dashboard — which is exactly how Repo B sat blocked for 50+ hours.

This is Hook 3 of the three-hook sweep (after #298 agent_crashed → bus alert and #299/#300 cron survival). Pragmatic Option A — direct fix through the existing surface, no bus-hooks framework dependency.

## Implementation
- `src/bus/approval.ts`: new `pingAgentChatId(agentDir, ...)` helper, called after `postApprovalToActivityChannel`. Plain-text body (parseMode: null) — no Markdown/HTML escaping concerns on arbitrary approval titles.
- `createApproval` signature widened with `agentDir?: string` 8th param.
- `src/cli/bus.ts`: both call sites (`create-approval`, `propose-experiment`) pass `env.agentDir` explicitly.
- `src/utils/env.ts`: `parseEnvFile` now exported (was private).

## Behavior
- agentDir + .env + BOT_TOKEN + CHAT_ID all present → sends plain-text ping with title, category, requesting agent, id, context, and a hint pointing operators at the orchestrator chat / dashboard.
- agentDir not provided → warn + skip.
- .env missing (bot-less agent) → silent skip (steady state, not misconfiguration).
- BOT_TOKEN or CHAT_ID missing → warn + skip.
- Telegram rejects → suppressed; approval creation still succeeds.

## Test plan
- [x] 7 new test cases in `tests/unit/bus/approval.test.ts` covering each branch
- [x] `npm test` — 734/734 pass
- [x] `npm run build` — clean