### PR TITLE
fix(dashboard): suppress hydration warning on <body>

### DIFF
--- a/dashboard/src/app/layout.tsx
+++ b/dashboard/src/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
       className={`${sora.variable} ${jetbrainsMono.variable} h-full antialiased`}
       suppressHydrationWarning
     >
-      <body className="min-h-full flex flex-col">
+      <body className="min-h-full flex flex-col" suppressHydrationWarning>
         <SessionProvider>
           <ThemeProvider attribute="class" defaultTheme="light" enableSystem>
             <TooltipProvider>


### PR DESCRIPTION
## Summary
Browser extensions (Grammarly, LastPass, etc.) inject attributes onto `<body>` before React hydrates. The `<html>` tag already has `suppressHydrationWarning` to handle this. Apply the same to `<body>` so users running these extensions don't see a noisy dev console error.

## Test plan
- [ ] Open dashboard with Grammarly extension active in dev mode — hydration error gone.
- [ ] Other dashboard hydration warnings (if any) still surface, since `suppressHydrationWarning` only affects direct attributes of the tag it's applied to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)