### PR TITLE
fix(daemon): send back-online Telegram for codex-app-server runtime (#392)

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -1,4 +1,4 @@
-import { appendFileSync, existsSync, readFileSync, statSync, writeFileSync } from 'fs';
+import { appendFileSync, existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs';
 import { join, sep } from 'path';
 import { homedir } from 'os';
 import type { AgentConfig, AgentStatus, CtxEnv } from '../types/index.js';
@@ -58,6 +58,11 @@ export class AgentProcess {
   // (each start() recreates the PTY, but the Telegram handle persists).
   private telegramApi: TelegramAPI | null = null;
   private telegramChatId: string | null = null;
+  // Issue #392: tracks whether the most recently built startup prompt consumed
+  // a handoff doc marker. start() reads this after spawn to decide whether the
+  // daemon should fire the codex-app-server back-online Telegram directly
+  // (skipped on handoff restart — the agent sends its own contextual reply).
+  private lastSpawnWasHandoff = false;
 
   constructor(name: string, env: CtxEnv, config: AgentConfig, log?: LogFn) {
     this.name = name;
@@ -166,6 +171,13 @@ export class AgentProcess {
       this.status = 'running';
       this.sessionStart = new Date();
       this.log(`Running (pid: ${this.pty.getPid()})`);
+
+      // Issue #392: codex-app-server does not reliably execute the inline
+      // "Send a Telegram message saying you are back online" instruction the
+      // way claude-code does, so fire the back-online ping directly from the
+      // daemon for that runtime. Skipped on handoff restart — the agent
+      // sends its own contextual "back — ..." reply in that case.
+      this.maybeSendCodexBootNotification();
 
       // Start session timer
       this.startSessionTimer();
@@ -515,6 +527,7 @@ export class AgentProcess {
     const deliverablesBlock = this.buildDeliverablesBlock();
     const handoffBlock = this.consumeHandoffBlock();
     const isHandoffRestart = handoffBlock.length > 0;
+    this.lastSpawnWasHandoff = isHandoffRestart;
     // HANDOFF UX: the pickup message MUST be the first action after reading the handoff doc —
     // before cron restoration, before heartbeat, before anything else. Placing this instruction
     // immediately after the handoffBlock in the prompt ensures it is not buried.
@@ -531,6 +544,8 @@ export class AgentProcess {
     const nowUtc = new Date().toISOString();
     const reminderBlock = this.buildReminderBlock();
     const deliverablesBlock = this.buildDeliverablesBlock();
+    // Session refresh (--continue) is never a handoff restart.
+    this.lastSpawnWasHandoff = false;
     return `SESSION CONTINUATION: Your CLI process was restarted with --continue to reload configs. Current UTC time: ${nowUtc}. Your full conversation history is preserved. Re-read AGENTS.md and ALL bootstrap files listed there. External crons are auto-loaded by the daemon — do NOT call CronCreate or CronList for cron restoration.${reminderBlock}${deliverablesBlock} Check inbox. Resume normal operations. After checking inbox, send a Telegram message to the user saying you are back online.`;
   }
 
@@ -584,7 +599,6 @@ export class AgentProcess {
     const markerPath = join(this.env.ctxRoot, 'state', this.name, '.handoff-doc-path');
     if (!existsSync(markerPath)) return '';
     try {
-      const { unlinkSync } = require('fs');
       const docPath = readFileSync(markerPath, 'utf-8').trim();
       unlinkSync(markerPath);
       if (!docPath || !existsSync(docPath)) return '';
@@ -592,6 +606,29 @@ export class AgentProcess {
     } catch {
       return '';
     }
+  }
+
+  /**
+   * Issue #392: send the back-online Telegram notification directly from the
+   * daemon when the codex-app-server runtime spawns. The boot prompt's inline
+   * "Send a Telegram message..." instruction reaches the codex thread but is
+   * not executed reliably as a tool call, leaving James without the standard
+   * post-restart notification claude-code peers send.
+   *
+   * Skipped when:
+   *  - runtime is anything other than codex-app-server (claude-code/hermes
+   *    already emit this via the prompt),
+   *  - the most recent prompt was built for a handoff restart (the agent
+   *    sends its own contextual "back — ..." reply in that case),
+   *  - no Telegram handle has been wired (no chat_id configured).
+   */
+  private maybeSendCodexBootNotification(): void {
+    if (this.config.runtime !== 'codex-app-server') return;
+    if (this.lastSpawnWasHandoff) return;
+    if (!this.telegramApi || !this.telegramChatId) return;
+    this.telegramApi
+      .sendMessage(this.telegramChatId, `Agent ${this.name} is back online`)
+      .catch(() => { /* non-fatal: notification is observability only */ });
   }
 
   private startSessionTimer(): void {

--- a/tests/unit/daemon/agent-process-codex-app-server.test.ts
+++ b/tests/unit/daemon/agent-process-codex-app-server.test.ts
@@ -70,6 +70,7 @@ vi.mock('fs', async () => {
   return {
     ...actual,
     mkdirSync: vi.fn(),
+    unlinkSync: vi.fn(),
     get existsSync() { return fsMocks.existsSync; },
     get readFileSync() { return fsMocks.readFileSync; },
     get writeFileSync() { return fsMocks.writeFileSync; },
@@ -127,6 +128,55 @@ describe('AgentProcess codex-app-server runtime', () => {
     await ap.start();
 
     expect(mockCodexAppServerPty.setTelegramHandle).toHaveBeenCalledWith(api, '12345');
+  });
+
+  it('sends back-online Telegram directly from daemon on fresh start (issue #392)', async () => {
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const api = { sendChatAction: vi.fn().mockResolvedValue(undefined), sendMessage };
+
+    ap.setTelegramHandle(api as any, '12345');
+    await ap.start();
+
+    expect(sendMessage).toHaveBeenCalledWith('12345', 'Agent codex-app-agent is back online');
+  });
+
+  it('skips back-online Telegram on handoff restart (issue #392)', async () => {
+    // Simulate handoff doc marker present at .handoff-doc-path so
+    // consumeHandoffBlock() returns a non-empty fragment, marking the spawn
+    // as a handoff restart that should suppress the daemon-direct ping.
+    // existsSync must return true for BOTH the marker file and the doc path
+    // it points at — consumeHandoffBlock checks both.
+    const handoffDocPath = '/tmp/handoff-doc.md';
+    fsMocks.existsSync.mockImplementation((path: string) =>
+      typeof path === 'string'
+      && (path.endsWith('.handoff-doc-path') || path === handoffDocPath),
+    );
+    fsMocks.readFileSync.mockReturnValue(handoffDocPath);
+
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const api = { sendChatAction: vi.fn().mockResolvedValue(undefined), sendMessage };
+
+    ap.setTelegramHandle(api as any, '12345');
+    await ap.start();
+
+    const prompt = mockCodexAppServerPty.spawn.mock.calls[0]?.[1] ?? '';
+    expect(prompt).toContain('CONTEXT HANDOFF');
+    expect(sendMessage).not.toHaveBeenCalled();
+  });
+
+  it('does not send daemon-direct back-online Telegram for claude-code runtime (issue #392)', async () => {
+    // claude-code already executes the inline "Send a Telegram message..."
+    // bootstrap instruction itself, so the daemon must not double up.
+    const ap = new AgentProcess('claude-agent', mockEnv, { runtime: 'claude-code' });
+    const sendMessage = vi.fn().mockResolvedValue(undefined);
+    const api = { sendChatAction: vi.fn().mockResolvedValue(undefined), sendMessage };
+
+    ap.setTelegramHandle(api as any, '12345');
+    await ap.start();
+
+    expect(sendMessage).not.toHaveBeenCalled();
   });
 
   it('uses direct kill path on stop, not Claude /exit choreography', async () => {


### PR DESCRIPTION
## Summary

- Closes #392 — codex-app-server runtime now sends the back-online Telegram on restart, matching claude-code behavior
- Daemon fires the notification directly from `AgentProcess.start()` after spawn succeeds for the codex-app-server runtime; mirrors the existing crash-recovery direct-send pattern in `agent-manager.ts:272`
- Skipped on handoff restart (the agent sends its own contextual reply via the `HANDOFF UX` prompt) and when no Telegram handle is wired

## Why

Claude-code executes the bootstrap prompt's `"Send a Telegram message..."` instruction as a tool call; codex-app-server's exec-per-turn model does not run that as a discrete turn, so James gets no notification when a codex-app-server peer (Stephen) restarts. This makes the daemon authoritative for the runtime-independent back-online ping.

## Implementation

- `agent-process.ts`: new `maybeSendCodexBootNotification()` invoked after `this.status = 'running'`; gated on `runtime === 'codex-app-server'`, `!lastSpawnWasHandoff`, and Telegram handle present
- `lastSpawnWasHandoff` flag set inside `buildStartupPrompt()` (using the existing `isHandoffRestart` computation) and cleared in `buildContinuePrompt()`
- `consumeHandoffBlock()` refactored to use the top-level `unlinkSync` import rather than `require('fs')` — enables clean mock-based test coverage of the handoff branch

## Test plan

- [x] 3 new unit tests in `tests/unit/daemon/agent-process-codex-app-server.test.ts`:
  - codex-app-server fresh start → daemon sends `Agent <name> is back online`
  - codex-app-server with handoff doc marker → daemon does NOT send (agent owns the reply)
  - claude-code runtime → daemon does NOT send (avoid double-ping; agent owns the reply)
- [x] Full test suite passes: 1699 passed / 1 skipped / 0 failed
- [ ] Manual verification post-merge: `cortextos restart codex-agent` → expect Telegram ping