### PR TITLE
docs(templates): clarify update-heartbeat vs log-event-heartbeat in HEARTBEAT.md Step 1

### DIFF
--- a/templates/agent/HEARTBEAT.md
+++ b/templates/agent/HEARTBEAT.md
@@ -11,6 +11,12 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+**Note:** `update-heartbeat` (Step 1) and `log-event heartbeat agent_heartbeat` (Step 4) are NOT interchangeable.
+- `update-heartbeat` refreshes the dashboard status-string field (what the dashboard reads to know you're alive).
+- `log-event heartbeat …` appends to the activity feed (JSONL append-only event log).
+
+Both are required every cycle. Skipping Step 1 leaves your dashboard view stale even though you're firing events.
+
 ## Step 2: Sweep inbox for un-ACK'd messages
 
 Messages arrive in real time via the fast-checker daemon — you don't need to poll for them. This step is a safety sweep for anything that wasn't ACK'd (e.g. a crash mid-processing).

--- a/templates/analyst/HEARTBEAT.md
+++ b/templates/analyst/HEARTBEAT.md
@@ -11,6 +11,12 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+**Note:** `update-heartbeat` (Step 1) and `log-event heartbeat agent_heartbeat` (Step 4) are NOT interchangeable.
+- `update-heartbeat` refreshes the dashboard status-string field (what the dashboard reads to know you're alive).
+- `log-event heartbeat …` appends to the activity feed (JSONL append-only event log).
+
+Both are required every cycle. Skipping Step 1 leaves your dashboard view stale even though you're firing events.
+
 ## Step 2: Check inbox
 
 ```bash

--- a/templates/hermes/HEARTBEAT.md
+++ b/templates/hermes/HEARTBEAT.md
@@ -11,6 +11,12 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+**Note:** `update-heartbeat` (Step 1) and `log-event heartbeat agent_heartbeat` (Step 4) are NOT interchangeable.
+- `update-heartbeat` refreshes the dashboard status-string field (what the dashboard reads to know you're alive).
+- `log-event heartbeat …` appends to the activity feed (JSONL append-only event log).
+
+Both are required every cycle. Skipping Step 1 leaves your dashboard view stale even though you're firing events.
+
 ## Step 2: Check inbox
 
 ```bash

--- a/templates/orchestrator/HEARTBEAT.md
+++ b/templates/orchestrator/HEARTBEAT.md
@@ -11,6 +11,12 @@ cortextos bus update-heartbeat "<1-sentence summary of current work>"
 
 If this fails, your agent shows as DEAD on the dashboard. Fix it before anything else.
 
+**Note:** `update-heartbeat` (Step 1) and `log-event heartbeat agent_heartbeat` (Step 4) are NOT interchangeable.
+- `update-heartbeat` refreshes the dashboard status-string field (what the dashboard reads to know you're alive).
+- `log-event heartbeat …` appends to the activity feed (JSONL append-only event log).
+
+Both are required every cycle. Skipping Step 1 leaves your dashboard view stale even though you're firing events.
+
 ## Step 2: Sweep inbox for un-ACK'd messages
 
 Messages arrive in real time via the fast-checker daemon — you don't need to poll for them. This step is a safety sweep for anything that wasn't ACK'd (e.g. a crash mid-processing).


### PR DESCRIPTION
## Summary

- Adds a 5-line note under Step 1 in all four agent HEARTBEAT.md templates (agent, orchestrator, hermes, analyst) clarifying that `update-heartbeat` and `log-event heartbeat agent_heartbeat` write to different fields and BOTH are required every cycle.
- Closes a documentation gap that caused dev's dashboard view to go stale 7h+ even while agent_heartbeat events were firing every cycle.

## Why

Analyst flagged the issue:
> "log_event populates the activity feed via JSONL events; update_heartbeat refreshes the dashboard status string. Different fields, different writers, different update cadences."

Step 1 said "DO THIS FIRST" but didn't make it explicit that it's a per-cycle requirement, not a session-start-only call. Combined with Step 4's `log-event heartbeat …`, an agent could plausibly read Step 4 as "satisfying" the heartbeat — which leaves the dashboard string stale.

## What changed

Same 5-line block added under Step 1 in all four templates:

```
**Note:** `update-heartbeat` (Step 1) and `log-event heartbeat agent_heartbeat` (Step 4) are NOT interchangeable.
- `update-heartbeat` refreshes the dashboard status-string field (what the dashboard reads to know you're alive).
- `log-event heartbeat …` appends to the activity feed (JSONL append-only event log).

Both are required every cycle. Skipping Step 1 leaves your dashboard view stale even though you're firing events.
```

## Test plan

- [x] All four templates touched with identical insert
- [x] Diff is +24 / -0, no other changes
- [ ] Live agents pick up the clarification on next session start (or when their owners propagate manually)

🤖 Generated with [Claude Code](https://claude.com/claude-code)