### PR TITLE
fix(types): AgentConfig.crash_window for PR #153 CrashLoopPauser (supersedes #153)

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -26,6 +26,12 @@ export class AgentProcess {
   private sessionTimer: ReturnType<typeof setTimeout> | null = null;
   private crashCount: number = 0;
   private maxCrashesPerDay: number = 10;
+  // CrashLoopPauser (instar-inspired): sliding-window crash detection.
+  // Timestamps of recent crashes within the configured window. If the
+  // window fills, the agent auto-pauses instead of retrying with backoff.
+  private crashTimestamps: number[] = [];
+  private crashWindowMs: number = 0;
+  private crashWindowMax: number = 0;
   private sessionStart: Date | null = null;
   private status: AgentStatus['status'] = 'stopped';
   private stopping: boolean = false;
@@ -65,6 +71,10 @@ export class AgentProcess {
     this.config = config;
     if (config.max_crashes_per_day !== undefined) {
       this.maxCrashesPerDay = config.max_crashes_per_day;
+    }
+    if (config.crash_window?.seconds) {
+      this.crashWindowMs = config.crash_window.seconds * 1000;
+      this.crashWindowMax = config.crash_window.max_crashes ?? 3;
     }
     this.dedup = new MessageDedup();
     this.log = log || ((msg) => console.log(`[${name}] ${msg}`));
@@ -420,7 +430,31 @@ export class AgentProcess {
       return;
     }
 
-    // Check crash limit
+    // CrashLoopPauser (instar-inspired): if a sliding window is configured,
+    // check whether the agent is crash-looping before falling through to
+    // the legacy daily counter. The window is a more precise signal than
+    // the per-day count: 3 crashes in 30 minutes is a crash loop even if
+    // the daily budget of 10 is far from exhausted.
+    if (this.crashWindowMs > 0) {
+      const now = Date.now();
+      this.crashTimestamps.push(now);
+      // Prune timestamps outside the window.
+      this.crashTimestamps = this.crashTimestamps.filter(
+        (ts) => now - ts <= this.crashWindowMs,
+      );
+      if (this.crashTimestamps.length >= this.crashWindowMax) {
+        this.log(
+          `CRASH_LOOP: ${this.crashTimestamps.length} crashes in ${this.crashWindowMs / 1000}s window — auto-pausing`,
+        );
+        this.appendCrashToRestartsLog(exitCode, 0, 'CRASH_LOOP');
+        this.status = 'halted';
+        this.notifyStatusChange();
+        return;
+      }
+    }
+
+    // Legacy daily crash counter (fallback when no crash_window is configured,
+    // or as a secondary gate when the window hasn't filled yet).
     this.crashCount++;
     const today = new Date().toISOString().split('T')[0];
     this.resetCrashCountIfNewDay(today);
@@ -678,7 +712,7 @@ export class AgentProcess {
   private appendCrashToRestartsLog(
     exitCode: number,
     backoffMs: number,
-    kind: 'CRASH' | 'HALTED',
+    kind: 'CRASH' | 'HALTED' | 'CRASH_LOOP',
   ): void {
     try {
       const logDir = join(this.env.ctxRoot, 'logs', this.name);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -157,6 +157,12 @@ export interface AgentConfig {
   startup_delay?: number;
   max_session_seconds?: number;
   max_crashes_per_day?: number;
+  /**
+   * Sliding-window crash-loop detector. When N crashes occur within the window,
+   * the agent auto-pauses (status: 'halted') instead of retrying. Absent = legacy
+   * daily counter only.
+   */
+  crash_window?: { seconds: number; max_crashes?: number };
   model?: string;
   working_directory?: string;
   enabled?: boolean;

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -346,3 +346,52 @@ describe('AgentProcess - BUG-048 fix (session timer re-reads config)', () => {
     expect(refreshSpy).not.toHaveBeenCalled();
   });
 });
+
+describe('AgentProcess — CrashLoopPauser (instar-inspired sliding window)', () => {
+  it('triggers CRASH_LOOP halt when crash_window fills', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {
+      crash_window: { seconds: 60, max_crashes: 3 },
+    });
+    await ap.start();
+
+    // Fire 3 crashes in rapid succession (well within the 60s window).
+    capturedOnExit!(1, 0);
+    expect(ap.getStatus().status).toBe('crashed'); // first crash — normal recovery
+
+    // Reset mocks and simulate the restart + second crash
+    mockPty.spawn.mockClear();
+    mockPty.onExit.mockClear();
+    capturedOnExit = null;
+    await ap.start();
+    capturedOnExit!(1, 0);
+    expect(ap.getStatus().status).toBe('crashed'); // second crash — still normal
+
+    mockPty.spawn.mockClear();
+    mockPty.onExit.mockClear();
+    capturedOnExit = null;
+    await ap.start();
+    capturedOnExit!(1, 0);
+    // Third crash in window → CRASH_LOOP → halted
+    expect(ap.getStatus().status).toBe('halted');
+  });
+
+  it('does not trigger CRASH_LOOP when no crash_window is configured (backward compat)', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {
+      max_crashes_per_day: 5,
+    });
+    await ap.start();
+
+    // 3 crashes — without crash_window, these are just normal crash recovery
+    for (let i = 0; i < 3; i++) {
+      capturedOnExit!(1, 0);
+      if (ap.getStatus().status !== 'halted') {
+        mockPty.spawn.mockClear();
+        mockPty.onExit.mockClear();
+        capturedOnExit = null;
+        await ap.start();
+      }
+    }
+    // Should be 'crashed' (recovering), NOT 'halted', because daily max is 5
+    expect(ap.getStatus().status).not.toBe('halted');
+  });
+});


### PR DESCRIPTION
## Summary

Re-roll of #153 (community contrib by Bob/@ClintMoody) with the missing AgentConfig type field added so the build doesn't break.

## Why

#153 introduces `CrashLoopPauser` — a sliding-window crash-loop detector in `src/daemon/agent-process.ts`. The implementation reads `config.crash_window.seconds` and `config.crash_window.max_crashes`, but the matching field was never added to the `AgentConfig` interface in `src/types/index.ts`. Result: 3 TS2339 errors blocking `tsc --noEmit`.

PR body acknowledged this ("depends on #152, OR adds the type itself") but never followed through. Surfaced in tonight's nightly cycle by cortext-designer Phase 4.5 typecheck gate.

## Diff vs. main

2 commits:

| Commit | Author | Effect |
|---|---|---|
| `a009b68d` | Bob (community) | full PR #153 content (CrashLoopPauser logic + 2 unit tests) |
| HEAD | Boris (co-author cortext-designer) | adds `crash_window?: { seconds: number; max_crashes?: number }` to AgentConfig |

Net: `+91 / -2` across 3 files (`src/types/index.ts`, `src/daemon/agent-process.ts`, `tests/unit/daemon/agent-process.test.ts`).

## Verification

- `tsc --noEmit` — PASS
- `npm run build` — PASS
- Cortext-designer Phase 4.5 typecheck gate — PASS (was the blocker pre-fix)
- Behavioral TCs pending — designer is checking out this branch now to run TC1–TC5 + restart_recovery

Will append the full sandbox result + score before requesting merge review.

## Closes

Closes #153 (replaces; same content + type fix; original author Bob credited via co-author trailer)

🤖 Sandbox-flagged by cortext-designer; co-author fix by Boris.