### PR TITLE
fix: replace stale CronList refs in templates and community skills

### DIFF
--- a/community/agents/agent/AGENTS.md
+++ b/community/agents/agent/AGENTS.md
@@ -243,7 +243,7 @@ cat >> "memory/$TODAY.md" << MEMEOF
 
 ## Session Start - $(date -u +%H:%M:%S UTC)
 - Status: online
-- Crons active: <list from CronList>
+- Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
 - Current state: <where things stand — what is in progress, pending, or needs attention>
 - Resuming: <what to do next and why, with enough context to act without re-reading everything>

--- a/community/agents/analyst/AGENTS.md
+++ b/community/agents/analyst/AGENTS.md
@@ -243,7 +243,7 @@ cat >> "memory/$TODAY.md" << MEMEOF
 
 ## Session Start - $(date -u +%H:%M:%S UTC)
 - Status: online
-- Crons active: <list from CronList>
+- Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
 - Current state: <where things stand — what is in progress, pending, or needs attention>
 - Resuming: <what to do next and why, with enough context to act without re-reading everything>

--- a/community/agents/orchestrator/AGENTS.md
+++ b/community/agents/orchestrator/AGENTS.md
@@ -243,7 +243,7 @@ cat >> "memory/$TODAY.md" << MEMEOF
 
 ## Session Start - $(date -u +%H:%M:%S UTC)
 - Status: online
-- Crons active: <list from CronList>
+- Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
 - Current state: <where things stand — what is in progress, pending, or needs attention>
 - Resuming: <what to do next and why, with enough context to act without re-reading everything>

--- a/community/agents/security/.claude/skills/heartbeat/SKILL.md
+++ b/community/agents/security/.claude/skills/heartbeat/SKILL.md
@@ -43,7 +43,7 @@ Call this:
 - When starting a new significant task
 - Before going into a long-running operation
 
-**Never claim a status you haven't verified.** If your crons were reset on restart, check CronList before saying "crons running."
+**Never claim a status you haven't verified.** If your crons were reset on restart, check `cortextos bus list-crons $CTX_AGENT_NAME` before saying "crons running."
 
 ---
 

--- a/community/skills/memory/SKILL.md
+++ b/community/skills/memory/SKILL.md
@@ -29,7 +29,7 @@ cat >> "memory/$TODAY.md" << MEMEOF
 
 ## Session Start - $(date -u +%H:%M:%S UTC)
 - Status: online
-- Crons active: <list from CronList>
+- Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
 - Current state: <where things stand — what is in progress, pending, or needs attention>
 - Resuming: <what to do next and why, with enough context to act without re-reading everything>

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
@@ -28,7 +28,7 @@ cat >> "memory/$TODAY.md" << MEMEOF
 
 ## Session Start - $(date -u +%H:%M:%S UTC)
 - Status: online
-- Crons active: <list from CronList>
+- Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
 - Current state: <where things stand — what is in progress, pending, or needs attention>
 - Resuming: <what to do next and why, with enough context to act without re-reading everything>

--- a/templates/agent/.claude/skills/heartbeat/SKILL.md
+++ b/templates/agent/.claude/skills/heartbeat/SKILL.md
@@ -43,7 +43,7 @@ Call this:
 - When starting a new significant task
 - Before going into a long-running operation
 
-**Never claim a status you haven't verified.** If your crons were reset on restart, check CronList before saying "crons running."
+**Never claim a status you haven't verified.** If your crons were reset on restart, check `cortextos bus list-crons $CTX_AGENT_NAME` before saying "crons running."
 
 ---
 

--- a/templates/agent/.claude/skills/memory/SKILL.md
+++ b/templates/agent/.claude/skills/memory/SKILL.md
@@ -28,7 +28,7 @@ cat >> "memory/$TODAY.md" << MEMEOF
 
 ## Session Start - $(date -u +%H:%M:%S UTC)
 - Status: online
-- Crons active: <list from CronList>
+- Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
 - Current state: <where things stand — what is in progress, pending, or needs attention>
 - Resuming: <what to do next and why, with enough context to act without re-reading everything>

--- a/templates/analyst/.claude/skills/heartbeat/SKILL.md
+++ b/templates/analyst/.claude/skills/heartbeat/SKILL.md
@@ -43,7 +43,7 @@ Call this:
 - When starting a new significant task
 - Before going into a long-running operation
 
-**Never claim a status you haven't verified.** If your crons were reset on restart, check CronList before saying "crons running."
+**Never claim a status you haven't verified.** If your crons were reset on restart, check `cortextos bus list-crons $CTX_AGENT_NAME` before saying "crons running."
 
 ---
 

--- a/templates/analyst/.claude/skills/memory/SKILL.md
+++ b/templates/analyst/.claude/skills/memory/SKILL.md
@@ -28,7 +28,7 @@ cat >> "memory/$TODAY.md" << MEMEOF
 
 ## Session Start - $(date -u +%H:%M:%S UTC)
 - Status: online
-- Crons active: <list from CronList>
+- Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
 - Current state: <where things stand — what is in progress, pending, or needs attention>
 - Resuming: <what to do next and why, with enough context to act without re-reading everything>

--- a/templates/orchestrator/.claude/skills/heartbeat/SKILL.md
+++ b/templates/orchestrator/.claude/skills/heartbeat/SKILL.md
@@ -43,7 +43,7 @@ Call this:
 - When starting a new significant task
 - Before going into a long-running operation
 
-**Never claim a status you haven't verified.** If your crons were reset on restart, check CronList before saying "crons running."
+**Never claim a status you haven't verified.** If your crons were reset on restart, check `cortextos bus list-crons $CTX_AGENT_NAME` before saying "crons running."
 
 ---
 


### PR DESCRIPTION
## Summary

- All 11 `CronList` tool references in memory/heartbeat skill templates and community agents replaced with `cortextos bus list-crons $CTX_AGENT_NAME`
- Affects: `templates/agent`, `templates/analyst`, `templates/orchestrator`, `templates/agent-codex`, `community/agents/{agent,analyst,orchestrator,security}`, `community/skills/memory`

## Background

`CronList` is a session-only Claude Code tool (lists crons created with `CronCreate` in the current session). New agents cloning from upstream would see this referenced in memory/heartbeat skill placeholders and call the wrong command when checking their cron schedule. The correct command for external (daemon-managed) crons is `cortextos bus list-crons $CTX_AGENT_NAME`.

The critical paths (AGENTS.md step 6, daemon bootstrap prompt, cron-management SKILL.md) were already correct. This clears the last stale references.

## Test plan

- [ ] Verify `grep -r "CronList" templates/ community/` returns no results after merge
- [ ] Existing integration test `community-templates-no-stale-cron-refs.test.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)