### PR TITLE
feat(telegram): handle edited_message updates

### DIFF
--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -359,7 +359,7 @@ export class TelegramAPI {
     return this.post('getUpdates', {
       offset,
       timeout,
-      allowed_updates: ['message', 'callback_query', 'message_reaction'],
+      allowed_updates: ['message', 'edited_message', 'callback_query', 'message_reaction'],
     });
   }
 

--- a/src/telegram/poller.ts
+++ b/src/telegram/poller.ts
@@ -5,6 +5,7 @@ import { TelegramAPI } from './api.js';
 import { ensureDir } from '../utils/atomic.js';
 
 export type MessageHandler = (msg: TelegramMessage) => void;
+export type EditedMessageHandler = (msg: TelegramMessage) => void;
 export type CallbackHandler = (query: TelegramCallbackQuery) => void;
 export type ReactionHandler = (reaction: TelegramMessageReaction) => void;
 
@@ -19,6 +20,7 @@ export class TelegramPoller {
   private stateDir: string;
   private offsetFileName: string;
   private messageHandlers: MessageHandler[] = [];
+  private editedMessageHandlers: EditedMessageHandler[] = [];
   private callbackHandlers: CallbackHandler[] = [];
   private reactionHandlers: ReactionHandler[] = [];
   private pollInterval: number;
@@ -52,6 +54,23 @@ export class TelegramPoller {
    */
   onMessage(handler: MessageHandler): void {
     this.messageHandlers.push(handler);
+  }
+
+  /**
+   * Register a handler for edits to previously sent messages.
+   *
+   * Telegram delivers edits as a separate `edited_message` update type, NOT
+   * as a re-emitted `message`. Subscribing here is opt-in: existing
+   * `onMessage` handlers do not fire on edits, so agents will not double-
+   * reply to the same conversation point unless they explicitly want to
+   * surface edits.
+   *
+   * Typical use: log the edit so the agent can notice content changed,
+   * then decide per-handler whether to re-process. Most chat-style agents
+   * should stay quiet on edits to avoid annoying re-replies.
+   */
+  onEditedMessage(handler: EditedMessageHandler): void {
+    this.editedMessageHandlers.push(handler);
   }
 
   /**
@@ -118,6 +137,18 @@ export class TelegramPoller {
             handler(update.message);
           } catch (err) {
             console.error('[telegram-poller] Message handler error:', err);
+            handlerFailed = true;
+            break;
+          }
+        }
+      }
+
+      if (!handlerFailed && update.edited_message) {
+        for (const handler of this.editedMessageHandlers) {
+          try {
+            handler(update.edited_message);
+          } catch (err) {
+            console.error('[telegram-poller] Edited-message handler error:', err);
             handlerFailed = true;
             break;
           }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -454,6 +454,14 @@ export interface OrgContext {
 export interface TelegramUpdate {
   update_id: number;
   message?: TelegramMessage;
+  /**
+   * An edit to a previously sent message. Telegram emits this as a separate
+   * update type from `message`; the bot must opt in via `allowed_updates`
+   * to receive it. Same shape as `message`. Handlers are registered
+   * separately on the poller (see `TelegramPoller.onEditedMessage`) so
+   * existing message handlers do not double-fire on edits.
+   */
+  edited_message?: TelegramMessage;
   callback_query?: TelegramCallbackQuery;
   message_reaction?: TelegramMessageReaction;
 }

--- a/tests/unit/telegram/poller.test.ts
+++ b/tests/unit/telegram/poller.test.ts
@@ -223,3 +223,89 @@ describe('TelegramPoller — offset-after-handler', () => {
     }
   });
 });
+
+function makeEditedMessageUpdate(updateId: number, messageId: number, text: string): TelegramUpdate {
+  return {
+    update_id: updateId,
+    edited_message: {
+      message_id: messageId,
+      chat: { id: 1, type: 'private' },
+      text,
+      edit_date: 1700000000,
+    } as any,
+  };
+}
+
+describe('TelegramPoller — edited_message handling', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'cortextos-poller-edit-'));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('does NOT fire onMessage handlers for edited_message updates (avoids double-reply)', async () => {
+    const { api } = makeStubApi([makeEditedMessageUpdate(200, 5, 'hello (edited)')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    const messageReceived: string[] = [];
+    poller.onMessage((msg) => {
+      messageReceived.push(msg.text ?? '');
+    });
+
+    await poller.pollOnce();
+
+    expect(messageReceived).toEqual([]);
+  });
+
+  it('fires onEditedMessage handlers when an edit arrives', async () => {
+    const { api } = makeStubApi([makeEditedMessageUpdate(201, 5, 'hello (edited)')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    const edits: { id: number; text: string }[] = [];
+    poller.onEditedMessage((msg) => {
+      edits.push({ id: msg.message_id, text: msg.text ?? '' });
+    });
+
+    await poller.pollOnce();
+
+    expect(edits).toEqual([{ id: 5, text: 'hello (edited)' }]);
+  });
+
+  it('advances offset after edited_message handler succeeds', async () => {
+    const { api } = makeStubApi([makeEditedMessageUpdate(202, 5, 'edited')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    poller.onEditedMessage(() => {
+      // ok
+    });
+
+    await poller.pollOnce();
+
+    const offsetFile = join(stateDir, '.telegram-offset');
+    expect(existsSync(offsetFile)).toBe(true);
+    expect(readFileSync(offsetFile, 'utf-8')).toBe('203');
+  });
+
+  it('keeps offset un-advanced if onEditedMessage handler throws', async () => {
+    const { api } = makeStubApi([makeEditedMessageUpdate(203, 5, 'edited')]);
+    const poller = new TelegramPoller(api, stateDir);
+
+    poller.onEditedMessage(() => {
+      throw new Error('boom');
+    });
+
+    await poller.pollOnce();
+
+    const offsetFile = join(stateDir, '.telegram-offset');
+    // Either the file does not exist yet (no successful update) or it
+    // remained at the pre-update value (0). Either is acceptable; the
+    // critical invariant is that we did NOT advance to 204.
+    if (existsSync(offsetFile)) {
+      expect(readFileSync(offsetFile, 'utf-8')).not.toBe('204');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Telegram's `getUpdates` emits edits as a separate `edited_message` update type. The poller's current `allowed_updates` whitelist excludes it, so Telegram never sends edits to the daemon — bots see edits land in the UI but can't react to them.
- This patch wires up edit handling end-to-end while keeping the channel opt-in.

## What changed

| File | Change |
|------|--------|
| `src/telegram/api.ts` | Add `'edited_message'` to `allowed_updates` |
| `src/types/index.ts` | Add `edited_message?: TelegramMessage` to `TelegramUpdate` with doc comment |
| `src/telegram/poller.ts` | Add `editedMessageHandlers` + `onEditedMessage(handler)` + dispatch in `pollOnce()` with the same offset-after-handler / fail-defers semantics as `message` |
| `tests/unit/telegram/poller.test.ts` | 4 new tests covering the new path |

## Why a separate handler list (not re-emitting through `onMessage`)

Most chat-style consumers reply when they see a message. If edits flowed through `onMessage`, every edit would re-trigger a reply to the same conversation point — annoying for users, costly for the agent. Making the edit channel opt-in via `onEditedMessage` lets consumers that DO care about edits (audit trails, content moderation, redact-after-send detection) subscribe explicitly, while existing consumers stay quiet on edits by default.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run tests/unit/telegram/poller.test.ts` — 12 passed (8 existing + 4 new)
- [x] New tests cover:
  - `onMessage` does NOT fire on `edited_message` (no double-reply)
  - `onEditedMessage` fires with correct payload
  - Offset advances after successful edit handler
  - Offset does NOT advance if edit handler throws (Telegram redelivers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)