### PR TITLE
fix(build): register hook-loop-detector entry in tsup.config.ts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## [Unreleased]
+
+### Hook Framework — Loop Detection (B1)
+
+- **`hook-loop-detector`**: new PreToolUse hook that detects and blocks repeated Claude tool-call loops. Two patterns are detected: (a) the same tool invoked with identical arguments 15+ times within the last 30 calls, and (b) two tools ping-ponging (24+ alternations within a 12-call dominant-pair window). Blocked calls are NOT recorded into history, so the wedge cannot self-perpetuate. History is time-windowed (60s) so a stale prior-session tail does not block the first call of a new session. After 30 minutes of continuous block, exactly one tool call is allowed through ("emergency escape") so the agent can issue a Telegram alert before re-entering the blocked window.
+- **`cortextos bus hook-loop-detector`**: CLI subcommand to invoke the hook, follows the existing hook-runner pattern.
+- **Settings wiring**: agent / orchestrator / analyst templates and the security community agent now ship with the hook enabled by default in `.claude/settings.json` (PreToolUse, no matcher, 5s timeout).
+- **State**: `${CTX_ROOT}/state/<agent>/loop-detector.json`. Recoverable from corruption (bad JSON → empty state).
+
 ## [0.2.0] — 2026-05-04 — External Persistent Crons
 
 Crons move from session-local (`/loop`, `CronCreate`) to daemon-managed `crons.json` files under `${CTX_ROOT}/state/{agent}/`. Auto-migrates from existing `config.json` on first daemon boot. Fully backward-compatible additive feature.

--- a/community/agents/security/.claude/settings.json
+++ b/community/agents/security/.claude/settings.json
@@ -33,6 +33,15 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-loop-detector",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -2402,6 +2402,11 @@ busCommand
   .description('Stop hook: writes last_idle.flag timestamp so fast-checker knows agent finished its turn')
   .action(() => runHook('hook-idle-flag'));
 
+busCommand
+  .command('hook-loop-detector')
+  .description('PreToolUse hook: detects and blocks repeated tool loops (same-args repetition + ping-pong alternation)')
+  .action(() => runHook('hook-loop-detector'));
+
 // --- OAuth token rotation commands ---
 
 busCommand

--- a/src/hooks/hook-loop-detector.ts
+++ b/src/hooks/hook-loop-detector.ts
@@ -1,0 +1,273 @@
+/**
+ * hook-loop-detector.ts — PreToolUse hook.
+ *
+ * Detects and blocks repeated tool loops:
+ * 1. Same tool and same args too many times.
+ * 2. Two tools ping-ponging repeatedly.
+ *
+ * Blocked calls are NOT recorded in history — the original design counted
+ * rejections toward the alternation window, which made the wedge
+ * self-perpetuating. The current design only records calls that pass.
+ *
+ * History is also time-windowed: entries older than {HISTORY_RETAIN_MS}
+ * are filtered out before each decision. This prevents a stale prior-session
+ * tail (which persists in the on-disk state file) from blocking the first
+ * tool call of a new session.
+ *
+ * After {EMERGENCY_ESCAPE_MS} of being continuously blocked, the next
+ * incoming call is allowed exactly once so the agent can send a Telegram
+ * alert. Subsequent calls keep blocking until the workflow itself changes
+ * (the next allowed call resets the blocked-window state).
+ *
+ * State: {ctxRoot}/state/{agentName}/loop-detector.json
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { createHash } from 'crypto';
+import { readStdin, parseHookInput } from './index.js';
+
+export const HISTORY_SIZE = 30;
+export const REPETITION_BLOCK = 15;
+export const PINGPONG_WINDOW = 12;
+export const PINGPONG_BLOCK = 24;
+export const PINGPONG_DOMINANCE = 0.8;
+export const EMERGENCY_ESCAPE_MS = 30 * 60 * 1000;
+// Entries older than this fall out of the active window. Without this,
+// alternation history persists across session restarts and the first
+// tool call after boot trips ping-pong against stale prior-session state.
+// Real loops fire fast (sub-second per call), so 60s is plenty of room
+// to detect them while letting any normal idle gap clear stale history.
+export const HISTORY_RETAIN_MS = 60 * 1000;
+
+export interface ToolCallRecord {
+  toolName: string;
+  argsHash: string;
+  ts: number;
+}
+
+export interface LoopDetectorState {
+  history: ToolCallRecord[];
+  firstBlockedAt?: number | null;
+  emergencyEscapeUsed?: boolean;
+}
+
+function sortObjectKeys(value: unknown): unknown {
+  if (value === null || typeof value !== 'object') return value;
+  if (Array.isArray(value)) return value.map(sortObjectKeys);
+  const obj = value as Record<string, unknown>;
+  return Object.keys(obj)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, k) => {
+      acc[k] = sortObjectKeys(obj[k]);
+      return acc;
+    }, {});
+}
+
+export function hashArgs(toolInput: unknown): string {
+  if (toolInput === null || toolInput === undefined) return '';
+  try {
+    const normalized = JSON.stringify(sortObjectKeys(toolInput));
+    return createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+  } catch {
+    return '';
+  }
+}
+
+function statePath(stateDir: string): string {
+  return join(stateDir, 'loop-detector.json');
+}
+
+export function loadState(stateDir: string): LoopDetectorState {
+  const p = statePath(stateDir);
+  if (!existsSync(p)) return { history: [], firstBlockedAt: null, emergencyEscapeUsed: false };
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf-8')) as Partial<LoopDetectorState>;
+    const rawHistory = Array.isArray(parsed.history) ? parsed.history : [];
+    const history: ToolCallRecord[] = rawHistory.filter(
+      (r): r is ToolCallRecord =>
+        r !== null &&
+        typeof r === 'object' &&
+        typeof (r as ToolCallRecord).toolName === 'string' &&
+        typeof (r as ToolCallRecord).argsHash === 'string' &&
+        typeof (r as ToolCallRecord).ts === 'number',
+    );
+    const firstBlockedAt =
+      typeof parsed.firstBlockedAt === 'number' ? parsed.firstBlockedAt : null;
+    const emergencyEscapeUsed =
+      typeof parsed.emergencyEscapeUsed === 'boolean' ? parsed.emergencyEscapeUsed : false;
+    return { history, firstBlockedAt, emergencyEscapeUsed };
+  } catch {
+    return { history: [], firstBlockedAt: null, emergencyEscapeUsed: false };
+  }
+}
+
+function saveState(stateDir: string, state: LoopDetectorState): void {
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(statePath(stateDir), JSON.stringify(state, null, 2) + '\n', 'utf-8');
+  } catch {
+    // Best-effort; never break a hook.
+  }
+}
+
+export function countRepetitions(
+  history: ToolCallRecord[],
+  toolName: string,
+  argsHash: string,
+): number {
+  return history.filter(r => r.toolName === toolName && r.argsHash === argsHash).length;
+}
+
+export function detectPingPong(history: ToolCallRecord[]): {
+  count: number;
+  tools: [string, string] | null;
+} {
+  if (history.length < PINGPONG_WINDOW) return { count: 0, tools: null };
+
+  const window = history.slice(-PINGPONG_WINDOW);
+  const freq: Record<string, number> = {};
+  for (const r of window) {
+    freq[r.toolName] = (freq[r.toolName] ?? 0) + 1;
+  }
+
+  const sorted = Object.entries(freq).sort((a, b) => b[1] - a[1]);
+  if (sorted.length < 2) return { count: 0, tools: null };
+
+  const [topTool, topCount] = sorted[0];
+  const [secondTool, secondCount] = sorted[1];
+  const combinedFraction = (topCount + secondCount) / PINGPONG_WINDOW;
+  if (combinedFraction < PINGPONG_DOMINANCE) return { count: 0, tools: null };
+
+  const pairSet = new Set([topTool, secondTool]);
+  const pairCalls = history.filter(r => pairSet.has(r.toolName));
+  let alternations = 0;
+  for (let i = 1; i < pairCalls.length; i += 1) {
+    if (pairCalls[i].toolName !== pairCalls[i - 1].toolName) {
+      alternations += 1;
+    }
+  }
+
+  return {
+    count: alternations,
+    tools: [topTool, secondTool],
+  };
+}
+
+function blockCall(reason: string): void {
+  process.stdout.write(JSON.stringify({ decision: 'block', reason }) + '\n');
+  process.exit(0);
+}
+
+export type HookAction = 'allow' | 'block' | 'escape';
+
+export interface HookDecision {
+  action: HookAction;
+  nextState: LoopDetectorState;
+  reason?: string;
+  alertMessage?: string;
+}
+
+/**
+ * Decide what to do with the next tool call.
+ *
+ * Pure: takes current state + the incoming call + a now timestamp, returns
+ * the next state and the action ('allow' | 'block' | 'escape'). Never reads
+ * stdin or fs and never exits the process — the actual hook entry-point
+ * orchestrates I/O around this function.
+ *
+ * State machine:
+ *   - allow → push call to history, reset firstBlockedAt and emergencyEscapeUsed.
+ *   - block → keep history unchanged, set firstBlockedAt if not already set.
+ *   - escape → keep history unchanged, set emergencyEscapeUsed. Granted exactly
+ *              once per blocked window after EMERGENCY_ESCAPE_MS elapsed since
+ *              firstBlockedAt. The next allowed call clears the window cleanly.
+ */
+export function decideHookAction(
+  state: LoopDetectorState,
+  toolName: string,
+  argsHash: string,
+  now: number,
+): HookDecision {
+  const recentHistory = state.history.filter(r => now - r.ts <= HISTORY_RETAIN_MS);
+  const newRecord: ToolCallRecord = { toolName, argsHash, ts: now };
+  const hypothetical = [...recentHistory, newRecord].slice(-HISTORY_SIZE);
+
+  const reps = countRepetitions(hypothetical, toolName, argsHash);
+  const pp = detectPingPong(hypothetical);
+  const wouldBlockReason: string | null =
+    reps >= REPETITION_BLOCK
+      ? `Tool loop detected: "${toolName}" called ${reps} times with identical arguments in the last ${HISTORY_SIZE} calls. Stop repeating this action and try a fundamentally different approach.`
+      : pp.count >= PINGPONG_BLOCK && pp.tools
+        ? `Tool loop detected: "${pp.tools[0]}" and "${pp.tools[1]}" are alternating repeatedly (${pp.count} alternations in the last ${hypothetical.length} calls). Stop this back-and-forth pattern and try a fundamentally different approach.`
+        : null;
+
+  if (wouldBlockReason === null) {
+    return {
+      action: 'allow',
+      nextState: {
+        history: hypothetical,
+        firstBlockedAt: null,
+        emergencyEscapeUsed: false,
+      },
+    };
+  }
+
+  const firstBlockedAt = state.firstBlockedAt ?? now;
+  const blockedDurationMs = now - firstBlockedAt;
+  const emergencyEscapeUsed = state.emergencyEscapeUsed === true;
+  const escapeAvailable =
+    blockedDurationMs >= EMERGENCY_ESCAPE_MS && !emergencyEscapeUsed;
+
+  if (escapeAvailable) {
+    const minutesBlocked = Math.floor(blockedDurationMs / 60000);
+    return {
+      action: 'escape',
+      nextState: {
+        history: recentHistory,
+        firstBlockedAt,
+        emergencyEscapeUsed: true,
+      },
+      alertMessage: `[hook-loop-detector] Emergency escape granted after ${minutesBlocked} min blocked. One tool call allowed; subsequent calls will block again until the workflow itself changes.`,
+    };
+  }
+
+  return {
+    action: 'block',
+    nextState: {
+      history: recentHistory,
+      firstBlockedAt,
+      emergencyEscapeUsed,
+    },
+    reason: wouldBlockReason,
+  };
+}
+
+async function main(): Promise<void> {
+  const input = await readStdin();
+  const { tool_name, tool_input } = parseHookInput(input);
+
+  const agentName = process.env.CTX_AGENT_NAME || '';
+  const ctxRoot = process.env.CTX_ROOT || join(homedir(), '.cortextos', 'default');
+  const stateDir = join(ctxRoot, 'state', agentName);
+
+  const state = loadState(stateDir);
+  const argsHash = hashArgs(tool_input);
+  const decision = decideHookAction(state, tool_name, argsHash, Date.now());
+
+  saveState(stateDir, decision.nextState);
+
+  if (decision.action === 'block' && decision.reason) {
+    blockCall(decision.reason);
+    return;
+  }
+
+  if (decision.action === 'escape' && decision.alertMessage) {
+    process.stderr.write(decision.alertMessage + '\n');
+  }
+
+  process.exit(0);
+}
+
+main().catch(() => process.exit(0));

--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -33,6 +33,15 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-loop-detector",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -33,6 +33,15 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-loop-detector",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/templates/orchestrator/.claude/settings.json
+++ b/templates/orchestrator/.claude/settings.json
@@ -33,6 +33,15 @@
     ],
     "PreToolUse": [
       {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-loop-detector",
+            "timeout": 5
+          }
+        ]
+      },
+      {
         "matcher": "AskUserQuestion",
         "hooks": [
           {

--- a/tests/unit/hooks/loop-detector.test.ts
+++ b/tests/unit/hooks/loop-detector.test.ts
@@ -1,0 +1,312 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  HISTORY_SIZE,
+  REPETITION_BLOCK,
+  PINGPONG_WINDOW,
+  PINGPONG_BLOCK,
+  EMERGENCY_ESCAPE_MS,
+  HISTORY_RETAIN_MS,
+  hashArgs,
+  countRepetitions,
+  detectPingPong,
+  decideHookAction,
+  loadState,
+  type ToolCallRecord,
+  type LoopDetectorState,
+} from '../../../src/hooks/hook-loop-detector';
+
+describe('hook-loop-detector hashArgs', () => {
+  it('returns empty string for nullish input', () => {
+    expect(hashArgs(null)).toBe('');
+    expect(hashArgs(undefined)).toBe('');
+  });
+
+  it('is order-independent for object keys', () => {
+    const a = hashArgs({ file_path: '/tmp/foo', old_string: 'x', new_string: 'y' });
+    const b = hashArgs({ new_string: 'y', old_string: 'x', file_path: '/tmp/foo' });
+    expect(a).toBe(b);
+  });
+
+  it('preserves array order', () => {
+    expect(hashArgs({ items: [1, 2, 3] })).not.toBe(hashArgs({ items: [3, 2, 1] }));
+  });
+});
+
+describe('hook-loop-detector repetition detection', () => {
+  const makeRecord = (toolName: string, argsHash: string): ToolCallRecord => ({
+    toolName,
+    argsHash,
+    ts: Date.now(),
+  });
+
+  it('counts exact tool plus args matches', () => {
+    const history = [
+      makeRecord('Read', 'abc'),
+      makeRecord('Read', 'abc'),
+      makeRecord('Edit', 'abc'),
+      makeRecord('Read', 'def'),
+    ];
+    expect(countRepetitions(history, 'Read', 'abc')).toBe(2);
+  });
+
+  it('keeps threshold reachable within history size', () => {
+    expect(HISTORY_SIZE).toBeGreaterThanOrEqual(REPETITION_BLOCK);
+  });
+});
+
+describe('hook-loop-detector ping-pong detection', () => {
+  const makeRecord = (toolName: string): ToolCallRecord => ({
+    toolName,
+    argsHash: hashArgs({ tool: toolName }),
+    ts: Date.now(),
+  });
+
+  it('ignores histories shorter than the window', () => {
+    const short = Array.from({ length: PINGPONG_WINDOW - 1 }, () => makeRecord('Read'));
+    expect(detectPingPong(short).count).toBe(0);
+  });
+
+  it('detects a clean alternating pair', () => {
+    const alternating = Array.from({ length: HISTORY_SIZE }, (_, i) =>
+      makeRecord(i % 2 === 0 ? 'Read' : 'Edit'),
+    );
+    const result = detectPingPong(alternating);
+    expect(result.count).toBeGreaterThanOrEqual(PINGPONG_BLOCK);
+    expect(result.tools).toContain('Read');
+    expect(result.tools).toContain('Edit');
+  });
+
+  it('does not flag monotone single-tool history as ping-pong', () => {
+    const monotone = Array.from({ length: PINGPONG_WINDOW }, () => makeRecord('Read'));
+    expect(detectPingPong(monotone).count).toBe(0);
+  });
+});
+
+describe('hook-loop-detector decideHookAction — blocked-call non-recording', () => {
+  const NOW = 1_800_000_000_000;
+
+  function alternatingHistory(length: number): ToolCallRecord[] {
+    return Array.from({ length }, (_, i) => ({
+      toolName: i % 2 === 0 ? 'Bash' : 'Skill',
+      argsHash: hashArgs({ i }),
+      ts: NOW - (length - i) * 1000,
+    }));
+  }
+
+  function repeatingHistory(length: number, toolName: string, argsHash: string): ToolCallRecord[] {
+    return Array.from({ length }, (_, i) => ({
+      toolName,
+      argsHash,
+      ts: NOW - (length - i) * 1000,
+    }));
+  }
+
+  it('does not record blocked calls in history when ping-pong threshold tripped', () => {
+    const state: LoopDetectorState = {
+      history: alternatingHistory(HISTORY_SIZE),
+      firstBlockedAt: null,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Skill', hashArgs({ next: true }), NOW);
+    expect(decision.action).toBe('block');
+    expect(decision.nextState.history).toEqual(state.history);
+    expect(decision.nextState.firstBlockedAt).toBe(NOW);
+    expect(decision.nextState.emergencyEscapeUsed).toBe(false);
+  });
+
+  it('does not record blocked calls in history when repetition threshold tripped', () => {
+    const repHash = hashArgs({ same: 'args' });
+    const state: LoopDetectorState = {
+      history: repeatingHistory(REPETITION_BLOCK, 'Read', repHash),
+      firstBlockedAt: null,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Read', repHash, NOW);
+    expect(decision.action).toBe('block');
+    expect(decision.nextState.history).toEqual(state.history);
+    expect(decision.nextState.firstBlockedAt).toBe(NOW);
+  });
+
+  it('preserves firstBlockedAt across repeated blocks within the same window', () => {
+    const earlier = NOW - 60_000;
+    const state: LoopDetectorState = {
+      history: alternatingHistory(HISTORY_SIZE),
+      firstBlockedAt: earlier,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Bash', hashArgs({ x: 1 }), NOW);
+    expect(decision.action).toBe('block');
+    expect(decision.nextState.firstBlockedAt).toBe(earlier);
+  });
+});
+
+describe('hook-loop-detector decideHookAction — emergency escape', () => {
+  const NOW = 1_800_000_000_000;
+
+  function alternatingHistory(length: number): ToolCallRecord[] {
+    return Array.from({ length }, (_, i) => ({
+      toolName: i % 2 === 0 ? 'Bash' : 'Skill',
+      argsHash: hashArgs({ i }),
+      ts: NOW - (length - i) * 1000,
+    }));
+  }
+
+  it('grants emergency escape after EMERGENCY_ESCAPE_MS blocked', () => {
+    const state: LoopDetectorState = {
+      history: alternatingHistory(HISTORY_SIZE),
+      firstBlockedAt: NOW - EMERGENCY_ESCAPE_MS - 1,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Bash', hashArgs({ alert: true }), NOW);
+    expect(decision.action).toBe('escape');
+    expect(decision.nextState.emergencyEscapeUsed).toBe(true);
+    expect(decision.nextState.history).toEqual(state.history);
+    expect(decision.alertMessage).toMatch(/Emergency escape granted after \d+ min blocked/);
+  });
+
+  it('only grants one emergency escape per blocked window', () => {
+    const state: LoopDetectorState = {
+      history: alternatingHistory(HISTORY_SIZE),
+      firstBlockedAt: NOW - 2 * EMERGENCY_ESCAPE_MS,
+      emergencyEscapeUsed: true,
+    };
+    const decision = decideHookAction(state, 'Skill', hashArgs({ retry: true }), NOW);
+    expect(decision.action).toBe('block');
+    expect(decision.nextState.emergencyEscapeUsed).toBe(true);
+  });
+
+  it('resets blocked-window state when call is allowed', () => {
+    const calmHistory: ToolCallRecord[] = [
+      { toolName: 'Read', argsHash: hashArgs({ a: 1 }), ts: NOW - 5000 },
+      { toolName: 'Read', argsHash: hashArgs({ b: 2 }), ts: NOW - 4000 },
+    ];
+    const state: LoopDetectorState = {
+      history: calmHistory,
+      firstBlockedAt: NOW - 60_000,
+      emergencyEscapeUsed: true,
+    };
+    const decision = decideHookAction(state, 'Read', hashArgs({ c: 3 }), NOW);
+    expect(decision.action).toBe('allow');
+    expect(decision.nextState.firstBlockedAt).toBeNull();
+    expect(decision.nextState.emergencyEscapeUsed).toBe(false);
+    expect(decision.nextState.history).toHaveLength(3);
+  });
+});
+
+describe('hook-loop-detector decideHookAction — threshold sanity', () => {
+  it('PINGPONG_BLOCK is set above the legitimate-alternation band', () => {
+    expect(PINGPONG_BLOCK).toBeGreaterThanOrEqual(20);
+    expect(PINGPONG_BLOCK).toBeLessThanOrEqual(HISTORY_SIZE);
+  });
+
+  it('HISTORY_RETAIN_MS is short enough to clear stale prior-session history', () => {
+    expect(HISTORY_RETAIN_MS).toBeLessThanOrEqual(5 * 60 * 1000);
+    expect(HISTORY_RETAIN_MS).toBeGreaterThanOrEqual(30 * 1000);
+  });
+});
+
+describe('hook-loop-detector decideHookAction — cross-session staleness', () => {
+  const NOW = 1_800_000_000_000;
+
+  function staleAlternatingHistory(length: number, ageMs: number): ToolCallRecord[] {
+    return Array.from({ length }, (_, i) => ({
+      toolName: i % 2 === 0 ? 'Bash' : 'Skill',
+      argsHash: hashArgs({ i }),
+      ts: NOW - ageMs - (length - i) * 1000,
+    }));
+  }
+
+  it('boot scenario: stale alternation from a prior session does not block the first new call', () => {
+    const state: LoopDetectorState = {
+      history: staleAlternatingHistory(HISTORY_SIZE, HISTORY_RETAIN_MS + 1000),
+      firstBlockedAt: null,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Bash', hashArgs({ first: 'boot' }), NOW);
+    expect(decision.action).toBe('allow');
+    expect(decision.nextState.history).toHaveLength(1);
+    expect(decision.nextState.history[0].toolName).toBe('Bash');
+  });
+
+  it('drops stale entries from nextState.history on allow', () => {
+    const stale = staleAlternatingHistory(5, HISTORY_RETAIN_MS + 1000);
+    const fresh: ToolCallRecord[] = [
+      { toolName: 'Read', argsHash: hashArgs({ a: 1 }), ts: NOW - 2000 },
+    ];
+    const state: LoopDetectorState = {
+      history: [...stale, ...fresh],
+      firstBlockedAt: null,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Edit', hashArgs({ b: 2 }), NOW);
+    expect(decision.action).toBe('allow');
+    expect(decision.nextState.history).toHaveLength(2);
+    expect(decision.nextState.history.map(r => r.toolName)).toEqual(['Read', 'Edit']);
+  });
+
+  it('drops stale entries from nextState.history on block', () => {
+    const stale = staleAlternatingHistory(5, HISTORY_RETAIN_MS + 1000);
+    const recentRepeats: ToolCallRecord[] = Array.from({ length: REPETITION_BLOCK }, (_, i) => ({
+      toolName: 'Read',
+      argsHash: 'samehash',
+      ts: NOW - (REPETITION_BLOCK - i) * 100,
+    }));
+    const state: LoopDetectorState = {
+      history: [...stale, ...recentRepeats],
+      firstBlockedAt: null,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Read', 'samehash', NOW);
+    expect(decision.action).toBe('block');
+    expect(decision.nextState.history.every(r => NOW - r.ts <= HISTORY_RETAIN_MS)).toBe(true);
+    expect(decision.nextState.history).toHaveLength(REPETITION_BLOCK);
+  });
+
+  it('still blocks when alternation is fresh and within the retain window', () => {
+    const recent: ToolCallRecord[] = Array.from({ length: HISTORY_SIZE }, (_, i) => ({
+      toolName: i % 2 === 0 ? 'Bash' : 'Skill',
+      argsHash: hashArgs({ i }),
+      ts: NOW - (HISTORY_SIZE - i) * 1000,
+    }));
+    const state: LoopDetectorState = {
+      history: recent,
+      firstBlockedAt: null,
+      emergencyEscapeUsed: false,
+    };
+    const decision = decideHookAction(state, 'Bash', hashArgs({ next: true }), NOW);
+    expect(decision.action).toBe('block');
+  });
+});
+
+describe('hook-loop-detector state loading', () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'loop-detector-test-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('returns empty history when state file does not exist', () => {
+    expect(loadState(tmpDir).history).toEqual([]);
+  });
+
+  it('filters corrupt records on load', () => {
+    writeFileSync(join(tmpDir, 'loop-detector.json'), JSON.stringify({
+      history: [
+        { toolName: 'Read', argsHash: 'abc', ts: 1000 },
+        { toolName: null, argsHash: 'def', ts: 2000 },
+        { toolName: 'Edit', argsHash: 789, ts: 3000 },
+        { toolName: 'Bash', argsHash: 'xyz', ts: 5000 },
+      ],
+    }), 'utf-8');
+    const state = loadState(tmpDir);
+    expect(state.history).toHaveLength(2);
+    expect(state.history.map(r => r.toolName)).toEqual(['Read', 'Bash']);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
     'hooks/hook-context-status': 'src/hooks/hook-context-status.ts',
+    'hooks/hook-loop-detector': 'src/hooks/hook-loop-detector.ts',
   },
   format: ['cjs'],
   target: 'node20',


### PR DESCRIPTION
## Summary
PR #390 added `src/hooks/hook-loop-detector.ts` and updated 4 agent template `settings.json` files to invoke `node dist/hooks/hook-loop-detector.js` on PreToolUse, but never added the file to `tsup.config.ts`'s entry list. Result: `dist/hooks/hook-loop-detector.js` never gets built and every PreToolUse on every agent using the updated templates fails silently with `MODULE_NOT_FOUND` (exit 1).

This PR adds the missing one-line entry. Logic and the 22/22 unit tests on PR #390 pass standalone per @cortext-designer's sandbox review — this is the only blocker.

## Test plan
- [ ] `npm run build` produces `dist/hooks/hook-loop-detector.js`
- [ ] `echo '{}' | node dist/hooks/hook-loop-detector.js` exits without `MODULE_NOT_FOUND`
- [ ] Existing 22/22 unit tests on the loop-detector logic still pass

Co-authored to original author @loganbronstein. Once PR #390 is rebased to include this fix (or this fix is merged independently), #390 can be re-reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)