### PR TITLE
fix(dashboard): hoist key onto Fragment in workflows row map

### DIFF
--- a/dashboard/src/app/(dashboard)/workflows/page.tsx
+++ b/dashboard/src/app/(dashboard)/workflows/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, Fragment } from 'react';
 import { useRouter } from 'next/navigation';
 import { useOrg } from '@/hooks/use-org';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -622,9 +622,8 @@ export default function WorkflowsPage() {
                   filteredRows.map(row => {
                     const isSelected = selectedCron?.agent === row.agent && selectedCron?.name === row.cron.name;
                     return (
-                      <>
+                      <Fragment key={`${row.agent}::${row.cron.name}`}>
                         <tr
-                          key={`${row.agent}::${row.cron.name}`}
                           className={`border-b last:border-0 cursor-pointer hover:bg-muted/50 transition-colors group ${isSelected ? 'bg-muted/70' : ''}`}
                           onClick={() => {
                             if (isSelected) {
@@ -732,7 +731,7 @@ export default function WorkflowsPage() {
                             </td>
                           </tr>
                         )}
-                      </>
+                      </Fragment>
                     );
                   })
                 )}


### PR DESCRIPTION
## Summary
- The `WorkflowsPage` row map returned a `<>` fragment with the `key` set on the inner `<tr>`. React reconciles by the outermost returned element, so the Fragment swallowed the key and the dev console warned "Each child in a list should have a unique key prop" pointing at the `<tbody>` (line 606).
- Replace the shorthand with `<Fragment key={...}>` and drop the redundant key from the inner `<tr>`. No behavior change.

## Test plan
- [ ] Open `/workflows` in dev mode, confirm React no longer warns about missing keys.
- [ ] Filter / search / select-row interactions still expand the inline detail row correctly.
- [ ] `npx tsc --noEmit` passes (verified locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)