### PR TITLE
chore(atomic-write): fix P1/P2 violations in 6 state-critical write callsites

### DIFF
--- a/src/bus/catalog.ts
+++ b/src/bus/catalog.ts
@@ -5,7 +5,8 @@
  * prepare-submission.sh, submit-community-item.sh.
  */
 
-import { existsSync, readFileSync, writeFileSync, readdirSync, statSync, mkdirSync, cpSync, rmSync, chmodSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, statSync, mkdirSync, cpSync, rmSync, chmodSync } from 'fs';
+import { atomicWriteSync } from '../utils/atomic.js';
 import { join, resolve, relative } from 'path';
 import { execSync, execFileSync } from 'child_process';
 import { ensureDir } from '../utils/atomic.js';
@@ -138,7 +139,7 @@ function readInstalled(ctxRoot: string): Record<string, { version: string; type:
 function writeInstalled(ctxRoot: string, data: Record<string, unknown>): void {
   const p = getInstalledPath(ctxRoot);
   ensureDir(ctxRoot);
-  writeFileSync(p, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  atomicWriteSync(p, JSON.stringify(data, null, 2));
 }
 
 // --- browseCatalog ---
@@ -502,7 +503,7 @@ export function submitCommunityItem(
     submitted_at: timestamp,
   });
 
-  writeFileSync(catalogPath, JSON.stringify(catalog, null, 2) + '\n', 'utf-8');
+  atomicWriteSync(catalogPath, JSON.stringify(catalog, null, 2));
 
   // Clean up staging
   rmSync(stagingDir, { recursive: true, force: true });

--- a/src/bus/cron-state.ts
+++ b/src/bus/cron-state.ts
@@ -15,9 +15,9 @@
  * Storage: state/<agent>/cron-state.json (same dir as pending-reminders.json).
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { ensureDir } from '../utils/atomic.js';
+import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
 
 export interface CronFireRecord {
   name: string;
@@ -73,7 +73,7 @@ export function updateCronFire(
   }
 
   state.updated_at = now;
-  writeFileSync(cronStatePath(stateDir), JSON.stringify(state, null, 2) + '\n', 'utf-8');
+  atomicWriteSync(cronStatePath(stateDir), JSON.stringify(state, null, 2));
 }
 
 /**

--- a/src/bus/reminders.ts
+++ b/src/bus/reminders.ts
@@ -12,10 +12,10 @@
  *   3. Agent processes the reminder, calls `cortextos bus ack-reminder <id>`
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { randomBytes } from 'crypto';
-import { ensureDir } from '../utils/atomic.js';
+import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
 import type { BusPaths } from '../types/index.js';
 
 export interface Reminder {
@@ -45,7 +45,7 @@ function readReminders(paths: BusPaths): Reminder[] {
 
 function writeReminders(paths: BusPaths, reminders: Reminder[]): void {
   ensureDir(paths.stateDir);
-  writeFileSync(remindersPath(paths), JSON.stringify(reminders, null, 2) + '\n', 'utf-8');
+  atomicWriteSync(remindersPath(paths), JSON.stringify(reminders, null, 2));
 }
 
 /**

--- a/src/cli/enable-agent.ts
+++ b/src/cli/enable-agent.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync } from 'fs';
+import { atomicWriteSync } from '../utils/atomic.js';
 import { join } from 'path';
 import { homedir } from 'os';
 import { IPCClient } from '../daemon/ipc-server.js';
@@ -116,7 +117,7 @@ function writeEnabledAgents(instanceId: string, agents: Record<string, any>): vo
   const path = getEnabledAgentsPath(instanceId);
   const dir = join(homedir(), '.cortextos', instanceId, 'config');
   mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(agents, null, 2) + '\n', 'utf-8');
+  atomicWriteSync(path, JSON.stringify(agents, null, 2));
 }
 
 export const enableAgentCommand = new Command('enable')

--- a/src/cli/goals.ts
+++ b/src/cli/goals.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
+import { atomicWriteSync } from '../utils/atomic.js';
 import { join } from 'path';
 
 export const goalsCommand = new Command('goals')
@@ -73,6 +74,6 @@ goalsCommand
       '',
     );
 
-    writeFileSync(goalsMdPath, lines.join('\n'), 'utf-8');
+    atomicWriteSync(goalsMdPath, lines.join('\n'));
     console.log(`Generated GOALS.md for ${options.agent}`);
   });

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,5 +1,6 @@
 import { Command } from 'commander';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync } from 'fs';
+import { atomicWriteSync } from '../utils/atomic.js';
 import { join } from 'path';
 import { homedir, platform } from 'os';
 import { execSync, spawn, spawnSync } from 'child_process';
@@ -163,7 +164,7 @@ export const startCommand = new Command('start')
           ...(existingOrg ? { org: existingOrg } : {}),
         };
         mkdirSync(join(ctxRoot, 'config'), { recursive: true });
-        writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+        atomicWriteSync(enabledPath, JSON.stringify(enabledAgents, null, 2));
         console.log(`  Registered ${agent} in enabled-agents.json`);
       }
 


### PR DESCRIPTION
## Summary

Fixes crash-safety violations in 6 callsites that write critical state files using bare `writeFileSync`. All are converted to `atomicWriteSync` (write → temp file → `rename`), which is already present in `src/utils/atomic.ts`. A rename is atomic on POSIX — readers always see either the old or the new file, never a partial write.

### Why this matters

A `writeFileSync` call that is interrupted mid-write (process killed, OOM, disk full, power loss) leaves a truncated or corrupted JSON file in place. The next process that reads this file either gets a parse error (usually silently swallowed, returning a default value and losing all previous state) or crashes. `atomicWriteSync` eliminates this failure mode entirely.

### Files changed

| File | Severity | Risk of bare writeFileSync |
|---|---|---|
| `src/cli/enable-agent.ts` | P1 | `enabled-agents.json` is read by daemon on every `loadAgents()` — corrupt file means no agents start |
| `src/cli/start.ts` | P1 | Same file, same risk |
| `src/bus/cron-state.ts` | P1 | `cron-state.json` is read on every daemon boot — corrupt file fires every cron immediately |
| `src/bus/reminders.ts` | P1 | `pending-reminders.json` — partial write silently loses all pending reminders |
| `src/bus/catalog.ts` | P1 | `catalog.json` — partial write during skill install corrupts the full catalog index |
| `src/cli/goals.ts` | P2 | `GOALS.md` — partial write injects corrupted markdown into agent context on next restart (borderline P1) |

All changes are drop-in replacements — identical call signature, no behavior change for callers.

## Test plan

- [ ] `npm run build` — TypeScript compiles clean
- [ ] `vitest run` — all tests pass (no behavior change)
- [ ] Verify `atomicWriteSync` is already tested in `tests/unit/utils/atomic.test.ts`

## Traceability

Cherry-picked from RevOps-Global-GIT/cortextos commits:
- `bfa3895` chore(atomic-write): fix P1 violation in cli/enable-agent.ts
- `6b9319c` chore(atomic-write): fix P1 violation in cli/start.ts
- `108e225` chore(atomic-write): fix P1 violation in bus/cron-state.ts
- `bc68c2e` chore(atomic-write): fix P1 violation in bus/reminders.ts
- `0b08a9e` chore(atomic-write): fix P1 violations in bus/catalog.ts (2 callsites)
- `33e091e` chore(atomic-write): fix P2 violation in cli/goals.ts (GOALS.md)

Note: Additional daemon callsites (`agent-process.ts`, `fast-checker.ts`, `daemon/index.ts`) diverged too much from grandamenium HEAD to cherry-pick cleanly. Will submit as a follow-up PR once adapted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)