### PR TITLE
docs(agent-management): hook reload lifecycle + hard-restart-from-CLI bug

### DIFF
--- a/community/agents/security/.claude/skills/agent-management/SKILL.md
+++ b/community/agents/security/.claude/skills/agent-management/SKILL.md
@@ -135,7 +135,25 @@ cortextos bus send-message <agent_name> high "soft-restart" "<reason>"
 cortextos bus hard-restart --reason "context exhaustion"
 ```
 
-**When to use:** Context window full, conversation corrupted, need clean slate.
+**When to use:** Context window full, conversation corrupted, need clean slate, or wiring a new hook (see Hook Reload Lifecycle below). Hard-restart sends an IPC `restart-agent` signal to the daemon, which kills the running PID and respawns it fresh. The respawn consumes the `.force-fresh` marker and skips `--continue`, so `settings.json` (including newly-wired hooks) is re-read from scratch.
+
+### Hook Reload Lifecycle
+
+`.claude/settings.json` hooks (PreToolUse, PostToolUse, Stop, SessionStart, etc) are loaded once when the Claude CLI process starts. They are NOT reloaded by `cortextos bus self-restart` — soft restart relaunches Claude with `--continue`, which reuses the existing process settings cache. Project-level hooks added or changed in `settings.json` since the original boot DO NOT take effect under soft restart.
+
+**When wiring a new hook to a running agent, use a hard restart, not a soft restart:**
+
+```bash
+# From inside the agent itself, or from another agent/terminal:
+cortextos bus hard-restart --reason "loading new hook"
+
+# Equivalent ops-side path:
+cortextos stop <agent> && cortextos start <agent>
+```
+
+Both kill the existing PID and respawn a fresh process that re-reads `settings.json` from scratch. Verify by adding a one-line debug write to your hook script before testing — if the file shows up after a benign tool call, the hook is loaded.
+
+This bit us hard on the coder-telegram-guardrail wire-up before upstream PR #217 fixed `bus hard-restart` to actually signal the daemon. On any fork that has not pulled in #217 (commit `a38ef7a`), `bus hard-restart` writes markers without killing the PID — fall back to external `stop && start` until the fork is rebased.
 
 ### Restart from Another Agent
 
@@ -360,6 +378,13 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 2. Check PM2 logs: `pm2 logs <agent-process-name>`
 3. Regenerate ecosystem config: `cortextos ecosystem` then `pm2 restart ecosystem.config.js`
 4. If exit code shows throttling, wait 10s then `cortextos enable <agent> --restart`
+
+### New Hook Not Firing After Wiring It Up
+1. Confirm `settings.json` is valid JSON and the hook block is in the right shape (matcher, type=command, etc).
+2. Try a benign tool call that should trigger the hook. If nothing happens, the hook is not loaded.
+3. **Do NOT soft-restart** — `--continue` does not reload project hooks (see Hook Reload Lifecycle in Section 2).
+4. Hard-restart the agent: `cortextos bus hard-restart --reason "load new hook"`. The daemon kills the PID and respawns a fresh process that re-reads `settings.json`.
+5. If the hook still does not fire after a fresh PID, instrument the script with an unconditional write to `/tmp/<agent>-hook-test.log` at the very top of `main()`, run a benign tool, and check whether the file appears. If yes, the hook is firing but the script is returning early. If no, the hook is wired wrong in `settings.json`.
 
 ---
 

--- a/community/skills/agent-management/SKILL.md
+++ b/community/skills/agent-management/SKILL.md
@@ -136,7 +136,25 @@ cortextos bus send-message <agent_name> high "soft-restart" "<reason>"
 cortextos bus hard-restart --reason "context exhaustion"
 ```
 
-**When to use:** Context window full, conversation corrupted, need clean slate.
+**When to use:** Context window full, conversation corrupted, need clean slate, or wiring a new hook (see Hook Reload Lifecycle below). Hard-restart sends an IPC `restart-agent` signal to the daemon, which kills the running PID and respawns it fresh. The respawn consumes the `.force-fresh` marker and skips `--continue`, so `settings.json` (including newly-wired hooks) is re-read from scratch.
+
+### Hook Reload Lifecycle
+
+`.claude/settings.json` hooks (PreToolUse, PostToolUse, Stop, SessionStart, etc) are loaded once when the Claude CLI process starts. They are NOT reloaded by `cortextos bus self-restart` — soft restart relaunches Claude with `--continue`, which reuses the existing process settings cache. Project-level hooks added or changed in `settings.json` since the original boot DO NOT take effect under soft restart.
+
+**When wiring a new hook to a running agent, use a hard restart, not a soft restart:**
+
+```bash
+# From inside the agent itself, or from another agent/terminal:
+cortextos bus hard-restart --reason "loading new hook"
+
+# Equivalent ops-side path:
+cortextos stop <agent> && cortextos start <agent>
+```
+
+Both kill the existing PID and respawn a fresh process that re-reads `settings.json` from scratch. Verify by adding a one-line debug write to your hook script before testing — if the file shows up after a benign tool call, the hook is loaded.
+
+This bit us hard on the coder-telegram-guardrail wire-up before upstream PR #217 fixed `bus hard-restart` to actually signal the daemon. On any fork that has not pulled in #217 (commit `a38ef7a`), `bus hard-restart` writes markers without killing the PID — fall back to external `stop && start` until the fork is rebased.
 
 ### Restart from Another Agent
 
@@ -367,6 +385,13 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 2. Check PM2 logs: `pm2 logs <agent-process-name>`
 3. Regenerate ecosystem config: `cortextos ecosystem` then `pm2 restart ecosystem.config.js`
 4. If exit code shows throttling, wait 10s then `cortextos enable <agent> --restart`
+
+### New Hook Not Firing After Wiring It Up
+1. Confirm `settings.json` is valid JSON and the hook block is in the right shape (matcher, type=command, etc).
+2. Try a benign tool call that should trigger the hook. If nothing happens, the hook is not loaded.
+3. **Do NOT soft-restart** — `--continue` does not reload project hooks (see Hook Reload Lifecycle in Section 2).
+4. Hard-restart the agent: `cortextos bus hard-restart --reason "load new hook"`. The daemon kills the PID and respawns a fresh process that re-reads `settings.json`.
+5. If the hook still does not fire after a fresh PID, instrument the script with an unconditional write to `/tmp/<agent>-hook-test.log` at the very top of `main()`, run a benign tool, and check whether the file appears. If yes, the hook is firing but the script is returning early. If no, the hook is wired wrong in `settings.json`.
 
 ---
 

--- a/templates/agent/.claude/skills/agent-management/SKILL.md
+++ b/templates/agent/.claude/skills/agent-management/SKILL.md
@@ -135,7 +135,25 @@ cortextos bus send-message <agent_name> high "soft-restart" "<reason>"
 cortextos bus hard-restart --reason "context exhaustion"
 ```
 
-**When to use:** Context window full, conversation corrupted, need clean slate.
+**When to use:** Context window full, conversation corrupted, need clean slate, or wiring a new hook (see Hook Reload Lifecycle below). Hard-restart sends an IPC `restart-agent` signal to the daemon, which kills the running PID and respawns it fresh. The respawn consumes the `.force-fresh` marker and skips `--continue`, so `settings.json` (including newly-wired hooks) is re-read from scratch.
+
+### Hook Reload Lifecycle
+
+`.claude/settings.json` hooks (PreToolUse, PostToolUse, Stop, SessionStart, etc) are loaded once when the Claude CLI process starts. They are NOT reloaded by `cortextos bus self-restart` — soft restart relaunches Claude with `--continue`, which reuses the existing process settings cache. Project-level hooks added or changed in `settings.json` since the original boot DO NOT take effect under soft restart.
+
+**When wiring a new hook to a running agent, use a hard restart, not a soft restart:**
+
+```bash
+# From inside the agent itself, or from another agent/terminal:
+cortextos bus hard-restart --reason "loading new hook"
+
+# Equivalent ops-side path:
+cortextos stop <agent> && cortextos start <agent>
+```
+
+Both kill the existing PID and respawn a fresh process that re-reads `settings.json` from scratch. Verify by adding a one-line debug write to your hook script before testing — if the file shows up after a benign tool call, the hook is loaded.
+
+This bit us hard on the coder-telegram-guardrail wire-up before upstream PR #217 fixed `bus hard-restart` to actually signal the daemon. On any fork that has not pulled in #217 (commit `a38ef7a`), `bus hard-restart` writes markers without killing the PID — fall back to external `stop && start` until the fork is rebased.
 
 ### Restart from Another Agent
 
@@ -360,6 +378,13 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 2. Check PM2 logs: `pm2 logs <agent-process-name>`
 3. Regenerate ecosystem config: `cortextos ecosystem` then `pm2 restart ecosystem.config.js`
 4. If exit code shows throttling, wait 10s then `cortextos enable <agent> --restart`
+
+### New Hook Not Firing After Wiring It Up
+1. Confirm `settings.json` is valid JSON and the hook block is in the right shape (matcher, type=command, etc).
+2. Try a benign tool call that should trigger the hook. If nothing happens, the hook is not loaded.
+3. **Do NOT soft-restart** — `--continue` does not reload project hooks (see Hook Reload Lifecycle in Section 2).
+4. Hard-restart the agent: `cortextos bus hard-restart --reason "load new hook"`. The daemon kills the PID and respawns a fresh process that re-reads `settings.json`.
+5. If the hook still does not fire after a fresh PID, instrument the script with an unconditional write to `/tmp/<agent>-hook-test.log` at the very top of `main()`, run a benign tool, and check whether the file appears. If yes, the hook is firing but the script is returning early. If no, the hook is wired wrong in `settings.json`.
 
 ---
 

--- a/templates/analyst/.claude/skills/agent-management/SKILL.md
+++ b/templates/analyst/.claude/skills/agent-management/SKILL.md
@@ -135,7 +135,25 @@ cortextos bus send-message <agent_name> high "soft-restart" "<reason>"
 cortextos bus hard-restart --reason "context exhaustion"
 ```
 
-**When to use:** Context window full, conversation corrupted, need clean slate.
+**When to use:** Context window full, conversation corrupted, need clean slate, or wiring a new hook (see Hook Reload Lifecycle below). Hard-restart sends an IPC `restart-agent` signal to the daemon, which kills the running PID and respawns it fresh. The respawn consumes the `.force-fresh` marker and skips `--continue`, so `settings.json` (including newly-wired hooks) is re-read from scratch.
+
+### Hook Reload Lifecycle
+
+`.claude/settings.json` hooks (PreToolUse, PostToolUse, Stop, SessionStart, etc) are loaded once when the Claude CLI process starts. They are NOT reloaded by `cortextos bus self-restart` — soft restart relaunches Claude with `--continue`, which reuses the existing process settings cache. Project-level hooks added or changed in `settings.json` since the original boot DO NOT take effect under soft restart.
+
+**When wiring a new hook to a running agent, use a hard restart, not a soft restart:**
+
+```bash
+# From inside the agent itself, or from another agent/terminal:
+cortextos bus hard-restart --reason "loading new hook"
+
+# Equivalent ops-side path:
+cortextos stop <agent> && cortextos start <agent>
+```
+
+Both kill the existing PID and respawn a fresh process that re-reads `settings.json` from scratch. Verify by adding a one-line debug write to your hook script before testing — if the file shows up after a benign tool call, the hook is loaded.
+
+This bit us hard on the coder-telegram-guardrail wire-up before upstream PR #217 fixed `bus hard-restart` to actually signal the daemon. On any fork that has not pulled in #217 (commit `a38ef7a`), `bus hard-restart` writes markers without killing the PID — fall back to external `stop && start` until the fork is rebased.
 
 ### Restart from Another Agent
 
@@ -360,6 +378,13 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 2. Check PM2 logs: `pm2 logs <agent-process-name>`
 3. Regenerate ecosystem config: `cortextos ecosystem` then `pm2 restart ecosystem.config.js`
 4. If exit code shows throttling, wait 10s then `cortextos enable <agent> --restart`
+
+### New Hook Not Firing After Wiring It Up
+1. Confirm `settings.json` is valid JSON and the hook block is in the right shape (matcher, type=command, etc).
+2. Try a benign tool call that should trigger the hook. If nothing happens, the hook is not loaded.
+3. **Do NOT soft-restart** — `--continue` does not reload project hooks (see Hook Reload Lifecycle in Section 2).
+4. Hard-restart the agent: `cortextos bus hard-restart --reason "load new hook"`. The daemon kills the PID and respawns a fresh process that re-reads `settings.json`.
+5. If the hook still does not fire after a fresh PID, instrument the script with an unconditional write to `/tmp/<agent>-hook-test.log` at the very top of `main()`, run a benign tool, and check whether the file appears. If yes, the hook is firing but the script is returning early. If no, the hook is wired wrong in `settings.json`.
 
 ---
 

--- a/templates/orchestrator/.claude/skills/agent-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/agent-management/SKILL.md
@@ -146,7 +146,25 @@ cortextos bus send-message <agent_name> high "soft-restart" "<reason>"
 cortextos bus hard-restart --reason "context exhaustion"
 ```
 
-**When to use:** Context window full, conversation corrupted, need clean slate.
+**When to use:** Context window full, conversation corrupted, need clean slate, or wiring a new hook (see Hook Reload Lifecycle below). Hard-restart sends an IPC `restart-agent` signal to the daemon, which kills the running PID and respawns it fresh. The respawn consumes the `.force-fresh` marker and skips `--continue`, so `settings.json` (including newly-wired hooks) is re-read from scratch.
+
+### Hook Reload Lifecycle
+
+`.claude/settings.json` hooks (PreToolUse, PostToolUse, Stop, SessionStart, etc) are loaded once when the Claude CLI process starts. They are NOT reloaded by `cortextos bus self-restart` — soft restart relaunches Claude with `--continue`, which reuses the existing process settings cache. Project-level hooks added or changed in `settings.json` since the original boot DO NOT take effect under soft restart.
+
+**When wiring a new hook to a running agent, use a hard restart, not a soft restart:**
+
+```bash
+# From inside the agent itself, or from another agent/terminal:
+cortextos bus hard-restart --reason "loading new hook"
+
+# Equivalent ops-side path:
+cortextos stop <agent> && cortextos start <agent>
+```
+
+Both kill the existing PID and respawn a fresh process that re-reads `settings.json` from scratch. Verify by adding a one-line debug write to your hook script before testing — if the file shows up after a benign tool call, the hook is loaded.
+
+This bit us hard on the coder-telegram-guardrail wire-up before upstream PR #217 fixed `bus hard-restart` to actually signal the daemon. On any fork that has not pulled in #217 (commit `a38ef7a`), `bus hard-restart` writes markers without killing the PID — fall back to external `stop && start` until the fork is rebased.
 
 ### Restart from Another Agent
 
@@ -371,6 +389,13 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 2. Check PM2 logs: `pm2 logs <agent-process-name>`
 3. Regenerate ecosystem config: `cortextos ecosystem` then `pm2 restart ecosystem.config.js`
 4. If exit code shows throttling, wait 10s then `cortextos enable <agent> --restart`
+
+### New Hook Not Firing After Wiring It Up
+1. Confirm `settings.json` is valid JSON and the hook block is in the right shape (matcher, type=command, etc).
+2. Try a benign tool call that should trigger the hook. If nothing happens, the hook is not loaded.
+3. **Do NOT soft-restart** — `--continue` does not reload project hooks (see Hook Reload Lifecycle in Section 2).
+4. Hard-restart the agent: `cortextos bus hard-restart --reason "load new hook"`. The daemon kills the PID and respawns a fresh process that re-reads `settings.json`.
+5. If the hook still does not fire after a fresh PID, instrument the script with an unconditional write to `/tmp/<agent>-hook-test.log` at the very top of `main()`, run a benign tool, and check whether the file appears. If yes, the hook is firing but the script is returning early. If no, the hook is wired wrong in `settings.json`.
 
 ---
 


### PR DESCRIPTION
## Why

Real lesson from wiring the coder Telegram guardrail hook on 2026-05-06: soft restart does not reload `.claude/settings.json` hooks because `--continue` reuses the existing process settings cache. Hard restart kills the PID and the fresh respawn re-reads settings.json from scratch — that is what you want when wiring a new hook.

This is undocumented in the canonical agent-management skill. PR adds it.

## What

Updates the canonical `agent-management` skill in 5 places (community + 3 templates + 1 community agent) with:

1. **New "Hook Reload Lifecycle" subsection** (under Restarting Agents) — explains that soft restart's `--continue` keeps the settings cache, so newly-wired hooks do not load. Points operators at hard restart.

2. **Updated "Hard Restart - When to use"** — adds "wiring a new hook" as a valid trigger and explains the IPC + `.force-fresh` mechanics.

3. **New "New Hook Not Firing After Wiring It Up" troubleshooting entry** — diagnostic recipe with the `/tmp/<agent>-hook-test.log` instrumentation pattern that proved the hook was wired correctly but not loaded.

## Note on the related bug

While debugging, I also tried to ship a fix for `bus hard-restart` not killing the PID from inside the agent's CLI (PR #325). Turns out **upstream main already had that fix in PR #217 (commit `a38ef7a`)** — the loganbronstein fork I was working on was 66 commits behind. Closed #325 as duplicate. The skill text now points operators at upstream PR #217 with a fork-rebase note for any deployment that has not pulled it yet.

## Files touched

All 5 canonical copies of the same skill:
- `community/skills/agent-management/SKILL.md`
- `templates/agent/.claude/skills/agent-management/SKILL.md`
- `templates/analyst/.claude/skills/agent-management/SKILL.md`
- `templates/orchestrator/.claude/skills/agent-management/SKILL.md`
- `community/agents/security/.claude/skills/agent-management/SKILL.md`

Identical content applied to each. (Side note for a future PR: these 5 copies exist because skill distribution is by file copy, not symlink. They drift over time. Worth consolidating, but out of scope here.)

## Closes

- task_1778042740480_306 (this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)