### PR TITLE
feat(self-healing): compact-boundary watcher — surface /compact moment via Telegram (BL-002 P1)

### DIFF
--- a/scripts/self-healing/README.md
+++ b/scripts/self-healing/README.md
@@ -11,6 +11,7 @@ If you're running an unattended single-operator deployment — or just want Tele
 | `watchdog.sh` | Daemon-level. Detects accumulated Telegram poller errors in PM2's daemon error log; restarts the daemon if a threshold of errors accumulates inside a 5-min window. | every 5 min |
 | `agent-recover.sh` | Per-agent. Detects agents whose process is alive but stdout has been idle ≥6 min while the daemon is still injecting messages — i.e., a hung PTY. Restarts JUST that agent (no daemon-wide restart) with a 20-min cooldown. | every 5 min |
 | `usage-monitor.sh` | Cost. Calls `ccusage blocks --json`, computes USD/hr for the active 5-hour Claude Code session window, sends Telegram alerts on tier transitions (default GREEN <$15, YELLOW $15–$30, RED >$30). | every 30 min |
+| `compact-boundary-watcher.sh` | Context. Scans every active Claude Code session JSONL under `~/.claude/projects/`; when a turn crosses a configured cache_read tier at a text-only or 5-min-idle boundary, sends a Telegram hint with the canned `/compact` prompt pre-quoted. Operator-typed `/compact` is the only way to keep a session below the 200K-context cliff; this surfaces the moment the agent cannot. Defaults: tiers 120K / 150K / 170K (≈ 60/75/85% of 200K). Idempotent — 1 hint per (session, tier). | every 10 min |
 
 Each script is matched by a launchd plist template you customize once.
 
@@ -28,7 +29,7 @@ Steps:
 ```bash
 # 1. Copy scripts into your local cortextOS state dir (so they live with your instance, not the repo)
 mkdir -p ~/.cortextos/default/scripts ~/.cortextos/default/logs
-cp scripts/self-healing/{watchdog,agent-recover,usage-monitor}.sh ~/.cortextos/default/scripts/
+cp scripts/self-healing/{watchdog,agent-recover,usage-monitor,compact-boundary-watcher}.sh ~/.cortextos/default/scripts/
 chmod +x ~/.cortextos/default/scripts/*.sh
 
 # 2. Render plist templates (substitute {USER}, {HOME}, {INSTANCE} for your values, then drop into ~/Library/LaunchAgents)
@@ -39,7 +40,7 @@ for f in scripts/self-healing/*.plist.template; do
 done
 
 # 3. Load the launchd jobs
-for f in ~/Library/LaunchAgents/com.cortextos.{watchdog,agent-recover,usage-monitor}.plist; do
+for f in ~/Library/LaunchAgents/com.cortextos.{watchdog,agent-recover,usage-monitor,compact-boundary-watcher}.plist; do
   launchctl load "$f"
 done
 
@@ -52,7 +53,7 @@ Each script writes to `~/.cortextos/<instance>/logs/<scriptname>.log`. Tail thos
 ## Uninstall
 
 ```bash
-for f in ~/Library/LaunchAgents/com.cortextos.{watchdog,agent-recover,usage-monitor}.plist; do
+for f in ~/Library/LaunchAgents/com.cortextos.{watchdog,agent-recover,usage-monitor,compact-boundary-watcher}.plist; do
   launchctl unload "$f"
   rm "$f"
 done
@@ -71,6 +72,12 @@ All thresholds live at the top of each script as shell variables — open the sc
 
 ### `usage-monitor.sh`
 - `YELLOW_THRESHOLD` (default `15`) and `RED_THRESHOLD` (default `30`) — USD/hr tier boundaries
+
+### `compact-boundary-watcher.sh`
+- `COMPACT_TIERS` (default `120,150,170`) — comma-separated cache_read tier thresholds in K tokens. One Telegram hint is emitted per `(session, tier)`. For 1M-Opus deployments override to e.g. `350,500,700`.
+- `COMPACT_SINCE_MINUTES` (default `5`) — only consider sessions whose JSONL has activity within this window. Tighter than the 10-min cron cadence so the hint stays "fresh."
+- `COMPACT_ANALYZE_PY` — override path to `analyze.py` if `$CTX_FRAMEWORK_ROOT/scripts/session-analysis/analyze.py` doesn't resolve.
+- Idempotency state: `~/.cortextos/<instance>/compact-watcher-state.tsv`. Delete to re-arm all sessions.
 
 ## Caveats
 

--- a/scripts/self-healing/com.cortextos.compact-boundary-watcher.plist.template
+++ b/scripts/self-healing/com.cortextos.compact-boundary-watcher.plist.template
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cortextos.compact-boundary-watcher</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{HOME}/.cortextos/{INSTANCE}/scripts/compact-boundary-watcher.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>600</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{HOME}/.cortextos/{INSTANCE}/logs/compact-boundary-watcher.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>{HOME}/.cortextos/{INSTANCE}/logs/compact-boundary-watcher.stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>CTX_INSTANCE_ID</key>
+        <string>{INSTANCE}</string>
+        <key>CTX_FRAMEWORK_ROOT</key>
+        <string>{HOME}/cortextos</string>
+    </dict>
+</dict>
+</plist>

--- a/scripts/self-healing/compact-boundary-watcher.sh
+++ b/scripts/self-healing/compact-boundary-watcher.sh
@@ -87,6 +87,14 @@ echo "$CANDIDATES_JSON" | "$JQ_BIN" -c '.[]' | while read -r row; do
   timestamp=$(echo "$row" | "$JQ_BIN" -r '.timestamp')
   why=$(echo "$row" | "$JQ_BIN" -r '.why')
 
+  # Defensive: skip rows where context_total isn't a positive integer
+  # (e.g. an assistant row with no usage block — analyze.py would emit 0,
+  # but jq's // fallback or upstream schema drift could yield "null").
+  if ! [[ "$context_total" =~ ^[0-9]+$ ]] || [ "$context_total" -eq 0 ]; then
+    echo "[$log_ts]   skip $agent_name $session_id (no context_total: '$context_total')" >> "$LOG_FILE"
+    continue
+  fi
+
   # Highest crossed tier (the alert speaks to the most urgent level reached).
   crossed_tier=""
   for tier_k in $(echo "$TIERS_RAW" | tr ',' ' '); do
@@ -135,8 +143,8 @@ Operator: paste this at the agent prompt to compact at the next phase boundary �
       echo "[$log_ts]   ERR  Telegram send failed: $response" >> "$LOG_FILE"
     fi
   else
-    # No bot configured — log only, still record state to avoid spam once it's wired.
+    # No bot configured — log only. Do NOT record state: once the bot is
+    # wired later, prior candidates would otherwise be permanently suppressed.
     echo "[$log_ts]   DRY  (no bot) $agent_name $session_id tier=${crossed_tier}K cr=${cr_human}" >> "$LOG_FILE"
-    printf '%s\t%s\t%s\n' "$session_id" "$crossed_tier" "$ts_now" >> "$STATE_FILE"
   fi
 done

--- a/scripts/self-healing/compact-boundary-watcher.sh
+++ b/scripts/self-healing/compact-boundary-watcher.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Compact-boundary watcher for cortextOS.
+# Scans every active Claude Code session JSONL and emits a Telegram hint when
+# context (cache_read+cache_create) crosses a tier boundary at a text-only or
+# 5-min-idle turn — surfacing the operator-typed /compact moment that agents
+# cannot self-invoke. Backstop against the runaway-session class of incident
+# (BL-2026-05-11-002, references session 28ec1a74's 146M-token / $334 burn).
+#
+# Tiers (tunable via COMPACT_TIERS, K tokens):
+#   120 / 150 / 170 — maps to ~60/75/85% of the 200K default context limit.
+#   For 1M-Opus deployments override e.g. COMPACT_TIERS="350,500,700".
+#
+# Idempotency: max 1 hint per (session, tier). State file at
+# $HOME/.cortextos/$INSTANCE/compact-watcher-state.tsv with rows
+# `session_id<TAB>tier_k<TAB>ts_iso`.
+#
+# Runs every 10 minutes via launchd. See README.md for install steps.
+
+set -u
+
+INSTANCE="${CTX_INSTANCE_ID:-default}"
+FRAMEWORK_ROOT="${CTX_FRAMEWORK_ROOT:-$HOME/cortextos}"
+ANALYZE_PY="${COMPACT_ANALYZE_PY:-$FRAMEWORK_ROOT/scripts/session-analysis/analyze.py}"
+STATE_DIR="$HOME/.cortextos/$INSTANCE"
+STATE_FILE="$STATE_DIR/compact-watcher-state.tsv"
+LOG_FILE="$STATE_DIR/logs/compact-boundary-watcher.log"
+
+# Tiers in K tokens, ascending.
+TIERS_RAW="${COMPACT_TIERS:-120,150,170}"
+# Activity window. Cron cadence is 10 min; window of 5 min keeps hints "fresh"
+# (don't re-alert on a session that went idle 8 min ago).
+SINCE_MINUTES="${COMPACT_SINCE_MINUTES:-5}"
+
+JQ_BIN="$(command -v jq)"
+PYTHON_BIN="$(command -v python3)"
+[ -z "$JQ_BIN" ] && { echo "compact-boundary-watcher: jq not on PATH" >&2; exit 1; }
+[ -z "$PYTHON_BIN" ] && { echo "compact-boundary-watcher: python3 not on PATH" >&2; exit 1; }
+[ -f "$ANALYZE_PY" ] || { echo "compact-boundary-watcher: analyze.py not at $ANALYZE_PY (set COMPACT_ANALYZE_PY or CTX_FRAMEWORK_ROOT)" >&2; exit 1; }
+
+# Auto-detect alert bot — same pattern as usage-monitor.sh.
+ALERT_BOT_ENV="${CORTEXTOS_ALERT_BOT_ENV:-}"
+if [ -z "$ALERT_BOT_ENV" ]; then
+  for ctx in "$FRAMEWORK_ROOT"/orgs/*/context.json; do
+    [ -f "$ctx" ] || continue
+    orch=$("$JQ_BIN" -r '.orchestrator // empty' "$ctx")
+    [ -z "$orch" ] && continue
+    org=$(basename "$(dirname "$ctx")")
+    candidate="$FRAMEWORK_ROOT/orgs/$org/agents/$orch/.env"
+    [ -f "$candidate" ] && ALERT_BOT_ENV="$candidate" && break
+  done
+fi
+
+BOT_TOKEN=""
+CHAT_ID=""
+if [ -n "$ALERT_BOT_ENV" ] && [ -f "$ALERT_BOT_ENV" ]; then
+  BOT_TOKEN=$(grep -E "^BOT_TOKEN=" "$ALERT_BOT_ENV" 2>/dev/null | cut -d= -f2)
+  CHAT_ID=$(grep -E "^CHAT_ID=" "$ALERT_BOT_ENV" 2>/dev/null | cut -d= -f2)
+fi
+
+mkdir -p "$STATE_DIR/logs"
+touch "$STATE_FILE"
+ts_now="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+log_ts="$(date '+%Y-%m-%d %H:%M:%S')"
+
+# Lowest tier drives the analyze.py threshold.
+MIN_TIER=$(echo "$TIERS_RAW" | tr ',' '\n' | sort -n | head -1)
+
+CANDIDATES_JSON=$("$PYTHON_BIN" "$ANALYZE_PY" recent-candidates \
+  --since-minutes "$SINCE_MINUTES" \
+  --threshold "$MIN_TIER" \
+  --format json 2>>"$LOG_FILE")
+
+if [ -z "$CANDIDATES_JSON" ] || [ "$CANDIDATES_JSON" = "[]" ]; then
+  echo "[$log_ts] no candidates (threshold ${MIN_TIER}K, window ${SINCE_MINUTES}m)" >> "$LOG_FILE"
+  exit 0
+fi
+
+count=$(echo "$CANDIDATES_JSON" | "$JQ_BIN" 'length')
+echo "[$log_ts] $count candidate(s) at threshold ${MIN_TIER}K, window ${SINCE_MINUTES}m" >> "$LOG_FILE"
+
+echo "$CANDIDATES_JSON" | "$JQ_BIN" -c '.[]' | while read -r row; do
+  session_id=$(echo "$row" | "$JQ_BIN" -r '.session_id')
+  agent_name=$(echo "$row" | "$JQ_BIN" -r '.agent_name // "unknown"')
+  branch=$(echo "$row" | "$JQ_BIN" -r '.branch // "unknown"')
+  cache_read=$(echo "$row" | "$JQ_BIN" -r '.cache_read')
+  context_total=$(echo "$row" | "$JQ_BIN" -r '.context_total')
+  timestamp=$(echo "$row" | "$JQ_BIN" -r '.timestamp')
+  why=$(echo "$row" | "$JQ_BIN" -r '.why')
+
+  # Highest crossed tier (the alert speaks to the most urgent level reached).
+  crossed_tier=""
+  for tier_k in $(echo "$TIERS_RAW" | tr ',' ' '); do
+    tier_tokens=$((tier_k * 1000))
+    if [ "$context_total" -ge "$tier_tokens" ]; then
+      crossed_tier="$tier_k"
+    fi
+  done
+  [ -z "$crossed_tier" ] && continue
+
+  # Idempotency — skip if (session, tier) already alerted.
+  if awk -v sid="$session_id" -v tier="$crossed_tier" -F'\t' \
+      '$1==sid && $2==tier {found=1; exit} END {exit !found}' "$STATE_FILE"; then
+    echo "[$log_ts]   skip $agent_name $session_id tier=${crossed_tier}K (already alerted)" >> "$LOG_FILE"
+    continue
+  fi
+
+  cr_human=$(awk -v n="$cache_read" 'BEGIN {
+    if (n>=1000000) printf "%.1fM", n/1000000;
+    else if (n>=1000) printf "%.1fK", n/1000;
+    else print n
+  }')
+
+  # Quote the canned /compact phase-boundary prompt inline so operator can copy-paste.
+  msg="🧹 *Compact-boundary hint — ${agent_name}*
+Session: \`${session_id:0:8}\`
+Branch: \`${branch}\`
+Context: *${cr_human}* cache_read (tier ${crossed_tier}K, ${why})
+Last turn: ${timestamp:0:19}
+
+Operator: paste this at the agent prompt to compact at the next phase boundary —
+
+\`\`\`
+/compact preserve: current branch name, last 5 commits with their messages, current spec file paths, open file paths, in-flight TODO/blockers, this phase's acceptance criteria. drop: completed code-evaluator subagent transcripts, deep-eval discussions on already-merged PRs, exploration discussions on resolved questions, intermediate debugging chains where the bug is fixed.
+\`\`\`"
+
+  if [ -n "$BOT_TOKEN" ] && [ -n "$CHAT_ID" ]; then
+    response=$(curl -sS --max-time 10 "https://api.telegram.org/bot${BOT_TOKEN}/sendMessage" \
+      -H "Content-Type: application/json" \
+      -d "$(printf '{"chat_id": %s, "text": %s, "parse_mode": "Markdown"}' "$CHAT_ID" "$(echo "$msg" | "$JQ_BIN" -Rs .)")" 2>&1)
+    ok=$(echo "$response" | "$JQ_BIN" -r '.ok // empty' 2>/dev/null)
+    if [ "$ok" = "true" ]; then
+      echo "[$log_ts]   ALERT $agent_name $session_id tier=${crossed_tier}K cr=${cr_human} branch=$branch" >> "$LOG_FILE"
+      printf '%s\t%s\t%s\n' "$session_id" "$crossed_tier" "$ts_now" >> "$STATE_FILE"
+    else
+      echo "[$log_ts]   ERR  Telegram send failed: $response" >> "$LOG_FILE"
+    fi
+  else
+    # No bot configured — log only, still record state to avoid spam once it's wired.
+    echo "[$log_ts]   DRY  (no bot) $agent_name $session_id tier=${crossed_tier}K cr=${cr_human}" >> "$LOG_FILE"
+    printf '%s\t%s\t%s\n' "$session_id" "$crossed_tier" "$ts_now" >> "$STATE_FILE"
+  fi
+done

--- a/scripts/session-analysis/analyze.py
+++ b/scripts/session-analysis/analyze.py
@@ -375,13 +375,20 @@ def cmd_recent_candidates(args):
                 continue
             age = (now - ts).total_seconds()
             if age > since_seconds:
-                break  # turns are time-ordered; earlier ones are too old
+                # Sidechain turns can produce non-monotonic timestamps, so
+                # keep walking rather than `break` — old turns get filtered
+                # by the age check itself.
+                continue
             ctx = t["cr"] + t["cc"]
             if ctx < threshold:
                 continue
             text_only = not t["tools"]
             gap = False
             if i + 1 < len(turns):
+                # turns[i+1] is the NEXT turn chronologically (higher index =
+                # later append). gap>300 ⇒ the agent paused 5+ min AFTER turn i,
+                # so turn i is the last safe boundary before the idle window.
+                # Matches cmd_compact's existing semantics.
                 nxt = _parse_iso(turns[i + 1]["ts"])
                 if nxt is not None:
                     gap = (nxt - ts).total_seconds() > 300

--- a/scripts/session-analysis/analyze.py
+++ b/scripts/session-analysis/analyze.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+"""Analyze Claude Code session JSONL logs for token-spend insights.
+
+Reads ~/.claude/projects/<encoded-cwd>/*.jsonl. The encoded-cwd is the
+absolute working directory with '/' replaced by '-'. Subcommands report
+project totals, per-session breakdowns, tool-level aggregation, hourly
+spend, USD estimates, and turns where /compact would have helped.
+"""
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import os
+import sys
+from collections import Counter, defaultdict
+from datetime import datetime, timezone
+from pathlib import Path
+
+# Anthropic Opus 4.x list pricing (USD per 1M tokens) — keep in sync with
+# https://www.anthropic.com/pricing when re-running cost reports.
+PRICING_USD_PER_MTOK = {
+    "input": 15.0,
+    "output": 75.0,
+    "cache_write_5m": 18.75,
+    "cache_write_1h": 30.0,
+    "cache_read": 1.50,
+}
+
+
+def human(n: float) -> str:
+    for unit in ("", "K", "M", "B"):
+        if abs(n) < 1000:
+            return f"{n:.1f}{unit}"
+        n /= 1000
+    return f"{n:.1f}T"
+
+
+def project_dir_for_cwd(cwd: str) -> Path:
+    encoded = cwd.replace("/", "-")
+    return Path.home() / ".claude" / "projects" / encoded
+
+
+def default_project_dir() -> Path:
+    return project_dir_for_cwd(os.getcwd())
+
+
+def iter_sessions(project_dir: Path):
+    for path in sorted(glob.glob(str(project_dir / "*.jsonl"))):
+        yield Path(path)
+
+
+def iter_events(jsonl_path: Path):
+    with jsonl_path.open() as f:
+        for line in f:
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def usage_of(event: dict) -> dict:
+    return event.get("message", {}).get("usage", {}) or {}
+
+
+def extract_tokens(u: dict) -> tuple[int, int, int, int, int, int]:
+    inp = u.get("input_tokens", 0)
+    out = u.get("output_tokens", 0)
+    cc = u.get("cache_creation_input_tokens", 0)
+    cr = u.get("cache_read_input_tokens", 0)
+    cache = u.get("cache_creation", {}) or {}
+    cc_5m = cache.get("ephemeral_5m_input_tokens", 0)
+    cc_1h = cache.get("ephemeral_1h_input_tokens", 0)
+    return inp, out, cc, cr, cc_5m, cc_1h
+
+
+def dollars(inp: int, out: int, cc_5m: int, cc_1h: int, cr: int) -> float:
+    p = PRICING_USD_PER_MTOK
+    return (
+        inp * p["input"]
+        + out * p["output"]
+        + cc_5m * p["cache_write_5m"]
+        + cc_1h * p["cache_write_1h"]
+        + cr * p["cache_read"]
+    ) / 1_000_000
+
+
+# ---------------------------------------------------------------- summary ----
+
+def cmd_summary(args):
+    project_dir = Path(args.project_dir)
+    if not project_dir.exists():
+        print(f"No session dir at {project_dir}", file=sys.stderr)
+        return 1
+    sessions = []
+    grand = Counter()
+    for path in iter_sessions(project_dir):
+        s = {
+            "sid": path.stem,
+            "size_bytes": path.stat().st_size,
+            "in": 0, "out": 0, "cc": 0, "cr": 0, "cc_5m": 0, "cc_1h": 0,
+            "main_in": 0, "main_out": 0, "sub_in": 0, "sub_out": 0,
+            "models": Counter(),
+            "agents": set(),
+            "branches": set(),
+            "first": None, "last": None,
+            "turns": 0,
+        }
+        for ev in iter_events(path):
+            t = ev.get("type")
+            if t == "agent-name" and ev.get("agentName"):
+                s["agents"].add(ev["agentName"])
+                continue
+            if t != "assistant":
+                continue
+            s["turns"] += 1
+            inp, out, cc, cr, cc_5m, cc_1h = extract_tokens(usage_of(ev))
+            s["in"] += inp; s["out"] += out; s["cc"] += cc; s["cr"] += cr
+            s["cc_5m"] += cc_5m; s["cc_1h"] += cc_1h
+            if ev.get("isSidechain"):
+                s["sub_in"] += inp + cc + cr; s["sub_out"] += out
+            else:
+                s["main_in"] += inp + cc + cr; s["main_out"] += out
+            s["models"][ev.get("message", {}).get("model", "?")] += 1
+            br = ev.get("gitBranch")
+            if br:
+                s["branches"].add(br)
+            ts = ev.get("timestamp")
+            if ts:
+                if not s["first"] or ts < s["first"]: s["first"] = ts
+                if not s["last"]  or ts > s["last"]:  s["last"] = ts
+        s["total"] = s["in"] + s["out"] + s["cc"] + s["cr"]
+        s["usd"] = dollars(s["in"], s["out"], s["cc_5m"], s["cc_1h"], s["cr"])
+        grand["in"] += s["in"]; grand["out"] += s["out"]
+        grand["cc"] += s["cc"]; grand["cr"] += s["cr"]
+        grand["cc_5m"] += s["cc_5m"]; grand["cc_1h"] += s["cc_1h"]
+        grand["turns"] += s["turns"]
+        sessions.append(s)
+
+    sessions.sort(key=lambda s: -s["total"])
+    total_tokens = sum(grand[k] for k in ("in", "out", "cc", "cr"))
+    total_usd = dollars(grand["in"], grand["out"], grand["cc_5m"], grand["cc_1h"], grand["cr"])
+
+    print(f"Project: {project_dir}")
+    print(f"Sessions: {len(sessions)}  |  Turns: {grand['turns']}")
+    print(f"Total tokens: {human(total_tokens)}  (~${total_usd:,.2f})")
+    print(f"  cache_read:   {human(grand['cr'])}  (~${grand['cr'] * PRICING_USD_PER_MTOK['cache_read'] / 1e6:,.2f})")
+    print(f"  cache_create: {human(grand['cc'])}  (5m={human(grand['cc_5m'])}  1h={human(grand['cc_1h'])})")
+    print(f"  input:        {human(grand['in'])}")
+    print(f"  output:       {human(grand['out'])}")
+    print()
+    hdr = f"{'session':36s} {'first':19s} {'turns':>5s} {'total':>8s} {'cr':>8s} {'cc':>7s} {'out':>7s} {'sub':>7s} {'usd':>8s}  branches | agents"
+    print(hdr)
+    print("-" * len(hdr))
+    for s in sessions:
+        agents = ",".join(sorted(s["agents"]))[:30] or "-"
+        brs = ",".join(sorted(s["branches"]))[:50]
+        print(
+            f"{s['sid']:36s} {(s['first'] or '')[:19]:19s} {s['turns']:>5d} "
+            f"{human(s['total']):>8s} {human(s['cr']):>8s} {human(s['cc']):>7s} "
+            f"{human(s['out']):>7s} {human(s['sub_in'] + s['sub_out']):>7s} "
+            f"${s['usd']:>7,.2f}  {brs} | {agents}"
+        )
+    return 0
+
+
+# ---------------------------------------------------------------- session ----
+
+def _load_session(path: Path):
+    turns = []   # list of dicts per assistant turn
+    agents = []
+    for ev in iter_events(path):
+        t = ev.get("type")
+        if t == "agent-name" and ev.get("agentName"):
+            agents.append(ev["agentName"])
+        if t != "assistant":
+            continue
+        inp, out, cc, cr, cc_5m, cc_1h = extract_tokens(usage_of(ev))
+        tools = []
+        for c in ev.get("message", {}).get("content", []) or []:
+            if c.get("type") == "tool_use":
+                tools.append(c.get("name", "?"))
+        turns.append({
+            "ts": ev.get("timestamp", ""),
+            "tools": tools,
+            "in": inp, "out": out, "cc": cc, "cr": cr,
+            "cc_5m": cc_5m, "cc_1h": cc_1h,
+            "sidechain": bool(ev.get("isSidechain")),
+            "model": ev.get("message", {}).get("model", "?"),
+            "branch": ev.get("gitBranch"),
+        })
+    return turns, agents
+
+
+def cmd_session(args):
+    project_dir = Path(args.project_dir)
+    matches = sorted(project_dir.glob(f"{args.session}*.jsonl"))
+    if not matches:
+        print(f"No session matching {args.session} in {project_dir}", file=sys.stderr)
+        return 1
+    if len(matches) > 1:
+        print(f"Multiple matches; using {matches[0].name}", file=sys.stderr)
+    path = matches[0]
+    turns, agents = _load_session(path)
+    if not turns:
+        print(f"No assistant turns in {path.name}")
+        return 0
+
+    tool_n = Counter()
+    tool_cr = defaultdict(int); tool_cc = defaultdict(int); tool_out = defaultdict(int)
+    by_hour = defaultdict(lambda: {"cr": 0, "cc": 0, "out": 0, "n": 0})
+    for t in turns:
+        cr, cc, out = t["cr"], t["cc"], t["out"]
+        for name in t["tools"]:
+            tool_n[name] += 1
+            tool_cr[name] += cr; tool_cc[name] += cc; tool_out[name] += out
+        h = t["ts"][:13]
+        by_hour[h]["cr"] += cr; by_hour[h]["cc"] += cc
+        by_hour[h]["out"] += out; by_hour[h]["n"] += 1
+
+    print(f"Session: {path.name}")
+    print(f"Turns: {len(turns)}  |  Sidechain turns: {sum(1 for t in turns if t['sidechain'])}")
+    print(f"Agents tagged: {sorted(set(agents)) or '-'}")
+    print()
+    print(f"=== Tool usage ({sum(tool_n.values())} calls) ===")
+    print(f"{'tool':18s} {'n':>5s} {'cache_read':>10s} {'cache_create':>13s} {'output':>8s}")
+    for name, n in tool_n.most_common():
+        print(f"{name:18s} {n:>5d} {human(tool_cr[name]):>10s} {human(tool_cc[name]):>13s} {human(tool_out[name]):>8s}")
+
+    print()
+    print(f"=== Top {args.top} turns by (cache_read + cache_create) ===")
+    biggest = sorted(turns, key=lambda t: -(t["cr"] + t["cc"]))[:args.top]
+    for t in biggest:
+        tools = ",".join(t["tools"]) or "(text)"
+        print(f"  {t['ts'][:19]}  tools={tools[:40]:40s} cr={human(t['cr']):>8s} cc={human(t['cc']):>7s} out={human(t['out']):>6s}")
+
+    print()
+    print("=== Tokens by hour ===")
+    for h in sorted(by_hour):
+        x = by_hour[h]
+        print(f"  {h}  turns={x['n']:>4d}  cr={human(x['cr']):>8s}  cc={human(x['cc']):>7s}  out={human(x['out']):>7s}")
+    return 0
+
+
+# ------------------------------------------------------------------ tools ----
+
+def cmd_tools(args):
+    project_dir = Path(args.project_dir)
+    n = Counter()
+    cr = defaultdict(int); cc = defaultdict(int); out = defaultdict(int); inp = defaultdict(int)
+    for path in iter_sessions(project_dir):
+        for ev in iter_events(path):
+            if ev.get("type") != "assistant":
+                continue
+            i, o, c, r, _, _ = extract_tokens(usage_of(ev))
+            for piece in ev.get("message", {}).get("content", []) or []:
+                if piece.get("type") == "tool_use":
+                    name = piece.get("name", "?")
+                    n[name] += 1
+                    cr[name] += r; cc[name] += c; out[name] += o; inp[name] += i
+    print(f"Project: {project_dir}")
+    print(f"{'tool':20s} {'calls':>6s} {'cache_read':>11s} {'cache_create':>13s} {'output':>8s} {'input':>8s}")
+    for name, c in n.most_common():
+        print(f"{name:20s} {c:>6d} {human(cr[name]):>11s} {human(cc[name]):>13s} {human(out[name]):>8s} {human(inp[name]):>8s}")
+    return 0
+
+
+# ------------------------------------------------------ compact-candidates ----
+
+def cmd_compact(args):
+    """List turns where /compact would have helped: large cache_read AND a likely-safe boundary
+    (turn ends with a TaskUpdate to 'completed' OR has no tool_use, OR is the last turn before a long gap)."""
+    project_dir = Path(args.project_dir)
+    threshold = args.threshold * 1000  # K
+    for path in iter_sessions(project_dir):
+        turns, _ = _load_session(path)
+        if not turns:
+            continue
+        printed_header = False
+        for i, t in enumerate(turns):
+            ctx = t["cr"] + t["cc"]
+            if ctx < threshold:
+                continue
+            # boundary heuristic: text-only turn (no tool_use), or last turn in a 5-minute idle gap
+            text_only = not t["tools"]
+            gap = False
+            if i + 1 < len(turns):
+                try:
+                    from datetime import datetime
+                    a = datetime.fromisoformat(t["ts"].rstrip("Z"))
+                    b = datetime.fromisoformat(turns[i + 1]["ts"].rstrip("Z"))
+                    gap = (b - a).total_seconds() > 300
+                except Exception:
+                    pass
+            if not (text_only or gap):
+                continue
+            if not printed_header:
+                print(f"\nSession {path.stem}:")
+                printed_header = True
+            why = "text-boundary" if text_only else "5m-idle-gap"
+            print(f"  {t['ts'][:19]}  cr={human(t['cr']):>7s} cc={human(t['cc']):>6s}  ({why})")
+    return 0
+
+
+# ----------------------------------------------------- recent-candidates ----
+
+def _derive_agent_name(project_dir_name: str) -> str | None:
+    """Best-effort agent name from encoded-cwd dir name.
+
+    Encoded-cwd replaces '/' with '-'. For cortextos agents the cwd ends in
+    '.../agents/<name>', so the dir name contains '-agents-<name>'.
+    Returns None for projects that don't match the cortextos layout.
+    """
+    marker = "-agents-"
+    idx = project_dir_name.rfind(marker)
+    if idx == -1:
+        return None
+    return project_dir_name[idx + len(marker):]
+
+
+def _parse_iso(ts: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp string into an aware UTC datetime, or None."""
+    if not ts:
+        return None
+    s = ts.rstrip("Z")
+    try:
+        d = datetime.fromisoformat(s)
+    except ValueError:
+        return None
+    if d.tzinfo is None:
+        d = d.replace(tzinfo=timezone.utc)
+    return d.astimezone(timezone.utc)
+
+
+def cmd_recent_candidates(args):
+    """Scan every ~/.claude/projects/<encoded-cwd>/, find the most-recently-modified
+    JSONL per agent, and report the latest compact-eligible boundary turn that
+    occurred within --since-minutes. Emits one entry per active session.
+
+    Used by scripts/self-healing/compact-boundary-watcher.sh (cron, every 10 min).
+    """
+    base = Path.home() / ".claude" / "projects"
+    if not base.exists():
+        print("[]" if args.format == "json" else "(no ~/.claude/projects)", file=sys.stderr)
+        return 0
+
+    threshold = args.threshold * 1000
+    since_seconds = args.since_minutes * 60
+    now = datetime.now(timezone.utc)
+    cutoff = now.timestamp() - since_seconds
+
+    results = []
+    for proj_dir in sorted(base.iterdir()):
+        if not proj_dir.is_dir():
+            continue
+        jsonls = [p for p in proj_dir.glob("*.jsonl") if p.is_file()]
+        if not jsonls:
+            continue
+        jsonls.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+        path = jsonls[0]
+        mtime = path.stat().st_mtime
+        if mtime < cutoff:
+            continue  # stale session — no activity in the window
+
+        turns, agents = _load_session(path)
+        if not turns:
+            continue
+
+        candidate = None
+        # Walk newest-first so the first match is the most recent eligible boundary
+        for i in range(len(turns) - 1, -1, -1):
+            t = turns[i]
+            ts = _parse_iso(t["ts"])
+            if ts is None:
+                continue
+            age = (now - ts).total_seconds()
+            if age > since_seconds:
+                break  # turns are time-ordered; earlier ones are too old
+            ctx = t["cr"] + t["cc"]
+            if ctx < threshold:
+                continue
+            text_only = not t["tools"]
+            gap = False
+            if i + 1 < len(turns):
+                nxt = _parse_iso(turns[i + 1]["ts"])
+                if nxt is not None:
+                    gap = (nxt - ts).total_seconds() > 300
+            if not (text_only or gap):
+                continue
+            candidate = {
+                "session_id": path.stem,
+                "project_dir": proj_dir.name,
+                "jsonl_path": str(path),
+                "agent_name": (agents[-1] if agents else None) or _derive_agent_name(proj_dir.name),
+                "branch": t.get("branch"),
+                "cache_read": t["cr"],
+                "cache_create": t["cc"],
+                "context_total": ctx,
+                "timestamp": t["ts"],
+                "why": "text-boundary" if text_only else "5m-idle-gap",
+                "model": t.get("model"),
+                "jsonl_mtime_unix": mtime,
+            }
+            break
+
+        if candidate:
+            results.append(candidate)
+
+    if args.format == "json":
+        print(json.dumps(results, indent=2))
+    else:
+        if not results:
+            print("(no recent compact candidates)")
+        for c in results:
+            agent = c["agent_name"] or "?"
+            print(
+                f"  {c['timestamp'][:19]}  agent={agent:20s} session={c['session_id'][:8]} "
+                f"cr={human(c['cache_read']):>8s} cc={human(c['cache_create']):>7s}  ({c['why']})"
+            )
+    return 0
+
+
+# ---------------------------------------------------------------- projects ----
+
+def cmd_projects(args):
+    base = Path.home() / ".claude" / "projects"
+    rows = []
+    for d in sorted(base.glob("*")):
+        if not d.is_dir():
+            continue
+        tot = Counter()
+        for path in d.glob("*.jsonl"):
+            for ev in iter_events(path):
+                if ev.get("type") != "assistant":
+                    continue
+                i, o, c, r, c5, c1 = extract_tokens(usage_of(ev))
+                tot["in"] += i; tot["out"] += o; tot["cc"] += c; tot["cr"] += r
+                tot["cc_5m"] += c5; tot["cc_1h"] += c1
+        total = tot["in"] + tot["out"] + tot["cc"] + tot["cr"]
+        usd = dollars(tot["in"], tot["out"], tot["cc_5m"], tot["cc_1h"], tot["cr"])
+        rows.append((total, usd, d.name, tot))
+    rows.sort(reverse=True)
+    print(f"{'project':70s} {'total':>9s} {'cache_read':>11s} {'output':>8s} {'usd':>9s}")
+    for total, usd, name, tot in rows[: args.limit]:
+        if total == 0:
+            continue
+        print(f"{name[:70]:70s} {human(total):>9s} {human(tot['cr']):>11s} {human(tot['out']):>8s} ${usd:>8,.2f}")
+    return 0
+
+
+# -------------------------------------------------------------------- main ----
+
+def build_parser():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--project-dir", default=str(default_project_dir()),
+        help="Path to ~/.claude/projects/<encoded-cwd>/ (default: derived from cwd)",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp = sub.add_parser("summary", help="Project totals + per-session table")
+    sp.set_defaults(func=cmd_summary)
+
+    sp = sub.add_parser("session", help="Drill into one session (prefix-match on session id)")
+    sp.add_argument("session", help="Session id or unique prefix")
+    sp.add_argument("--top", type=int, default=10, help="Show top-N largest turns (default 10)")
+    sp.set_defaults(func=cmd_session)
+
+    sp = sub.add_parser("tools", help="Tool usage aggregated across all sessions")
+    sp.set_defaults(func=cmd_tools)
+
+    sp = sub.add_parser("compact-candidates", help="Find turns where /compact would have helped")
+    sp.add_argument("--threshold", type=int, default=200, help="Min cache_read+cache_create in K tokens (default 200)")
+    sp.set_defaults(func=cmd_compact)
+
+    sp = sub.add_parser(
+        "recent-candidates",
+        help="Scan every agent dir under ~/.claude/projects/ and report sessions with a recent compact-eligible boundary (for compact-boundary-watcher cron)",
+    )
+    sp.add_argument("--since-minutes", type=int, default=10,
+                    help="Only consider sessions whose JSONL was modified in the last N minutes (default 10)")
+    sp.add_argument("--threshold", type=int, default=120,
+                    help="Min cache_read+cache_create in K tokens (default 120 — tuned for 200K-context models)")
+    sp.add_argument("--format", choices=("text", "json"), default="text",
+                    help="Output format (default text; json for cron consumption)")
+    sp.set_defaults(func=cmd_recent_candidates)
+
+    sp = sub.add_parser("projects", help="Compare token spend across ALL ~/.claude/projects/")
+    sp.add_argument("--limit", type=int, default=20)
+    sp.set_defaults(func=cmd_projects)
+    return p
+
+
+def main(argv=None):
+    args = build_parser().parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Phase 1 of BL-2026-05-11-002. Backstops the runaway-session class of incident — reference: session `28ec1a74` burned 146M tokens / ~\$334 in a 2h window because 30+ text-only boundary turns crossed the safe-`/compact` threshold and the operator was never nudged. `/compact` is operator-typed; agents cannot self-invoke. This watcher closes the surfacing gap.

> **Note**: `scripts/session-analysis/analyze.py` was originally fork-side tooling; it's bundled here in full (507 lines) since the watcher depends on its `recent-candidates` subcommand. If you'd prefer it land as a separate PR first, happy to split.

- **`scripts/session-analysis/analyze.py`** (new) — token-spend analysis tool over `~/.claude/projects/<encoded-cwd>/*.jsonl`. Subcommands: project totals, per-session, tools, hourly, USD estimates, `compact-candidates`, and the new **`recent-candidates`** used by the watcher — walks every project, picks the most-recently-modified JSONL per agent, emits JSON for sessions with a recent compact-eligible boundary (`cache_read+cache_create ≥ threshold` AND `text-only OR 5-min-idle-gap`).
- **`compact-boundary-watcher.sh`** — launchd cron, 10-min cadence. Tier-based rate-limit (`120K / 150K / 170K` default = ~60/75/85% of 200K context). One alert per `(session, tier)`. Reuses bot auto-discovery + curl-to-Telegram pattern from `usage-monitor.sh`. Quotes the canned phase-boundary `/compact` prompt inline for one-keystroke operator paste.
- **`com.cortextos.compact-boundary-watcher.plist.template`** — paired launchd plist.
- **README** — install + tuning entries.

Out of scope (separate BL): Phase 3 `SessionEnd` retro hook.

## Test plan

- [x] `python3 analyze.py --help` shows new `recent-candidates` subcommand alongside existing ones; `py_compile` clean.
- [x] `analyze.py recent-candidates` against live fleet JSONLs at threshold 50K: 5 candidates detected (analyst/boss/devops/engineer/fullstack). JSON output validates.
- [x] E2E dry-run (no bot env): 5 candidates → 5 DRY entries on run 1; run 2 deduped all 5 via state-file `(session_id, tier)` key. After fix: DRY mode no longer writes state, so wiring a bot later won't suppress historical candidates.
- [x] Live message preview sent to Saurav via engineer bot — Markdown code block renders correctly for paste.
- [x] code-evaluator pass — 3 findings addressed (commit `9691d0d`): `break`→`continue` for non-monotonic timestamps, integer-guard on `-ge` comparison, dry-run no-state-write.
- [x] Rebased onto current `upstream/main` (2026-05-13) — `npm run typecheck` + `npm test` (1699 passed / 8 skipped) clean on the rebuilt branch.
- [ ] Acceptance gate (post-merge, runtime): re-run `analyze.py compact-candidates --threshold 120` against the next long multi-phase session and confirm 0 text-only candidates emitted after the operator's first ack.

## Calibration

`120K` matches the orange-boundary (75%) of 200K-default context per `.claude/docs/code-quality/compact-instructions.md`. Legacy `350K` was tuned for 1M Opus; for 1M-Opus deployments override `COMPACT_TIERS="350,500,700"`.

## History

Originally opened 2026-05-11 carrying ~100 unrelated fork-internal commits. Force-pushed 2026-05-13 after rebuilding cleanly on `upstream/main` (commits `938f995` + `9691d0d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)