### PR TITLE
fix(templates): set permissions.defaultMode=bypassPermissions in all agent templates (#198)

### DIFF
--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -7,7 +7,8 @@
       "Write",
       "WebFetch",
       "WebSearch"
-    ]
+    ],
+    "defaultMode": "bypassPermissions"
   },
   "statusLine": {
     "type": "command",

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -7,7 +7,8 @@
       "Write",
       "WebFetch",
       "WebSearch"
-    ]
+    ],
+    "defaultMode": "bypassPermissions"
   },
   "statusLine": {
     "type": "command",

--- a/templates/orchestrator/.claude/settings.json
+++ b/templates/orchestrator/.claude/settings.json
@@ -7,7 +7,8 @@
       "Write",
       "WebFetch",
       "WebSearch"
-    ]
+    ],
+    "defaultMode": "bypassPermissions"
   },
   "statusLine": {
     "type": "command",


### PR DESCRIPTION
## Summary

Adds the documented `permissions.defaultMode` field to all three agent settings templates (`templates/{agent,orchestrator,analyst}/.claude/settings.json`) so newly-spawned agents boot in non-blocking permission mode and don't stall on first tool call.

## What changed

For each template, the existing `permissions` object grows by one field:

```diff
   "permissions": {
     "allow": [
       "Bash",
       "Read",
       "Edit",
       "Write",
       "WebFetch",
       "WebSearch"
-    ]
+    ],
+    "defaultMode": "bypassPermissions"
   },
```

Three identical one-line additions across three files: `+6 / -3`, no logic changes.

## Why the schema-correct form, not the issue body's proposed form

Issue #198 proposed adding `"bypassPermissions": true` as a top-level field — the form `paul` used in the local fix and that the four lifeos production agents (`codex-test`, `goggins`, `skoolio`, `codex-builder`, all at line 86 of their `.claude/settings.json`) currently use.

That form is **no longer schema-valid**. Claude Code's `settings.json` validator returned the following when the top-level form was attempted in this PR's first iteration:

> `Settings validation failed: Unrecognized field: bypassPermissions. Check for typos or refer to the documentation for valid fields`

The full schema dump confirms `permissions.defaultMode` is the documented field, with enum value `"bypassPermissions"` as one of the legitimate modes (alongside `acceptEdits`, `auto`, `default`, `dontAsk`, `plan`). Claude Code's runtime is silently lenient about the top-level legacy form for backwards compatibility, but writes of the legacy form are rejected — so we can't ship it in templates that the harness will edit later.

This PR uses the documented schema-correct form.

### Out of scope: lifeos agent migration

The four production lifeos agents still using the legacy top-level `"bypassPermissions": true` form should be migrated to `permissions.defaultMode: "bypassPermissions"` in a separate PR so it can be coordinated with their respective restart windows. Filing that as a follow-up; it's not part of this template-only patch.

## Verification

Phase 4.5 fully green on `nightly-soak-2026-05-07`-equivalent base (branched off `grandamenium/main` `68055a36`):

| Gate | Result |
|------|--------|
| JSON parse (all 3 templates) | PASS |
| `npx tsc --noEmit` | PASS — no errors |
| `npm run build` (CLI + daemon + hooks) | PASS — `dist/cli.js` 398.40 KB, `dist/daemon.js` 230.09 KB |
| `npm run build` (dashboard) | PASS — Compiled successfully in 5.4s |

Sandbox-executor SKILL test (per Boris's ask for behavioral confirmation) is queued as a separate run on this PR — will append the verdict + tool-call evidence in a follow-up comment before requesting merge.

## Closes

Closes #198.