### PR TITLE
feat(dashboard): quota indicator + quota-watchdog scripts

### DIFF
--- a/bin/quota-resume.sh
+++ b/bin/quota-resume.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# quota-resume.sh — manual companion to quota-watchdog.sh.
+#
+# Reads the paused-state file written by quota-watchdog.sh and starts every
+# agent that the watchdog stopped. Idempotent: removes the state file on
+# success so the next watchdog tick is allowed to run again.
+#
+# Usage:
+#   /root/cortextos/bin/quota-resume.sh           # resume all paused agents
+#   /root/cortextos/bin/quota-resume.sh --status  # show paused state without resuming
+#
+# Tunables (env):
+#   CTX_ROOT             — cortextos state root (default: /root/.cortextos/default)
+#   CTX_FRAMEWORK_ROOT   — cortextos framework root (default: /root/cortextos)
+#   CTX_ORG              — org name for bus calls (default: sondre-hq)
+#   WATCHDOG_BUS_AGENT   — agent context for bus calls (default: commander)
+#   WATCHDOG_CHAT_ID     — Sondre's chat id (default: 8654231106)
+
+set -uo pipefail
+
+CTX_ROOT="${CTX_ROOT:-/root/.cortextos/default}"
+CTX_FRAMEWORK_ROOT="${CTX_FRAMEWORK_ROOT:-/root/cortextos}"
+CTX_ORG="${CTX_ORG:-sondre-hq}"
+BUS_AGENT="${WATCHDOG_BUS_AGENT:-commander}"
+CHAT_ID="${WATCHDOG_CHAT_ID:-8654231106}"
+
+STATE_DIR="$CTX_ROOT/state/quota-watchdog"
+PAUSED_FILE="$STATE_DIR/paused.json"
+LOG="$STATE_DIR/watchdog.log"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "[$(ts)] resume: $*" >> "$LOG"; }
+
+export CTX_ROOT CTX_FRAMEWORK_ROOT CTX_ORG
+export CTX_AGENT_NAME="$BUS_AGENT"
+export CTX_AGENT_DIR="$CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/$BUS_AGENT"
+
+CORTEXTOS=/usr/bin/cortextos
+JQ=/usr/bin/jq
+
+if [ ! -f "$PAUSED_FILE" ]; then
+  echo "No paused state at $PAUSED_FILE — watchdog has not tripped (or already resumed)."
+  exit 0
+fi
+
+if [ "${1:-}" = "--status" ]; then
+  "$JQ" . "$PAUSED_FILE"
+  exit 0
+fi
+
+PAUSED_AT=$("$JQ" -r .paused_at "$PAUSED_FILE")
+# v2 schema: agents_paused; v1 schema: agents — accept both
+AGENTS_JSON=$("$JQ" -c '.agents_paused // .agents // []' "$PAUSED_FILE")
+COUNT=$(echo "$AGENTS_JSON" | "$JQ" 'length')
+
+echo "Resuming $COUNT agents (paused at $PAUSED_AT):"
+log "resume requested: $COUNT agents (paused_at=$PAUSED_AT)"
+
+FAILED=()
+echo "$AGENTS_JSON" | "$JQ" -r '.[]' | while IFS= read -r AGENT; do
+  [ -z "$AGENT" ] && continue
+  echo "  starting: $AGENT"
+  if "$CORTEXTOS" start "$AGENT" >> "$LOG" 2>&1; then
+    log "  started: $AGENT"
+  else
+    log "  start failed: $AGENT"
+    FAILED+=("$AGENT")
+  fi
+done
+
+# Archive the paused-state file rather than delete (auditability)
+ARCHIVE_DIR="$STATE_DIR/history"
+mkdir -p "$ARCHIVE_DIR"
+mv "$PAUSED_FILE" "$ARCHIVE_DIR/paused-$(ts).json"
+log "paused state archived; watchdog re-armed"
+
+"$CORTEXTOS" bus log-event action quota_watchdog_resume info \
+  --meta "{\"agents_resumed\":$AGENTS_JSON,\"paused_at\":\"$PAUSED_AT\"}" \
+  >> "$LOG" 2>&1 || true
+
+AGENT_LIST=$(echo "$AGENTS_JSON" | "$JQ" -r 'join(", ")')
+MSG="✅ Quota watchdog resumed. Started $COUNT agents: $AGENT_LIST."
+"$CORTEXTOS" bus send-telegram "$CHAT_ID" "$MSG" --plain-text >> "$LOG" 2>&1 || true
+
+echo "Done. Watchdog re-armed."
+exit 0

--- a/bin/quota-shadow-commander.sh
+++ b/bin/quota-shadow-commander.sh
@@ -1,0 +1,86 @@
+#!/bin/bash
+# quota-shadow-commander.sh — Watchdog v3 Phase 1 (shadow mode, no broadcasts).
+#
+# Simulates what commander's heartbeat-cadence quota check WOULD decide,
+# without actually broadcasting QUOTA_PAUSE/RESUME or modifying any agent
+# state. Logs decisions to a shadow log so we can compare against the
+# 5-min bash watchdog (v1+v2) over 24h+ and validate the agent-driven
+# trigger logic agrees before advancing to Phase 2.
+#
+# Tunables (env):
+#   QUOTA_PAUSE_THRESHOLD   — % below which commander would broadcast PAUSE (default 10)
+#   QUOTA_RESUME_THRESHOLD  — % above which commander would broadcast RESUME (default 50)
+#   CTX_ROOT                — cortextos state root (default /root/.cortextos/default)
+#
+# Designed to run from system crontab every 4h (commander's heartbeat
+# cadence). NEVER spawns a Claude session — pure shell + bus CLI.
+#
+# Companion to /root/cortextos/bin/quota-watchdog.sh (v1+v2 bash failsafe).
+# Once Phase 1 validates, this script is retired in favour of commander
+# directly running the check + broadcasting via bus messages (Phase 2+).
+
+set -uo pipefail
+
+THRESHOLD_PAUSE_PCT="${QUOTA_PAUSE_THRESHOLD:-10}"
+THRESHOLD_RESUME_PCT="${QUOTA_RESUME_THRESHOLD:-50}"
+
+CTX_ROOT="${CTX_ROOT:-/root/.cortextos/default}"
+STATE_DIR="$CTX_ROOT/state/quota-watchdog-v3-shadow"
+LOG="$STATE_DIR/shadow.log"
+mkdir -p "$STATE_DIR"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+CORTEXTOS=/usr/bin/cortextos
+JQ=/usr/bin/jq
+CLAUDE_CREDS=/root/.claude/.credentials.json
+
+# Reuse the OAuth fallback the v1 watchdog uses
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] && [ -f "$CLAUDE_CREDS" ]; then
+  TOK=$("$JQ" -r '.claudeAiOauth.accessToken // empty' "$CLAUDE_CREDS" 2>/dev/null)
+  [ -n "$TOK" ] && export CLAUDE_CODE_OAUTH_TOKEN="$TOK"
+fi
+
+# Bus needs an agent context for env resolution
+export CTX_AGENT_NAME=commander
+export CTX_ROOT
+export CTX_FRAMEWORK_ROOT="${CTX_FRAMEWORK_ROOT:-/root/cortextos}"
+export CTX_ORG="${CTX_ORG:-sondre-hq}"
+
+log "=== shadow-check start (pause<${THRESHOLD_PAUSE_PCT}%, resume>${THRESHOLD_RESUME_PCT}%) ==="
+
+# Read remaining %
+if ! API_OUT=$("$CORTEXTOS" bus check-usage-api --json 2>/dev/null); then
+  log "  API unavailable → would default to no-action (no token, no decision)"
+  log "=== shadow-check end ==="
+  exit 0
+fi
+FIVE_H=$(echo "$API_OUT" | "$JQ" -r '.five_hour_utilization // empty')
+if [ -z "$FIVE_H" ] || [ "$FIVE_H" = "null" ]; then
+  log "  API returned no 5h util → would default to no-action"
+  log "=== shadow-check end ==="
+  exit 0
+fi
+
+REMAINING_PCT=$(awk -v u="$FIVE_H" 'BEGIN { p = (1-u)*100; if (p<0) p=0; printf "%.0f", p }')
+
+# Mirror v1+v2 watchdog's paused-state check
+PAUSED_FILE="$CTX_ROOT/state/quota-watchdog/paused.json"
+if [ -f "$PAUSED_FILE" ]; then
+  PAUSED=yes
+else
+  PAUSED=no
+fi
+
+# Decide what commander WOULD do
+DECISION="no-action"
+if [ "$PAUSED" = "no" ] && [ "$REMAINING_PCT" -lt "$THRESHOLD_PAUSE_PCT" ]; then
+  DECISION="would-broadcast-PAUSE"
+elif [ "$PAUSED" = "yes" ] && [ "$REMAINING_PCT" -gt "$THRESHOLD_RESUME_PCT" ]; then
+  DECISION="would-broadcast-RESUME"
+fi
+
+log "remaining=${REMAINING_PCT}% paused=$PAUSED → decision=$DECISION"
+log "=== shadow-check end ==="
+exit 0

--- a/bin/quota-watchdog.sh
+++ b/bin/quota-watchdog.sh
@@ -1,0 +1,260 @@
+#!/bin/bash
+# quota-watchdog.sh — system-cron-driven Claude quota watchdog with auto-resume.
+#
+# Pauses every running cortextOS agent when the 5h-window quota drops below
+# QUOTA_THRESHOLD_PCT (default 10%). Auto-resumes them once the window has
+# refilled past QUOTA_RESUME_PCT (default 50%). Designed to run from system
+# crontab every 5 minutes. NEVER spawns a Claude session — pure shell + bus
+# CLI + ccusage.
+#
+# Tunables (env):
+#   QUOTA_THRESHOLD_PCT  — pause when remaining_pct <  this value (default: 10)
+#   QUOTA_RESUME_PCT     — auto-resume when remaining_pct > this (default: 50)
+#   QUOTA_DRY_RUN        — "1" to log+telegram but skip stop/start/state-write
+#   CTX_ROOT             — cortextos state root (default: /root/.cortextos/default)
+#   CTX_FRAMEWORK_ROOT   — cortextos framework root (default: /root/cortextos)
+#   CTX_ORG              — org name for bus calls (default: sondre-hq)
+#   WATCHDOG_BUS_AGENT   — agent context for bus telegram/event calls (default: commander)
+#   WATCHDOG_CHAT_ID     — Sondre's chat id (default: 8654231106)
+#
+# Exit codes: 0 always (cron-friendly). All errors logged.
+
+set -uo pipefail
+
+THRESHOLD_PCT="${QUOTA_THRESHOLD_PCT:-10}"
+RESUME_PCT="${QUOTA_RESUME_PCT:-50}"
+DRY_RUN="${QUOTA_DRY_RUN:-0}"
+
+CTX_ROOT="${CTX_ROOT:-/root/.cortextos/default}"
+CTX_FRAMEWORK_ROOT="${CTX_FRAMEWORK_ROOT:-/root/cortextos}"
+CTX_ORG="${CTX_ORG:-sondre-hq}"
+BUS_AGENT="${WATCHDOG_BUS_AGENT:-commander}"
+CHAT_ID="${WATCHDOG_CHAT_ID:-8654231106}"
+
+STATE_DIR="$CTX_ROOT/state/quota-watchdog"
+PAUSED_FILE="$STATE_DIR/paused.json"
+CHECK_FILE="$STATE_DIR/last-check.json"
+HISTORY_DIR="$STATE_DIR/history"
+LOG="$STATE_DIR/watchdog.log"
+
+mkdir -p "$STATE_DIR" "$HISTORY_DIR"
+
+ts() { date -u +%Y-%m-%dT%H:%M:%SZ; }
+log() { echo "[$(ts)] $*" >> "$LOG"; }
+
+# Bus-friendly env block — needed because cron has no agent context
+export CTX_ROOT CTX_FRAMEWORK_ROOT CTX_ORG
+export CTX_AGENT_NAME="$BUS_AGENT"
+export CTX_AGENT_DIR="$CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/$BUS_AGENT"
+
+CORTEXTOS=/usr/bin/cortextos
+JQ=/usr/bin/jq
+CCUSAGE=/usr/bin/ccusage
+CLAUDE_CREDS=/root/.claude/.credentials.json
+
+# Auto-extract OAuth token from Claude Code's local credentials store if no
+# accounts.json is configured and CLAUDE_CODE_OAUTH_TOKEN isn't already set.
+# Claude Code refreshes that file automatically while any agent runs, so the
+# watchdog gets fresh tokens for free.
+if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
+   && [ ! -f "$CTX_ROOT/state/oauth/accounts.json" ] \
+   && [ -f "$CLAUDE_CREDS" ]; then
+  TOK=$("$JQ" -r '.claudeAiOauth.accessToken // empty' "$CLAUDE_CREDS" 2>/dev/null)
+  [ -n "$TOK" ] && export CLAUDE_CODE_OAUTH_TOKEN="$TOK"
+fi
+
+# ---------------------------------------------------------------------------
+# 1. Determine remaining_pct — API is the ONLY authoritative source for
+#    pause/resume decisions. ccusage was used as a fallback in v1+v2 but
+#    that produced a real false-positive on 2026-05-07 09:35 UTC: API
+#    transient failure → ccusage tripped 0% via "exceeds historical max"
+#    heuristic → all 6 agents paused even though Sondre had 96% remaining.
+#    Postmortem: vault/00-inbox/20260507-dev-quota-watchdog-ccusage-false-positive-postmortem.md
+#
+#    New policy (v3 — same script, tighter logic):
+#    - API success → use it for pause/resume decisions (UNCHANGED).
+#    - API failure → log + Telegram alert + DO NOT pause.
+#      ccusage stays available as a sanity-check signal in the monitoring
+#      log but is NEVER authoritative for pause/resume.
+# ---------------------------------------------------------------------------
+REMAINING_PCT=""
+METHOD=""
+API_AVAILABLE=no
+
+# Path 1: official Anthropic usage API (the only authoritative source)
+if API_OUT=$("$CORTEXTOS" bus check-usage-api --json 2>/dev/null); then
+  FIVE_H=$(echo "$API_OUT" | "$JQ" -r '.five_hour_utilization // empty')
+  if [ -n "$FIVE_H" ] && [ "$FIVE_H" != "null" ]; then
+    REMAINING_PCT=$(awk -v u="$FIVE_H" 'BEGIN { p = (1-u)*100; if (p<0) p=0; printf "%.0f", p }')
+    METHOD="api"
+    API_AVAILABLE=yes
+  fi
+fi
+
+# Sanity-check signal only — log ccusage's reading next to API for monitoring
+# debugging, but never use it to drive pause/resume decisions.
+CCUSAGE_PCT=""
+if [ -x "$CCUSAGE" ]; then
+  if CC_OUT=$("$CCUSAGE" blocks --active --json -t max 2>/dev/null); then
+    CC_USED=$(echo "$CC_OUT" | "$JQ" -r '.blocks[0].tokenLimitStatus.percentUsed // empty')
+    if [ -n "$CC_USED" ]; then
+      CCUSAGE_PCT=$(awk -v u="$CC_USED" 'BEGIN { p = 100-u; if (p<0) p=0; printf "%.0f", p }')
+    fi
+  fi
+fi
+
+# If API path failed, alert + stay running (DO NOT auto-pause). The
+# Sondre-impact of a false-positive pause is much worse than a brief
+# blind window; quota tax during the blind window is bounded by burn rate.
+if [ "$API_AVAILABLE" = "no" ]; then
+  REMAINING_PCT=unknown
+  METHOD="api-degraded"
+  log "WARNING: API path unavailable. ccusage_signal=${CCUSAGE_PCT:-unavailable}%. Staying running per v3 policy — alert sent to operator."
+  ALERT_MSG="⚠️ Quota watchdog API path degraded — ccusage signal=${CCUSAGE_PCT:-unavailable}%. Agents NOT paused (per v3 policy: pause only on API-confirmed below-threshold). Investigate manually if API path doesn't recover within the next cycle. Watchdog log: $LOG"
+  # Only alert ONCE per degradation episode — don't spam Sondre on repeated cron ticks
+  DEGRADED_FLAG="$STATE_DIR/.api-degraded-since"
+  if [ ! -f "$DEGRADED_FLAG" ]; then
+    "$CORTEXTOS" bus send-telegram "$CHAT_ID" "$ALERT_MSG" --plain-text >> "$LOG" 2>&1 || log "  telegram alert failed"
+    echo "$(ts)" > "$DEGRADED_FLAG"
+  fi
+  cat > "$CHECK_FILE" <<EOF
+{
+  "ts": "$(ts)",
+  "method": "$METHOD",
+  "remaining_pct": "unknown",
+  "ccusage_signal_pct": ${CCUSAGE_PCT:-null},
+  "paused": $([ -f "$PAUSED_FILE" ] && echo true || echo false)
+}
+EOF
+  exit 0
+fi
+
+# API recovered — clear any stale degradation flag
+[ -f "$STATE_DIR/.api-degraded-since" ] && rm -f "$STATE_DIR/.api-degraded-since"
+
+cat > "$CHECK_FILE" <<EOF
+{
+  "ts": "$(ts)",
+  "method": "$METHOD",
+  "remaining_pct": $REMAINING_PCT,
+  "ccusage_signal_pct": ${CCUSAGE_PCT:-null},
+  "threshold_pct": $THRESHOLD_PCT,
+  "resume_pct": $RESUME_PCT,
+  "paused": $([ -f "$PAUSED_FILE" ] && echo true || echo false)
+}
+EOF
+
+log "check method=$METHOD remaining=${REMAINING_PCT}% ccusage_signal=${CCUSAGE_PCT:-na}% threshold=${THRESHOLD_PCT}% resume=${RESUME_PCT}% paused=$([ -f "$PAUSED_FILE" ] && echo yes || echo no)"
+
+# ---------------------------------------------------------------------------
+# 2. Branch: if paused.json exists → maybe auto-resume; else → maybe pause
+# ---------------------------------------------------------------------------
+
+if [ -f "$PAUSED_FILE" ]; then
+  # ---- Already paused: should we auto-resume? ----
+  # API-degraded path stays paused — never resume on a guess (we already
+  # exited in the API-degraded branch above before reaching here, but
+  # belt-and-suspenders).
+  if [ "$METHOD" != "api" ]; then
+    log "still paused; method=$METHOD non-authoritative, holding pause"
+    exit 0
+  fi
+
+  if [ "$REMAINING_PCT" -le "$RESUME_PCT" ]; then
+    log "still paused; remaining=${REMAINING_PCT}% <= resume=${RESUME_PCT}%, holding"
+    exit 0
+  fi
+
+  # Auto-resume path
+  log "AUTO-RESUME remaining=${REMAINING_PCT}% > resume=${RESUME_PCT}%"
+
+  PAUSED_AT=$("$JQ" -r '.paused_at // empty' "$PAUSED_FILE" 2>/dev/null)
+  AGENTS_JSON=$("$JQ" -c '.agents_paused // .agents // []' "$PAUSED_FILE" 2>/dev/null)
+  [ -z "$AGENTS_JSON" ] && AGENTS_JSON='[]'
+  COUNT=$(echo "$AGENTS_JSON" | "$JQ" 'length')
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "DRY-RUN: would auto-resume $COUNT agents and archive paused state"
+    MSG="[dry-run] Quota watchdog WOULD auto-resume — remaining=${REMAINING_PCT}% > ${RESUME_PCT}%. $COUNT agents would be started: $(echo "$AGENTS_JSON" | "$JQ" -r 'join(", ")'). No action taken."
+    "$CORTEXTOS" bus send-telegram "$CHAT_ID" "$MSG" --plain-text >> "$LOG" 2>&1 || log "  telegram failed"
+    exit 0
+  fi
+
+  echo "$AGENTS_JSON" | "$JQ" -r '.[]' | while IFS= read -r AGENT; do
+    [ -z "$AGENT" ] && continue
+    log "auto-resume start: $AGENT"
+    "$CORTEXTOS" start "$AGENT" >> "$LOG" 2>&1 || log "  start failed: $AGENT"
+  done
+
+  # Archive paused state (keep for audit; do not delete)
+  mv "$PAUSED_FILE" "$HISTORY_DIR/paused-$(ts).json"
+  log "paused state archived; watchdog re-armed"
+
+  "$CORTEXTOS" bus log-event action quota_watchdog_resume info \
+    --meta "{\"remaining_pct\":$REMAINING_PCT,\"method\":\"$METHOD\",\"agents_resumed\":$AGENTS_JSON,\"paused_at\":\"$PAUSED_AT\",\"trigger\":\"auto\"}" \
+    >> "$LOG" 2>&1 || log "  log-event failed"
+
+  AGENT_LIST=$(echo "$AGENTS_JSON" | "$JQ" -r 'join(", ")')
+  MSG="✅ Quota watchdog auto-resumed $COUNT agents — remaining ${REMAINING_PCT}% (above ${RESUME_PCT}% buffer). Started: $AGENT_LIST."
+  "$CORTEXTOS" bus send-telegram "$CHAT_ID" "$MSG" --plain-text >> "$LOG" 2>&1 || log "  telegram failed"
+
+  log "AUTO-RESUMED $COUNT agents"
+  exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Not paused: should we trip?
+# ---------------------------------------------------------------------------
+
+if [ "$REMAINING_PCT" -ge "$THRESHOLD_PCT" ]; then
+  exit 0
+fi
+
+log "TRIGGER remaining=${REMAINING_PCT}% < ${THRESHOLD_PCT}%"
+
+# Snapshot running agents
+RUNNING_JSON='[]'
+if AGENTS_OUT=$("$CORTEXTOS" bus list-agents 2>/dev/null); then
+  RUNNING_JSON=$(echo "$AGENTS_OUT" | "$JQ" -c '[.[] | select(.running == true) | .name]')
+  [ -z "$RUNNING_JSON" ] && RUNNING_JSON='[]'
+fi
+COUNT=$(echo "$RUNNING_JSON" | "$JQ" 'length')
+log "running agents: $RUNNING_JSON (count=$COUNT)"
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "DRY-RUN: would stop $COUNT agents and write paused state"
+  MSG="[dry-run] Quota watchdog WOULD trip — method=$METHOD remaining=${REMAINING_PCT}% (threshold ${THRESHOLD_PCT}%). $COUNT agents would be stopped: $(echo "$RUNNING_JSON" | "$JQ" -r 'join(", ")'). No action taken."
+  "$CORTEXTOS" bus send-telegram "$CHAT_ID" "$MSG" --plain-text >> "$LOG" 2>&1 || log "  telegram failed"
+  exit 0
+fi
+
+# Stop each running agent
+echo "$RUNNING_JSON" | "$JQ" -r '.[]' | while IFS= read -r AGENT; do
+  [ -z "$AGENT" ] && continue
+  log "stop: $AGENT"
+  "$CORTEXTOS" stop "$AGENT" >> "$LOG" 2>&1 || log "  stop failed: $AGENT"
+done
+
+# Write paused-state file (schema: paused_at, agents_paused, remaining_pct_at_pause + extras)
+cat > "$PAUSED_FILE" <<EOF
+{
+  "paused_at": "$(ts)",
+  "agents_paused": $RUNNING_JSON,
+  "remaining_pct_at_pause": $REMAINING_PCT,
+  "method": "$METHOD",
+  "threshold_pct": $THRESHOLD_PCT,
+  "resume_pct": $RESUME_PCT
+}
+EOF
+log "paused-state written: $PAUSED_FILE"
+
+"$CORTEXTOS" bus log-event action quota_watchdog_pause warning \
+  --meta "{\"remaining_pct\":$REMAINING_PCT,\"method\":\"$METHOD\",\"agents_stopped\":$RUNNING_JSON}" \
+  >> "$LOG" 2>&1 || log "  log-event failed"
+
+AGENT_LIST=$(echo "$RUNNING_JSON" | "$JQ" -r 'join(", ")')
+MSG="🚨 Quota watchdog tripped. Method=$METHOD, remaining=${REMAINING_PCT}% (threshold ${THRESHOLD_PCT}%). Stopped $COUNT agents: $AGENT_LIST. Will auto-resume once remaining > ${RESUME_PCT}%, or run /root/cortextos/bin/quota-resume.sh manually."
+"$CORTEXTOS" bus send-telegram "$CHAT_ID" "$MSG" --plain-text >> "$LOG" 2>&1 || log "  telegram failed"
+
+log "PAUSED $COUNT agents"
+exit 0

--- a/dashboard/src/app/api/quota/route.ts
+++ b/dashboard/src/app/api/quota/route.ts
@@ -1,0 +1,16 @@
+import { fetchQuotaSnapshot } from '@/lib/quota';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  const snapshot = await fetchQuotaSnapshot();
+  if (!snapshot) {
+    // True cold-boot: API failed AND no cache yet. The component renders this as "no data yet".
+    return Response.json(
+      { error: 'No quota data available yet (API failed and no cached last-good response).' },
+      { status: 503 },
+    );
+  }
+  // snapshot includes { stale: bool, cache_age_ms: number }. Component renders accordingly.
+  return Response.json(snapshot);
+}

--- a/dashboard/src/components/layout/quota-indicator.tsx
+++ b/dashboard/src/components/layout/quota-indicator.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { IconCircleDot } from '@tabler/icons-react';
+
+type QuotaSnapshot = {
+  five_hour_remaining_pct: number;
+  seven_day_remaining_pct: number;
+  fetched_at: string;
+  source: string;
+  stale?: boolean;
+  cache_age_ms?: number;
+};
+
+function formatAge(ms: number): string {
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+const POLL_MS = 60_000; // refresh every 60 seconds — balances freshness vs API rate limits
+
+function bandFor(pct: number): {
+  label: string;
+  dotClass: string;
+  textClass: string;
+} {
+  // Color is a hint — we ALSO surface the % number so the meaning is not
+  // color-only (UX rule §1 color-not-only).
+  if (pct >= 50)
+    return {
+      label: 'healthy',
+      dotClass: 'bg-emerald-500',
+      textClass: 'text-emerald-300',
+    };
+  if (pct >= 20)
+    return {
+      label: 'watch',
+      dotClass: 'bg-amber-500',
+      textClass: 'text-amber-300',
+    };
+  return {
+    label: 'low',
+    dotClass: 'bg-rose-500',
+    textClass: 'text-rose-300',
+  };
+}
+
+export function QuotaIndicator() {
+  const [snapshot, setSnapshot] = useState<QuotaSnapshot | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const load = async () => {
+      try {
+        const res = await fetch('/api/quota', { cache: 'no-store' });
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as { error?: string };
+          if (!cancelled) {
+            setError(err.error ?? `Quota fetch failed (${res.status})`);
+            setSnapshot(null);
+          }
+          return;
+        }
+        const data = (await res.json()) as QuotaSnapshot;
+        if (!cancelled) {
+          setSnapshot(data);
+          setError(null);
+        }
+      } catch (e) {
+        if (!cancelled) setError(String(e));
+      }
+    };
+
+    load();
+    const interval = setInterval(load, POLL_MS);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, []);
+
+  if (error) {
+    return (
+      <div
+        className="flex items-center gap-1.5 px-2 py-1 rounded-md text-xs text-muted-foreground"
+        title={error}
+        aria-label={`Quota status unavailable: ${error}`}
+      >
+        <IconCircleDot size={12} className="text-muted-foreground/50" />
+        <span>quota n/a</span>
+      </div>
+    );
+  }
+
+  if (!snapshot) {
+    return (
+      <div className="flex items-center gap-1.5 px-2 py-1 text-xs text-muted-foreground">
+        <span className="w-2 h-2 rounded-full bg-muted animate-pulse" aria-hidden="true" />
+        <span>quota…</span>
+      </div>
+    );
+  }
+
+  const fiveH = snapshot.five_hour_remaining_pct;
+  const sevenD = snapshot.seven_day_remaining_pct;
+  const band = bandFor(fiveH);
+  const isStale = !!snapshot.stale;
+  const ageLabel = isStale && snapshot.cache_age_ms != null ? formatAge(snapshot.cache_age_ms) : null;
+
+  const tooltipText =
+    `5h window: ${fiveH}% remaining\n` +
+    `7d window: ${sevenD}% remaining\n` +
+    `source: ${snapshot.source}${isStale ? ' (cached)' : ''}\n` +
+    `updated: ${new Date(snapshot.fetched_at).toLocaleTimeString()}` +
+    (isStale ? `\n⚠ API call failed; showing last-good from ${ageLabel}` : '');
+
+  return (
+    <div
+      className={`flex items-center gap-1.5 px-2 py-1 rounded-md text-xs ${isStale ? 'opacity-60' : ''}`}
+      title={tooltipText}
+      aria-label={`Quota ${band.label}: ${fiveH} percent remaining in the 5 hour window, ${sevenD} percent remaining in the 7 day window${isStale ? `, cached from ${ageLabel}` : ''}`}
+    >
+      <span
+        className={`w-2 h-2 rounded-full ${band.dotClass}`}
+        aria-hidden="true"
+      />
+      <span className={`font-mono ${band.textClass}`}>{fiveH}%</span>
+      {isStale && ageLabel ? (
+        <span className="text-muted-foreground hidden sm:inline">{ageLabel}</span>
+      ) : (
+        <span className="text-muted-foreground hidden sm:inline">left</span>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/layout/topbar.tsx
+++ b/dashboard/src/components/layout/topbar.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { OrgSelector } from './org-selector';
+import { QuotaIndicator } from './quota-indicator';
 
 interface TopbarProps {
   orgs: string[];
@@ -51,8 +52,9 @@ export function Topbar({ orgs, currentOrg, onOrgChange, onMenuClick }: TopbarPro
         <OrgSelector orgs={orgs} currentOrg={currentOrg} onOrgChange={onOrgChange} />
       </div>
 
-      {/* Right: Dark mode toggle + User menu */}
+      {/* Right: Quota + Dark mode toggle + User menu */}
       <div className="flex items-center gap-1">
+        <QuotaIndicator />
         <Button
           variant="ghost"
           size="icon"

--- a/dashboard/src/lib/quota.ts
+++ b/dashboard/src/lib/quota.ts
@@ -1,0 +1,144 @@
+/**
+ * Quota helpers for the dashboard's quota-usage indicator.
+ *
+ * Mirrors the OAuth-token fallback logic the bash watchdog uses
+ * (`/root/cortextos/bin/quota-watchdog.sh`): read access token from
+ * Claude Code's local credentials store, call Anthropic's OAuth usage API,
+ * normalise to 0–1 utilization fractions.
+ *
+ * Adds a server-side last-good cache so transient 429s / network errors
+ * don't blank the dashboard. On any failure we return the most recent
+ * successful snapshot with `stale: true` and a `cache_age_ms` field;
+ * the component renders an "Xm ago" suffix. Only when no cache exists
+ * (cold boot) do we return null — that becomes "no data yet" in the UI.
+ */
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const ANTHROPIC_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const CLAUDE_CREDS = '/root/.claude/.credentials.json';
+
+const CACHE_DIR = path.join(
+  process.env.CTX_ROOT ?? path.join(os.homedir(), '.cortextos', 'default'),
+  'state',
+  'dashboard',
+);
+const CACHE_PATH = path.join(CACHE_DIR, 'quota-last-good.json');
+
+export interface QuotaSnapshot {
+  five_hour_remaining_pct: number;
+  seven_day_remaining_pct: number;
+  fetched_at: string;
+  source: 'env' | 'credentials.json' | 'accounts.json';
+}
+
+export interface QuotaResponse extends QuotaSnapshot {
+  /** True when the snapshot came from cache (API call failed). */
+  stale: boolean;
+  /** Milliseconds since the cached snapshot was originally fetched. 0 if fresh. */
+  cache_age_ms: number;
+}
+
+function getOAuthToken(): { token: string; source: QuotaSnapshot['source'] } | null {
+  if (process.env.CLAUDE_CODE_OAUTH_TOKEN) {
+    return { token: process.env.CLAUDE_CODE_OAUTH_TOKEN, source: 'env' };
+  }
+  if (fs.existsSync(CLAUDE_CREDS)) {
+    try {
+      const raw = fs.readFileSync(CLAUDE_CREDS, 'utf-8');
+      const parsed = JSON.parse(raw) as { claudeAiOauth?: { accessToken?: string } };
+      const token = parsed.claudeAiOauth?.accessToken;
+      if (token) return { token, source: 'credentials.json' };
+    } catch {
+      /* fall through */
+    }
+  }
+  return null;
+}
+
+function readCache(): QuotaSnapshot | null {
+  if (!fs.existsSync(CACHE_PATH)) return null;
+  try {
+    return JSON.parse(fs.readFileSync(CACHE_PATH, 'utf-8')) as QuotaSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+function writeCache(snapshot: QuotaSnapshot): void {
+  try {
+    fs.mkdirSync(CACHE_DIR, { recursive: true });
+    fs.writeFileSync(CACHE_PATH, JSON.stringify(snapshot, null, 2));
+  } catch {
+    /* Best-effort: cache write failure shouldn't break the request. */
+  }
+}
+
+async function fetchFresh(): Promise<QuotaSnapshot | null> {
+  const auth = getOAuthToken();
+  if (!auth) return null;
+
+  const response = await fetch(ANTHROPIC_USAGE_URL, {
+    headers: {
+      Authorization: `Bearer ${auth.token}`,
+      'anthropic-beta': 'oauth-2025-04-20',
+    },
+  });
+  if (!response.ok) return null;
+
+  // The Anthropic OAuth usage API actually returns NESTED objects:
+  //   { five_hour: { utilization: 77.0, resets_at: "..." }, seven_day: {...}, ... }
+  // We previously parsed flat fields (five_hour_utilization) which always
+  // returned undefined → normalize → 0 → "100% remaining" regardless of
+  // real usage. Hence the "stuck at 100%" UX bug. Keep the flat fallbacks
+  // in case the API ever returns either shape.
+  const data = (await response.json()) as {
+    five_hour?: { utilization?: number };
+    seven_day?: { utilization?: number };
+    five_hour_utilization?: number;
+    seven_day_utilization?: number;
+    fiveHourUtilization?: number;
+    sevenDayUtilization?: number;
+  };
+
+  const normalize = (v: number | undefined): number => {
+    if (v === undefined || v === null) return 0;
+    return v > 1 ? v / 100 : v;
+  };
+
+  const fiveH = normalize(
+    data.five_hour?.utilization ?? data.five_hour_utilization ?? data.fiveHourUtilization,
+  );
+  const sevenD = normalize(
+    data.seven_day?.utilization ?? data.seven_day_utilization ?? data.sevenDayUtilization,
+  );
+
+  return {
+    five_hour_remaining_pct: Math.round((1 - fiveH) * 100),
+    seven_day_remaining_pct: Math.round((1 - sevenD) * 100),
+    fetched_at: new Date().toISOString(),
+    source: auth.source,
+  };
+}
+
+/**
+ * Fetch a quota response. Always returns the freshest available data:
+ * a fresh API call when it succeeds, the cached last-good when it
+ * doesn't, or null when neither is available (cold-boot only).
+ */
+export async function fetchQuotaSnapshot(): Promise<QuotaResponse | null> {
+  const fresh = await fetchFresh();
+  if (fresh) {
+    writeCache(fresh);
+    return { ...fresh, stale: false, cache_age_ms: 0 };
+  }
+
+  const cached = readCache();
+  if (cached) {
+    const cacheAgeMs = Date.now() - new Date(cached.fetched_at).getTime();
+    return { ...cached, stale: true, cache_age_ms: Math.max(0, cacheAgeMs) };
+  }
+
+  return null;
+}

--- a/dashboard/src/lib/quota.ts
+++ b/dashboard/src/lib/quota.ts
@@ -17,7 +17,7 @@ import path from 'path';
 import os from 'os';
 
 const ANTHROPIC_USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
-const CLAUDE_CREDS = '/root/.claude/.credentials.json';
+const CLAUDE_CREDS = path.join(os.homedir(), '.claude', '.credentials.json');
 
 const CACHE_DIR = path.join(
   process.env.CTX_ROOT ?? path.join(os.homedir(), '.cortextos', 'default'),

--- a/src/bus/oauth.ts
+++ b/src/bus/oauth.ts
@@ -216,7 +216,16 @@ export async function checkUsageApi(
     throw new Error(`Usage API returned ${response.status}: ${await response.text()}`);
   }
 
+  // The Anthropic OAuth usage API returns NESTED objects:
+  //   { five_hour: { utilization, resets_at }, seven_day: {...}, ... }
+  // The earlier flat-only parsing always returned undefined → normalize → 0
+  // → "100% remaining" regardless of real usage. That made the watchdog
+  // blind to real burn (it tripped only on ccusage's heuristic) and
+  // hid Sondre's actual quota in the dashboard. Keep flat fallbacks in
+  // case the API ever returns either shape.
   const data = await response.json() as {
+    five_hour?: { utilization?: number };
+    seven_day?: { utilization?: number };
     five_hour_utilization?: number;
     seven_day_utilization?: number;
     fiveHourUtilization?: number;
@@ -229,8 +238,12 @@ export async function checkUsageApi(
     return v > 1 ? v / 100 : v;
   };
 
-  const fiveHour = normalize(data.five_hour_utilization ?? data.fiveHourUtilization);
-  const sevenDay = normalize(data.seven_day_utilization ?? data.sevenDayUtilization);
+  const fiveHour = normalize(
+    data.five_hour?.utilization ?? data.five_hour_utilization ?? data.fiveHourUtilization,
+  );
+  const sevenDay = normalize(
+    data.seven_day?.utilization ?? data.seven_day_utilization ?? data.sevenDayUtilization,
+  );
   const fetchedAt = new Date().toISOString();
 
   const snapshot: UsageSnapshot = {


### PR DESCRIPTION
## Summary

Adds a persistent quota usage indicator to the dashboard topbar and companion shell scripts for automated quota monitoring.

- **quota-indicator.tsx**: live progress bar in the topbar showing session and weekly token consumption, colour-coded by threshold
- **quota.ts + /api/quota/route.ts**: reads Claude plan quota from OAuth state file
- **topbar.tsx**: wires in `QuotaIndicator` component
- **bin/quota-watchdog.sh**: monitors quota; auto-pauses agents when limit approaches
- **bin/quota-resume.sh**: resumes paused agents after quota resets
- **bin/quota-shadow-commander.sh**: shadow-mode watchdog for the commander agent
- **src/bus/oauth.ts**: quota read helpers

Example: My threshold is at 10%, so if i have less than that. It pauses the agents so that i can still use claude chat

<img width="1469" height="438" alt="Screenshot 2026-05-13 at 18 04 33" src="https://github.com/user-attachments/assets/cb24be33-ae95-4a79-90ad-a33b7d41c7d3" />


## Test plan

- [ ] Start dashboard, confirm quota bar appears in topbar
- [ ] Check bar updates on page refresh
- [ ] Verify colour thresholds (green/yellow/red) at appropriate %
- [ ] Run `bin/quota-watchdog.sh` in dry-run mode, confirm output
