### PR TITLE
fix(dashboard): use systemName for heartbeat lookup + agent detail link

### DIFF
--- a/dashboard/src/components/overview/agent-status-grid.tsx
+++ b/dashboard/src/components/overview/agent-status-grid.tsx
@@ -7,7 +7,7 @@ import { IconRobot, IconChevronRight } from '@tabler/icons-react';
 import type { AgentSummary, Heartbeat } from '@/lib/types';
 
 interface AgentStatusGridProps {
-  agents: (AgentSummary & { emoji?: string })[];
+  agents: (AgentSummary & { emoji?: string; systemName?: string })[];
   heartbeats: Record<string, Heartbeat>;
 }
 
@@ -27,7 +27,8 @@ export function AgentStatusGrid({ agents, heartbeats }: AgentStatusGridProps) {
           </p>
         ) : (
           agents.map((agent) => {
-            const hb = heartbeats[agent.name];
+            const systemName = agent.systemName ?? agent.name;
+            const hb = heartbeats[systemName];
             const currentTask = hb?.current_task || '';
             const taskPreview = currentTask
               .replace(/^WORKING ON:\s*/i, '')
@@ -35,8 +36,8 @@ export function AgentStatusGrid({ agents, heartbeats }: AgentStatusGridProps) {
 
             return (
               <Link
-                key={agent.name}
-                href={`/agents/${encodeURIComponent(agent.name)}`}
+                key={systemName}
+                href={`/agents/${encodeURIComponent(systemName)}`}
                 className="group flex items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/50 transition-colors"
               >
                 <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-sm">


### PR DESCRIPTION
## Summary

- Resolve `systemName` (from `discoverAgents`) on the agent object instead of using the display name from `IDENTITY.md`.
- Use that for both the heartbeat-map key and the `/agents/<name>` detail href on the overview page.

## Why

Agents whose display name differs from their system name (e.g. `sentinel` → `Sentinel2`) had two bugs on the overview page:

- Heartbeat lookup used display name → current task always blank.
- Detail page link used display name → `/agents/Sentinel2` could not resolve agent config, making configs appear broken.

## Test plan

- [ ] Spin up an agent with `IDENTITY.md` display name different from its system name; verify the overview page shows current task + correct detail link.
- [ ] `npm run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)