### PR TITLE
fix(cli): validate org name in `init` and `add-agent --org` (#407)

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, copyFi
 import { join, resolve } from 'path';
 import { homedir } from 'os';
 import { OrgContext } from '../types';
-import { validateAgentName } from '../utils/validate';
+import { validateAgentName, validateOrgName } from '../utils/validate';
 
 const VALID_RUNTIMES = ['claude-code', 'hermes', 'codex-app-server'] as const;
 type RuntimeKind = typeof VALID_RUNTIMES[number];
@@ -71,6 +71,20 @@ export const addAgentCommand = new Command('add-agent')
 
     if (!org) {
       console.error('No organization found. Run "cortextos init <org>" first.');
+      process.exit(1);
+    }
+
+    // Mirror the BUG-041 fix above for the resolved org name.
+    // Mixed-case orgs pass through add-agent today (whether supplied via --org or
+    // auto-detected from the orgs/ directory), get committed to disk, and then
+    // break every `cortextos bus *` invocation at runtime because env.ts strictly
+    // validates CTX_ORG. The dashboard API also rejects them with HTTP 400.
+    // Canonical rule: src/utils/validate.ts:validateOrgName (/^[a-z0-9_-]+$/).
+    try {
+      validateOrgName(org);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      console.error(`Org names must match /^[a-z0-9_-]+$/ (lowercase letters, numbers, underscores, hyphens).`);
       process.exit(1);
     }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync, readd
 import { join } from 'path';
 import { homedir } from 'os';
 import { ensureDir } from '../utils/atomic.js';
+import { validateOrgName } from '../utils/validate.js';
 import type { OrgContext } from '../types/index.js';
 
 export const initCommand = new Command('init')
@@ -10,6 +11,21 @@ export const initCommand = new Command('init')
   .option('--instance <id>', 'Instance ID', 'default')
   .description('Create a new cortextOS organization')
   .action(async (orgName: string, options: { instance: string }) => {
+    // Validate the org name BEFORE creating anything on disk.
+    // Without this, mixed-case names like 'teamStupid' pass through `init`,
+    // get written to disk, and then fail every dashboard add-agent and every
+    // `cortextos bus *` invocation at runtime because `src/utils/env.ts` and
+    // the dashboard API both call `validateOrgName()` strictly. Mirrors the
+    // BUG-041 fix for `validateAgentName()` in src/cli/add-agent.ts.
+    try {
+      validateOrgName(orgName);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      console.error(`Org names must match /^[a-z0-9_-]+$/ (lowercase letters, numbers, underscores, hyphens).`);
+      console.error(`Examples of valid names: acme, myco, demo, team-1, team_alpha`);
+      process.exit(1);
+    }
+
     const instanceId = options.instance;
     const ctxRoot = join(homedir(), '.cortextos', instanceId);
     const projectRoot = process.cwd();

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { spawnSync } from 'child_process';
 import { TelegramAPI, formatValidateError } from '../telegram/api.js';
+import { validateAgentName, validateOrgName } from '../utils/validate.js';
 
 function rl(): Interface {
   return createInterface({ input: process.stdin, output: process.stdout });
@@ -165,14 +166,6 @@ async function validateTelegramCredsInteractive(
   return null;
 }
 
-function validateAgentName(name: string): boolean {
-  return /^[a-z0-9_-]+$/.test(name);
-}
-
-function validateOrgName(name: string): boolean {
-  return /^[a-z0-9_-]+$/.test(name);
-}
-
 function findProjectRoot(): string {
   // Prefer CTX_FRAMEWORK_ROOT if set (running inside cortextOS session)
   if (process.env.CTX_FRAMEWORK_ROOT && existsSync(join(process.env.CTX_FRAMEWORK_ROOT, 'dist', 'cli.js'))) {
@@ -237,7 +230,9 @@ export const setupCommand = new Command('setup')
     let orgName = '';
     while (true) {
       orgName = await askRequired(iface, '  Organization name: ', 'Organization name cannot be empty.');
-      if (!validateOrgName(orgName)) {
+      try {
+        validateOrgName(orgName);
+      } catch {
         console.log('  Invalid name. Use lowercase letters, numbers, hyphens, and underscores only.');
         continue;
       }
@@ -265,7 +260,9 @@ export const setupCommand = new Command('setup')
     let orchName = '';
     while (true) {
       orchName = await askDefault(iface, '  Orchestrator agent name', 'boss');
-      if (!validateAgentName(orchName)) {
+      try {
+        validateAgentName(orchName);
+      } catch {
         console.log('  Invalid name. Use lowercase letters, numbers, hyphens, and underscores only.');
         continue;
       }
@@ -350,7 +347,9 @@ export const setupCommand = new Command('setup')
       let agentName = '';
       while (true) {
         agentName = await askRequired(iface, '  Agent name: ', 'Agent name is required.');
-        if (!validateAgentName(agentName)) {
+        try {
+          validateAgentName(agentName);
+        } catch {
           console.log('  Invalid name. Use lowercase letters, numbers, hyphens, and underscores only.');
           continue;
         }

--- a/tests/unit/cli/add-agent-validation.test.ts
+++ b/tests/unit/cli/add-agent-validation.test.ts
@@ -93,3 +93,66 @@ describe('BUG-041: add-agent agent name validation', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });
+
+/**
+ * Issue #407 regression test: `cortextos add-agent` must reject invalid
+ * --org values for the same reasons it rejects invalid agent names —
+ * mixed-case orgs pass scaffolding but then break every `cortextos bus *`
+ * invocation at runtime (env.ts strictly validates CTX_ORG) and every
+ * dashboard add-agent attempt (POST /api/agents returns HTTP 400).
+ */
+describe('issue #407: add-agent --org name validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects --org teamStupid (camelCase) before any filesystem write', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'validagent', '--template', 'agent', '--org', 'teamStupid']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join(' ');
+    expect(errorOutput).toContain("Invalid org name 'teamStupid'");
+    expect(errorOutput).toContain('/^[a-z0-9_-]+$/');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects --org with spaces', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'validagent', '--template', 'agent', '--org', 'my org']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects --org path-traversal attempts', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'validagent', '--template', 'agent', '--org', '../escape']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/cli/init-validation.test.ts
+++ b/tests/unit/cli/init-validation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #407 regression test: `cortextos init` must reject invalid org
+ * names (mixed-case, spaces, path traversal, etc.) BEFORE creating any
+ * filesystem artifacts.
+ *
+ * Before the fix, `cortextos init teamStupid` succeeded at the CLI level,
+ * wrote `orgs/teamStupid/` to disk, registered the org context, and THEN
+ * failed every dashboard `POST /api/agents` call (HTTP 400) and every
+ * `cortextos bus *` invocation at runtime because `src/utils/env.ts` and
+ * the dashboard API both call `validateOrgName()` strictly. Affected orgs
+ * were unusable from any UI surface.
+ *
+ * The fix calls `validateOrgName()` at the entry of the init action, so
+ * bad names are rejected upfront and the caller gets a clear error before
+ * any filesystem state is touched.
+ *
+ * Mirrors the BUG-041 pattern in `add-agent-validation.test.ts`.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { initCommand } from '../../../src/cli/init';
+
+describe('issue #407: init org name validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects teamStupid (camelCase) before any filesystem write', async () => {
+    // Commander calls process.exit(1) on validation failure. We intercept it
+    // by throwing, which we catch via expect().rejects. This avoids the test
+    // runner itself exiting on process.exit().
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', 'teamStupid'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join(' ');
+    expect(errorOutput).toContain("Invalid org name 'teamStupid'");
+    expect(errorOutput).toContain('/^[a-z0-9_-]+$/');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects a single-uppercase-letter name (Acme)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', 'Acme'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects names with spaces', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', 'my org'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects path traversal attempts', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', '../evil'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
<!--
Local-only notes — not part of the PR body itself.
Title used when filing: fix(cli): validate org name in `init` and `add-agent --org` (#407)
Pass this file to `gh pr edit 408 --body-file PR-BODY.md` to update.
-->

**Disclosure:** I'm not a working developer; this patch was drafted with
AI assistance (Claude Opus 4.7). I confirmed the bug from real use, ran
all local gates, and reviewed every diff — but defer to you on style and
architecture judgements. The commits carry a `Co-Authored-By: Claude`
trailer.

I filed #407 about an hour before opening this — submitting proactively
because the fix follows the exact pattern already established by the
BUG-041 fix for agent names. Happy to close and wait if you'd prefer to
discuss the approach in the issue first.

## Summary

`cortextos init <org>` and `cortextos add-agent --org <org>` accepted mixed-case
org names like `teamStupid`, which then broke every dashboard add-agent call
(HTTP 400) and every `cortextos bus *` invocation at runtime — both surfaces
validate strictly via `validateOrgName()` (`/^[a-z0-9_-]+$/`). The canonical
helper already existed in `src/utils/validate.ts` but the two CLI entry points
bypassed it. This wires it in, mirroring the BUG-041 pattern, and dedupes the
locally-redeclared copy in `src/cli/setup.ts`. Closes #407.

## Test plan

All four CI-gate equivalents run locally on this branch:

- [x] `npm run typecheck` — clean
- [x] `npm run build` — 151ms, no errors
- [x] `npm test` — **1713 pass, 1 skipped, 0 fail** (106 test files)
- [x] `npm run test:codex` — **48/48 pass** (6 test files)
- [x] `cd dashboard && npx tsc --noEmit` — clean

New unit tests cover the rejection paths only (the existing success-path tests
remain unchanged):

**`tests/unit/cli/init-validation.test.ts`** (new, 4 cases):
- camelCase rejection (`teamStupid`) — verifies error message includes
  `Invalid org name 'teamStupid'` and the regex `/^[a-z0-9_-]+$/`
- single-uppercase rejection (`Acme`)
- spaces (`my org`)
- path traversal (`../evil`)

**`tests/unit/cli/add-agent-validation.test.ts`** (extended with a new
`describe('issue #407: add-agent --org name validation', …)` block, 3 cases):
- camelCase `--org` rejection
- spaces in `--org`
- path traversal in `--org`

Manual smoke (recommended; not run on a real install yet):
```bash
node dist/cli.js init teamStupid
# expect: "Error: Invalid org name 'teamStupid'..." + exit 1, no orgs/teamStupid/ created
node dist/cli.js add-agent foo --template agent --org teamStupid
# expect: "Error: Invalid org name 'teamStupid'..." + exit 1
```

## Checklist

- [x] `npm run build` passes
- [x] `npm test` passes
- [x] No new secrets or credentials committed
- [x] **Agent Awareness:** N/A — no new commands, endpoints, hooks, or behaviour
  surfaces. This is stricter input validation on existing commands. Existing
  `templates/*/CLAUDE.md` references already use lowercase orgs in every
  example, so no template updates were required.
- [x] **Migration Parity:** N/A — no agent-installed files (hooks, settings.json,
  agent CLAUDE.md sections) changed. Existing valid (lowercase) orgs and agents
  are unaffected; only invalid input is now rejected earlier and louder.
