### PR TITLE
fix(kb): bump ingest timeout + retry Gemini 503s

### DIFF
--- a/knowledge-base/scripts/mmrag.py
+++ b/knowledge-base/scripts/mmrag.py
@@ -732,20 +732,44 @@ def ingest_pdf(client, config, collection, file_path):
 
     print(f"  Analyzing PDF: {file_path.name}...")
 
-    # First pass: get page count and full extraction
-    response = client.models.generate_content(
-        model=config.get("gemini_model", "gemini-2.5-flash"),
-        contents=[
-            types.Part.from_bytes(data=data, mime_type="application/pdf"),
-            "Extract ALL content from this PDF. For each page, include:\n"
-            "1. Page number\n"
-            "2. All text content (headings, body, lists, footnotes)\n"
-            "3. Description of any images, charts, diagrams, or tables\n"
-            "4. Key concepts and topics on that page\n"
-            "Separate each page's content with '=== PAGE N ===' markers.\n"
-            "Be thorough - this will be used for search and retrieval.",
-        ],
+    # Gemini Flash returns 503 UNAVAILABLE during high-demand windows.
+    # Without retries, a single 503 kills the ingest. Retry up to 3 times
+    # with exponential backoff (5s, 15s, 45s). Re-raise on the last failure.
+    extraction_prompt = (
+        "Extract ALL content from this PDF. For each page, include:\n"
+        "1. Page number\n"
+        "2. All text content (headings, body, lists, footnotes)\n"
+        "3. Description of any images, charts, diagrams, or tables\n"
+        "4. Key concepts and topics on that page\n"
+        "Separate each page's content with '=== PAGE N ===' markers.\n"
+        "Be thorough - this will be used for search and retrieval."
     )
+    response = None
+    last_err = None
+    for attempt, backoff in enumerate([5, 15, 45], start=1):
+        try:
+            response = client.models.generate_content(
+                model=config.get("gemini_model", "gemini-2.5-flash"),
+                contents=[
+                    types.Part.from_bytes(data=data, mime_type="application/pdf"),
+                    extraction_prompt,
+                ],
+            )
+            break
+        except Exception as e:
+            err_str = str(e)
+            last_err = e
+            # Only retry transient failures (503 UNAVAILABLE, 429 rate limit,
+            # 500 internal). Auth / 4xx config errors fail fast.
+            if not any(code in err_str for code in ["503", "429", "500", "UNAVAILABLE", "RESOURCE_EXHAUSTED"]):
+                raise
+            if attempt < 3:
+                print(f"    Transient error ({err_str[:80]}...); retrying in {backoff}s (attempt {attempt}/3)")
+                time.sleep(backoff)
+            else:
+                print(f"    Exhausted retries on transient error: {err_str[:200]}")
+    if response is None:
+        raise last_err if last_err else RuntimeError("PDF ingest failed without exception captured")
     if _tracker:
         _tracker.track_generation(response)
     text = response.text

--- a/knowledge-base/scripts/mmrag.py
+++ b/knowledge-base/scripts/mmrag.py
@@ -735,6 +735,14 @@ def ingest_pdf(client, config, collection, file_path):
     # Gemini Flash returns 503 UNAVAILABLE during high-demand windows.
     # Without retries, a single 503 kills the ingest. Retry up to 3 times
     # with exponential backoff (5s, 15s, 45s). Re-raise on the last failure.
+    # Predicate uses google.genai.errors.APIError's structured .code (HTTP int)
+    # and .status (gRPC-style text). Substring matching on str(e) was rejected
+    # because it false-positived non-transient errors whose body text
+    # incidentally contained "500"/"503" (e.g. a 403 mentioning a resource id
+    # with "503" in it would have wrongly triggered the retry loop).
+    from google.genai import errors as _genai_errors
+    TRANSIENT_HTTP_CODES = {429, 500, 503}
+    TRANSIENT_STATUS_NAMES = {"UNAVAILABLE", "RESOURCE_EXHAUSTED"}
     extraction_prompt = (
         "Extract ALL content from this PDF. For each page, include:\n"
         "1. Page number\n"
@@ -756,18 +764,20 @@ def ingest_pdf(client, config, collection, file_path):
                 ],
             )
             break
-        except Exception as e:
-            err_str = str(e)
+        except _genai_errors.APIError as e:
             last_err = e
-            # Only retry transient failures (503 UNAVAILABLE, 429 rate limit,
-            # 500 internal). Auth / 4xx config errors fail fast.
-            if not any(code in err_str for code in ["503", "429", "500", "UNAVAILABLE", "RESOURCE_EXHAUSTED"]):
+            # Structured retry predicate: only retry on real transient
+            # SDK-level conditions. Auth / 4xx config errors fail fast even
+            # when their response body text incidentally contains digits like
+            # "503" — this was the false-positive class flagged in PR review.
+            is_transient = (e.code in TRANSIENT_HTTP_CODES) or (e.status in TRANSIENT_STATUS_NAMES)
+            if not is_transient:
                 raise
             if attempt < 3:
-                print(f"    Transient error ({err_str[:80]}...); retrying in {backoff}s (attempt {attempt}/3)")
+                print(f"    Transient error (HTTP {e.code} {e.status or ''}); retrying in {backoff}s (attempt {attempt}/3)")
                 time.sleep(backoff)
             else:
-                print(f"    Exhausted retries on transient error: {err_str[:200]}")
+                print(f"    Exhausted retries on transient error: HTTP {e.code} {e.status or ''}")
     if response is None:
         raise last_err if last_err else RuntimeError("PDF ingest failed without exception captured")
     if _tracker:

--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -301,9 +301,24 @@ export function ingestKnowledgeBase(
   const args = [mmragPath, 'ingest', ...paths, '--collection', collection];
   if (force) args.push('--force');
 
+  // Multimodal PDF ingestion via Gemini Flash routinely takes 2–5 min for
+  // documents over ~10 pages with images/tables. Two minutes was too low and
+  // produced ETIMEDOUT mid-Gemini-call. Default 10 min, override via env,
+  // floored at 60s so nobody accidentally sets it to 0 or a value smaller
+  // than a single Gemini call needs.
+  const KB_INGEST_TIMEOUT_FLOOR_MS = 60_000;
+  const KB_INGEST_TIMEOUT_DEFAULT_MS = 600_000;
+  const requestedTimeout = Number(process.env.KB_INGEST_TIMEOUT_MS);
+  const ingestTimeoutMs = Math.max(
+    KB_INGEST_TIMEOUT_FLOOR_MS,
+    Number.isFinite(requestedTimeout) && requestedTimeout > 0
+      ? requestedTimeout
+      : KB_INGEST_TIMEOUT_DEFAULT_MS,
+  );
+
   execFileSync(pythonPath, args, {
     encoding: 'utf-8',
-    timeout: 120000,
+    timeout: ingestTimeoutMs,
     env,
     stdio: 'inherit',
   });


### PR DESCRIPTION
## Summary

`cortextos bus kb-ingest` was hitting `ETIMEDOUT` mid-call on multimodal PDFs. Two changes fix the immediate failure mode and the bonus retry hole:

1. **JS-side timeout configurable.** `src/bus/knowledge-base.ts` had a hardcoded 120 000 ms `execFileSync` ceiling — too short for Gemini Flash to extract text + image/chart/table descriptions from a >10-page PDF (live test on a 28-page compliance PDF showed Gemini still actively processing at the 100 s mark when the JS layer killed it). New default is 600 000 ms (10 min), overridable via `KB_INGEST_TIMEOUT_MS` env var, floored at 60 000 ms so a misconfiguration can't accidentally set it below a single Gemini call's needs.

2. **Python-side 503 retry.** `mmrag.py ingest_pdf()` was a single Gemini call with no retry; one transient `503 UNAVAILABLE` (Gemini's high-demand load shed) killed the ingest with no recovery. The Gemini call is now wrapped with up to 3 attempts (5 s / 15 s / 45 s exponential backoff). Only retries transient classes (503, 429, 500, `UNAVAILABLE`, `RESOURCE_EXHAUSTED`); 4xx auth / config errors still fail fast.

## Live confirmation

The same 28-page PDF that previously hit `ETIMEDOUT` now ingests successfully in **231 seconds** (3 min 51 s) — 28 chunks at $0.022. Cleanly above the old 120 s ceiling and well within the new 600 s default.

## Test plan
- [x] `npm run build` — clean
- [x] `npm test` — 727 / 727 passing
- [x] Live ingest of `E4-117R-02-09-10675-00-677.pdf` (28-page, 605 KB, AES-encrypted, multimodal) — succeeds in 231 s
- [ ] Reviewer confirms env-var override works in their setup

## Follow-up (not in this PR)
Stretch idea per chief: chunk PDFs >10 pages into 5-page Gemini batches per call. Bounds per-call latency, parallelizable, reduces the blast radius of any single 503. Deferred to a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)