### PR TITLE
fix(hooks): bus fan-out reachable without Telegram creds (closes #317)

### DIFF
--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -251,6 +251,27 @@ async function main(): Promise<void> {
     return;
   }
 
+  // Real-crash agent alerts: notify chief + analyst on crash and daemon-crashed
+  // so silent failures get visibility on the bus, not just on Telegram. Gated
+  // by the same dedup window as the Telegram send (handled above), and skipped
+  // for clean exits / planned restarts / rate-limit pauses. Hoisted above the
+  // Telegram-credential gate so agents without BOT_TOKEN/CHAT_ID still reach
+  // the bus (issue #317).
+  if (endType === 'crash' || endType === 'daemon-crashed') {
+    const agentDir = process.env.CTX_AGENT_DIR || process.cwd();
+    const maxCrashes = readMaxCrashesPerDay(agentDir);
+    const restartAttempted = maxCrashes === null || crashCount < maxCrashes;
+    notifyAgents({
+      agentName,
+      endType,
+      reason,
+      lastTask,
+      crashCount,
+      restartAttempted,
+      recipients: ['chief', 'analyst'],
+    });
+  }
+
   const botToken = process.env.BOT_TOKEN;
   const chatId = process.env.CHAT_ID;
   if (!botToken || !chatId) return;
@@ -309,25 +330,6 @@ async function main(): Promise<void> {
         body: JSON.stringify({ chat_id: chatId, text: message }),
       });
     } catch { /* ignore send failures */ }
-  }
-
-  // Real-crash agent alerts: notify chief + analyst on crash and daemon-crashed
-  // so silent failures get visibility on the bus, not just on Telegram. Gated
-  // by the same dedup window as the Telegram send (handled above), and skipped
-  // for clean exits / planned restarts / rate-limit pauses.
-  if (endType === 'crash' || endType === 'daemon-crashed') {
-    const agentDir = process.env.CTX_AGENT_DIR || process.cwd();
-    const maxCrashes = readMaxCrashesPerDay(agentDir);
-    const restartAttempted = maxCrashes === null || crashCount < maxCrashes;
-    notifyAgents({
-      agentName,
-      endType,
-      reason,
-      lastTask,
-      crashCount,
-      restartAttempted,
-      recipients: ['chief', 'analyst'],
-    });
   }
 }
 


### PR DESCRIPTION
## Summary

Issue #317: PR #298 added a chief+analyst bus fan-out on \`crash\` / \`daemon-crashed\` so silent failures hit the bus, not just Telegram. The new block was placed *after* the \`BOT_TOKEN\`/\`CHAT_ID\` early-return — making the fan-out unreachable for the exact agents it was meant to cover (hermes-runtime, pre-onboarding, intentionally Telegram-disabled).

## Fix

One-block hoist: move the \`if (endType === 'crash' || endType === 'daemon-crashed')\` block above \`if (!botToken || !chatId) return;\` in \`src/hooks/hook-crash-alert.ts\`.

- Quiet-hours suppression and \`shouldSuppressDedup\` still run before the fan-out, so dedup behaviour is preserved.
- For Telegram-equipped agents nothing changes — same fan-out, same Telegram message.
- For Telegram-less agents, fan-out now fires (was a no-op before).

## Verification

- \`npm run typecheck\` — clean.
- \`npx vitest run tests/unit/hooks/hook-crash-alert.test.ts\` — 12/12 PASS, no regressions.

The empirical reproduction in the issue body (0-vs-2 messages depending on \`BOT_TOKEN\`) is exactly what this re-order corrects.

## Test plan

- [ ] Sandbox: trigger \`crash\` end type with no \`BOT_TOKEN\` / \`CHAT_ID\` → confirm chief + analyst inboxes receive priority-1 message.
- [ ] Sandbox: trigger \`crash\` end type with valid Telegram creds → confirm both Telegram message and bus fan-out fire (no double-send).
- [ ] Sandbox: trigger \`crash\` during quiet hours → confirm dedup/quiet-hours suppression still skips both branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)