### PR TITLE
fix(bus): add --skip-images to kb-ingest to prevent PNG hang

### DIFF
--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -1,6 +1,6 @@
 import { execFileSync } from 'child_process';
 import { existsSync, mkdirSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { extname, join } from 'path';
 import { homedir } from 'os';
 import type { BusPaths } from '../types/index.js';
 import { normalizeOrgName } from '../utils/org.js';
@@ -238,6 +238,11 @@ export function queryKnowledgeBase(
   return { results: [], total: 0, query: question, collection: `shared-${org}` };
 }
 
+/** Image extensions that the Gemini image-description API processes.
+ *  When skipImages is true these are filtered out before invoking mmrag.py
+ *  to prevent the ingest process from hanging on API calls for each file. */
+const IMAGE_EXTENSIONS = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.bmp', '.tiff', '.tif']);
+
 /**
  * Ingest files into the knowledge base.
  */
@@ -248,11 +253,12 @@ export function ingestKnowledgeBase(
     agent?: string;
     scope?: 'shared' | 'private';
     force?: boolean;
+    skipImages?: boolean;
     frameworkRoot: string;
     instanceId: string;
   },
 ): void {
-  const { agent, scope = 'shared', force, frameworkRoot, instanceId } = options;
+  const { agent, scope = 'shared', force, skipImages, frameworkRoot, instanceId } = options;
   // Normalize once (see queryKnowledgeBase for rationale).
   const org = normalizeOrgName(frameworkRoot, options.org);
 
@@ -293,12 +299,35 @@ export function ingestKnowledgeBase(
     mkdirSync(chromaDir, { recursive: true });
   }
 
+  // Filter out image files when --skip-images is set. The Gemini
+  // image-description API is called for each image file; with large screenshot
+  // batches (e.g. 260 PNGs from playwright-qa/) this hangs the ingest process
+  // for hours. Skipped files are logged so the operator knows what was omitted.
+  let ingestPaths = paths;
+  if (skipImages) {
+    const skipped: string[] = [];
+    ingestPaths = paths.filter((p) => {
+      if (IMAGE_EXTENSIONS.has(extname(p).toLowerCase())) {
+        skipped.push(p);
+        return false;
+      }
+      return true;
+    });
+    if (skipped.length > 0) {
+      console.log(`[kb-ingest] Skipping ${skipped.length} image file(s) (--skip-images)`);
+    }
+    if (ingestPaths.length === 0) {
+      console.log('[kb-ingest] No non-image files to ingest after filtering.');
+      return;
+    }
+  }
+
   console.log(`Ingesting into collection: ${collection}`);
-  for (const p of paths) {
+  for (const p of ingestPaths) {
     console.log(`  Source: ${p}`);
   }
 
-  const args = [mmragPath, 'ingest', ...paths, '--collection', collection];
+  const args = [mmragPath, 'ingest', ...ingestPaths, '--collection', collection];
   if (force) args.push('--force');
 
   // Multimodal PDF ingestion via Gemini Flash routinely takes 2–5 min for

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1127,7 +1127,8 @@ busCommand
   .option('--agent <name>', 'Agent name (for private scope)')
   .option('--scope <s>', 'Scope: shared or private', 'shared')
   .option('--force', 'Re-ingest even if already indexed')
-  .action((paths: string[], opts: { org?: string; agent?: string; scope?: string; force?: boolean }) => {
+  .option('--skip-images', 'Skip PNG/JPG/GIF/WebP files (prevents hanging on image-description API)')
+  .action((paths: string[], opts: { org?: string; agent?: string; scope?: string; force?: boolean; skipImages?: boolean }) => {
     const env = resolveEnv();
     const org = opts.org || env.org;
     if (!org) {
@@ -1142,6 +1143,7 @@ busCommand
       agent: opts.agent || env.agentName,
       scope: (opts.scope as 'shared' | 'private') || 'shared',
       force: opts.force,
+      skipImages: opts.skipImages,
       frameworkRoot: env.frameworkRoot || process.cwd(),
       instanceId: env.instanceId,
     });

--- a/tests/unit/bus/knowledge-base.test.ts
+++ b/tests/unit/bus/knowledge-base.test.ts
@@ -181,6 +181,72 @@ describe('queryKnowledgeBase — graceful missing-config', () => {
   });
 });
 
+// Regression: --skip-images filters image files before invoking mmrag.py
+// to prevent hangs on the Gemini image-description API (260 PNGs observed
+// locking the ingest process for hours during overnight analyst runs).
+describe('ingestKnowledgeBase — --skip-images flag', () => {
+  beforeEach(() => {
+    mockConfiguredKb();
+    execFileSyncMock.mockReturnValue('');
+  });
+
+  it('with skipImages: PNG files are excluded from the mmrag.py argv', () => {
+    ingestKnowledgeBase(
+      ['/docs/readme.md', '/screenshots/page1.png', '/screenshots/page2.PNG'],
+      { ...baseOptions, skipImages: true },
+    );
+
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const [, argv] = execFileSyncMock.mock.calls[0] as [string, string[], object];
+    expect(argv).toContain('/docs/readme.md');
+    expect(argv).not.toContain('/screenshots/page1.png');
+    expect(argv).not.toContain('/screenshots/page2.PNG');
+  });
+
+  it('with skipImages: JPG/JPEG/GIF/WebP are also excluded', () => {
+    const imagePaths = ['/a.jpg', '/b.jpeg', '/c.gif', '/d.webp', '/e.bmp'];
+    ingestKnowledgeBase(
+      ['/docs/spec.md', ...imagePaths],
+      { ...baseOptions, skipImages: true },
+    );
+
+    const [, argv] = execFileSyncMock.mock.calls[0] as [string, string[], object];
+    expect(argv).toContain('/docs/spec.md');
+    for (const img of imagePaths) {
+      expect(argv).not.toContain(img);
+    }
+  });
+
+  it('with skipImages: logs count of skipped images', () => {
+    ingestKnowledgeBase(
+      ['/docs/readme.md', '/img/a.png', '/img/b.jpg'],
+      { ...baseOptions, skipImages: true },
+    );
+
+    expect(logLog.some((m) => m.includes('Skipping 2 image file(s)'))).toBe(true);
+  });
+
+  it('with skipImages: early-returns cleanly when all paths are images', () => {
+    ingestKnowledgeBase(
+      ['/img/a.png', '/img/b.jpg'],
+      { ...baseOptions, skipImages: true },
+    );
+
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+    expect(logLog.some((m) => m.includes('No non-image files'))).toBe(true);
+  });
+
+  it('without skipImages: PNG files pass through to mmrag.py unchanged', () => {
+    ingestKnowledgeBase(
+      ['/docs/readme.md', '/screenshots/page1.png'],
+      { ...baseOptions, skipImages: false },
+    );
+
+    const [, argv] = execFileSyncMock.mock.calls[0] as [string, string[], object];
+    expect(argv).toContain('/screenshots/page1.png');
+  });
+});
+
 describe('kb warn messages — UX invariants', () => {
   it('both warn messages name the org and suggest "run setup"', () => {
     // Drive ingest path


### PR DESCRIPTION
## Summary
- Adds \`--skip-images\` CLI flag and \`skipImages\` option to \`ingestKnowledgeBase()\`
- Filters out PNG/JPG/JPEG/GIF/WebP/BMP/TIFF files before passing paths to mmrag.py
- Skipped count is logged; all-images input returns early without spawning Python

## Root cause
With 260 PNGs (e.g. playwright-qa/ screenshot batches) the Gemini image-description API is called per file, hanging the ingest process for hours (observed overnight in analyst runs).

## Test plan
- [x] 5 new unit tests: PNG excluded, all image types excluded, skip-count logged, all-images early-return, pass-through when flag absent
- [x] 10/10 tests pass (`npx vitest run tests/unit/bus/knowledge-base.test.ts`)
- [x] Build clean (`npm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)