### PR TITLE
feat(telegram): wire whisper-cli voice transcription into media pipeline

### DIFF
--- a/scripts/install-whisper-model.sh
+++ b/scripts/install-whisper-model.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# install-whisper-model.sh — download the whisper.cpp GGML model used for
+# Telegram voice transcription. Idempotent. Skips the download if the model
+# already exists at the target path.
+#
+# Default model: ggml-tiny.en.bin (~75 MB). Override by setting WHISPER_MODEL
+# (e.g. ggml-base.en.bin for higher accuracy at ~140 MB) and WHISPER_MODEL_DIR.
+#
+# This script is intentionally separate from npm install so the bundle stays
+# slim. Run it once during onboarding; re-run only to upgrade the model.
+
+set -euo pipefail
+
+WHISPER_MODEL="${WHISPER_MODEL:-ggml-tiny.en.bin}"
+WHISPER_MODEL_DIR="${WHISPER_MODEL_DIR:-${HOME}/.cortextos/models}"
+URL_BASE="${WHISPER_MODEL_URL_BASE:-https://huggingface.co/ggerganov/whisper.cpp/resolve/main}"
+
+target="${WHISPER_MODEL_DIR}/${WHISPER_MODEL}"
+
+if [ -f "$target" ]; then
+  echo "[install-whisper-model] already present: $target"
+  exit 0
+fi
+
+if ! command -v whisper-cli >/dev/null 2>&1; then
+  echo "[install-whisper-model] WARN: whisper-cli not on PATH. Install with 'brew install whisper-cpp' (macOS) before running this script."
+fi
+
+if ! command -v ffmpeg >/dev/null 2>&1; then
+  echo "[install-whisper-model] WARN: ffmpeg not on PATH. Install with 'brew install ffmpeg' (macOS) before running this script."
+fi
+
+mkdir -p "$WHISPER_MODEL_DIR"
+
+url="${URL_BASE}/${WHISPER_MODEL}"
+echo "[install-whisper-model] downloading $WHISPER_MODEL → $target"
+echo "[install-whisper-model] source: $url"
+
+if command -v curl >/dev/null 2>&1; then
+  curl -fL --retry 3 --connect-timeout 30 -o "${target}.partial" "$url"
+elif command -v wget >/dev/null 2>&1; then
+  wget -O "${target}.partial" "$url"
+else
+  echo "[install-whisper-model] ERROR: neither curl nor wget available." >&2
+  exit 1
+fi
+
+mv "${target}.partial" "$target"
+size_mb=$(du -m "$target" | awk '{print $1}')
+echo "[install-whisper-model] OK ${size_mb}M at $target"

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -54,6 +54,31 @@ function tryInstallJq(): boolean {
   return false;
 }
 
+function tryInstallWhisperCpp(): boolean {
+  if (IS_MAC && commandExists('brew')) {
+    try { execSync('brew install whisper-cpp', { stdio: 'inherit' }); return true; } catch { return false; }
+  }
+  return false;
+}
+
+function tryInstallFfmpeg(): boolean {
+  if (IS_MAC && commandExists('brew')) {
+    try { execSync('brew install ffmpeg', { stdio: 'inherit' }); return true; } catch { return false; }
+  }
+  if (!IS_WINDOWS && !IS_MAC) {
+    try { execSync('sudo apt-get install -y ffmpeg', { stdio: 'inherit' }); return true; } catch { return false; }
+  }
+  if (IS_WINDOWS) {
+    if (commandExists('winget')) {
+      try { execSync('winget install Gyan.FFmpeg --silent', { stdio: 'inherit' }); return true; } catch { /* try choco */ }
+    }
+    if (commandExists('choco')) {
+      try { execSync('choco install ffmpeg -y', { stdio: 'inherit' }); return true; } catch { return false; }
+    }
+  }
+  return false;
+}
+
 export const installCommand = new Command('install')
   .option('--instance <id>', 'Instance ID', 'default')
   .description('Install cortextOS — create state directories, check and install dependencies')
@@ -228,6 +253,51 @@ export const installCommand = new Command('install')
       } catch {
         console.log('  ✓ jq: installed');
       }
+    }
+
+    // Voice transcription deps — whisper-cli + ffmpeg + GGML model.
+    // Best-effort: failures degrade voice messages to path-only (no transcript)
+    // but never block install. Disable entirely with CTX_TELEGRAM_NO_TRANSCRIBE=1.
+    if (!commandExists('whisper-cli')) {
+      console.log('  - whisper-cli: not found. Installing...');
+      const installed = tryInstallWhisperCpp();
+      if (installed && commandExists('whisper-cli')) {
+        console.log('  ✓ whisper-cli: installed');
+      } else {
+        console.log('  ! whisper-cli: could not auto-install.');
+        if (IS_MAC) console.log('    Install with: brew install whisper-cpp');
+        else if (IS_WINDOWS) console.log('    See: https://github.com/ggerganov/whisper.cpp#quick-start');
+        else console.log('    Build from source: https://github.com/ggerganov/whisper.cpp');
+        console.log('    Voice messages will be delivered without transcripts until installed.');
+      }
+    } else {
+      console.log('  ✓ whisper-cli: installed');
+    }
+
+    if (!commandExists('ffmpeg')) {
+      console.log('  - ffmpeg: not found. Installing...');
+      const installed = tryInstallFfmpeg();
+      if (installed && commandExists('ffmpeg')) {
+        console.log('  ✓ ffmpeg: installed');
+      } else {
+        console.log('  ! ffmpeg: could not auto-install.');
+        if (IS_MAC) console.log('    Install with: brew install ffmpeg');
+        else if (IS_WINDOWS) console.log('    Install with: winget install Gyan.FFmpeg');
+        else console.log('    Install with: sudo apt-get install -y ffmpeg');
+      }
+    } else {
+      console.log('  ✓ ffmpeg: installed');
+    }
+
+    // GGML whisper model — idempotent download via shipped script.
+    const modelScript = join(process.cwd(), 'scripts', 'install-whisper-model.sh');
+    if (existsSync(modelScript)) {
+      const modelResult = spawnSync('bash', [modelScript], { stdio: 'inherit', timeout: 5 * 60 * 1000 });
+      if (modelResult.status !== 0) {
+        console.log('  ! whisper model: download failed. Re-run: bash scripts/install-whisper-model.sh');
+      }
+    } else {
+      console.log(`  ! whisper model installer not found at ${modelScript}; skipping`);
     }
 
     // Python venv for Knowledge Base

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -372,7 +372,7 @@ export class AgentManager {
             } else if (media.type === 'document') {
               formatted = FastChecker.formatTelegramDocumentMessage(from, effectiveChatId, media.text, relFilePath, media.file_name!);
             } else if (media.type === 'voice' || media.type === 'audio') {
-              formatted = FastChecker.formatTelegramVoiceMessage(from, effectiveChatId, relFilePath, media.duration);
+              formatted = FastChecker.formatTelegramVoiceMessage(from, effectiveChatId, relFilePath, media.duration, media.transcript);
             } else {
               // video or video_note
               formatted = FastChecker.formatTelegramVideoMessage(from, effectiveChatId, media.text, relFilePath, media.file_name || '', media.duration);

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -349,11 +349,10 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
    * Format a Telegram voice/audio message for injection.
    * Matches bash fast-checker.sh format.
    *
-   * `transcript` is optional and only emitted when populated by an upstream
-   * transcription service. Whisper integration is not currently wired in
-   * cortextos src/ (only in tools/graphify); call sites pass undefined until
-   * that pipeline is in place. The codex extractor surfaces the transcript
-   * block when present.
+   * `transcript` is populated by `src/telegram/transcribe.ts` when whisper-cli
+   * and the GGML model are available; otherwise it stays undefined and the
+   * agent receives only the .ogg path. The codex extractor surfaces the
+   * transcript block when present.
    */
   static formatTelegramVoiceMessage(
     from: string,

--- a/src/telegram/media.ts
+++ b/src/telegram/media.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { TelegramAPI } from './api.js';
+import { transcribeVoice } from './transcribe.js';
 import { TelegramMessage } from '../types/index.js';
 import { ensureDir } from '../utils/atomic.js';
 
@@ -19,6 +20,7 @@ export interface ProcessedMedia {
   file_path?: string;
   file_name?: string;
   duration?: number;
+  transcript?: string;
 }
 
 /**
@@ -149,6 +151,8 @@ export async function processMediaMessage(
     const data = await api.downloadFile(filePath);
     fs.writeFileSync(localFile, data);
 
+    const transcript = await transcribeVoice(localFile);
+
     return {
       type: 'voice',
       chat_id: chatId,
@@ -157,6 +161,7 @@ export async function processMediaMessage(
       date,
       file_path: localFile,
       duration: msg.voice.duration,
+      transcript: transcript || undefined,
     };
   }
 

--- a/src/telegram/transcribe.ts
+++ b/src/telegram/transcribe.ts
@@ -1,0 +1,137 @@
+/**
+ * Voice transcription via local whisper.cpp (whisper-cli).
+ *
+ * Returns null on any failure (binary missing, model missing, timeout,
+ * empty output). The caller treats null as "no transcript available" and
+ * the agent still receives the .ogg path — agents capable of running
+ * whisper themselves can do so.
+ *
+ * Disable entirely with CTX_TELEGRAM_NO_TRANSCRIBE=1.
+ * Override binaries / model with CTX_WHISPER_BIN, CTX_FFMPEG_BIN,
+ * CTX_WHISPER_MODEL.
+ */
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+
+function resolveModelPath(): string {
+  if (process.env.CTX_WHISPER_MODEL) return process.env.CTX_WHISPER_MODEL;
+  return path.join(os.homedir(), '.cortextos', 'models', 'ggml-tiny.en.bin');
+}
+
+function resolveBin(envVar: string, fallback: string): string {
+  return process.env[envVar] || fallback;
+}
+
+export interface TranscribeOptions {
+  timeoutMs?: number;
+  modelPath?: string;
+  log?: (line: string) => void;
+}
+
+/**
+ * Transcribe a Telegram voice .ogg file. Returns the trimmed transcript
+ * text, or null if transcription was unavailable / failed.
+ */
+export async function transcribeVoice(
+  oggPath: string,
+  opts: TranscribeOptions = {},
+): Promise<string | null> {
+  if (process.env.CTX_TELEGRAM_NO_TRANSCRIBE === '1') return null;
+  if (!oggPath || !fs.existsSync(oggPath)) return null;
+
+  const log = opts.log || (() => {});
+  const modelPath = opts.modelPath || resolveModelPath();
+  const ffmpegBin = resolveBin('CTX_FFMPEG_BIN', 'ffmpeg');
+  const whisperBin = resolveBin('CTX_WHISPER_BIN', 'whisper-cli');
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  if (!fs.existsSync(modelPath)) {
+    log(`[transcribe] model not found at ${modelPath} — skipping; run scripts/install-whisper-model.sh to enable transcription`);
+    return null;
+  }
+
+  const wavPath = oggPath.replace(/\.ogg$/i, '.wav');
+  const ffmpegOk = await runProcess(
+    ffmpegBin,
+    ['-y', '-i', oggPath, '-ar', '16000', '-ac', '1', '-c:a', 'pcm_s16le', wavPath],
+    timeoutMs,
+  );
+  if (!ffmpegOk.ok) {
+    log(`[transcribe] ffmpeg failed (${ffmpegOk.reason}) — skipping`);
+    return null;
+  }
+
+  try {
+    const whisper = await runProcess(
+      whisperBin,
+      ['-m', modelPath, '-f', wavPath, '-nt', '-np'],
+      timeoutMs,
+      true,
+    );
+    if (!whisper.ok) {
+      log(`[transcribe] whisper-cli failed (${whisper.reason}) — skipping`);
+      return null;
+    }
+    const text = (whisper.stdout || '').trim();
+    if (!text) {
+      log('[transcribe] whisper-cli produced empty output — skipping');
+      return null;
+    }
+    return text;
+  } finally {
+    if (fs.existsSync(wavPath)) {
+      try { fs.unlinkSync(wavPath); } catch { /* ignore cleanup error */ }
+    }
+  }
+}
+
+interface ProcessResult {
+  ok: boolean;
+  reason?: string;
+  stdout?: string;
+}
+
+function runProcess(
+  bin: string,
+  args: string[],
+  timeoutMs: number,
+  capture = false,
+): Promise<ProcessResult> {
+  return new Promise((resolve) => {
+    let stdout = '';
+    let timer: NodeJS.Timeout | null = null;
+    let settled = false;
+    const settle = (r: ProcessResult) => {
+      if (settled) return;
+      settled = true;
+      if (timer) clearTimeout(timer);
+      resolve(r);
+    };
+
+    let proc;
+    try {
+      proc = spawn(bin, args, {
+        stdio: ['ignore', capture ? 'pipe' : 'ignore', 'ignore'],
+      });
+    } catch (err) {
+      return settle({ ok: false, reason: `spawn-error: ${(err as Error).message}` });
+    }
+
+    if (capture && proc.stdout) {
+      proc.stdout.on('data', (chunk: Buffer) => { stdout += chunk.toString('utf8'); });
+    }
+    proc.on('error', (err) => settle({ ok: false, reason: `error: ${err.message}` }));
+    proc.on('close', (code) => {
+      if (code === 0) return settle({ ok: true, stdout });
+      settle({ ok: false, reason: `exit-${code}`, stdout });
+    });
+    timer = setTimeout(() => {
+      try { proc.kill('SIGKILL'); } catch { /* ignore */ }
+      settle({ ok: false, reason: 'timeout' });
+    }, timeoutMs);
+  });
+}

--- a/tests/unit/telegram/media.test.ts
+++ b/tests/unit/telegram/media.test.ts
@@ -56,13 +56,23 @@ describe('sanitizeFilename', () => {
 
 describe('processMediaMessage', () => {
   let downloadDir: string;
+  let prevNoTranscribe: string | undefined;
 
   beforeEach(() => {
     downloadDir = mkdtempSync(join(tmpdir(), 'cortextos-media-test-'));
+    // Disable transcription in unit tests to avoid spawning whisper-cli on
+    // junk audio bytes. transcribe.ts has dedicated tests.
+    prevNoTranscribe = process.env.CTX_TELEGRAM_NO_TRANSCRIBE;
+    process.env.CTX_TELEGRAM_NO_TRANSCRIBE = '1';
   });
 
   afterEach(() => {
     rmSync(downloadDir, { recursive: true, force: true });
+    if (prevNoTranscribe === undefined) {
+      delete process.env.CTX_TELEGRAM_NO_TRANSCRIBE;
+    } else {
+      process.env.CTX_TELEGRAM_NO_TRANSCRIBE = prevNoTranscribe;
+    }
   });
 
   function makeMsg(overrides: Partial<TelegramMessage>): TelegramMessage {
@@ -172,6 +182,17 @@ describe('processMediaMessage', () => {
     expect(result!.duration).toBe(5);
     expect(result!.file_path).toMatch(/voice_\d+\.ogg$/);
     expect(existsSync(result!.file_path!)).toBe(true);
+  });
+
+  it('voice message has undefined transcript when transcription disabled', async () => {
+    const msg = makeMsg({
+      voice: { file_id: 'voice1', duration: 5 },
+    });
+    const api = createMockApi('voice/file_123.ogg');
+    const result = await processMediaMessage(msg, api, downloadDir);
+
+    expect(result).not.toBeNull();
+    expect(result!.transcript).toBeUndefined();
   });
 
   it('processes video messages with filename', async () => {

--- a/tests/unit/telegram/transcribe.test.ts
+++ b/tests/unit/telegram/transcribe.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { transcribeVoice } from '../../../src/telegram/transcribe';
+
+describe('transcribeVoice', () => {
+  let workDir: string;
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), 'cortextos-transcribe-test-'));
+    savedEnv = {
+      CTX_TELEGRAM_NO_TRANSCRIBE: process.env.CTX_TELEGRAM_NO_TRANSCRIBE,
+      CTX_WHISPER_BIN: process.env.CTX_WHISPER_BIN,
+      CTX_FFMPEG_BIN: process.env.CTX_FFMPEG_BIN,
+      CTX_WHISPER_MODEL: process.env.CTX_WHISPER_MODEL,
+    };
+    delete process.env.CTX_TELEGRAM_NO_TRANSCRIBE;
+    delete process.env.CTX_WHISPER_BIN;
+    delete process.env.CTX_FFMPEG_BIN;
+    delete process.env.CTX_WHISPER_MODEL;
+  });
+
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+    for (const [k, v] of Object.entries(savedEnv)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('returns null when CTX_TELEGRAM_NO_TRANSCRIBE=1', async () => {
+    process.env.CTX_TELEGRAM_NO_TRANSCRIBE = '1';
+    const oggPath = join(workDir, 'voice.ogg');
+    writeFileSync(oggPath, 'fake-audio');
+    expect(await transcribeVoice(oggPath)).toBeNull();
+  });
+
+  it('returns null when ogg file does not exist', async () => {
+    expect(await transcribeVoice(join(workDir, 'missing.ogg'))).toBeNull();
+  });
+
+  it('returns null when ogg path is empty', async () => {
+    expect(await transcribeVoice('')).toBeNull();
+  });
+
+  it('returns null when model file does not exist', async () => {
+    const oggPath = join(workDir, 'voice.ogg');
+    writeFileSync(oggPath, 'fake-audio');
+    process.env.CTX_WHISPER_MODEL = join(workDir, 'no-such-model.bin');
+    expect(await transcribeVoice(oggPath)).toBeNull();
+  });
+
+  it('returns null when ffmpeg binary is missing', async () => {
+    const oggPath = join(workDir, 'voice.ogg');
+    const fakeModel = join(workDir, 'model.bin');
+    writeFileSync(oggPath, 'fake-audio');
+    writeFileSync(fakeModel, 'fake-model');
+    process.env.CTX_WHISPER_MODEL = fakeModel;
+    process.env.CTX_FFMPEG_BIN = '/nonexistent/path/ffmpeg-does-not-exist';
+    expect(await transcribeVoice(oggPath)).toBeNull();
+  });
+
+  it('returns null when whisper binary is missing', async () => {
+    const oggPath = join(workDir, 'voice.ogg');
+    const fakeModel = join(workDir, 'model.bin');
+    writeFileSync(oggPath, 'fake-audio');
+    writeFileSync(fakeModel, 'fake-model');
+    process.env.CTX_WHISPER_MODEL = fakeModel;
+    process.env.CTX_FFMPEG_BIN = 'true'; // exit 0, do nothing
+    process.env.CTX_WHISPER_BIN = '/nonexistent/path/whisper-cli-does-not-exist';
+    // ffmpeg "true" succeeds without producing wav, but the path returned still
+    // gets handed to whisper which fails on missing-binary. Either branch
+    // yields null — both are valid graceful-fallback outcomes.
+    expect(await transcribeVoice(oggPath)).toBeNull();
+  });
+
+  it('respects timeoutMs option', async () => {
+    const oggPath = join(workDir, 'voice.ogg');
+    const fakeModel = join(workDir, 'model.bin');
+    writeFileSync(oggPath, 'fake-audio');
+    writeFileSync(fakeModel, 'fake-model');
+    process.env.CTX_WHISPER_MODEL = fakeModel;
+    process.env.CTX_FFMPEG_BIN = 'sleep'; // never returns within timeout
+    const start = Date.now();
+    const result = await transcribeVoice(oggPath, { timeoutMs: 100 });
+    const elapsed = Date.now() - start;
+    expect(result).toBeNull();
+    expect(elapsed).toBeLessThan(2000);
+  });
+});


### PR DESCRIPTION
## Summary

Voice `.ogg` files received via Telegram are now transcribed locally with whisper-cli + ffmpeg the moment they're downloaded in `src/telegram/media.ts`, threaded through `ProcessedMedia.transcript`, and surfaced to agents via `FastChecker.formatTelegramVoiceMessage`.

`cortextos install` now provisions whisper-cli + ffmpeg + the GGML model end-to-end, so new agents get voice transcripts out of the box rather than per-operator manual setup.

## Why

Previously, the framework downloaded voice notes but never produced a transcript. The `formatTelegramVoiceMessage` function had a `transcript?: string` parameter wired aspirationally but no producer was ever attached, so every call site passed `undefined`. As a result:

- Agents received only the `.ogg` path with no inline transcript
- Some agents (Claude Code, when knowledgeable about whisper) emergently shelled out to whisper-cli themselves; most agents (Codex, fresh templates, Haiku-class agents) did not — voice messages effectively arrived as "[voice message]"
- Behaviour was inconsistent across templates and runtimes

This PR makes voice transcription a default framework capability rather than an emergent agent behaviour, uniformly across all runtimes that flow through the daemon's media pipeline (claude-code, codex-app-server).

## Coverage audit

- **claude-code agents:** route through agent-manager → processMediaMessage → formatTelegramVoiceMessage. Receive transcript. ✓
- **codex-app-server agents:** same daemon path; `src/pty/codex-app-server-pty.ts` (lines 264–345) extracts the transcript block from the formatted message and re-injects to codex. ✓
- **bash fast-checker:** the comment "Matches bash fast-checker.sh format" in `src/daemon/fast-checker.ts` is a legacy doc reference; no bash version exists on disk. Not a coverage gap.

## Behaviour

- **Best-effort with graceful fallback.** Any failure (missing whisper-cli, missing ffmpeg, missing model, timeout) returns `null`; the agent still receives the `.ogg` path. No regression vs. previous behaviour.
- **Defaults**: `ggml-tiny.en.bin` (~75 MB) at `~/.cortextos/models/`. Override via `CTX_WHISPER_MODEL`, `CTX_WHISPER_BIN`, `CTX_FFMPEG_BIN`.
- **Disable entirely**: `CTX_TELEGRAM_NO_TRANSCRIBE=1`.
- **Auto-install**: `cortextos install` now installs whisper-cli (mac via brew) + ffmpeg (mac brew, linux apt, windows winget/choco) + downloads the GGML model. Each step is best-effort; install continues on failure with a hint to install manually.
- **Manual install path** (for environments where auto-install can't reach): `bash scripts/install-whisper-model.sh` is idempotent and skips if the model is already present.

## Files

| File | Change |
|---|---|
| `src/telegram/transcribe.ts` | New module — wraps ffmpeg → whisper-cli with timeout + cleanup |
| `src/telegram/media.ts` | Calls `transcribeVoice()` post-download; adds `transcript?` to `ProcessedMedia` |
| `src/daemon/agent-manager.ts` | Passes `media.transcript` into `formatTelegramVoiceMessage` (1-line change) |
| `src/daemon/fast-checker.ts` | Updated comment to reflect that the producer is now wired |
| `src/cli/install.ts` | Auto-installs whisper-cpp + ffmpeg via brew/apt/winget; runs the model installer |
| `tests/unit/telegram/transcribe.test.ts` | 7 new tests: env disable, missing inputs, missing binaries, timeout |
| `tests/unit/telegram/media.test.ts` | Sets `CTX_TELEGRAM_NO_TRANSCRIBE=1` so existing tests don't shell out |
| `scripts/install-whisper-model.sh` | Idempotent GGML model installer |

## Sandbox haiku-agent verification

To confirm this fix is genuinely necessary (not a model-class quirk), I ran a controlled experiment with haiku-4.5:

- **Pre-PR prompt** (path only, no transcript): haiku replied "I don't have the ability to listen to audio files directly. Could you transcribe?" in 1 turn with 0 tool calls — never even attempted whisper.
- **Post-PR prompt** (transcript block injected by media.ts): haiku engaged with the transcribed content directly.

This confirms emergent transcription is model-dependent and unreliable; framework-level transcription is required for uniform behaviour.

## Test plan

- [x] `npm run lint` (tsc --noEmit) clean
- [x] `npm run build` clean
- [x] Full telegram unit test suite passes (85 tests)
- [x] End-to-end verified locally on a real 28s `.ogg`: transcript correctly contained the spoken phrase
- [x] Sandbox haiku-4.5 control: confirms the path-only prompt is unreadable to haiku-class agents; the transcript-block prompt is readable
- [ ] Reviewer should run `cortextos install` (or `bash scripts/install-whisper-model.sh`) then send a voice message to a sandbox agent to confirm the transcript surfaces in the agent prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)