### PR TITLE
docs+skills: Agent Awareness Standard + Phase 0E services health check (orphan commits from soak)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+<!-- 1-3 sentences: what changed and why -->
+
+## Test plan
+<!-- How to verify this change works -->
+
+## Checklist
+
+- [ ] `npm run build` passes
+- [ ] `npm test` passes
+- [ ] No new secrets or credentials committed
+- [ ] **Agent Awareness:** if this adds a command, endpoint, hook, or behavior change — updated the relevant `templates/*/CLAUDE.md` template(s)
+- [ ] **Migration Parity:** if this changes agent-installed files (hooks, settings.json defaults, CLAUDE.md sections) — existing agents will receive the change on next restart, not just new agents via `init`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,20 @@ Once approved, `review_status` will be set to `"approved"` and the item will app
 
 ---
 
+## Agent Awareness Standard
+
+cortextOS agents discover features through their CLAUDE.md template. A feature that exists in code but isn't mentioned in the agent template is invisible — no agent will ever use it.
+
+**Before merging any feature PR**, verify:
+
+- [ ] **Does this feature add a new bus command, CLI command, or API endpoint?** If yes, add it to `templates/agent/CLAUDE.md` (and `templates/orchestrator/CLAUDE.md`, `templates/analyst/CLAUDE.md`, `templates/security/CLAUDE.md` if applicable) with a usage example.
+- [ ] **Does this feature change agent behavior or add a new hook?** If yes, update the relevant template's session-start or workflow section.
+- [ ] **Does this feature add or modify a skill?** If yes, ensure the skill's `SKILL.md` has a current `description` and `triggers` list so agents know when to load it.
+
+A feature without a template update ships dark. If you're unsure whether a template update is needed, it is.
+
+---
+
 ## Questions
 
 Open a GitHub issue or message the cortextOS community channel.

--- a/community/skills/morning-review/SKILL.md
+++ b/community/skills/morning-review/SKILL.md
@@ -89,6 +89,57 @@ cortextos bus complete-task "$TASK_ID" --result "<what was produced>"
 
 ---
 
+## Phase 0E: Services Health Check
+
+Probe each configured external service BEFORE the briefing. Auth failures discovered here get into the briefing as actionable items — not discovered 3 hours later when the user needs the service.
+
+**For each service, run the probe. If it fails, create a [HUMAN] task immediately.**
+
+### Google Calendar
+```bash
+# Try listing 1 event via MCP. If the tool errors or returns auth failure:
+gcal_list_events (limit 1)
+```
+- **OK**: note "GCal OK" for the briefing
+- **FAIL**: create a human task and flag it:
+  ```bash
+  cortextos bus create-task "[HUMAN] Google Calendar reauth needed — OAuth token expired or revoked" \
+    --desc "GCal probe failed during morning review. Reauth at https://accounts.google.com. Agents cannot create/read calendar events until fixed." \
+    --priority high --assignee human
+  ```
+
+### Notion
+```bash
+# Try a trivial search via MCP
+notion-search (query: "test", page_size: 1)
+```
+- **OK**: note "Notion OK"
+- **FAIL**: create human task with reauth instructions
+
+### Knowledge Base
+```bash
+cortextos bus kb-query "health check" --org $CTX_ORG
+```
+- **OK or empty results**: note "KB configured"
+- **Not configured warning**: note "KB not configured" (informational, not a failure)
+
+### Telegram
+Already implicitly validated by the boot message in Phase 0. If the boot message failed to send, the agent would not have reached this phase.
+
+### Briefing integration
+Include a **Services** line in Message 1 of the briefing:
+```
+Services: GCal OK | Notion OK | KB configured
+```
+Or if any failed:
+```
+Services: GCal FAILED (reauth needed — task created) | Notion OK | KB not configured
+```
+
+Auth failures are the "silent productivity killer" class — everything looks healthy on the dashboard but the agent can't do real work. This check surfaces them proactively.
+
+---
+
 ## Phase 1: Goals Cascade (MANDATORY — before task scheduling)
 
 ### 1A: Read org goals

--- a/templates/orchestrator/.claude/skills/morning-review/SKILL.md
+++ b/templates/orchestrator/.claude/skills/morning-review/SKILL.md
@@ -88,6 +88,55 @@ cortextos bus complete-task "$TASK_ID" --result "<what was produced>"
 
 ---
 
+## Phase 0E: Services Health Check
+
+Probe each configured external service BEFORE the briefing. Auth failures discovered here get into the briefing as actionable items — not discovered hours later when the user needs the service.
+
+**For each service, run the probe. If it fails, create a [HUMAN] task immediately.**
+
+### Google Calendar
+```bash
+# Try listing 1 event via MCP. If the tool errors or returns auth failure:
+gcal_list_events (limit 1)
+```
+- **OK**: note "GCal OK" for the briefing
+- **FAIL**: create a human task:
+  ```bash
+  cortextos bus create-task "[HUMAN] Google Calendar reauth needed — OAuth token expired or revoked" \
+    --desc "GCal probe failed during morning review. Reauth at https://accounts.google.com. Agents cannot create/read calendar events until fixed." \
+    --priority high --assignee human
+  ```
+
+### Notion
+```bash
+# Try a trivial search via MCP
+notion-search (query: "test", page_size: 1)
+```
+- **OK**: note "Notion OK"
+- **FAIL**: create human task with reauth instructions
+
+### Knowledge Base
+```bash
+cortextos bus kb-query "health check" --org $CTX_ORG
+```
+- **OK or empty results**: note "KB configured"
+- **Not configured warning**: note "KB not configured" (informational, not a failure)
+
+### Telegram
+Already implicitly validated by the boot message. If it failed, the agent would not have reached this phase.
+
+### Briefing integration
+Include a **Services** line in Message 1:
+```
+Services: GCal OK | Notion OK | KB configured
+```
+Or if any failed:
+```
+Services: GCal FAILED (reauth needed — task created) | Notion OK | KB not configured
+```
+
+---
+
 ## Phase 1: Goals Cascade (MANDATORY — before task scheduling)
 
 ### 1A: Read org goals


### PR DESCRIPTION
## Summary

Two docs/skills commits that were validated as part of `nightly-soak-2026-05-07` but did not have their own PRs (committed directly to soak by Bob/ClintMoody on Apr 17). Opening this PR so they get the same review-and-merge surface as the other 9 walkthrough PRs.

Both commits passed the per-PR walkthrough with @grandamenium on 2026-05-08 and were marked MERGE.

## Commits

1. `feat(skills): services health check in morning review (Phase 0E)` — adds a Phase 0E services-health-check step to the morning-review skill. Probes GCal/Notion/KB/Telegram before assembling the briefing; on auth failure creates a `[HUMAN]` reauth task and adds a `Services:` line to Message 1. Pure markdown — touches `community/skills/morning-review/SKILL.md` + `templates/orchestrator/.claude/skills/morning-review/SKILL.md` only. 100 insertions / 0 deletions.

2. `docs: Agent Awareness Standard + PR template` — adds CONTRIBUTING.md "Agent Awareness Standard" section (template-update reminder for feature PRs) + new `.github/PULL_REQUEST_TEMPLATE.md` with checklist items for build/test/no-secrets + Agent Awareness + Migration Parity. 27 insertions / 0 deletions across 2 files. GitHub will auto-populate this template on subsequent PR descriptions.

## Test plan

- [x] `npx tsc --noEmit` PASS (no TS impact — markdown only)
- [x] Both files render correctly in GitHub markdown preview
- [x] No runtime/daemon/dashboard/bus/CLI changes; no skill executable changes

## Soak evidence

Both commits were on `nightly-soak-2026-05-07` for 24h+ alongside the 9 other walkthrough PRs (3ca687ec → 6a592df6 window). No regressions observed in the soak window.

## Author attribution

Both commits authored by Bob (ClintMoody@users.noreply.github.com). Cherry-picked onto this branch with `--no-edit` to preserve original Author field. I am the merger, not the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)