### PR TITLE
feat(dashboard): Obsidian wiki viewer

### DIFF
--- a/dashboard/src/app/(dashboard)/wiki/page.tsx
+++ b/dashboard/src/app/(dashboard)/wiki/page.tsx
@@ -1,0 +1,13 @@
+export const dynamic = 'force-dynamic';
+
+import { WikiShell } from '@/components/wiki/wiki-shell';
+
+interface PageProps {
+  searchParams: Promise<{ org?: string }>;
+}
+
+export default async function WikiPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+  const org = params.org ?? 'sondre-hq';
+  return <WikiShell org={org} />;
+}

--- a/dashboard/src/app/api/wiki/inbox/route.ts
+++ b/dashboard/src/app/api/wiki/inbox/route.ts
@@ -1,0 +1,59 @@
+import fs from 'fs';
+import path from 'path';
+import { NextRequest } from 'next/server';
+import {
+  getVaultRoot,
+  parseFrontmatter,
+  firstMeaningfulLine,
+} from '@/lib/vault';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const org = url.searchParams.get('org') ?? 'sondre-hq';
+
+  const vaultRoot = getVaultRoot(org);
+  if (!vaultRoot) {
+    return Response.json({ error: `Vault not found for org "${org}"` }, { status: 404 });
+  }
+
+  const inboxDir = path.join(vaultRoot, '00-inbox');
+  if (!fs.existsSync(inboxDir)) {
+    return Response.json({ vaultRoot, items: [] });
+  }
+
+  const items = [];
+  for (const entry of fs.readdirSync(inboxDir, { withFileTypes: true })) {
+    if (!entry.isFile()) continue;
+    if (!entry.name.endsWith('.md')) continue;
+    if (entry.name.startsWith('.')) continue;
+
+    const abs = path.join(inboxDir, entry.name);
+    const stat = fs.statSync(abs);
+    let frontmatter = {};
+    let excerpt = '';
+
+    try {
+      const raw = fs.readFileSync(abs, 'utf-8');
+      const parsed = parseFrontmatter(raw);
+      frontmatter = parsed.frontmatter;
+      excerpt = firstMeaningfulLine(parsed.body);
+    } catch {
+      /* tolerate read errors — surface row anyway */
+    }
+
+    items.push({
+      filename: entry.name,
+      relPath: path.join('00-inbox', entry.name),
+      mtimeMs: stat.mtimeMs,
+      sizeBytes: stat.size,
+      frontmatter,
+      excerpt,
+    });
+  }
+
+  items.sort((a, b) => b.mtimeMs - a.mtimeMs);
+
+  return Response.json({ vaultRoot, items });
+}

--- a/dashboard/src/app/api/wiki/note/route.ts
+++ b/dashboard/src/app/api/wiki/note/route.ts
@@ -1,0 +1,49 @@
+import fs from 'fs';
+import { NextRequest } from 'next/server';
+import {
+  getVaultRoot,
+  parseFrontmatter,
+  resolveVaultPath,
+} from '@/lib/vault';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const org = url.searchParams.get('org') ?? 'sondre-hq';
+  const relPath = url.searchParams.get('path');
+
+  if (!relPath) {
+    return Response.json({ error: 'path query param required' }, { status: 400 });
+  }
+
+  const vaultRoot = getVaultRoot(org);
+  if (!vaultRoot) {
+    return Response.json({ error: `Vault not found for org "${org}"` }, { status: 404 });
+  }
+
+  const abs = resolveVaultPath(vaultRoot, relPath);
+  if (!abs) {
+    return Response.json(
+      { error: 'Path must be inside one of the PARA dirs and contain no traversal' },
+      { status: 400 },
+    );
+  }
+
+  if (!fs.existsSync(abs) || !fs.statSync(abs).isFile()) {
+    return Response.json({ error: 'Note not found' }, { status: 404 });
+  }
+
+  const raw = fs.readFileSync(abs, 'utf-8');
+  const stat = fs.statSync(abs);
+  const { frontmatter, body } = parseFrontmatter(raw);
+
+  return Response.json({
+    relPath,
+    raw,
+    body,
+    frontmatter,
+    mtimeMs: stat.mtimeMs,
+    sizeBytes: stat.size,
+  });
+}

--- a/dashboard/src/app/api/wiki/note/route.ts
+++ b/dashboard/src/app/api/wiki/note/route.ts
@@ -8,10 +8,16 @@ import {
 
 export const dynamic = 'force-dynamic';
 
+const ORG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
 export async function GET(req: NextRequest) {
   const url = new URL(req.url);
   const org = url.searchParams.get('org') ?? 'sondre-hq';
   const relPath = url.searchParams.get('path');
+
+  if (!ORG_RE.test(org)) {
+    return Response.json({ error: 'Invalid org parameter' }, { status: 400 });
+  }
 
   if (!relPath) {
     return Response.json({ error: 'path query param required' }, { status: 400 });

--- a/dashboard/src/app/api/wiki/search/route.ts
+++ b/dashboard/src/app/api/wiki/search/route.ts
@@ -1,0 +1,80 @@
+import fs from 'fs';
+import path from 'path';
+import { NextRequest } from 'next/server';
+import { getVaultRoot, listAllNotes, parseFrontmatter } from '@/lib/vault';
+
+export const dynamic = 'force-dynamic';
+
+const MAX_RESULTS = 50;
+const SNIPPET_RADIUS = 60;
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const org = url.searchParams.get('org') ?? 'sondre-hq';
+  const q = (url.searchParams.get('q') ?? '').trim();
+
+  if (q.length < 2) {
+    return Response.json({ q, results: [] });
+  }
+
+  const vaultRoot = getVaultRoot(org);
+  if (!vaultRoot) {
+    return Response.json({ error: `Vault not found for org "${org}"` }, { status: 404 });
+  }
+
+  const needle = q.toLowerCase();
+  const results: Array<{
+    relPath: string;
+    filename: string;
+    matchedIn: 'filename' | 'content' | 'both';
+    snippet: string;
+    frontmatter: Record<string, unknown>;
+    mtimeMs: number;
+  }> = [];
+
+  for (const note of listAllNotes(vaultRoot)) {
+    if (results.length >= MAX_RESULTS) break;
+
+    const filename = path.basename(note.relPath);
+    const filenameMatches = filename.toLowerCase().includes(needle);
+
+    let raw = '';
+    try {
+      raw = fs.readFileSync(note.absPath, 'utf-8');
+    } catch {
+      continue;
+    }
+
+    const idx = raw.toLowerCase().indexOf(needle);
+    const contentMatches = idx !== -1;
+
+    if (!filenameMatches && !contentMatches) continue;
+
+    let snippet = '';
+    if (contentMatches) {
+      const start = Math.max(0, idx - SNIPPET_RADIUS);
+      const end = Math.min(raw.length, idx + needle.length + SNIPPET_RADIUS);
+      snippet = (start > 0 ? '…' : '') + raw.slice(start, end).replace(/\s+/g, ' ').trim() + (end < raw.length ? '…' : '');
+    }
+
+    const { frontmatter } = parseFrontmatter(raw);
+
+    results.push({
+      relPath: note.relPath,
+      filename,
+      matchedIn: filenameMatches && contentMatches ? 'both' : filenameMatches ? 'filename' : 'content',
+      snippet,
+      frontmatter,
+      mtimeMs: note.mtimeMs,
+    });
+  }
+
+  // Filename matches first, then content matches; within each, newest first
+  results.sort((a, b) => {
+    const rank = (m: typeof a.matchedIn) => (m === 'both' ? 0 : m === 'filename' ? 1 : 2);
+    const r = rank(a.matchedIn) - rank(b.matchedIn);
+    return r !== 0 ? r : b.mtimeMs - a.mtimeMs;
+  });
+
+  return Response.json({ q, results });
+}

--- a/dashboard/src/app/api/wiki/tree/route.ts
+++ b/dashboard/src/app/api/wiki/tree/route.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import path from 'path';
+import { NextRequest } from 'next/server';
+import { getVaultRoot, PARA_DIRS } from '@/lib/vault';
+
+export const dynamic = 'force-dynamic';
+
+type TreeNode =
+  | {
+      kind: 'dir';
+      name: string;
+      relPath: string;
+      children: TreeNode[];
+    }
+  | {
+      kind: 'file';
+      name: string;
+      relPath: string;
+      mtimeMs: number;
+    };
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const org = url.searchParams.get('org') ?? 'sondre-hq';
+
+  const vaultRoot = getVaultRoot(org);
+  if (!vaultRoot) {
+    return Response.json({ error: `Vault not found for org "${org}"` }, { status: 404 });
+  }
+
+  const root: TreeNode[] = [];
+  for (const dir of PARA_DIRS) {
+    const abs = path.join(vaultRoot, dir);
+    if (!fs.existsSync(abs)) continue;
+    if (!fs.statSync(abs).isDirectory()) continue;
+
+    root.push({
+      kind: 'dir',
+      name: dir,
+      relPath: dir,
+      children: walkDir(abs, vaultRoot, /* sortByMtime */ dir === '00-inbox'),
+    });
+  }
+
+  return Response.json({ vaultRoot, root });
+}
+
+function walkDir(
+  abs: string,
+  vaultRoot: string,
+  sortByMtime: boolean,
+): TreeNode[] {
+  const entries = fs.readdirSync(abs, { withFileTypes: true });
+  const dirs: TreeNode[] = [];
+  const files: Array<{ node: TreeNode; mtimeMs: number; name: string }> = [];
+
+  for (const entry of entries) {
+    if (entry.name.startsWith('.')) continue;
+    const childAbs = path.join(abs, entry.name);
+    const relPath = path.relative(vaultRoot, childAbs);
+
+    if (entry.isDirectory()) {
+      dirs.push({
+        kind: 'dir',
+        name: entry.name,
+        relPath,
+        children: walkDir(childAbs, vaultRoot, /* nested dirs always alpha */ false),
+      });
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      const stat = fs.statSync(childAbs);
+      files.push({
+        node: {
+          kind: 'file',
+          name: entry.name,
+          relPath,
+          mtimeMs: stat.mtimeMs,
+        },
+        mtimeMs: stat.mtimeMs,
+        name: entry.name,
+      });
+    }
+  }
+
+  // Dirs alphabetical
+  dirs.sort((a, b) => a.name.localeCompare(b.name));
+
+  // Files: 00-inbox sorts newest-first; other dirs alphabetical
+  if (sortByMtime) files.sort((a, b) => b.mtimeMs - a.mtimeMs);
+  else files.sort((a, b) => a.name.localeCompare(b.name));
+
+  return [...dirs, ...files.map((f) => f.node)];
+}

--- a/dashboard/src/components/layout/bottom-nav.tsx
+++ b/dashboard/src/components/layout/bottom-nav.tsx
@@ -20,6 +20,7 @@ import {
   IconClock,
   IconTarget,
   IconX,
+  IconNotes,
 } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
 
@@ -35,6 +36,7 @@ const morePages = [
   { label: 'Comms', href: '/comms', icon: IconMessages },
   { label: 'Activity', href: '/activity', icon: IconActivity },
   { label: 'Knowledge Base', href: '/knowledge-base', icon: IconBook2 },
+  { label: 'Wiki', href: '/wiki', icon: IconNotes },
   { label: 'Workflows', href: '/workflows', icon: IconClock },
   { label: 'Strategy', href: '/strategy', icon: IconTarget },
   { label: 'Experiments', href: '/experiments', icon: IconFlask },

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   IconClock,
   IconTarget,
   IconMessages,
+  IconNotes,
 } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
@@ -47,6 +48,7 @@ const navItems: NavItem[] = [
 
   // Intelligence
   { label: 'Knowledge Base', href: '/knowledge-base', icon: IconBook2, section: 'intel' },
+  { label: 'Wiki', href: '/wiki', icon: IconNotes, section: 'intel' },
   { label: 'Experiments', href: '/experiments', icon: IconFlask, section: 'intel' },
   { label: 'Skills', href: '/skills', icon: IconPuzzle, section: 'intel' },
 ];

--- a/dashboard/src/components/wiki/folder-tree.tsx
+++ b/dashboard/src/components/wiki/folder-tree.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import {
+  IconChevronRight,
+  IconFolder,
+  IconFolderOpen,
+  IconFileText,
+} from '@tabler/icons-react';
+
+export type TreeNode =
+  | {
+      kind: 'dir';
+      name: string;
+      relPath: string;
+      children: TreeNode[];
+    }
+  | {
+      kind: 'file';
+      name: string;
+      relPath: string;
+      mtimeMs: number;
+    };
+
+interface FolderTreeProps {
+  nodes: TreeNode[];
+  selected: string | null;
+  onSelectFile: (relPath: string) => void;
+  /** sessionStorage key for persisting expanded state across reloads */
+  storageKey?: string;
+}
+
+export function FolderTree({
+  nodes,
+  selected,
+  onSelectFile,
+  storageKey = 'wiki:expanded',
+}: FolderTreeProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(() => {
+    if (typeof window === 'undefined') return new Set(['00-inbox']);
+    try {
+      const raw = sessionStorage.getItem(storageKey);
+      if (!raw) return new Set(['00-inbox']);
+      return new Set(JSON.parse(raw) as string[]);
+    } catch {
+      return new Set(['00-inbox']);
+    }
+  });
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      sessionStorage.setItem(storageKey, JSON.stringify([...expanded]));
+    } catch {
+      /* sessionStorage unavailable — fall through silently */
+    }
+  }, [expanded, storageKey]);
+
+  // When selecting a file, auto-expand its ancestor dirs so it's visible
+  useEffect(() => {
+    if (!selected) return;
+    const parts = selected.split('/');
+    if (parts.length <= 1) return;
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      let acc = '';
+      for (let i = 0; i < parts.length - 1; i++) {
+        acc = acc ? `${acc}/${parts[i]}` : parts[i];
+        next.add(acc);
+      }
+      return next;
+    });
+  }, [selected]);
+
+  const toggle = (relPath: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(relPath)) next.delete(relPath);
+      else next.add(relPath);
+      return next;
+    });
+  };
+
+  if (nodes.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground p-4 text-center">
+        Empty vault.
+      </div>
+    );
+  }
+
+  return (
+    <div role="tree" aria-label="Vault file tree" className="text-sm">
+      {nodes.map((node) => (
+        <TreeRow
+          key={node.relPath}
+          node={node}
+          depth={0}
+          expanded={expanded}
+          selected={selected}
+          onToggle={toggle}
+          onSelectFile={onSelectFile}
+        />
+      ))}
+    </div>
+  );
+}
+
+function TreeRow({
+  node,
+  depth,
+  expanded,
+  selected,
+  onToggle,
+  onSelectFile,
+}: {
+  node: TreeNode;
+  depth: number;
+  expanded: Set<string>;
+  selected: string | null;
+  onToggle: (relPath: string) => void;
+  onSelectFile: (relPath: string) => void;
+}) {
+  // 12px per depth level — aligns with the dashboard's 4/8dp spacing rhythm
+  // while staying readable inside the 280–360px sidebar pane.
+  const padLeft = 8 + depth * 12;
+
+  if (node.kind === 'dir') {
+    const isOpen = expanded.has(node.relPath);
+    return (
+      <>
+        <button
+          type="button"
+          onClick={() => onToggle(node.relPath)}
+          role="treeitem"
+          aria-expanded={isOpen}
+          aria-level={depth + 1}
+          className="w-full flex items-center gap-1.5 py-1 hover:bg-accent/40 rounded transition-colors text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+          style={{ paddingLeft: padLeft }}
+        >
+          <IconChevronRight
+            size={14}
+            strokeWidth={2}
+            className={`text-muted-foreground shrink-0 transition-transform ${
+              isOpen ? 'rotate-90' : ''
+            }`}
+            aria-hidden="true"
+          />
+          {isOpen ? (
+            <IconFolderOpen size={15} className="text-amber-500/80 shrink-0" aria-hidden="true" />
+          ) : (
+            <IconFolder size={15} className="text-amber-500/80 shrink-0" aria-hidden="true" />
+          )}
+          <span className="font-mono text-xs truncate">{node.name}</span>
+          {node.children.length > 0 && (
+            <span className="ml-auto text-[10px] text-muted-foreground pr-1.5">
+              {node.children.length}
+            </span>
+          )}
+        </button>
+        {isOpen && (
+          <div role="group">
+            {node.children.map((child) => (
+              <TreeRow
+                key={child.relPath}
+                node={child}
+                depth={depth + 1}
+                expanded={expanded}
+                selected={selected}
+                onToggle={onToggle}
+                onSelectFile={onSelectFile}
+              />
+            ))}
+          </div>
+        )}
+      </>
+    );
+  }
+
+  const isSelected = selected === node.relPath;
+  const display = node.name.replace(/\.md$/, '');
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelectFile(node.relPath)}
+      role="treeitem"
+      aria-level={depth + 1}
+      aria-selected={isSelected}
+      className={`w-full flex items-center gap-1.5 py-1 rounded transition-colors text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring ${
+        isSelected
+          ? 'bg-accent text-foreground'
+          : 'hover:bg-accent/40 text-foreground/90'
+      }`}
+      // Indent file rows so they line up under their parent dir's contents
+      // (i.e. past the chevron+folder-icon column of the dir above).
+      style={{ paddingLeft: padLeft + 16 }}
+    >
+      <IconFileText size={14} className="text-muted-foreground/70 shrink-0" aria-hidden="true" />
+      <span className="font-mono text-xs truncate">{display}</span>
+    </button>
+  );
+}

--- a/dashboard/src/components/wiki/wiki-renderer.tsx
+++ b/dashboard/src/components/wiki/wiki-renderer.tsx
@@ -1,0 +1,203 @@
+'use client';
+
+import React from 'react';
+
+/**
+ * Wikilink-aware markdown renderer for the dashboard /wiki page.
+ *
+ * Mirrors the shape of @/lib/render-markdown.tsx but extends inline parsing
+ * to handle [[wikilink]] references and routes them through onWikilink. We
+ * keep this purpose-specific so the global renderMarkdown stays simple.
+ */
+
+interface WikiRendererProps {
+  text: string;
+  onWikilink: (slug: string) => void;
+}
+
+export function WikiRenderer({ text, onWikilink }: WikiRendererProps) {
+  const lines = text.split('\n');
+  const nodes: React.ReactNode[] = [];
+  let i = 0;
+  let keyCounter = 0;
+  const key = () => keyCounter++;
+
+  const renderInline = (line: string): React.ReactNode => {
+    const parts: React.ReactNode[] = [];
+    // Order: wikilinks before plain links so [[ doesn't get eaten by [
+    const re =
+      /(\[\[([^\]]+)\]\]|\*\*(.+?)\*\*|\*([^*]+?)\*|`([^`]+)`|\[([^\]]+)\]\(([^)]+)\))/g;
+    let last = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(line)) !== null) {
+      if (m.index > last) parts.push(line.slice(last, m.index));
+      if (m[2] !== undefined) {
+        const slug = m[2].trim();
+        // <a> instead of <button> — HTML allows <a> inside <p> but not <button>.
+        // href="#" + preventDefault keeps the link semantic without navigating.
+        parts.push(
+          <a
+            key={key()}
+            href="#"
+            role="link"
+            onClick={(e) => {
+              e.preventDefault();
+              onWikilink(slug);
+            }}
+            className="text-primary underline underline-offset-2 hover:text-primary/80 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring rounded-sm cursor-pointer"
+          >
+            {slug}
+          </a>,
+        );
+      } else if (m[3] !== undefined) {
+        parts.push(<strong key={key()}>{m[3]}</strong>);
+      } else if (m[4] !== undefined) {
+        parts.push(<em key={key()}>{m[4]}</em>);
+      } else if (m[5] !== undefined) {
+        parts.push(
+          <code
+            key={key()}
+            className="bg-muted px-1 py-0.5 rounded text-xs font-mono"
+          >
+            {m[5]}
+          </code>,
+        );
+      } else if (m[6] !== undefined) {
+        parts.push(
+          <a
+            key={key()}
+            href={m[7]}
+            className="text-primary underline"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            {m[6]}
+          </a>,
+        );
+      }
+      last = m.index + m[0].length;
+    }
+    if (last < line.length) parts.push(line.slice(last));
+    return parts.length === 1 ? parts[0] : <>{parts}</>;
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (line.startsWith('```')) {
+      const lang = line.slice(3).trim();
+      const codeLines: string[] = [];
+      i++;
+      while (i < lines.length && !lines[i].startsWith('```')) {
+        codeLines.push(lines[i]);
+        i++;
+      }
+      nodes.push(
+        <pre
+          key={key()}
+          className="bg-muted rounded-md p-3 text-xs font-mono overflow-x-auto my-2 whitespace-pre-wrap"
+        >
+          {lang && (
+            <span className="text-muted-foreground text-[10px] block mb-1">
+              {lang}
+            </span>
+          )}
+          {codeLines.join('\n')}
+        </pre>,
+      );
+      i++;
+      continue;
+    }
+
+    if (/^---+$/.test(line.trim())) {
+      nodes.push(<hr key={key()} className="border-muted my-3" />);
+      i++;
+      continue;
+    }
+
+    const h3 = line.match(/^### (.+)/);
+    if (h3) {
+      nodes.push(
+        <h3 key={key()} className="text-sm font-semibold mt-4 mb-1">
+          {renderInline(h3[1])}
+        </h3>,
+      );
+      i++;
+      continue;
+    }
+    const h2 = line.match(/^## (.+)/);
+    if (h2) {
+      nodes.push(
+        <h2
+          key={key()}
+          className="text-base font-semibold mt-5 mb-2 pb-1 border-b"
+        >
+          {renderInline(h2[1])}
+        </h2>,
+      );
+      i++;
+      continue;
+    }
+    const h1 = line.match(/^# (.+)/);
+    if (h1) {
+      nodes.push(
+        <h1 key={key()} className="text-lg font-bold mt-4 mb-2">
+          {renderInline(h1[1])}
+        </h1>,
+      );
+      i++;
+      continue;
+    }
+
+    if (/^[-*] /.test(line)) {
+      const items: React.ReactNode[] = [];
+      while (i < lines.length && /^[-*] /.test(lines[i])) {
+        items.push(
+          <li key={key()} className="ml-4 text-sm">
+            {renderInline(lines[i].replace(/^[-*] /, ''))}
+          </li>,
+        );
+        i++;
+      }
+      nodes.push(
+        <ul key={key()} className="list-disc list-inside space-y-0.5 my-1">
+          {items}
+        </ul>,
+      );
+      continue;
+    }
+
+    if (/^\d+\. /.test(line)) {
+      const items: React.ReactNode[] = [];
+      while (i < lines.length && /^\d+\. /.test(lines[i])) {
+        items.push(
+          <li key={key()} className="ml-4 text-sm">
+            {renderInline(lines[i].replace(/^\d+\. /, ''))}
+          </li>,
+        );
+        i++;
+      }
+      nodes.push(
+        <ol key={key()} className="list-decimal list-inside space-y-0.5 my-1">
+          {items}
+        </ol>,
+      );
+      continue;
+    }
+
+    if (line.trim() === '') {
+      nodes.push(<div key={key()} className="h-2" />);
+      i++;
+      continue;
+    }
+
+    nodes.push(
+      <p key={key()} className="text-sm leading-relaxed">
+        {renderInline(line)}
+      </p>,
+    );
+    i++;
+  }
+
+  return <>{nodes}</>;
+}

--- a/dashboard/src/components/wiki/wiki-shell.tsx
+++ b/dashboard/src/components/wiki/wiki-shell.tsx
@@ -1,0 +1,421 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { WikiRenderer } from './wiki-renderer';
+import { FolderTree, type TreeNode } from './folder-tree';
+
+// Re-export TreeNode for upstream API typing convenience
+export type { TreeNode };
+
+type Frontmatter = {
+  type?: string;
+  tags?: string[];
+  created?: string;
+  updated?: string;
+  status?: string;
+  agent?: string;
+  session?: string;
+  relates_to?: string[];
+  [key: string]: unknown;
+};
+
+
+type SearchHit = {
+  relPath: string;
+  filename: string;
+  matchedIn: 'filename' | 'content' | 'both';
+  snippet: string;
+  frontmatter: Frontmatter;
+  mtimeMs: number;
+};
+
+type NoteResponse = {
+  relPath: string;
+  raw: string;
+  body: string;
+  frontmatter: Frontmatter;
+  mtimeMs: number;
+  sizeBytes: number;
+};
+
+interface WikiShellProps {
+  org: string;
+}
+
+export function WikiShell({ org }: WikiShellProps) {
+  const [tree, setTree] = useState<TreeNode[] | null>(null);
+  const [vaultRoot, setVaultRoot] = useState<string | null>(null);
+  const [vaultError, setVaultError] = useState<string | null>(null);
+
+  const [selected, setSelected] = useState<string | null>(null);
+  const [note, setNote] = useState<NoteResponse | null>(null);
+  const [noteError, setNoteError] = useState<string | null>(null);
+  const [noteLoading, setNoteLoading] = useState(false);
+
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SearchHit[] | null>(null);
+  const [searching, setSearching] = useState(false);
+  const searchAbort = useRef<AbortController | null>(null);
+
+  const loadTree = useCallback(async () => {
+    try {
+      const res = await fetch(`/api/wiki/tree?org=${encodeURIComponent(org)}`);
+      if (!res.ok) {
+        const err = (await res.json().catch(() => ({}))) as { error?: string };
+        setVaultError(err.error ?? `Tree load failed (${res.status})`);
+        setTree([]);
+        return;
+      }
+      const data = await res.json();
+      setTree(data.root as TreeNode[]);
+      setVaultRoot(data.vaultRoot ?? null);
+      setVaultError(null);
+    } catch (e) {
+      setVaultError(String(e));
+      setTree([]);
+    }
+  }, [org]);
+
+  useEffect(() => {
+    loadTree();
+  }, [loadTree]);
+
+  const loadNote = useCallback(
+    async (relPath: string) => {
+      setNoteLoading(true);
+      setNote(null);
+      setNoteError(null);
+      try {
+        const res = await fetch(
+          `/api/wiki/note?org=${encodeURIComponent(org)}&path=${encodeURIComponent(relPath)}`,
+        );
+        if (!res.ok) {
+          const err = (await res.json().catch(() => ({}))) as { error?: string };
+          setNoteError(err.error ?? `Note load failed (${res.status})`);
+          return;
+        }
+        setNote((await res.json()) as NoteResponse);
+      } catch (e) {
+        setNoteError(String(e));
+      } finally {
+        setNoteLoading(false);
+      }
+    },
+    [org],
+  );
+
+  useEffect(() => {
+    if (selected) loadNote(selected);
+    else setNote(null);
+  }, [selected, loadNote]);
+
+  // Debounced search
+  useEffect(() => {
+    if (query.trim().length < 2) {
+      setResults(null);
+      setSearching(false);
+      return;
+    }
+    setSearching(true);
+    if (searchAbort.current) searchAbort.current.abort();
+    const ctrl = new AbortController();
+    searchAbort.current = ctrl;
+    const t = setTimeout(async () => {
+      try {
+        const res = await fetch(
+          `/api/wiki/search?org=${encodeURIComponent(org)}&q=${encodeURIComponent(query)}`,
+          { signal: ctrl.signal },
+        );
+        if (!res.ok) {
+          setResults([]);
+          return;
+        }
+        const data = await res.json();
+        setResults(data.results as SearchHit[]);
+      } catch (e: unknown) {
+        if ((e as Error).name !== 'AbortError') setResults([]);
+      } finally {
+        setSearching(false);
+      }
+    }, 220);
+    return () => {
+      clearTimeout(t);
+      ctrl.abort();
+    };
+  }, [query, org]);
+
+  const onWikilink = useCallback(
+    async (slug: string) => {
+      // Resolve via the search route (filename-first), pick the best filename match
+      try {
+        const res = await fetch(
+          `/api/wiki/search?org=${encodeURIComponent(org)}&q=${encodeURIComponent(slug)}`,
+        );
+        if (!res.ok) return;
+        const data = await res.json();
+        const hits = (data.results as SearchHit[]) ?? [];
+        const exact = hits.find((h) => {
+          const base = h.filename.replace(/\.md$/, '');
+          return base === slug || h.relPath.replace(/\.md$/, '') === slug;
+        });
+        if (exact) setSelected(exact.relPath);
+        else if (hits[0]) setSelected(hits[0].relPath);
+      } catch {
+        /* swallow */
+      }
+    },
+    [org],
+  );
+
+  const paneContent = useMemo(() => {
+    if (query.trim().length >= 2) {
+      return (
+        <SearchResults
+          results={results}
+          searching={searching}
+          selected={selected}
+          onSelect={setSelected}
+        />
+      );
+    }
+    if (tree === null) {
+      return (
+        <div className="space-y-1 px-1">
+          {[1, 2, 3, 4, 5, 6].map((i) => (
+            <div key={i} className="h-6 rounded bg-muted/30 animate-pulse" />
+          ))}
+        </div>
+      );
+    }
+    return (
+      <FolderTree nodes={tree} selected={selected} onSelectFile={setSelected} />
+    );
+  }, [query, results, searching, tree, selected]);
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold">Wiki</h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            {vaultRoot ? (
+              <>
+                Read-only view of{' '}
+                <code className="text-xs font-mono">{vaultRoot}</code>
+              </>
+            ) : vaultError ? (
+              <span className="text-destructive">{vaultError}</span>
+            ) : (
+              'Loading vault…'
+            )}
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-[minmax(280px,360px)_1fr] gap-4 min-h-[60vh]">
+        <div className="border rounded-xl bg-card overflow-hidden flex flex-col">
+          <div className="p-3 border-b">
+            <Input
+              type="search"
+              placeholder="Search vault…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              className="h-9"
+              aria-label="Search vault"
+            />
+            <p className="text-[10px] text-muted-foreground mt-1.5">
+              {query.trim().length >= 2
+                ? `${searching ? 'Searching' : 'Results in'} all PARA dirs`
+                : 'Vault tree. Click folders to expand, files to open. Type 2+ chars to search.'}
+            </p>
+          </div>
+          <ScrollArea className="flex-1">
+            <div className="p-2">{paneContent}</div>
+          </ScrollArea>
+        </div>
+
+        <div className="border rounded-xl bg-card overflow-hidden flex flex-col">
+          {!selected ? (
+            <EmptyState />
+          ) : noteLoading ? (
+            <div className="p-6 text-sm text-muted-foreground">Loading note…</div>
+          ) : noteError ? (
+            <div className="p-6 text-sm text-destructive">{noteError}</div>
+          ) : note ? (
+            <NoteView
+              note={note}
+              onWikilink={onWikilink}
+              onClose={() => setSelected(null)}
+            />
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+
+
+function SearchResults({
+  results,
+  searching,
+  selected,
+  onSelect,
+}: {
+  results: SearchHit[] | null;
+  searching: boolean;
+  selected: string | null;
+  onSelect: (relPath: string) => void;
+}) {
+  if (results === null && searching) {
+    return (
+      <div className="text-sm text-muted-foreground p-4 text-center">
+        Searching…
+      </div>
+    );
+  }
+  if (results === null || results.length === 0) {
+    return (
+      <div className="text-sm text-muted-foreground p-4 text-center">
+        No matches.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {results.map((hit) => (
+        <button
+          key={hit.relPath}
+          type="button"
+          onClick={() => onSelect(hit.relPath)}
+          className={`w-full text-left rounded-lg border px-3 py-2.5 transition-colors ${
+            selected === hit.relPath
+              ? 'bg-accent border-accent-foreground/20'
+              : 'bg-background border-border hover:bg-accent/40'
+          }`}
+        >
+          <div className="flex items-center justify-between gap-2 min-w-0">
+            <span className="text-xs font-mono truncate min-w-0 flex-1">
+              {hit.filename.replace(/\.md$/, '')}
+            </span>
+            <span className="text-[10px] text-muted-foreground shrink-0">
+              {hit.matchedIn === 'both'
+                ? 'name+content'
+                : hit.matchedIn === 'filename'
+                  ? 'name'
+                  : 'content'}
+            </span>
+          </div>
+          <p className="text-[10px] text-muted-foreground mt-0.5">{hit.relPath}</p>
+          {hit.snippet && (
+            <p className="text-xs mt-1.5 line-clamp-2 leading-snug">
+              {hit.snippet}
+            </p>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function NoteView({
+  note,
+  onWikilink,
+  onClose,
+}: {
+  note: NoteResponse;
+  onWikilink: (slug: string) => void;
+  onClose: () => void;
+}) {
+  return (
+    <ScrollArea className="flex-1">
+      <div className="p-6 max-w-3xl mx-auto">
+        <div className="flex items-start justify-between gap-4 mb-4">
+          <div className="min-w-0">
+            <p className="text-[11px] font-mono text-muted-foreground truncate">
+              {note.relPath}
+            </p>
+            <h2 className="text-lg font-semibold mt-1 break-words">
+              {String(note.frontmatter.title ?? '') ||
+                note.relPath.split('/').pop()?.replace(/\.md$/, '')}
+            </h2>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            onClick={onClose}
+            className="shrink-0"
+            aria-label="Close note"
+          >
+            Close
+          </Button>
+        </div>
+
+        <FrontmatterChips frontmatter={note.frontmatter} />
+
+        <div className="mt-5 prose prose-invert max-w-none">
+          <WikiRenderer text={note.body} onWikilink={onWikilink} />
+        </div>
+      </div>
+    </ScrollArea>
+  );
+}
+
+function FrontmatterChips({ frontmatter }: { frontmatter: Frontmatter }) {
+  const chips: Array<{ label: string; value: string }> = [];
+  if (frontmatter.type) chips.push({ label: 'type', value: String(frontmatter.type) });
+  if (frontmatter.status) chips.push({ label: 'status', value: String(frontmatter.status) });
+  if (frontmatter.agent) chips.push({ label: 'agent', value: String(frontmatter.agent) });
+  if (frontmatter.created) chips.push({ label: 'created', value: String(frontmatter.created) });
+  if (frontmatter.updated && frontmatter.updated !== frontmatter.created)
+    chips.push({ label: 'updated', value: String(frontmatter.updated) });
+  if (frontmatter.session) chips.push({ label: 'session', value: String(frontmatter.session) });
+
+  if (chips.length === 0 && (!frontmatter.tags || frontmatter.tags.length === 0))
+    return null;
+
+  return (
+    <div className="rounded-lg border bg-muted/30 p-3 text-xs space-y-2">
+      <div className="flex flex-wrap gap-x-4 gap-y-1">
+        {chips.map((c) => (
+          <span key={c.label} className="flex items-center gap-1.5">
+            <span className="text-muted-foreground">{c.label}:</span>
+            <span className="font-mono">{c.value}</span>
+          </span>
+        ))}
+      </div>
+      {frontmatter.tags && frontmatter.tags.length > 0 && (
+        <div className="flex items-center gap-1.5 flex-wrap">
+          <span className="text-muted-foreground">tags:</span>
+          {frontmatter.tags.map((t: string) => (
+            <span
+              key={t}
+              className="text-[10px] text-muted-foreground bg-background px-1.5 py-0.5 rounded border"
+            >
+              {t}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="flex-1 grid place-items-center p-8">
+      <div className="text-center max-w-sm">
+        <p className="text-sm text-muted-foreground">
+          Select a note from the left to view it.
+        </p>
+        <p className="text-xs text-muted-foreground mt-1">
+          Inbox shows newest-first. Type to search across the full vault.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/lib/vault.ts
+++ b/dashboard/src/lib/vault.ts
@@ -1,0 +1,192 @@
+/**
+ * Vault helpers for the dashboard /wiki page.
+ *
+ * Resolves the org's Obsidian vault path, parses frontmatter, scopes file
+ * reads to PARA-tree paths only (read-only — no writes from the dashboard).
+ */
+import fs from 'fs';
+import path from 'path';
+import { CTX_FRAMEWORK_ROOT } from './config';
+
+export const PARA_DIRS = [
+  '00-inbox',
+  '01-projects',
+  '02-areas',
+  '03-resources',
+  '04-archive',
+  '05-daily',
+  '06-maps',
+] as const;
+
+export type ParaDir = (typeof PARA_DIRS)[number];
+
+const VAULT_FALLBACK = '/root/storage/Documents/Github/sondres-orchestrator/vault';
+
+export function getVaultRoot(org: string): string | null {
+  // 1. Try parsing orgs/<org>/knowledge.md for an "Obsidian vault" path entry
+  const knowledgePath = path.join(CTX_FRAMEWORK_ROOT, 'orgs', org, 'knowledge.md');
+  if (fs.existsSync(knowledgePath)) {
+    try {
+      const content = fs.readFileSync(knowledgePath, 'utf-8');
+      // Match a code path like `/root/.../vault/` after "Obsidian vault" mentions
+      const match = content.match(
+        /Obsidian vault[^\n]*?`([^`]+vault\/?)`/i,
+      );
+      if (match) {
+        const p = match[1].replace(/\/$/, '');
+        if (fs.existsSync(p) && fs.statSync(p).isDirectory()) return p;
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+
+  // 2. Fallback to the known sondre-hq vault location
+  if (fs.existsSync(VAULT_FALLBACK) && fs.statSync(VAULT_FALLBACK).isDirectory()) {
+    return VAULT_FALLBACK;
+  }
+
+  return null;
+}
+
+export type Frontmatter = {
+  type?: string;
+  tags?: string[];
+  created?: string;
+  updated?: string;
+  status?: string;
+  agent?: string;
+  session?: string;
+  relates_to?: string[];
+  [key: string]: unknown;
+};
+
+export function parseFrontmatter(raw: string): {
+  frontmatter: Frontmatter;
+  body: string;
+} {
+  const m = raw.match(/^---\s*\n([\s\S]*?)\n---\s*\n?([\s\S]*)$/);
+  if (!m) return { frontmatter: {}, body: raw };
+
+  const fm: Frontmatter = {};
+  const block = m[1];
+
+  for (const line of block.split('\n')) {
+    const kv = line.match(/^(\w+):\s*(.*)$/);
+    if (!kv) continue;
+    const key = kv[1];
+    let value: unknown = kv[2].trim();
+    const v = value as string;
+
+    if (v === '') {
+      value = '';
+    } else if (v.startsWith('[') && v.endsWith(']')) {
+      // Array — comma split inside the brackets, strip quotes
+      value = v
+        .slice(1, -1)
+        .split(',')
+        .map((s) => s.trim().replace(/^["']|["']$/g, ''))
+        .filter(Boolean);
+    } else {
+      // Strip surrounding quotes if present
+      value = v.replace(/^["']|["']$/g, '');
+    }
+
+    fm[key] = value;
+  }
+
+  return { frontmatter: fm, body: m[2] };
+}
+
+export function firstMeaningfulLine(body: string, max = 160): string {
+  for (const raw of body.split('\n')) {
+    const line = raw.trim();
+    if (!line) continue;
+    if (line.startsWith('#')) continue; // skip headings
+    if (line.startsWith('```')) continue;
+    if (line === '---') continue;
+    return line.length > max ? line.slice(0, max).trimEnd() + '…' : line;
+  }
+  return '';
+}
+
+/**
+ * Resolves a relative vault path safely. Refuses anything outside the vault
+ * root or outside the PARA dirs.
+ */
+export function resolveVaultPath(
+  vaultRoot: string,
+  relPath: string,
+): string | null {
+  // Strip leading slashes; we want a relative path inside the vault
+  const cleaned = relPath.replace(/^\/+/, '');
+  // Reject any traversal attempts up front
+  if (cleaned.includes('..')) return null;
+  // Must start with one of the PARA dir names
+  const top = cleaned.split('/')[0];
+  if (!PARA_DIRS.includes(top as ParaDir)) return null;
+
+  const abs = path.resolve(vaultRoot, cleaned);
+  // Defense in depth — confirm resolved path is inside the vault root
+  if (!abs.startsWith(path.resolve(vaultRoot) + path.sep)) return null;
+  return abs;
+}
+
+/**
+ * Walk all PARA dirs and collect every .md file. Used by search.
+ */
+export function listAllNotes(vaultRoot: string): Array<{
+  relPath: string;
+  absPath: string;
+  mtimeMs: number;
+}> {
+  const out: Array<{ relPath: string; absPath: string; mtimeMs: number }> = [];
+  for (const dir of PARA_DIRS) {
+    const abs = path.join(vaultRoot, dir);
+    if (!fs.existsSync(abs)) continue;
+    walk(abs, vaultRoot, out);
+  }
+  return out;
+}
+
+function walk(
+  abs: string,
+  vaultRoot: string,
+  out: Array<{ relPath: string; absPath: string; mtimeMs: number }>,
+) {
+  for (const entry of fs.readdirSync(abs, { withFileTypes: true })) {
+    if (entry.name.startsWith('.')) continue;
+    const child = path.join(abs, entry.name);
+    if (entry.isDirectory()) {
+      walk(child, vaultRoot, out);
+    } else if (entry.isFile() && entry.name.endsWith('.md')) {
+      const stat = fs.statSync(child);
+      out.push({
+        relPath: path.relative(vaultRoot, child),
+        absPath: child,
+        mtimeMs: stat.mtimeMs,
+      });
+    }
+  }
+}
+
+/**
+ * Resolve a wikilink slug (e.g. "20260506-dev-foo" or "foo/bar") to a vault
+ * file path. Searches all PARA dirs for the first matching basename (with or
+ * without .md extension).
+ */
+export function resolveWikilink(
+  vaultRoot: string,
+  slug: string,
+): string | null {
+  const normalized = slug.replace(/\.md$/, '');
+  for (const note of listAllNotes(vaultRoot)) {
+    const base = path.basename(note.relPath, '.md');
+    if (base === normalized) return note.relPath;
+  }
+  // Also try exact relative path match (e.g. "01-projects/coliseum")
+  for (const note of listAllNotes(vaultRoot)) {
+    if (note.relPath.replace(/\.md$/, '') === normalized) return note.relPath;
+  }
+  return null;
+}

--- a/dashboard/src/lib/vault.ts
+++ b/dashboard/src/lib/vault.ts
@@ -6,6 +6,7 @@
  */
 import fs from 'fs';
 import path from 'path';
+import os from 'os';
 import { CTX_FRAMEWORK_ROOT } from './config';
 
 export const PARA_DIRS = [
@@ -20,7 +21,8 @@ export const PARA_DIRS = [
 
 export type ParaDir = (typeof PARA_DIRS)[number];
 
-const VAULT_FALLBACK = '/root/storage/Documents/Github/sondres-orchestrator/vault';
+const VAULT_FALLBACK = process.env.CTX_VAULT_PATH
+  ?? path.join(os.homedir(), 'storage', 'Documents', 'Github', 'sondres-orchestrator', 'vault');
 
 export function getVaultRoot(org: string): string | null {
   // 1. Try parsing orgs/<org>/knowledge.md for an "Obsidian vault" path entry


### PR DESCRIPTION
## Summary

Note: Reason i think this is nice, is that now we can read every Plan or other files the agents will use

Adds a read-only wiki viewer to the dashboard that renders markdown files from the agent's Obsidian vault.

- **wiki page + wiki-shell.tsx**: full-page wiki browser with folder tree and markdown renderer
- **folder-tree.tsx**: recursive collapsible tree of vault directories
- **wiki-renderer.tsx**: markdown renderer with code highlighting
- **api/wiki/tree + search + note + inbox routes**: serve vault directory tree, search, and note content
- **vault.ts**: server-side vault path resolution and file reading
- **sidebar.tsx**: adds "Wiki" nav item under Intelligence section
- **bottom-nav.tsx**: adds wiki to mobile bottom navigation

## Test plan

- [ ] Open /wiki, confirm folder tree renders vault contents
- [ ] Click a note, confirm markdown renders correctly
- [ ] Try search, confirm results return matching notes
- [ ] Verify /inbox shows vault inbox folder

## Demo video
https://github.com/user-attachments/assets/8690a9a6-6f36-46af-ac6d-9ce41c9742bc


