### PR TITLE
feat(kb): fault-injectable mmrag client for ingest test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ ${APPDATA}/
 knowledge-base/venv/
 knowledge-base/__pycache__/
 knowledge-base/scripts/__pycache__/
+knowledge-base/scripts/_test_clients/__pycache__/
 tests/playwright/dashboard-ui.spec.ts
 
 # Local ops docs (personal, not for public repo)

--- a/knowledge-base/scripts/_test_clients/README.md
+++ b/knowledge-base/scripts/_test_clients/README.md
@@ -1,0 +1,64 @@
+# `_test_clients/` — fault-injectable Gemini clients
+
+Test-only stand-ins for `google.genai.Client`, used to behaviorally verify the
+retry loop in `mmrag._retry_generate_content` without hitting the real Gemini
+API.
+
+## How the indirection works
+
+`mmrag.get_genai_client()` checks `MMRAG_GEMINI_CLIENT_FACTORY`. If unset, it
+returns the real `google.genai.Client` (current production behavior, unchanged
+byte-for-byte). If set, the variable is interpreted as a dotted import path of
+a callable; the result of `factory(api_key)` is used as the client.
+
+The path may be written `module.attr` or `module:attr` (the colon form is
+preferred because it disambiguates submodule vs attribute lookups).
+
+## Reference client: `fault_injection.py`
+
+A scripted-response client that lets a test driver dictate the outcome of each
+`generate_content()` call.
+
+```bash
+export MMRAG_GEMINI_CLIENT_FACTORY=_test_clients.fault_injection:make_client
+export MMRAG_FAULT_INJECTION_SCRIPT="503,503,200"
+```
+
+The script is a comma-separated list of one entry per call. Each entry is
+`<http_code>` or `<http_code>:<message>`. `200` returns a stub success
+response; any other code raises an `APIError` with the corresponding gRPC
+status name set on `.status` and `.code` set to the HTTP int. See the
+docstring at the top of `fault_injection.py` for the full code → status map.
+
+The client only scripts `generate_content` — `embed_content` raises loudly if
+called. Tests should target `_retry_generate_content` directly rather than
+running the full `ingest_pdf` pipeline.
+
+## Running the tests
+
+```bash
+cd knowledge-base/scripts
+python -m _test_clients.test_retry
+```
+
+Three scenarios run in milliseconds (`backoffs=(0, 0, 0)` skips real sleeps):
+
+1. **transient_then_success** — `503 → 200` returns the success response.
+2. **all_exhausted** — `503 → 503 → 503` re-raises the last `APIError`.
+3. **fail_fast_nontransient** — a `403` whose message text contains `"503"`
+   raises immediately. This is the false-positive class flagged in the PR #309
+   review (substring-match would have entered the retry loop); the structured
+   `.code`/`.status` predicate rejects it. Same scenario the #309 sandbox
+   covered as TC-8 — recreated here as a unit test.
+
+The exit code is 0 on all-pass, 1 on any assertion failure.
+
+## Why this lives in `knowledge-base/scripts/_test_clients/` and not elsewhere
+
+`mmrag.py` runs as a script (`python knowledge-base/scripts/mmrag.py …`),
+which puts its own directory on `sys.path[0]` automatically. That makes
+`_test_clients.fault_injection` importable from `mmrag` with no path-manip
+boilerplate at runtime.
+
+The leading underscore marks the package as test-internal — it's not part of
+the user-facing CLI surface and doesn't ship in the runtime hot path.

--- a/knowledge-base/scripts/_test_clients/fault_injection.py
+++ b/knowledge-base/scripts/_test_clients/fault_injection.py
@@ -1,0 +1,109 @@
+"""Fault-injecting Gemini client for testing mmrag._retry_generate_content.
+
+Wired via two env vars consumed by mmrag.get_genai_client:
+
+    MMRAG_GEMINI_CLIENT_FACTORY=_test_clients.fault_injection:make_client
+    MMRAG_FAULT_INJECTION_SCRIPT="503,503,200"
+
+The script is a comma-separated list of one entry per generate_content() call.
+Each entry is either "<code>" or "<code>:<message>". Code 200 returns a stub
+success response; any other code raises an APIError with the corresponding
+status name.
+
+Code -> status mapping (set is intentionally narrow — covers what the retry
+loop predicate distinguishes between transient and non-transient):
+
+    429 -> RESOURCE_EXHAUSTED   (transient)
+    500 -> INTERNAL             (transient by HTTP code)
+    503 -> UNAVAILABLE          (transient)
+    400 -> INVALID_ARGUMENT     (non-transient)
+    401 -> UNAUTHENTICATED      (non-transient)
+    403 -> PERMISSION_DENIED    (non-transient)
+"""
+
+import os
+from google.genai.errors import APIError
+
+
+_STATUS_FOR_CODE = {
+    429: "RESOURCE_EXHAUSTED",
+    500: "INTERNAL",
+    503: "UNAVAILABLE",
+    400: "INVALID_ARGUMENT",
+    401: "UNAUTHENTICATED",
+    403: "PERMISSION_DENIED",
+}
+
+
+class _InjectedAPIError(APIError):
+    """APIError subclass that sets .code/.status/.message directly.
+
+    Avoids invoking APIError.__init__ because the SDK's constructor expects a
+    real HTTP response object and parses response_json in version-specific
+    ways. Subclassing preserves `except google.genai.errors.APIError` catches
+    in callers (an _InjectedAPIError is-a APIError).
+    """
+    def __init__(self, code, status, message=""):
+        Exception.__init__(self, message)
+        self.code = code
+        self.status = status
+        self.message = message
+
+
+class _StubResponse:
+    def __init__(self, text):
+        self.text = text
+        self.usage_metadata = None
+
+
+class _StubModels:
+    def __init__(self, script):
+        self._script = list(script)
+        self._index = 0
+
+    def generate_content(self, model=None, contents=None, **kwargs):
+        if self._index >= len(self._script):
+            raise RuntimeError(
+                f"fault_injection: script exhausted at attempt {self._index + 1} "
+                f"(scripted {len(self._script)} responses)"
+            )
+        code, message = self._script[self._index]
+        self._index += 1
+        if code == 200:
+            return _StubResponse(message or "[stub] fault-injection success")
+        status = _STATUS_FOR_CODE.get(code, "UNKNOWN")
+        raise _InjectedAPIError(code, status, message or f"injected {code} {status}")
+
+    def embed_content(self, *a, **kw):
+        raise RuntimeError(
+            "fault_injection: embed_content is not scripted. Tests should target "
+            "_retry_generate_content directly, not the full ingest_pdf pipeline."
+        )
+
+
+class FaultInjectionClient:
+    def __init__(self, script):
+        self.models = _StubModels(script)
+
+
+def _parse_script(spec):
+    entries = []
+    for chunk in spec.split(","):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        if ":" in chunk:
+            code_s, message = chunk.split(":", 1)
+        else:
+            code_s, message = chunk, ""
+        entries.append((int(code_s), message))
+    return entries
+
+
+def make_client(api_key=None):
+    """Factory entry point. Signature matches the real Client constructor;
+    api_key is accepted but ignored — fault injection is fully driven by
+    MMRAG_FAULT_INJECTION_SCRIPT.
+    """
+    spec = os.environ.get("MMRAG_FAULT_INJECTION_SCRIPT", "200")
+    return FaultInjectionClient(_parse_script(spec))

--- a/knowledge-base/scripts/_test_clients/test_retry.py
+++ b/knowledge-base/scripts/_test_clients/test_retry.py
@@ -1,0 +1,126 @@
+"""Behavioral tests for mmrag._retry_generate_content.
+
+Run from knowledge-base/scripts:
+
+    python -m _test_clients.test_retry
+
+Exits 0 on all-pass, 1 on any failure. Three scenarios:
+
+  1. transient_then_success: 503 → 200 → returns response, no raise
+  2. all_exhausted: 503 → 503 → 503 → raises last APIError
+  3. fail_fast_nontransient: 403 (with '503' in body) → raises immediately;
+     proves the predicate is structural (.code / .status), not textual.
+
+backoffs is passed as (0, 0, 0) so tests run in milliseconds.
+"""
+
+import os
+import sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PARENT = os.path.dirname(HERE)
+if PARENT not in sys.path:
+    sys.path.insert(0, PARENT)
+
+import mmrag
+from _test_clients import fault_injection
+
+
+FAILURES = []
+
+
+def _check(label, cond, detail=""):
+    if cond:
+        print(f"  PASS  {label}")
+    else:
+        print(f"  FAIL  {label}: {detail}")
+        FAILURES.append(label)
+
+
+def test_transient_then_success():
+    print("\n[test 1/3] transient_then_success: 503 -> 200")
+    client = fault_injection.FaultInjectionClient(
+        fault_injection._parse_script("503:gemini busy,200:hello world")
+    )
+    response = mmrag._retry_generate_content(
+        client, model="x", contents=["x"], backoffs=(0, 0, 0)
+    )
+    _check("returns response after one transient", response is not None)
+    _check(
+        "response.text matches scripted message",
+        getattr(response, "text", None) == "hello world",
+        detail=f"got {getattr(response, 'text', None)!r}",
+    )
+    _check(
+        "consumed exactly 2 attempts",
+        client.models._index == 2,
+        detail=f"got {client.models._index}",
+    )
+
+
+def test_all_exhausted():
+    print("\n[test 2/3] all_exhausted: 503 -> 503 -> 503 -> re-raise")
+    client = fault_injection.FaultInjectionClient(
+        fault_injection._parse_script("503,503,503")
+    )
+    raised = None
+    try:
+        mmrag._retry_generate_content(
+            client, model="x", contents=["x"], backoffs=(0, 0, 0)
+        )
+    except Exception as e:
+        raised = e
+    _check("raises after all attempts exhausted", raised is not None)
+    if raised is not None:
+        _check("raised.code is 503", getattr(raised, "code", None) == 503)
+        _check(
+            "raised.status is UNAVAILABLE",
+            getattr(raised, "status", None) == "UNAVAILABLE",
+        )
+    _check(
+        "consumed exactly 3 attempts",
+        client.models._index == 3,
+        detail=f"got {client.models._index}",
+    )
+
+
+def test_fail_fast_nontransient():
+    print("\n[test 3/3] fail_fast_nontransient: 403 (with '503' in body) -> raises immediately")
+    client = fault_injection.FaultInjectionClient(
+        fault_injection._parse_script(
+            "403:Permission denied for resource ID 503-pseudo,200:should not reach"
+        )
+    )
+    raised = None
+    try:
+        mmrag._retry_generate_content(
+            client, model="x", contents=["x"], backoffs=(0, 0, 0)
+        )
+    except Exception as e:
+        raised = e
+    _check("raises immediately on non-transient", raised is not None)
+    if raised is not None:
+        _check("raised.code is 403", getattr(raised, "code", None) == 403)
+        _check(
+            "raised.status is PERMISSION_DENIED",
+            getattr(raised, "status", None) == "PERMISSION_DENIED",
+        )
+    _check(
+        "did NOT consume the second scripted attempt (predicate is structural, not textual)",
+        client.models._index == 1,
+        detail=f"got {client.models._index}",
+    )
+
+
+if __name__ == "__main__":
+    test_transient_then_success()
+    test_all_exhausted()
+    test_fail_fast_nontransient()
+    print()
+    if FAILURES:
+        print(f"FAILED: {len(FAILURES)} assertion(s)")
+        for f in FAILURES:
+            print(f"  - {f}")
+        sys.exit(1)
+    print(f"ALL PASS (3 scenarios)")
+    sys.exit(0)

--- a/knowledge-base/scripts/mmrag.py
+++ b/knowledge-base/scripts/mmrag.py
@@ -61,6 +61,11 @@ EMBEDDING_PRICE_PER_M = 0.20
 FLASH_INPUT_PRICE_PER_M = 0.15
 FLASH_OUTPUT_PRICE_PER_M = 0.60
 
+# Retry classifier for the Gemini generate_content call inside ingest_pdf.
+# Module-level so a fault-injection test client can reference the same set.
+TRANSIENT_HTTP_CODES = {429, 500, 503}
+TRANSIENT_STATUS_NAMES = {"UNAVAILABLE", "RESOURCE_EXHAUSTED"}
+
 USAGE_FILE = MMRAG_DIR / "usage.json"
 
 # ---------------------------------------------------------------------------
@@ -172,9 +177,74 @@ def get_api_key(config):
 # ---------------------------------------------------------------------------
 # Gemini clients
 # ---------------------------------------------------------------------------
+def _load_factory(dotted_path):
+    """Resolve a dotted import path to a callable.
+
+    Accepts 'pkg.mod.attr' or 'pkg.mod:attr'. The colon form is unambiguous when
+    the attribute name collides with a submodule name, so it is preferred.
+    """
+    if ":" in dotted_path:
+        module_path, _, attr_path = dotted_path.partition(":")
+    else:
+        module_path, _, attr_path = dotted_path.rpartition(".")
+    if not module_path or not attr_path:
+        raise ValueError(
+            f"MMRAG_GEMINI_CLIENT_FACTORY {dotted_path!r} must be 'module.attr' or 'module:attr'"
+        )
+    import importlib
+    obj = importlib.import_module(module_path)
+    for part in attr_path.split("."):
+        obj = getattr(obj, part)
+    if not callable(obj):
+        raise TypeError(
+            f"MMRAG_GEMINI_CLIENT_FACTORY {dotted_path!r} resolved to non-callable {type(obj).__name__}"
+        )
+    return obj
+
+
 def get_genai_client(api_key):
+    """Construct a Gemini client.
+
+    Default returns google.genai.Client(api_key=api_key) — byte-identical to
+    the prior behavior. To inject a fake client (e.g. for testing the retry
+    loop in ingest_pdf), set the env-var MMRAG_GEMINI_CLIENT_FACTORY to a
+    dotted import path of a callable taking (api_key) and returning an object
+    with .models.generate_content / .models.embed_content compatible shape.
+    See knowledge-base/scripts/_test_clients/fault_injection.py for a reference.
+    """
+    factory_path = os.environ.get("MMRAG_GEMINI_CLIENT_FACTORY")
+    if factory_path:
+        return _load_factory(factory_path)(api_key)
     from google import genai
     return genai.Client(api_key=api_key)
+
+
+def _retry_generate_content(client, *, model, contents, backoffs=(5, 15, 45)):
+    """Call client.models.generate_content with bounded retries on transient APIErrors.
+
+    Retries on HTTP code in TRANSIENT_HTTP_CODES or status name in
+    TRANSIENT_STATUS_NAMES; re-raises immediately on any other APIError (auth,
+    malformed request, etc.); re-raises last_err after all attempts exhausted.
+
+    backoffs is a tuple of sleep seconds between attempts. len(backoffs) is the
+    attempt count. Tests pass (0, 0, 0) to skip sleeps.
+    """
+    from google.genai import errors as _genai_errors
+    last_err = None
+    for attempt, backoff in enumerate(backoffs, start=1):
+        try:
+            return client.models.generate_content(model=model, contents=contents)
+        except _genai_errors.APIError as e:
+            last_err = e
+            is_transient = (e.code in TRANSIENT_HTTP_CODES) or (e.status in TRANSIENT_STATUS_NAMES)
+            if not is_transient:
+                raise
+            if attempt < len(backoffs):
+                print(f"    Transient error (HTTP {e.code} {e.status or ''}); retrying in {backoff}s (attempt {attempt}/{len(backoffs)})")
+                time.sleep(backoff)
+            else:
+                print(f"    Exhausted retries on transient error: HTTP {e.code} {e.status or ''}")
+    raise last_err if last_err else RuntimeError("retry loop completed without response or error")
 
 
 def embed_content(client, config, content, task_type="RETRIEVAL_DOCUMENT"):
@@ -732,17 +802,10 @@ def ingest_pdf(client, config, collection, file_path):
 
     print(f"  Analyzing PDF: {file_path.name}...")
 
-    # Gemini Flash returns 503 UNAVAILABLE during high-demand windows.
-    # Without retries, a single 503 kills the ingest. Retry up to 3 times
-    # with exponential backoff (5s, 15s, 45s). Re-raise on the last failure.
-    # Predicate uses google.genai.errors.APIError's structured .code (HTTP int)
-    # and .status (gRPC-style text). Substring matching on str(e) was rejected
-    # because it false-positived non-transient errors whose body text
-    # incidentally contained "500"/"503" (e.g. a 403 mentioning a resource id
-    # with "503" in it would have wrongly triggered the retry loop).
-    from google.genai import errors as _genai_errors
-    TRANSIENT_HTTP_CODES = {429, 500, 503}
-    TRANSIENT_STATUS_NAMES = {"UNAVAILABLE", "RESOURCE_EXHAUSTED"}
+    # Gemini Flash returns 503 UNAVAILABLE during high-demand windows. Without
+    # retries, a single 503 kills the ingest. _retry_generate_content wraps the
+    # call with bounded retries on transient SDK conditions (HTTP 429/500/503,
+    # status UNAVAILABLE/RESOURCE_EXHAUSTED) and fails fast on everything else.
     extraction_prompt = (
         "Extract ALL content from this PDF. For each page, include:\n"
         "1. Page number\n"
@@ -752,34 +815,14 @@ def ingest_pdf(client, config, collection, file_path):
         "Separate each page's content with '=== PAGE N ===' markers.\n"
         "Be thorough - this will be used for search and retrieval."
     )
-    response = None
-    last_err = None
-    for attempt, backoff in enumerate([5, 15, 45], start=1):
-        try:
-            response = client.models.generate_content(
-                model=config.get("gemini_model", "gemini-2.5-flash"),
-                contents=[
-                    types.Part.from_bytes(data=data, mime_type="application/pdf"),
-                    extraction_prompt,
-                ],
-            )
-            break
-        except _genai_errors.APIError as e:
-            last_err = e
-            # Structured retry predicate: only retry on real transient
-            # SDK-level conditions. Auth / 4xx config errors fail fast even
-            # when their response body text incidentally contains digits like
-            # "503" — this was the false-positive class flagged in PR review.
-            is_transient = (e.code in TRANSIENT_HTTP_CODES) or (e.status in TRANSIENT_STATUS_NAMES)
-            if not is_transient:
-                raise
-            if attempt < 3:
-                print(f"    Transient error (HTTP {e.code} {e.status or ''}); retrying in {backoff}s (attempt {attempt}/3)")
-                time.sleep(backoff)
-            else:
-                print(f"    Exhausted retries on transient error: HTTP {e.code} {e.status or ''}")
-    if response is None:
-        raise last_err if last_err else RuntimeError("PDF ingest failed without exception captured")
+    response = _retry_generate_content(
+        client,
+        model=config.get("gemini_model", "gemini-2.5-flash"),
+        contents=[
+            types.Part.from_bytes(data=data, mime_type="application/pdf"),
+            extraction_prompt,
+        ],
+    )
     if _tracker:
         _tracker.track_generation(response)
     text = response.text


### PR DESCRIPTION
## Summary

Closes the GAP-2 coverage gap surfaced in the PR #309 audit. The retry loop's "transient-then-success" and "all-attempts-exhausted" branches were not behaviorally covered because exercising them requires fault injection that survives a real Gemini SDK call.

This PR adds an opt-in env-var indirection plus a reference fault-injection client and a standalone test runner that exercises the three branches in milliseconds.

## What changed

- **`MMRAG_GEMINI_CLIENT_FACTORY` env-var indirection** in `get_genai_client()`. Default unset = real `google.genai.Client(api_key=...)`, byte-identical to current behavior. When set, it is treated as a dotted import path (`pkg.mod.attr` or `pkg.mod:attr`) of a callable that takes `(api_key)` and returns a client object satisfying the `.models.generate_content` shape.
- **Refactor**: extracted the retry loop from `ingest_pdf` into a module-level helper `_retry_generate_content(client, *, model, contents, backoffs=(5,15,45))`. `backoffs` is now parameterized so tests can pass `(0,0,0)` and complete in milliseconds. `TRANSIENT_HTTP_CODES` and `TRANSIENT_STATUS_NAMES` hoisted to module scope so the fault-injection client can reference the same set.
- **Reference fault-injection client** at `knowledge-base/scripts/_test_clients/fault_injection.py`. Reads `MMRAG_FAULT_INJECTION_SCRIPT` (e.g. `"503,503,200"`) and replays scripted responses per call. Uses an `_InjectedAPIError` subclass that bypasses the SDK's `__init__` (which expects a real HTTP response object); subclassing preserves `except APIError` catches in callers.
- **Standalone test runner** at `_test_clients/test_retry.py` covering three scenarios — see Test plan below. No pytest dependency added.

## What this PR deliberately does NOT do

- Touch the JS-side `KB_INGEST_TIMEOUT_MS` plumbing (separate concern, PR #309).
- Add pytest, mock, responses, or any other test/mock dependency.
- Change runtime behavior when the env var is unset.

## Why this shape

Boris and James greenlit the title and shape after the PR #309 review. The substring-match retry predicate that PR #309 replaced was flagged for false-positive risk; #309 closed that class with a structured `APIError.code`/`.status` predicate, and the sandbox covered it with TC-8 (synthetic 403 whose body contains "503"). But the success-path and exhausted-path branches stayed uncovered because the sandbox-edit-then-revert technique used for TC-8 doesn't scale to the success branch — the inject point bypasses the actual SDK call. The factory indirection puts the inject point exactly where it can mint real `APIError` subclasses through the SDK type hierarchy, which is what the predicate actually inspects.

## Test plan

Run from the repo root:

```bash
cd knowledge-base
python3 -m venv venv && source venv/bin/activate && pip install google-genai
cd scripts
python -m _test_clients.test_retry
```

Expected: `ALL PASS (3 scenarios)`. Three scenarios:

- [x] `transient_then_success` — `503 → 200` returns the success response (covers the loop's `break` branch)
- [x] `all_exhausted` — `503 → 503 → 503` re-raises the last `APIError` with `.code=503`, `.status="UNAVAILABLE"` (covers the `raise last_err` branch)
- [x] `fail_fast_nontransient` — `403` whose message text contains `"503"` raises immediately with `.code=403`, `.status="PERMISSION_DENIED"`, second scripted attempt is NOT consumed. Same scenario as PR #309 audit's TC-8, recreated as a unit test.

Default-path sanity (no env var set):

- [x] `mmrag.get_genai_client('fake-key')` returns `google.genai.client.Client` (byte-identical to prior behavior)

Factory-path sanity:

- [x] With `MMRAG_GEMINI_CLIENT_FACTORY=_test_clients.fault_injection:make_client` set, `mmrag.get_genai_client('fake-key')` returns `_test_clients.fault_injection.FaultInjectionClient`

Bad-factory-path sanity:

- [x] Malformed path (no dot or colon) raises `ValueError` with the offending value
- [x] Non-existent module raises `ModuleNotFoundError`
- [x] Path resolving to a non-callable raises `TypeError` with the resolved type

🤖 Generated with [Claude Code](https://claude.com/claude-code)