### PR TITLE
fix(task): eliminate task-ID collision flake (3→8 random digits)

### DIFF
--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -39,7 +39,11 @@ export function createTask(
   validatePriority(priority);
 
   const epoch = Date.now();
-  const rand = randomDigits(3);
+  // 8 digits: same-millisecond collision probability is ~1e-8 instead of ~1e-3.
+  // Two createTask calls in the same ms with a 3-digit suffix collided in CI
+  // (run 25618845172), making the new task's id equal to its declared blocker
+  // and tripping detectCycleOrThrow with "X ultimately blocks itself via X".
+  const rand = randomDigits(8);
   const taskId = `task_${epoch}_${rand}`;
   const now = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
 

--- a/tests/unit/bus/task.test.ts
+++ b/tests/unit/bus/task.test.ts
@@ -37,7 +37,7 @@ describe('Task Management', () => {
         priority: 'high',
       });
 
-      expect(taskId).toMatch(/^task_\d+_\d{3}$/);
+      expect(taskId).toMatch(/^task_\d+_\d{8}$/);
 
       const content = JSON.parse(readFileSync(join(paths.taskDir, `${taskId}.json`), 'utf-8'));
 


### PR DESCRIPTION
## Summary

CI run [25618845172](https://github.com/grandamenium/cortextos/actions/runs/25618845172) failed on `tests/unit/bus/task.test.ts:761` ("once the dependent completes, the blocker becomes eligible") with:

> `Dependency cycle: task_1778384098273_871 ultimately blocks itself via task_1778384098273_871`

Note: same task id on both sides. This is a flaky-test root cause, not a logic bug, and not introduced by the branch under test (`feat/voice-transcription`, which does not touch `src/bus/task.ts` or its tests).

## Root Cause

`createTask` in `src/bus/task.ts:42` generated ids as:

```ts
const taskId = `task_${Date.now()}_${randomDigits(3)}`;
```

Two `createTask` calls landing in the same millisecond have a ~1/1000 chance of colliding on the 3-digit suffix. When they collide, the new task's id matches its own declared blocker — and `detectCycleOrThrow` correctly rejects it as a self-dependency.

The hot test path in `task.test.ts:761` is:

```ts
const blocker = createTask(...);
const dependent = createTask(..., { blockedBy: [blocker] });  // ← collides ~0.1% of CI runs
```

## Fix

Bump `randomDigits(3)` → `randomDigits(8)`, dropping collision probability from ~1e-3 to ~1e-8 per same-millisecond call pair. The id-format assertion in `task.test.ts:40` was tightened to `\d{8}`. The looser regex in `codex-bus-roundtrip.test.ts:101` (`[a-z0-9]+`) is unaffected.

## Test Plan

- [x] `npm run build` — exit 0
- [x] `npm test` — 1688 passed, 1 skipped, 0 failed (vs. baseline CI run: 1 failed)
- [x] `npx vitest run tests/unit/bus/task.test.ts` — 40 passed (vs. 39 passed + 1 failed in failing CI run)

## Why merge fast

`feat/voice-transcription` (PR-in-flight) is currently blocked by this flake on its CI re-run. Merging this fix unblocks any branch that exercises the bus task path, not just voice-transcription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)