### PR TITLE
fix(daemon): thread --model through spawn-worker to AgentPTY (closes #283)

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -742,7 +742,7 @@ export class AgentManager {
       }, 30_000); // keep for 30s after exit
     });
 
-    await worker.spawn({ ...env, ...(model ? {} : {}) }, prompt);
+    await worker.spawn(env, prompt, config);
   }
 
   /**

--- a/src/daemon/worker-process.ts
+++ b/src/daemon/worker-process.ts
@@ -43,7 +43,7 @@ export class WorkerProcess {
   /**
    * Spawn the worker Claude Code session with the given task prompt.
    */
-  async spawn(env: CtxEnv, prompt: string): Promise<void> {
+  async spawn(env: CtxEnv, prompt: string, config: { model?: string } = {}): Promise<void> {
     // Ensure bus dirs exist so the worker can use cortextos bus commands
     try {
       mkdirSync(join(env.ctxRoot, 'inbox', this.name), { recursive: true });
@@ -52,7 +52,7 @@ export class WorkerProcess {
     } catch { /* ignore */ }
 
     const logPath = join(env.ctxRoot, 'logs', this.name, 'stdout.log');
-    this.pty = new AgentPTY(env, {}, logPath);
+    this.pty = new AgentPTY(env, config, logPath);
 
     this.pty.onExit((code) => {
       this.exitCode = code;

--- a/tests/unit/daemon/worker-process.test.ts
+++ b/tests/unit/daemon/worker-process.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // Capture PTY exit handler so tests can simulate worker exit
 let capturedOnExit: ((code: number) => void) | null = null;
+let capturedPtyConfig: unknown = null;
 const mockPty = {
   spawn: vi.fn().mockResolvedValue(undefined),
   kill: vi.fn(),
@@ -13,7 +14,10 @@ const mockPty = {
 };
 
 vi.mock('../../../src/pty/agent-pty.js', () => ({
-  AgentPTY: function AgentPTY() { return mockPty; },
+  AgentPTY: function AgentPTY(_env: unknown, config: unknown) {
+    capturedPtyConfig = config;
+    return mockPty;
+  },
 }));
 
 const mockInjectMessage = vi.fn();
@@ -40,6 +44,7 @@ const mockEnv = {
 
 beforeEach(() => {
   capturedOnExit = null;
+  capturedPtyConfig = null;
   mockPty.spawn.mockClear();
   mockPty.kill.mockClear();
   mockPty.write.mockClear();
@@ -141,6 +146,20 @@ describe('WorkerProcess', () => {
       capturedOnExit!(1);
       expect(w.getStatus().status).toBe('failed');
       expect(w.getStatus().exitCode).toBe(1);
+    });
+  });
+
+  describe('model config (#283)', () => {
+    it('passes empty config to AgentPTY when no model arg is supplied', async () => {
+      const w = new WorkerProcess('w-model-default', '/tmp/proj', undefined);
+      await w.spawn(mockEnv, 'task');
+      expect(capturedPtyConfig).toEqual({});
+    });
+
+    it('threads model into AgentPTY config when supplied', async () => {
+      const w = new WorkerProcess('w-model-explicit', '/tmp/proj', undefined);
+      await w.spawn(mockEnv, 'task', { model: 'claude-opus-4-7' });
+      expect(capturedPtyConfig).toEqual({ model: 'claude-opus-4-7' });
     });
   });
 


### PR DESCRIPTION
## Summary

Issue #283: \`spawn-worker --model\` was silently dropped before the model reached the Claude Code argv. Workers fell back to whatever \`~/.claude/settings.json\` had, which has drifted to invalid values in the wild (\`opus[1m]\` ANSI leak), wedging the session at the model-selection screen while \`list-workers\` still reported \`running (pid …)\`.

## Fix

Two-line wiring fix:

\`src/daemon/worker-process.ts\`
- \`spawn(env, prompt)\` → \`spawn(env, prompt, config = {})\`
- \`new AgentPTY(env, {}, ...)\` → \`new AgentPTY(env, config, ...)\`

\`src/daemon/agent-manager.ts\`
- \`worker.spawn({ ...env, ...(model ? {} : {}) }, prompt)\` → \`worker.spawn(env, prompt, config)\`
  (the existing \`const config = model ? { model } : {}\` line is now actually used)

\`AgentPTY.buildClaudeArgs\` already appends \`--model\` when \`config.model\` is set, so no PTY-layer change is needed.

## Tests

Added two unit tests in \`tests/unit/daemon/worker-process.test.ts\` to lock the contract:

- \`spawn(env, prompt)\` → AgentPTY config is \`{}\`
- \`spawn(env, prompt, { model: 'claude-opus-4-7' })\` → AgentPTY config is \`{ model: 'claude-opus-4-7' }\`

Mock now captures the AgentPTY constructor's config arg.

\`npx vitest run tests/unit/daemon/\` — 302/302 PASS, including the 2 new tests (16/16 in worker-process suite).
\`npm run typecheck\` — clean.

## Out of scope

Bug 2 in the issue (fallback to parent agent's \`config.json\` model when \`--model\` is omitted) is intentionally left for a follow-up so this PR stays a surgical wiring fix.

## Test plan

- [ ] \`cortextos spawn-worker test --dir /tmp/x --prompt \"echo hi\" --model claude-haiku-4-5-20251001\` — verify worker session shows \`--model claude-haiku-4-5-20251001\` in spawn argv (check \`logs/test/stdout.log\`).
- [ ] Spawn without \`--model\` — verify worker uses Claude Code default (no \`--model\` arg appended).
- [ ] Spawn with bogus model \`--model not-a-model\` — verify worker still hits the model-selection screen (this PR doesn't add validation, only wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)