### PR TITLE
feat(pty): CodexPTY adapter runtime

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -3,7 +3,7 @@ import { join, sep } from 'path';
 import { homedir } from 'os';
 import type { AgentConfig, AgentStatus, CtxEnv } from '../types/index.js';
 import { AgentPTY } from '../pty/agent-pty.js';
-import { CodexPTY } from '../pty/codex-pty.js';
+import { CodexPTY, codexSessionExists } from '../pty/codex-pty.js';
 import { HermesPTY, hermesDbExists } from '../pty/hermes-pty.js';
 import { MessageDedup, injectMessage } from '../pty/inject.js';
 import type { TelegramAPI } from '../telegram/api.js';
@@ -472,6 +472,10 @@ export class AgentProcess {
     // Check for existing conversation
     const launchDir = this.config.working_directory || this.env.agentDir;
     if (!launchDir) return false;
+
+    if (this.config.runtime === 'codex') {
+      return codexSessionExists(launchDir);
+    }
 
     // Claude projects dir uses the absolute path with all separators replaced by dashes
     // e.g. /Users/foo/agents/boss -> -Users-foo-agents-boss (leading sep becomes -)

--- a/src/pty/codex-pty.ts
+++ b/src/pty/codex-pty.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
-import { existsSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { homedir } from 'os';
+import { execFileSync } from 'child_process';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { AgentPTY } from './agent-pty.js';
 import { OutputBuffer } from './output-buffer.js';
@@ -34,14 +35,14 @@ type SpawnFn = (file: string, args: string[], options: IPtySpawnOptions) => IPty
  * AgentPTY interface expected by agent-process.ts and fast-checker.ts.
  *
  * Key design decisions:
- * - _alive stays true until explicit kill() — daemon never sees "crashed" between turns
+ * - alive stays true until explicit kill() — daemon never sees "crashed" between turns
  * - write() accumulates bracketed-paste input until Enter, then queues an exec
  * - drainQueue() serializes: one exec process at a time, no concurrent spawns
  * - --json flag gives structured JSONL output: bootstrap on thread.started, idle on turn.completed
  * - last_idle.flag written on turn.completed (not process exit) for fast-checker typing indicator
  */
-export class CodexPTY {
-  private _alive = false;          // true after first spawn, false only after kill()
+export class CodexPTY extends AgentPTY {
+  private alive = false;           // true after first spawn, false only after kill()
   private _executing = false;      // true while a codex exec process is running
   private _writeBuffer = '';       // accumulates write() calls between Enter signals
   private _execQueue: string[] = []; // pending messages awaiting exec
@@ -62,6 +63,7 @@ export class CodexPTY {
   private _typingLastSent = 0;
 
   constructor(env: CtxEnv, config: AgentConfig, logPath?: string) {
+    super(env, config, logPath, '"type":"thread.started"');
     this._env = env;
     this._config = config;
     this._cwd = config.working_directory || env.agentDir || process.cwd();
@@ -77,7 +79,7 @@ export class CodexPTY {
    * mode='fresh': new session; mode='continue': resume prior session for this cwd.
    */
   async spawn(mode: 'fresh' | 'continue', prompt: string): Promise<void> {
-    if (this._alive) {
+    if (this.alive) {
       throw new Error('CodexPTY already spawned. Kill first.');
     }
 
@@ -86,13 +88,18 @@ export class CodexPTY {
       this._spawnFn = nodePty.spawn;
     }
 
-    this._alive = true;
+    this.alive = true;
 
     const args = mode === 'continue' && this.hasExistingSession()
       ? this.buildResumeArgs(prompt)
       : this.buildFreshArgs(prompt);
 
-    await this.runExec(args);
+    try {
+      await this.runExec(args);
+    } catch (err) {
+      this.alive = false;
+      throw err;
+    }
   }
 
   /**
@@ -101,7 +108,7 @@ export class CodexPTY {
    * Bracketed paste markers (ESC[200~ / ESC[201~) are stripped.
    */
   write(data: string): void {
-    if (!this._alive) return;
+    if (!this.alive) return;
 
     if (data === '\r') {
       // Enter received — flush accumulated buffer as a new exec turn
@@ -120,10 +127,10 @@ export class CodexPTY {
 
   /**
    * Kill the current exec process and stop the queue.
-   * Sets _alive=false so the daemon knows the session is terminated.
+   * Sets alive=false so the daemon knows the session is terminated.
    */
   kill(): void {
-    this._alive = false;
+    this.alive = false;
     this._execQueue = [];
     if (this._currentPty) {
       try {
@@ -140,7 +147,7 @@ export class CodexPTY {
    * Stays true between exec turns — the daemon uses this for crash detection.
    */
   isAlive(): boolean {
-    return this._alive;
+    return this.alive;
   }
 
   /**
@@ -193,7 +200,7 @@ export class CodexPTY {
    * Writes last_idle.flag after each turn.completed JSONL event.
    */
   private async drainQueue(): Promise<void> {
-    while (this._alive && this._execQueue.length > 0) {
+    while (this.alive && this._execQueue.length > 0) {
       const msg = this._execQueue.shift()!;
       this._executing = true;
       try {
@@ -246,6 +253,10 @@ export class CodexPTY {
         }
         // Write idle flag on process exit as fallback (catches turn.completed race)
         this.writeIdleFlag();
+        if (exitCode && exitCode !== 0 && this.alive) {
+          reject(new Error(`codex exec exited with code ${exitCode}`));
+          return;
+        }
         resolve();
       });
     });
@@ -258,6 +269,7 @@ export class CodexPTY {
    */
   private writeIdleFlag(): void {
     try {
+      mkdirSync(this._stateDir, { recursive: true });
       const flagPath = join(this._stateDir, 'last_idle.flag');
       writeFileSync(flagPath, Math.floor(Date.now() / 1000).toString(), 'utf-8');
     } catch { /* non-fatal */ }
@@ -303,14 +315,18 @@ export class CodexPTY {
    * --enable <feature>: codex feature flags defaulted on for cortextOS agents
    */
   private buildFreshArgs(prompt: string): string[] {
-    return [
+    const args = [
       'exec',
       '--skip-git-repo-check',
       '--sandbox', 'workspace-write',
       '--json',
       ...this.featureFlagArgs(),
-      prompt,
     ];
+    if (this._config.model) {
+      args.push('--model', this._config.model);
+    }
+    args.push(prompt);
+    return args;
   }
 
   /**
@@ -320,7 +336,7 @@ export class CodexPTY {
    * --enable <feature>: codex feature flags defaulted on for cortextOS agents
    */
   private buildResumeArgs(prompt: string): string[] {
-    return [
+    const args = [
       'exec',
       'resume',
       '--last',
@@ -328,8 +344,12 @@ export class CodexPTY {
       '--dangerously-bypass-approvals-and-sandbox',
       '--json',
       ...this.featureFlagArgs(),
-      prompt,
     ];
+    if (this._config.model) {
+      args.push('--model', this._config.model);
+    }
+    args.push(prompt);
+    return args;
   }
 
   /**
@@ -337,17 +357,7 @@ export class CodexPTY {
    * Queries state_5.sqlite threads table (cwd-filtered, non-archived).
    */
   private hasExistingSession(): boolean {
-    const dbPath = join(homedir(), '.codex', 'state_5.sqlite');
-    if (!existsSync(dbPath)) return false;
-    try {
-      // Use synchronous sqlite3 via child_process to avoid adding a dependency
-      const { execFileSync } = require('child_process');
-      const query = `SELECT id FROM threads WHERE cwd = '${this._cwd.replace(/'/g, "''")}' AND archived = 0 ORDER BY updated_at DESC LIMIT 1;`;
-      const result = execFileSync('sqlite3', [dbPath, query], { encoding: 'utf-8', timeout: 3000 }).trim();
-      return result.length > 0;
-    } catch {
-      return false;
-    }
+    return codexSessionExists(this._cwd);
   }
 
   /**
@@ -358,7 +368,10 @@ export class CodexPTY {
     const env: Record<string, string> = {};
 
     // Base environment
-    const keepVars = ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL', 'TMPDIR'];
+    const keepVars = [
+      'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
+      'TMPDIR', 'TEMP', 'TMP', 'OPENAI_API_KEY', 'CODEX_HOME',
+    ];
     for (const key of keepVars) {
       if (process.env[key]) env[key] = process.env[key]!;
     }
@@ -403,5 +416,22 @@ export class CodexPTY {
         }
       }
     } catch { /* ignore */ }
+  }
+}
+
+/**
+ * Check whether Codex has a non-archived session for this launch directory.
+ * Used by AgentProcess.shouldContinue() to select `codex exec resume --last`.
+ */
+export function codexSessionExists(cwd: string, codexHome?: string): boolean {
+  const dbPath = join(codexHome || join(homedir(), '.codex'), 'state_5.sqlite');
+  if (!existsSync(dbPath)) return false;
+  try {
+    // Use the sqlite3 CLI to avoid introducing a runtime dependency.
+    const query = `SELECT id FROM threads WHERE cwd = '${cwd.replace(/'/g, "''")}' AND archived = 0 ORDER BY updated_at DESC LIMIT 1;`;
+    const result = execFileSync('sqlite3', [dbPath, query], { encoding: 'utf-8', timeout: 3000 }).trim();
+    return result.length > 0;
+  } catch {
+    return false;
   }
 }

--- a/tests/unit/daemon/agent-process-codex.test.ts
+++ b/tests/unit/daemon/agent-process-codex.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+let capturedOnExit: ((exitCode: number, signal?: number) => void) | null = null;
+
+const mockPty = {
+  spawn: vi.fn().mockResolvedValue(undefined),
+  kill: vi.fn().mockImplementation(() => capturedOnExit?.(0, undefined)),
+  write: vi.fn(),
+  getPid: vi.fn().mockReturnValue(null),
+  isAlive: vi.fn().mockReturnValue(true),
+  onExit: vi.fn().mockImplementation((cb: (exitCode: number, signal?: number) => void) => {
+    capturedOnExit = cb;
+  }),
+  getOutputBuffer: vi.fn().mockReturnValue({ isBootstrapped: vi.fn().mockReturnValue(true) }),
+};
+
+vi.mock('../../../src/pty/agent-pty.js', () => ({
+  AgentPTY: function AgentPTY() { return mockPty; },
+}));
+
+const mockCodexSessionExists = vi.fn().mockReturnValue(false);
+vi.mock('../../../src/pty/codex-pty.js', () => ({
+  CodexPTY: function CodexPTY() { return mockPty; },
+  codexSessionExists: (...args: unknown[]) => mockCodexSessionExists(...args),
+}));
+
+vi.mock('../../../src/pty/hermes-pty.js', () => ({
+  HermesPTY: function HermesPTY() { return mockPty; },
+  hermesDbExists: vi.fn().mockReturnValue(false),
+}));
+
+const mockInjectMessage = vi.fn();
+vi.mock('../../../src/pty/inject.js', () => ({
+  injectMessage: mockInjectMessage,
+  MessageDedup: class { isDuplicate() { return false; } },
+}));
+
+vi.mock('../../../src/utils/atomic.js', () => ({
+  ensureDir: vi.fn(),
+  atomicWriteSync: vi.fn(),
+}));
+
+vi.mock('../../../src/utils/env.js', () => ({
+  writeCortextosEnv: vi.fn(),
+  resolveEnv: vi.fn().mockReturnValue({ instanceId: 'test', ctxRoot: '/tmp/test' }),
+}));
+
+vi.mock('../../../src/bus/reminders.js', () => ({
+  getOverdueReminders: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock('../../../src/utils/paths.js', () => ({
+  resolvePaths: vi.fn().mockReturnValue({}),
+}));
+
+const fsMocks = {
+  existsSync: vi.fn().mockReturnValue(false),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  appendFileSync: vi.fn(),
+  statSync: vi.fn(),
+};
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    mkdirSync: vi.fn(),
+    get existsSync() { return fsMocks.existsSync; },
+    get readFileSync() { return fsMocks.readFileSync; },
+    get writeFileSync() { return fsMocks.writeFileSync; },
+    get appendFileSync() { return fsMocks.appendFileSync; },
+    get statSync() { return fsMocks.statSync; },
+  };
+});
+
+const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+
+const mockEnv = {
+  instanceId: 'test',
+  ctxRoot: '/tmp/test-ctx',
+  frameworkRoot: '/tmp/fw',
+  agentName: 'codex-agent',
+  agentDir: '/tmp/fw/orgs/acme/agents/codex-agent',
+  org: 'acme',
+  projectRoot: '/tmp/fw',
+};
+
+beforeEach(() => {
+  capturedOnExit = null;
+  mockCodexSessionExists.mockReset().mockReturnValue(false);
+  mockPty.spawn.mockClear();
+  mockPty.kill.mockClear();
+  mockPty.write.mockClear();
+  mockPty.isAlive.mockReset().mockReturnValue(true);
+  mockPty.onExit.mockClear();
+  mockInjectMessage.mockClear();
+  fsMocks.existsSync.mockReset().mockReturnValue(false);
+  fsMocks.readFileSync.mockReset();
+  fsMocks.writeFileSync.mockReset();
+  fsMocks.appendFileSync.mockReset();
+  fsMocks.statSync.mockReset();
+});
+
+describe('AgentProcess - Codex runtime', () => {
+  it('spawns in fresh mode when no Codex cwd session exists', async () => {
+    mockCodexSessionExists.mockReturnValue(false);
+    const ap = new AgentProcess('codex-agent', mockEnv, { runtime: 'codex' });
+
+    await ap.start();
+
+    expect(mockCodexSessionExists).toHaveBeenCalledWith(mockEnv.agentDir);
+    expect(mockPty.spawn).toHaveBeenCalledWith('fresh', expect.any(String));
+  });
+
+  it('spawns in continue mode when a Codex cwd session exists', async () => {
+    mockCodexSessionExists.mockReturnValue(true);
+    const ap = new AgentProcess('codex-agent', mockEnv, { runtime: 'codex' });
+
+    await ap.start();
+
+    expect(mockPty.spawn).toHaveBeenCalledWith('continue', expect.any(String));
+  });
+
+  it('stops Codex without sending Claude REPL commands', async () => {
+    const ap = new AgentProcess('codex-agent', mockEnv, { runtime: 'codex' });
+    await ap.start();
+
+    await ap.stop();
+
+    expect(mockPty.write).not.toHaveBeenCalledWith('\x03');
+    expect(mockPty.write).not.toHaveBeenCalledWith('/exit\r\n');
+    expect(mockPty.kill).toHaveBeenCalled();
+  });
+});

--- a/tests/unit/pty/codex-pty.test.ts
+++ b/tests/unit/pty/codex-pty.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { join } from 'path';
+import { homedir } from 'os';
 
 const fsMocks = {
   existsSync: vi.fn().mockReturnValue(false),
+  mkdirSync: vi.fn(),
   writeFileSync: vi.fn(),
 };
 
@@ -10,9 +13,15 @@ vi.mock('fs', async () => {
   return {
     ...actual,
     get existsSync() { return fsMocks.existsSync; },
+    get mkdirSync() { return fsMocks.mkdirSync; },
     get writeFileSync() { return fsMocks.writeFileSync; },
   };
 });
+
+const execFileSync = vi.fn();
+vi.mock('child_process', () => ({
+  execFileSync,
+}));
 
 // Stub node-pty so CodexPTY can be imported without a native addon
 vi.mock('node-pty', () => ({
@@ -25,7 +34,7 @@ vi.mock('node-pty', () => ({
   }),
 }));
 
-const { CodexPTY } = await import('../../../src/pty/codex-pty.js');
+const { CodexPTY, codexSessionExists } = await import('../../../src/pty/codex-pty.js');
 
 const mockEnv = {
   instanceId: 'test',
@@ -39,7 +48,41 @@ const mockEnv = {
 
 beforeEach(() => {
   fsMocks.existsSync.mockReset().mockReturnValue(false);
+  fsMocks.mkdirSync.mockReset();
   fsMocks.writeFileSync.mockReset();
+  execFileSync.mockReset();
+});
+
+describe('codexSessionExists', () => {
+  it('returns false when Codex state DB is absent', () => {
+    fsMocks.existsSync.mockReturnValue(false);
+    expect(codexSessionExists('/tmp/work')).toBe(false);
+  });
+
+  it('queries state_5.sqlite for a non-archived cwd session', () => {
+    const expectedPath = join(homedir(), '.codex', 'state_5.sqlite');
+    fsMocks.existsSync.mockReturnValue(true);
+    execFileSync.mockReturnValue('thread-id\n');
+
+    expect(codexSessionExists("/tmp/paul's-work")).toBe(true);
+    expect(execFileSync).toHaveBeenCalledWith(
+      'sqlite3',
+      [
+        expectedPath,
+        "SELECT id FROM threads WHERE cwd = '/tmp/paul''s-work' AND archived = 0 ORDER BY updated_at DESC LIMIT 1;",
+      ],
+      { encoding: 'utf-8', timeout: 3000 },
+    );
+  });
+
+  it('returns false when sqlite lookup fails', () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    execFileSync.mockImplementation(() => {
+      throw new Error('sqlite3 missing');
+    });
+
+    expect(codexSessionExists('/tmp/work')).toBe(false);
+  });
 });
 
 describe('CodexPTY typing-indicator wiring (issue #330)', () => {
@@ -117,5 +160,38 @@ describe('CodexPTY bootstrap pattern', () => {
     const pty = new CodexPTY(mockEnv, {});
     pty.getOutputBuffer().push('loading codex...\n');
     expect(pty.getOutputBuffer().isBootstrapped()).toBe(false);
+  });
+
+  it('builds fresh exec args with features, model, and prompt', () => {
+    const pty = new CodexPTY(mockEnv, { model: 'gpt-5-codex' });
+    const args = (pty as unknown as { buildFreshArgs(prompt: string): string[] })
+      .buildFreshArgs('hello');
+
+    expect(args).toEqual([
+      'exec',
+      '--skip-git-repo-check',
+      '--sandbox', 'workspace-write',
+      '--json',
+      '--enable', 'goals',
+      '--model', 'gpt-5-codex',
+      'hello',
+    ]);
+  });
+
+  it('builds resume exec args with --last and noninteractive bypass', () => {
+    const pty = new CodexPTY(mockEnv, {});
+    const args = (pty as unknown as { buildResumeArgs(prompt: string): string[] })
+      .buildResumeArgs('next');
+
+    expect(args).toEqual([
+      'exec',
+      'resume',
+      '--last',
+      '--skip-git-repo-check',
+      '--dangerously-bypass-approvals-and-sandbox',
+      '--json',
+      '--enable', 'goals',
+      'next',
+    ]);
   });
 });


### PR DESCRIPTION
## Summary
- harden CodexPTY as an AgentPTY subclass around turn-based codex exec
- wire Codex session detection into daemon continue mode and skip Claude REPL shutdown for codex runtime
- add focused unit tests for CodexPTY args/session probing and AgentProcess codex runtime behavior

## Verification
- npm run typecheck
- npm run build
- npm test