### PR TITLE
fix(env): enforce CTX_AGENT_DIR subordination to CTX_FRAMEWORK_ROOT (#313)

### DIFF
--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync, writeFileSync } from 'fs';
-import { join, basename } from 'path';
+import { join, basename, resolve as resolvePath, sep } from 'path';
 import { homedir } from 'os';
 import type { CtxEnv } from '../types/index.js';
 import { ensureDir } from './atomic.js';
@@ -81,6 +81,32 @@ export function resolveEnv(overrides?: Partial<CtxEnv>): CtxEnv {
         if (!orchestrator && ctx.orchestrator) orchestrator = ctx.orchestrator;
       }
     } catch { /* ignore */ }
+  }
+
+  // Sandbox/live isolation (issue #313): when both CTX_FRAMEWORK_ROOT and CTX_AGENT_DIR
+  // are set, the resolved agentDir MUST be subordinate to frameworkRoot. Catches the leak
+  // class where a CLI subprocess inherits CTX_AGENT_DIR (or CTX_PROJECT_ROOT) from a live
+  // agent shell while only CTX_FRAMEWORK_ROOT was overridden — agentDir then silently
+  // points at the live install. Equality check on projectRoot vs frameworkRoot catches
+  // the same divergence on the projectRoot axis.
+  if (agentDir && frameworkRoot) {
+    const fwRootResolved = resolvePath(frameworkRoot);
+    const agentDirResolved = resolvePath(agentDir);
+    if (agentDirResolved !== fwRootResolved && !agentDirResolved.startsWith(fwRootResolved + sep)) {
+      throw new Error(
+        `Resolved CTX_AGENT_DIR '${agentDir}' is not under CTX_FRAMEWORK_ROOT '${frameworkRoot}'. ` +
+        `This indicates a sandbox/live environment leak — likely CTX_FRAMEWORK_ROOT was overridden ` +
+        `but CTX_AGENT_DIR or CTX_PROJECT_ROOT was inherited from the parent shell. ` +
+        `Refusing to proceed.`,
+      );
+    }
+  }
+  if (projectRoot && frameworkRoot && resolvePath(projectRoot) !== resolvePath(frameworkRoot)) {
+    throw new Error(
+      `CTX_PROJECT_ROOT '${projectRoot}' must equal CTX_FRAMEWORK_ROOT '${frameworkRoot}'. ` +
+      `A divergence indicates a sandbox/live environment leak — likely one of the two was ` +
+      `inherited from the parent shell while the other was overridden. Refusing to proceed.`,
+    );
   }
 
   // Security (H9): Validate agent name and org before they flow into filesystem paths.

--- a/tests/sprint7-environment.test.ts
+++ b/tests/sprint7-environment.test.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { detectDayNightMode } from '../src/bus/heartbeat.js';
+import { resolveEnv } from '../src/utils/env.js';
 
 describe('Sprint 7: Environment & Config Completeness', () => {
   const testDir = join(tmpdir(), `cortextos-sprint7-${Date.now()}`);
@@ -151,6 +152,80 @@ describe('Sprint 7: Environment & Config Completeness', () => {
       expect(existsSync(ctxRoot)).toBe(true);
       rmSync(ctxRoot, { recursive: true, force: true });
       expect(existsSync(ctxRoot)).toBe(false);
+    });
+  });
+
+  describe('Sandbox/live env subordination (issue #313)', () => {
+    const ctxKeys = [
+      'CTX_FRAMEWORK_ROOT',
+      'CTX_AGENT_DIR',
+      'CTX_PROJECT_ROOT',
+      'CTX_AGENT_NAME',
+      'CTX_ORG',
+      'CTX_INSTANCE_ID',
+      'CTX_ROOT',
+      'CTX_TIMEZONE',
+      'CTX_ORCHESTRATOR',
+    ];
+    const savedEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const k of ctxKeys) {
+        savedEnv[k] = process.env[k];
+        delete process.env[k];
+      }
+    });
+
+    afterEach(() => {
+      for (const k of ctxKeys) {
+        if (savedEnv[k] === undefined) delete process.env[k];
+        else process.env[k] = savedEnv[k];
+      }
+    });
+
+    it('TC-A subordinate: agentDir under frameworkRoot resolves without throwing', () => {
+      const fwRoot = join(testDir, 'sandbox');
+      const agentDir = join(fwRoot, 'orgs', 'test', 'agents', 'foo');
+      expect(() => resolveEnv({
+        frameworkRoot: fwRoot,
+        projectRoot: fwRoot,
+        agentDir,
+        agentName: 'foo',
+      })).not.toThrow();
+    });
+
+    it('TC-B leak: agentDir not under frameworkRoot throws sandbox/live leak error', () => {
+      const fwRoot = join(testDir, 'sandbox');
+      const liveAgentDir = '/Users/cortextos/cortextos/orgs/testorg/agents/cortext-designer';
+      expect(() => resolveEnv({
+        frameworkRoot: fwRoot,
+        agentDir: liveAgentDir,
+        agentName: 'cortext-designer',
+      })).toThrow(/not under CTX_FRAMEWORK_ROOT/);
+    });
+
+    it('TC-C divergence: projectRoot diverging from frameworkRoot throws', () => {
+      const fwRoot = join(testDir, 'sandbox');
+      expect(() => resolveEnv({
+        frameworkRoot: fwRoot,
+        agentDir: join(fwRoot, 'orgs', 'foo', 'agents', 'bar'),
+        projectRoot: '/Users/cortextos/cortextos',
+        agentName: 'bar',
+      })).toThrow(/must equal CTX_FRAMEWORK_ROOT/);
+    });
+
+    it('TC-D back-compat: happy-path frameworkRoot=projectRoot with derived agentDir resolves', () => {
+      const root = join(testDir, 'repo');
+      mkdirSync(root, { recursive: true });
+      const result = resolveEnv({
+        frameworkRoot: root,
+        projectRoot: root,
+        agentName: 'test-agent',
+        org: 'testorg',
+      });
+      expect(result.frameworkRoot).toBe(root);
+      expect(result.projectRoot).toBe(root);
+      expect(result.agentDir).toBe(join(root, 'orgs', 'testorg', 'agents', 'test-agent'));
     });
   });
 });


### PR DESCRIPTION
## Summary

Closes #313 — sandbox/live env-isolation leak class.

Adds two path-divergence canaries inside `resolveEnv()` (the shared env-assembly bottleneck for every CLI subcommand):

1. When both `CTX_FRAMEWORK_ROOT` and `CTX_AGENT_DIR` are set, the resolved `agentDir` must be subordinate to `frameworkRoot`. Otherwise throws.
2. When both `CTX_PROJECT_ROOT` and `CTX_FRAMEWORK_ROOT` are set, they must be equal. Otherwise throws.

Both canaries fail-fast at env-resolution time, before any filesystem write can land in the wrong tree.

## Why this is needed

The PR-242 TC-C precedent surfaced the actual leak vector: a CLI subprocess (`pty-send`, `bus send-message`, etc.) launched from a **live agent shell** inherits `CTX_AGENT_DIR` (and/or `CTX_PROJECT_ROOT`) from the parent. If the runner overrides only `CTX_FRAMEWORK_ROOT` thinking that fully redirects the install, the inherited per-agent vars silently point the resolved `agentDir` back at the live install — and writes (config edits, experiment files, hook outputs) land there instead of the sandbox.

The leak is hard to spot because every individual var is set to a plausible-looking value; only the *combination* is incoherent.

## Why this layer

`resolveEnv()` in `src/utils/env.ts` is the single bottleneck where every CLI subcommand assembles its env context. Catching it here is one diff that protects every code path.

A daemon-side check was considered and rejected: `CTX_AGENT_DIR` and `CTX_PROJECT_ROOT` aren't daemon-boot env vars — they're per-agent CLI subprocess env, set by the daemon at PTY-spawn time and inherited from the parent shell when invoked manually. The daemon never sees the leak; only the resolution layer does.

## Scope

- Narrow, additive: one import change + one new check block in `resolveEnv()`.
- No behavior change for correctly-configured installs (back-compat covered by TC-D).
- Preflight check (warn if any `CTX_*` is set when `--instance-id` flag forces an override) is deferred to a follow-up.

## Test coverage

`tests/sprint7-environment.test.ts` adds a new `Sandbox/live env subordination (issue #313)` describe block with 4 cases:

| TC | Scenario | Expected |
|----|----------|----------|
| TC-A | `agentDir` under `frameworkRoot` | resolves without throwing |
| TC-B | `agentDir` outside `frameworkRoot` (live-leak shape) | throws \`not under CTX_FRAMEWORK_ROOT\` |
| TC-C | `projectRoot` diverges from `frameworkRoot` | throws \`must equal CTX_FRAMEWORK_ROOT\` |
| TC-D | back-compat happy-path with derived `agentDir` | resolves; `agentDir` derives correctly |

## Test plan

- [x] \`npm run typecheck\` — exit 0
- [x] \`npm run lint\` — exit 0
- [x] \`npm run build\` (CLI) — exit 0
- [x] \`cd dashboard && npm run build\` — exit 0
- [x] \`npx vitest run tests/sprint7-environment.test.ts\` — 13/13 PASS (9 existing + 4 new)
- [ ] sandbox-executor self-validation against this PR (Phase 1-5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)