### PR TITLE
telegram: add react-telegram command for single-emoji acks

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -239,6 +239,7 @@ export const addAgentCommand = new Command('add-agent')
             '',
             '- Agent-to-agent: `cortextos bus send-message <agent> <priority> "<text>"`',
             '- Telegram to user: `cortextos bus send-telegram <chat_id> "<text>"`',
+            '- React to a Telegram message (single emoji ack, no verbal noise): `cortextos bus react-telegram <chat_id> <message_id> 👍`',
             '- Check inbox: `cortextos bus check-inbox`',
             '',
           ].join('\n');
@@ -447,5 +448,6 @@ Complete tasks: \`cortextos bus complete-task <id> --result "<text>"\`
 Log events: \`cortextos bus log-event <category> <event> <severity>\`
 Update heartbeat: \`cortextos bus update-heartbeat "<status>"\`
 Send Telegram: \`cortextos bus send-telegram <chat_id> "<text>"\`
+React to Telegram message (single emoji ack): \`cortextos bus react-telegram <chat_id> <message_id> 👍\`
 `;
 }

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1023,6 +1023,54 @@ busCommand
   });
 
 busCommand
+  .command('react-telegram')
+  .description("Set the bot's reaction on a Telegram message (single emoji ack)")
+  .argument('<chat-id>', 'Telegram chat ID')
+  .argument('<message-id>', 'ID of the message to react to')
+  .argument('[emoji]', 'Reaction emoji (default: 👍). Pass an empty string to clear.', '👍')
+  .action(async (chatId: string, messageIdRaw: string, emoji: string) => {
+    const messageId = Number(messageIdRaw);
+    if (!Number.isFinite(messageId) || messageId <= 0) {
+      console.error(`Invalid message-id '${messageIdRaw}'. Must be a positive integer.`);
+      process.exit(1);
+    }
+
+    // Resolve bot token: agent .env first, then process.env (same flow as
+    // send-telegram so the agent identity / personality of the reaction
+    // matches the agent that owns the conversation).
+    const env = resolveEnv();
+    let botToken = '';
+    if (env.agentDir) {
+      const { readFileSync, existsSync } = require('fs');
+      const { join } = require('path');
+      const agentEnv = join(env.agentDir, '.env');
+      if (existsSync(agentEnv)) {
+        const content = readFileSync(agentEnv, 'utf-8');
+        const match = content.match(/^BOT_TOKEN=(.+)$/m);
+        if (match && match[1].trim()) botToken = match[1].trim();
+      }
+    }
+    if (!botToken) botToken = process.env.BOT_TOKEN || '';
+    if (!botToken) {
+      console.error('Error: BOT_TOKEN not configured. Set it in your agent .env file or as an environment variable to enable Telegram.');
+      process.exit(1);
+    }
+
+    const api = new TelegramAPI(botToken);
+    try {
+      // Empty string clears the reaction; otherwise send a single-emoji array.
+      // Telegram limits bots to one reaction per message; we treat that as the
+      // primitive here. Multi-emoji is a future feature if/when needed.
+      const emojis = emoji === '' ? [] : [emoji];
+      await api.setMessageReaction(chatId, messageId, emojis);
+      console.log(emojis.length > 0 ? `Reacted ${emoji}` : 'Reaction cleared');
+    } catch (err: any) {
+      console.error(`Failed to react: ${err.message || err}`);
+      process.exit(1);
+    }
+  });
+
+busCommand
   .command('create-approval')
   .description('Request human approval for a high-stakes action')
   .argument('<title>', 'What you are requesting approval for')

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -178,6 +178,7 @@ export const initCommand = new Command('init')
               '',
               '- Agent-to-agent: `cortextos bus send-message <agent> <priority> "<text>"`',
               '- Telegram to user: `cortextos bus send-telegram <chat_id> "<text>"`',
+              '- React to a Telegram message (single emoji ack, no verbal noise): `cortextos bus react-telegram <chat_id> <message_id> 👍`',
               '- Check inbox: `cortextos bus check-inbox`',
               '',
             ].join('\n');

--- a/src/telegram/api.ts
+++ b/src/telegram/api.ts
@@ -515,6 +515,37 @@ export class TelegramAPI {
   }
 
   /**
+   * Set the bot's reaction on a message.
+   *
+   * Wraps Telegram's setMessageReaction Bot API method. Use this when an
+   * agent wants to acknowledge a message with a single emoji instead of
+   * sending a full verbal reply. Cleaner than message-spam acks ("got it",
+   * "on it", "sounds good") -- the reaction is one bit of signal that lives
+   * on the original message.
+   *
+   * Pass an empty `emojis` array to clear the bot's reactions on the message.
+   *
+   * Telegram limits bots to ONE reaction per message. The full list of
+   * reaction emojis the API accepts is documented here:
+   * https://core.telegram.org/bots/api#reactiontypeemoji
+   *
+   * Note: bots can only react to messages within ~48h of the message being
+   * sent (the same window that applies to deleteMessage). Older messages
+   * return an error.
+   */
+  async setMessageReaction(
+    chatId: string | number,
+    messageId: number,
+    emojis: string[] = [],
+  ): Promise<any> {
+    return this.post('setMessageReaction', {
+      chat_id: chatId,
+      message_id: messageId,
+      reaction: emojis.map((emoji) => ({ type: 'emoji', emoji })),
+    });
+  }
+
+  /**
    * Edit a message's text.
    */
   async editMessageText(


### PR DESCRIPTION
## Summary

Adds `cortextos bus react-telegram <chat-id> <message-id> [emoji]` so agents can acknowledge a Telegram message with a single emoji reaction instead of sending a full verbal reply. Today every agent response is a message, which clutters chats with low-content "got it / on it / sounds good" noise. Reactions are the right shape for one-bit acks.

## What changed

- **`TelegramAPI.setMessageReaction(chatId, messageId, emojis)`** in `src/telegram/api.ts` — wraps Telegram's `setMessageReaction` Bot API endpoint. Pass an empty array to clear the bot's reaction. Bots can only react within ~48h of message send (same window as `deleteMessage`).
- **`cortextos bus react-telegram <chat-id> <message-id> [emoji]`** in `src/cli/bus.ts` — CLI command mirroring `send-telegram` (same bot token resolution flow, same env-fallback, same error shape). Default emoji is `👍`. Pass empty string to clear.
- **Default agent templates** in `src/cli/init.ts` and `src/cli/add-agent.ts` — documented the new command alongside the existing `send-telegram` entry in the SYSTEM.md / USER.md scaffolds so newly-created agents inherit awareness.

## Why this is safe

- Pure additive: no existing code path touched, no signatures changed. Existing `send-telegram`, `sendMessage`, etc. unchanged.
- Bot token resolution mirrors `send-telegram` byte-for-byte (agent `.env` first, then `process.env`).
- Telegram's `setMessageReaction` is server-validated; invalid emoji or out-of-window message returns an explicit API error which the CLI surfaces.

## Verified end-to-end

```
> # send a probe message, capture its id
> message_id: 580
> cortextos bus react-telegram 5459602728 580 👍
Reacted 👍
```

Visible thumbs-up reaction confirmed on the recipient's Telegram client.

## What's NOT in this PR

The usage policy — *when* an agent should react vs send a verbal reply — lives in each agent's IDENTITY/SOUL prompt, not in framework code. This PR ships the capability; the prompt rules ship per-agent. Suggested policy shape for agent prompts:

> React with an emoji instead of sending a verbal reply when ALL of these are true: you have nothing to add beyond acknowledging the message; the message doesn't ask a question, carry a directive needing status, or deliver content you must engage with; silence would feel ambiguous but a verbal "got it" would be noise.
>
> Defaults: 👍 = got it / acked. 👀 = looking at it. 🔥 = endorsing a take. ✅ = done. When in doubt, verbal.

That belongs in agent dirs, not here.