### PR TITLE
feat(dashboard): git-repo page — ahead/behind + per-commit diff

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -32,6 +32,7 @@
         "react-dom": "19.2.4",
         "recharts": "^3.8.0",
         "shadcn": "^4.1.0",
+        "shiki": "^4.0.2",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0"
       },
@@ -2040,9 +2041,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2058,9 +2056,6 @@
       "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2078,9 +2073,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2096,9 +2088,6 @@
       "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -3053,6 +3042,106 @@
       "integrity": "sha512-831qok9r2t8AlxLko40y2ebgSDhenenCatLVeW/uBtnHPyhHOvG0C7TvfgecV+wHzIm5KUICgzmVpWS+IMEAeg==",
       "license": "MIT"
     },
+    "node_modules/@shikijs/core": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-4.0.2.tgz",
+      "integrity": "sha512-hxT0YF4ExEqB8G/qFdtJvpmHXBYJ2lWW7qTHDarVkIudPFE6iCIrqdgWxGn5s+ppkGXI0aEGlibI0PAyzP3zlw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/primitive": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.5"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-4.0.2.tgz",
+      "integrity": "sha512-7PW0Nm49DcoUIQEXlJhNNBHyoGMjalRETTCcjMqEaMoJRLljy1Bi/EGV3/qLBgLKQejdspiiYuHGQW6dX94Nag==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^4.3.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-4.0.2.tgz",
+      "integrity": "sha512-UpCB9Y2sUKlS9z8juFSKz7ZtysmeXCgnRF0dlhXBkmQnek7lAToPte8DkxmEYGNTMii72zU/lyXiCB6StuZeJg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-4.0.2.tgz",
+      "integrity": "sha512-KaXby5dvoeuZzN0rYQiPMjFoUrz4hgwIE+D6Du9owcHcl6/g16/yT5BQxSW5cGt2MZBz6Hl0YuRqf12omRfUUg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/primitive": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/primitive/-/primitive-4.0.2.tgz",
+      "integrity": "sha512-M6UMPrSa3fN5ayeJwFVl9qWofl273wtK1VG8ySDZ1mQBfhCpdd8nEx7nPZ/tk7k+TYcpqBZzj/AnwxT9lO+HJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-4.0.2.tgz",
+      "integrity": "sha512-mjCafwt8lJJaVSsQvNVrJumbnnj1RI8jbUKrPKgE6E3OvQKxnuRoBaYC51H4IGHePsGN/QtALglWBU7DoKDFnA==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "4.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-4.0.2.tgz",
+      "integrity": "sha512-qzbeRooUTPnLE+sHD/Z8DStmaDgnbbc/pMrU203950aRqjX/6AFHeDYT+j00y2lPdz0ywJKx7o/7qnqTivtlXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "license": "MIT"
+    },
     "node_modules/@sindresorhus/merge-streams": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
@@ -3574,6 +3663,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3596,6 +3694,15 @@
       "dependencies": {
         "@types/ms": "*",
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
       }
     },
     "node_modules/@types/ms": {
@@ -3645,6 +3752,12 @@
       "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
@@ -3952,6 +4065,12 @@
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
+      "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
+      "license": "ISC"
     },
     "node_modules/@unrs/resolver-binding-android-arm-eabi": {
       "version": "1.11.1",
@@ -5028,6 +5147,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chai": {
       "version": "6.2.2",
       "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
@@ -5053,6 +5182,26 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chokidar": {
@@ -5250,6 +5399,16 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/commander": {
       "version": "14.0.3",
@@ -5784,6 +5943,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -5798,6 +5966,19 @@
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/diff": {
       "version": "8.0.4",
@@ -7027,6 +7208,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -7396,6 +7578,42 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/headers-polyfill": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/headers-polyfill/-/headers-polyfill-4.0.3.tgz",
@@ -7438,6 +7656,16 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http-errors": {
@@ -8951,6 +9179,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdn-data": {
       "version": "2.27.1",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
@@ -8992,6 +9241,95 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/micromatch": {
       "version": "4.0.8",
@@ -9639,6 +9977,23 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/oniguruma-parser": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/oniguruma-parser/-/oniguruma-parser-0.12.2.tgz",
+      "integrity": "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw==",
+      "license": "MIT"
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-4.3.6.tgz",
+      "integrity": "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA==",
+      "license": "MIT",
+      "dependencies": {
+        "oniguruma-parser": "^0.12.2",
+        "regex": "^6.1.0",
+        "regex-recursion": "^6.0.2"
+      }
+    },
     "node_modules/open": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
@@ -10110,6 +10465,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -10455,6 +10820,30 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "license": "MIT"
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
@@ -11054,6 +11443,25 @@
         "node": ">=8"
       }
     },
+    "node_modules/shiki": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-4.0.2.tgz",
+      "integrity": "sha512-eAVKTMedR5ckPo4xne/PjYQYrU3qx78gtJZ+sHlXEg5IHhhoQhMfZVzetTYuaJS0L2Ef3AcCRzCHV8T0WI6nIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "4.0.2",
+        "@shikijs/engine-javascript": "4.0.2",
+        "@shikijs/engine-oniguruma": "4.0.2",
+        "@shikijs/langs": "4.0.2",
+        "@shikijs/themes": "4.0.2",
+        "@shikijs/types": "4.0.2",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/side-channel": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
@@ -11212,6 +11620,16 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stable-hash": {
@@ -11419,6 +11837,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/stringify-object": {
@@ -11763,6 +12195,16 @@
         "node": ">=20"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/ts-api-utils": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
@@ -12043,6 +12485,74 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/universalify": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
@@ -12219,6 +12729,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/victory-vendor": {
@@ -12884,6 +13422,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -35,6 +35,7 @@
     "react-dom": "19.2.4",
     "recharts": "^3.8.0",
     "shadcn": "^4.1.0",
+    "shiki": "^4.0.2",
     "tailwind-merge": "^3.5.0",
     "tw-animate-css": "^1.4.0"
   },

--- a/dashboard/src/app/(dashboard)/git-repo/page.tsx
+++ b/dashboard/src/app/(dashboard)/git-repo/page.tsx
@@ -1,0 +1,132 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { BranchPicker } from '@/components/git-repo/branch-picker';
+import { StatusCard } from '@/components/git-repo/status-card';
+import { CommitList } from '@/components/git-repo/commit-list';
+import { DiffViewer } from '@/components/git-repo/diff-viewer';
+import type {
+  GitBranches,
+  GitStatus,
+  CommitSummary,
+} from '@/components/git-repo/types';
+
+export default function GitRepoPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const branchParam = searchParams.get('branch');
+  const shaParam = searchParams.get('sha');
+
+  const [branches, setBranches] = useState<GitBranches | null>(null);
+  const [status, setStatus] = useState<GitStatus | null>(null);
+  const [commits, setCommits] = useState<CommitSummary[]>([]);
+  const [loadingCommits, setLoadingCommits] = useState(true);
+
+  const branch = branchParam ?? branches?.current ?? '';
+
+  function setSearch(next: { branch?: string | null; sha?: string | null }) {
+    const params = new URLSearchParams(searchParams.toString());
+    if (next.branch === null) params.delete('branch');
+    else if (next.branch !== undefined) params.set('branch', next.branch);
+    if (next.sha === null) params.delete('sha');
+    else if (next.sha !== undefined) params.set('sha', next.sha);
+    const qs = params.toString();
+    router.replace(qs ? `/git-repo?${qs}` : '/git-repo', { scroll: false });
+  }
+
+  useEffect(() => {
+    fetch('/api/git/branches')
+      .then((res) => res.json())
+      .then((data: GitBranches) => setBranches(data))
+      .catch(() => setBranches({ branches: [], current: '' }));
+  }, []);
+
+  const loadStatusAndCommits = useCallback(async (b: string) => {
+    if (!b) return;
+    setLoadingCommits(true);
+    try {
+      const [statusRes, commitsRes] = await Promise.all([
+        fetch(`/api/git/status?branch=${encodeURIComponent(b)}`),
+        fetch(`/api/git/commits?branch=${encodeURIComponent(b)}`),
+      ]);
+      const statusData: GitStatus = statusRes.ok
+        ? await statusRes.json()
+        : { branch: b, upstream: 'upstream/main', upstreamRemoteUrl: null, ahead: 0, behind: 0, lastFetchedAt: null };
+      const commitsData: CommitSummary[] = commitsRes.ok ? await commitsRes.json() : [];
+      setStatus(statusData);
+      setCommits(commitsData);
+    } finally {
+      setLoadingCommits(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (branch) loadStatusAndCommits(branch);
+  }, [branch, loadStatusAndCommits]);
+
+  function handleSelectBranch(next: string) {
+    setSearch({ branch: next, sha: null });
+  }
+
+  function handleSelectSha(sha: string) {
+    setSearch({ sha });
+  }
+
+  function handleClearSha() {
+    setSearch({ sha: null });
+  }
+
+  function handleFetched() {
+    if (branch) loadStatusAndCommits(branch);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">Git Repo</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          Compare the current branch against{' '}
+          <code className="text-xs font-mono">upstream/main</code> and inspect each commit before
+          opening a PR.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        {branches ? (
+          <BranchPicker
+            branches={branches.branches}
+            current={branches.current}
+            selected={branch}
+            onSelect={handleSelectBranch}
+          />
+        ) : (
+          <div className="h-8 w-[220px] rounded-md bg-muted/40 animate-pulse" />
+        )}
+      </div>
+
+      <StatusCard status={status} commits={commits} onFetched={handleFetched} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-[400px_minmax(0,1fr)] gap-4">
+        <div className="space-y-2">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground/70 px-1">
+            Commits ahead ({commits.length})
+          </h2>
+          <CommitList
+            commits={commits}
+            loading={loadingCommits}
+            selectedSha={shaParam}
+            onSelect={handleSelectSha}
+          />
+        </div>
+
+        <div className="space-y-2">
+          <h2 className="text-xs font-semibold uppercase tracking-widest text-muted-foreground/70 px-1">
+            Diff
+          </h2>
+          <DiffViewer branch={branch} sha={shaParam} onClear={handleClearSha} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/app/api/git/_util.ts
+++ b/dashboard/src/app/api/git/_util.ts
@@ -1,0 +1,31 @@
+import { execFileSync } from 'child_process';
+import { getFrameworkRoot } from '@/lib/config';
+
+export const BRANCH_RE = /^[a-zA-Z0-9_./-]+$/;
+export const SHA_RE = /^[a-f0-9]{7,40}$/;
+export const UPSTREAM_REF = 'upstream/main';
+
+export function git(args: string[], opts: { maxBuffer?: number } = {}): string {
+  return execFileSync('git', args, {
+    cwd: getFrameworkRoot(),
+    encoding: 'utf8',
+    timeout: 15000,
+    maxBuffer: opts.maxBuffer ?? 16 * 1024 * 1024,
+  });
+}
+
+export function validateBranch(branch: string | null | undefined): string | null {
+  if (!branch) return null;
+  if (!BRANCH_RE.test(branch)) return null;
+  return branch;
+}
+
+export function validateSha(sha: string | null | undefined): string | null {
+  if (!sha) return null;
+  if (!SHA_RE.test(sha)) return null;
+  return sha;
+}
+
+export function jsonError(message: string, status: number) {
+  return Response.json({ error: message }, { status });
+}

--- a/dashboard/src/app/api/git/branches/route.ts
+++ b/dashboard/src/app/api/git/branches/route.ts
@@ -1,0 +1,18 @@
+import { git, jsonError } from '../_util';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  try {
+    const branchesOut = git(['branch', '--format=%(refname:short)']);
+    const branches = branchesOut
+      .split('\n')
+      .map((b) => b.trim())
+      .filter(Boolean);
+    const current = git(['rev-parse', '--abbrev-ref', 'HEAD']).trim();
+    return Response.json({ branches, current });
+  } catch (err) {
+    console.error('[api/git/branches] error', err);
+    return jsonError('Failed to list branches', 500);
+  }
+}

--- a/dashboard/src/app/api/git/commits/[sha]/route.ts
+++ b/dashboard/src/app/api/git/commits/[sha]/route.ts
@@ -1,0 +1,115 @@
+import { git, jsonError, validateSha } from '../../_util';
+
+export const dynamic = 'force-dynamic';
+
+const SEP = '\x1f';
+
+interface DiffFile {
+  path: string;
+  oldPath: string | null;
+  status: 'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'other';
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  patch: string;
+}
+
+function parseStatus(code: string): DiffFile['status'] {
+  if (code.startsWith('A')) return 'added';
+  if (code.startsWith('D')) return 'deleted';
+  if (code.startsWith('M')) return 'modified';
+  if (code.startsWith('R')) return 'renamed';
+  if (code.startsWith('C')) return 'copied';
+  return 'other';
+}
+
+export async function GET(
+  _req: Request,
+  ctx: { params: Promise<{ sha: string }> },
+) {
+  const { sha: rawSha } = await ctx.params;
+  const sha = validateSha(rawSha);
+  if (!sha) return jsonError('Invalid SHA', 400);
+
+  try {
+    const headerFormat = ['%H', '%s', '%b', '%an', '%ae', '%aI'].join(SEP);
+    const header = git(['show', '-s', `--pretty=format:${headerFormat}`, sha]);
+    const [fullSha, subject, body, author, authorEmail, date] = header.split(SEP);
+
+    // numstat: additions \t deletions \t path (or - - for binary)
+    const numstatRaw = git(['show', '--numstat', '--format=', sha]);
+    const numstat = new Map<string, { additions: number; deletions: number; binary: boolean }>();
+    for (const line of numstatRaw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const parts = trimmed.split('\t');
+      if (parts.length < 3) continue;
+      const [a, d, p] = parts;
+      const binary = a === '-' && d === '-';
+      numstat.set(p, {
+        additions: binary ? 0 : parseInt(a, 10) || 0,
+        deletions: binary ? 0 : parseInt(d, 10) || 0,
+        binary,
+      });
+    }
+
+    // name-status: code \t path [\t newpath for renames]
+    const nameStatusRaw = git(['show', '--name-status', '--format=', sha]);
+    const fileMetas: Array<{ path: string; oldPath: string | null; status: DiffFile['status'] }> =
+      [];
+    for (const line of nameStatusRaw.split('\n')) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      const parts = trimmed.split('\t');
+      const code = parts[0];
+      const status = parseStatus(code);
+      if (status === 'renamed' || status === 'copied') {
+        fileMetas.push({ path: parts[2], oldPath: parts[1], status });
+      } else {
+        fileMetas.push({ path: parts[1], oldPath: null, status });
+      }
+    }
+
+    // unified diff per file: emit one git show per file, scoped via -- <path>
+    // to keep the response shape predictable. Caps each patch to 200KB.
+    const PATCH_CAP = 200 * 1024;
+    const files: DiffFile[] = [];
+    for (const meta of fileMetas) {
+      const stats = numstat.get(meta.path) ?? { additions: 0, deletions: 0, binary: false };
+      let patch = '';
+      if (!stats.binary) {
+        try {
+          const raw = git(
+            ['show', '--format=', '--patch', sha, '--', meta.path],
+            { maxBuffer: 32 * 1024 * 1024 },
+          );
+          patch = raw.length > PATCH_CAP ? raw.slice(0, PATCH_CAP) + '\n...(truncated)\n' : raw;
+        } catch {
+          patch = '';
+        }
+      }
+      files.push({
+        path: meta.path,
+        oldPath: meta.oldPath,
+        status: meta.status,
+        additions: stats.additions,
+        deletions: stats.deletions,
+        binary: stats.binary,
+        patch,
+      });
+    }
+
+    return Response.json({
+      sha: fullSha,
+      subject,
+      body: (body ?? '').trim(),
+      author,
+      authorEmail,
+      date,
+      files,
+    });
+  } catch (err) {
+    console.error('[api/git/commits/[sha]] error', err);
+    return jsonError('Failed to read commit', 500);
+  }
+}

--- a/dashboard/src/app/api/git/commits/route.ts
+++ b/dashboard/src/app/api/git/commits/route.ts
@@ -1,0 +1,63 @@
+import { git, jsonError, validateBranch, UPSTREAM_REF } from '../_util';
+
+export const dynamic = 'force-dynamic';
+
+const SEP = '\x1f';
+const REC = '\x1e';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const branch = validateBranch(url.searchParams.get('branch'));
+  if (!branch) return jsonError('Invalid or missing branch', 400);
+
+  try {
+    // \x1e prefix on each record so split() yields one chunk per commit.
+    // If we appended \x1e instead, each chunk would contain the *previous*
+    // commit's shortstat + the *current* commit's header — misaligned.
+    const format = ['%H', '%h', '%s', '%an', '%ae', '%aI'].join(SEP);
+    const raw = git([
+      'log',
+      `--pretty=format:${REC}${format}`,
+      '--shortstat',
+      `${UPSTREAM_REF}..${branch}`,
+    ]);
+
+    const commits = raw
+      .split(REC)
+      .map((chunk) => chunk.trim())
+      .filter(Boolean)
+      .map((chunk) => {
+        const nl = chunk.indexOf('\n');
+        const header = nl === -1 ? chunk : chunk.slice(0, nl);
+        const stat = nl === -1 ? '' : chunk.slice(nl + 1).trim();
+        const [sha, shortSha, subject, author, authorEmail, date] = header.split(SEP);
+
+        let filesChanged = 0;
+        let insertions = 0;
+        let deletions = 0;
+        const filesMatch = stat.match(/(\d+) files? changed/);
+        const insMatch = stat.match(/(\d+) insertions?\(\+\)/);
+        const delMatch = stat.match(/(\d+) deletions?\(-\)/);
+        if (filesMatch) filesChanged = parseInt(filesMatch[1], 10);
+        if (insMatch) insertions = parseInt(insMatch[1], 10);
+        if (delMatch) deletions = parseInt(delMatch[1], 10);
+
+        return {
+          sha,
+          shortSha,
+          subject,
+          author,
+          authorEmail,
+          date,
+          filesChanged,
+          insertions,
+          deletions,
+        };
+      });
+
+    return Response.json(commits);
+  } catch (err) {
+    console.error('[api/git/commits] error', err);
+    return jsonError('Failed to list commits', 500);
+  }
+}

--- a/dashboard/src/app/api/git/fetch/route.ts
+++ b/dashboard/src/app/api/git/fetch/route.ts
@@ -1,0 +1,13 @@
+import { git, jsonError } from '../_util';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST() {
+  try {
+    git(['fetch', 'upstream', '--prune']);
+    return Response.json({ ok: true, fetchedAt: new Date().toISOString() });
+  } catch (err) {
+    console.error('[api/git/fetch] error', err);
+    return jsonError('git fetch upstream failed', 500);
+  }
+}

--- a/dashboard/src/app/api/git/status/route.ts
+++ b/dashboard/src/app/api/git/status/route.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+import { getFrameworkRoot } from '@/lib/config';
+import { git, jsonError, validateBranch, UPSTREAM_REF } from '../_util';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const branch = validateBranch(url.searchParams.get('branch'));
+  if (!branch) return jsonError('Invalid or missing branch', 400);
+
+  try {
+    const aheadCount = parseInt(
+      git(['rev-list', '--count', `${UPSTREAM_REF}..${branch}`]).trim(),
+      10,
+    );
+    const behindCount = parseInt(
+      git(['rev-list', '--count', `${branch}..${UPSTREAM_REF}`]).trim(),
+      10,
+    );
+
+    let lastFetchedAt: string | null = null;
+    const fetchHead = path.join(getFrameworkRoot(), '.git', 'FETCH_HEAD');
+    if (fs.existsSync(fetchHead)) {
+      lastFetchedAt = fs.statSync(fetchHead).mtime.toISOString();
+    }
+
+    let upstreamRemoteUrl: string | null = null;
+    try {
+      upstreamRemoteUrl = git(['remote', 'get-url', 'upstream']).trim();
+    } catch {
+      upstreamRemoteUrl = null;
+    }
+
+    return Response.json({
+      branch,
+      upstream: UPSTREAM_REF,
+      upstreamRemoteUrl,
+      ahead: Number.isFinite(aheadCount) ? aheadCount : 0,
+      behind: Number.isFinite(behindCount) ? behindCount : 0,
+      lastFetchedAt,
+    });
+  } catch (err) {
+    console.error('[api/git/status] error', err);
+    return jsonError('Failed to read status (is upstream/main fetched?)', 500);
+  }
+}

--- a/dashboard/src/components/git-repo/branch-picker.tsx
+++ b/dashboard/src/components/git-repo/branch-picker.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+import { IconChevronDown, IconGitBranch } from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+interface BranchPickerProps {
+  branches: string[];
+  current: string;
+  selected: string;
+  onSelect: (branch: string) => void;
+}
+
+export function BranchPicker({ branches, current, selected, onSelect }: BranchPickerProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={(props) => (
+          <Button {...props} variant="outline" size="default" className="min-w-[220px] justify-between">
+            <span className="flex items-center gap-2 truncate">
+              <IconGitBranch size={14} className="text-muted-foreground" />
+              <span className="font-mono text-[13px] truncate">{selected || '—'}</span>
+              {selected === current && (
+                <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                  HEAD
+                </span>
+              )}
+            </span>
+            <IconChevronDown size={14} className="text-muted-foreground" />
+          </Button>
+        )}
+      />
+      <DropdownMenuContent className="min-w-[260px]" align="start">
+        {branches.map((b) => (
+          <DropdownMenuItem
+            key={b}
+            onClick={() => onSelect(b)}
+            className="flex items-center gap-2"
+          >
+            <IconGitBranch size={14} className="text-muted-foreground" />
+            <span className="font-mono text-[13px] flex-1 truncate">{b}</span>
+            {b === current && (
+              <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+                HEAD
+              </span>
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/dashboard/src/components/git-repo/commit-list.tsx
+++ b/dashboard/src/components/git-repo/commit-list.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { IconChevronRight } from '@tabler/icons-react';
+import { cn } from '@/lib/utils';
+import type { CommitSummary } from './types';
+
+interface CommitListProps {
+  commits: CommitSummary[];
+  loading: boolean;
+  selectedSha: string | null;
+  onSelect: (sha: string) => void;
+}
+
+function relativeDate(iso: string): string {
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const sec = Math.round((now - then) / 1000);
+  if (sec < 60) return 'just now';
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  if (day < 30) return `${day}d ago`;
+  return new Date(iso).toLocaleDateString();
+}
+
+export function CommitList({ commits, loading, selectedSha, onSelect }: CommitListProps) {
+  if (loading) {
+    return (
+      <div className="rounded-xl border bg-card overflow-hidden">
+        {[1, 2, 3, 4].map((i) => (
+          <div key={i} className="h-[68px] border-b last:border-b-0 p-3">
+            <div className="h-4 w-3/4 bg-muted/40 rounded animate-pulse" />
+            <div className="h-3 w-1/2 bg-muted/30 rounded animate-pulse mt-2" />
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  if (commits.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed p-6 text-center text-sm text-muted-foreground">
+        No commits ahead of upstream/main on this branch.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border bg-card overflow-hidden">
+      {commits.map((c, idx) => {
+        const selected = c.sha === selectedSha;
+        return (
+          <button
+            key={c.sha}
+            onClick={() => onSelect(c.sha)}
+            className={cn(
+              'group w-full text-left flex items-start gap-3 p-3 border-b last:border-b-0 transition-colors',
+              'hover:bg-muted/40 focus:outline-none focus:bg-muted/40',
+              selected && 'bg-primary/10 hover:bg-primary/10',
+            )}
+            aria-current={selected ? 'true' : undefined}
+          >
+            <span
+              className={cn(
+                'mt-0.5 inline-flex items-center justify-center w-5 h-5 rounded-full text-[10px] font-mono tabular-nums shrink-0',
+                selected
+                  ? 'bg-primary text-primary-foreground'
+                  : 'bg-muted text-muted-foreground',
+              )}
+              aria-hidden
+            >
+              {idx + 1}
+            </span>
+            <div className="min-w-0 flex-1">
+              <div className="text-sm font-medium truncate leading-tight">{c.subject}</div>
+              <div className="mt-1 flex items-center gap-1.5 text-xs text-muted-foreground">
+                <span className="font-mono">{c.shortSha}</span>
+                <span className="text-muted-foreground/40">·</span>
+                <span className="truncate max-w-[140px]">{c.author}</span>
+                <span className="text-muted-foreground/40">·</span>
+                <span>{relativeDate(c.date)}</span>
+              </div>
+              <div className="mt-1 flex items-center gap-2 text-[11px] tabular-nums text-muted-foreground">
+                <span>
+                  {c.filesChanged} {c.filesChanged === 1 ? 'file' : 'files'}
+                </span>
+                <span className="text-emerald-600/90 dark:text-emerald-400/90">+{c.insertions}</span>
+                <span className="text-red-600/90 dark:text-red-400/90">−{c.deletions}</span>
+              </div>
+            </div>
+            <IconChevronRight
+              size={14}
+              className={cn(
+                'mt-1 shrink-0 transition-colors',
+                selected ? 'text-primary' : 'text-muted-foreground/40 group-hover:text-muted-foreground',
+              )}
+            />
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/components/git-repo/diff-parser.ts
+++ b/dashboard/src/components/git-repo/diff-parser.ts
@@ -1,0 +1,132 @@
+export type DiffLineType = 'add' | 'del' | 'context' | 'header' | 'meta';
+
+export interface DiffLine {
+  type: DiffLineType;
+  content: string;
+  oldNum: number | null;
+  newNum: number | null;
+}
+
+export interface DiffHunk {
+  header: string;
+  oldStart: number;
+  newStart: number;
+  lines: DiffLine[];
+}
+
+export function parsePatch(patch: string): DiffHunk[] {
+  const hunks: DiffHunk[] = [];
+  if (!patch) return hunks;
+
+  const lines = patch.split('\n');
+  let current: DiffHunk | null = null;
+  let oldCursor = 0;
+  let newCursor = 0;
+
+  for (const line of lines) {
+    if (line.startsWith('@@')) {
+      const m = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+      if (m) {
+        oldCursor = parseInt(m[1], 10);
+        newCursor = parseInt(m[2], 10);
+        current = {
+          header: line,
+          oldStart: oldCursor,
+          newStart: newCursor,
+          lines: [],
+        };
+        hunks.push(current);
+      }
+      continue;
+    }
+    if (!current) continue;
+    if (
+      line.startsWith('diff --git') ||
+      line.startsWith('index ') ||
+      line.startsWith('--- ') ||
+      line.startsWith('+++ ') ||
+      line.startsWith('new file mode') ||
+      line.startsWith('deleted file mode') ||
+      line.startsWith('similarity index') ||
+      line.startsWith('rename from') ||
+      line.startsWith('rename to') ||
+      line.startsWith('Binary files')
+    ) {
+      continue;
+    }
+
+    if (line.startsWith('+')) {
+      current.lines.push({
+        type: 'add',
+        content: line.slice(1),
+        oldNum: null,
+        newNum: newCursor,
+      });
+      newCursor++;
+    } else if (line.startsWith('-')) {
+      current.lines.push({
+        type: 'del',
+        content: line.slice(1),
+        oldNum: oldCursor,
+        newNum: null,
+      });
+      oldCursor++;
+    } else if (line.startsWith(' ') || line === '') {
+      current.lines.push({
+        type: 'context',
+        content: line.slice(1),
+        oldNum: oldCursor,
+        newNum: newCursor,
+      });
+      oldCursor++;
+      newCursor++;
+    } else if (line.startsWith('\\')) {
+      current.lines.push({ type: 'meta', content: line, oldNum: null, newNum: null });
+    }
+  }
+
+  return hunks;
+}
+
+const EXT_TO_LANG: Record<string, string> = {
+  ts: 'typescript',
+  tsx: 'tsx',
+  mts: 'typescript',
+  cts: 'typescript',
+  js: 'javascript',
+  jsx: 'jsx',
+  mjs: 'javascript',
+  cjs: 'javascript',
+  json: 'json',
+  jsonc: 'json',
+  css: 'css',
+  scss: 'scss',
+  html: 'html',
+  md: 'markdown',
+  mdx: 'mdx',
+  sh: 'bash',
+  bash: 'bash',
+  zsh: 'bash',
+  py: 'python',
+  rb: 'ruby',
+  go: 'go',
+  rs: 'rust',
+  java: 'java',
+  c: 'c',
+  h: 'c',
+  cpp: 'cpp',
+  hpp: 'cpp',
+  yaml: 'yaml',
+  yml: 'yaml',
+  toml: 'toml',
+  sql: 'sql',
+  xml: 'xml',
+};
+
+export function languageFromPath(path: string): string {
+  const base = path.split('/').pop() ?? '';
+  if (base === 'Dockerfile') return 'docker';
+  if (base.endsWith('.gitignore') || base === '.env') return 'text';
+  const ext = base.includes('.') ? base.slice(base.lastIndexOf('.') + 1).toLowerCase() : '';
+  return EXT_TO_LANG[ext] ?? 'text';
+}

--- a/dashboard/src/components/git-repo/diff-viewer.tsx
+++ b/dashboard/src/components/git-repo/diff-viewer.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { IconLoader2, IconArrowLeft } from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import { FileDiff } from './file-diff';
+import type { CommitDetail } from './types';
+
+interface DiffViewerProps {
+  branch: string;
+  sha: string | null;
+  onClear: () => void;
+}
+
+export function DiffViewer({ branch, sha, onClear }: DiffViewerProps) {
+  const [detail, setDetail] = useState<CommitDetail | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!sha) {
+      setDetail(null);
+      setError(null);
+      return;
+    }
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+    fetch(`/api/git/commits/${sha}`)
+      .then(async (res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return (await res.json()) as CommitDetail;
+      })
+      .then((data) => {
+        if (!cancelled) setDetail(data);
+      })
+      .catch((err) => {
+        if (!cancelled) setError(String(err.message ?? err));
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sha]);
+
+  if (!sha) {
+    return (
+      <div className="rounded-xl border border-dashed bg-card/30 min-h-[400px] flex items-center justify-center text-sm text-muted-foreground">
+        Select a commit to view its diff.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Button variant="ghost" size="xs" onClick={onClear} className="gap-1">
+          <IconArrowLeft size={12} />
+          Back
+        </Button>
+        <span className="font-mono">{branch}</span>
+        <span className="text-muted-foreground/40">›</span>
+        <span className="font-mono text-foreground">{sha.slice(0, 7)}</span>
+      </div>
+
+      {loading && (
+        <div className="rounded-xl border bg-card p-6 flex items-center gap-2 text-sm text-muted-foreground">
+          <IconLoader2 size={14} className="animate-spin" />
+          Loading diff...
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-xl border border-destructive/30 bg-destructive/5 p-4 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {detail && !loading && (
+        <>
+          <div className="rounded-xl border bg-card p-4 space-y-1">
+            <h2 className="text-lg font-semibold leading-snug">{detail.subject}</h2>
+            {detail.body && (
+              <pre className="text-xs whitespace-pre-wrap text-muted-foreground font-sans mt-2">
+                {detail.body}
+              </pre>
+            )}
+            <div className="mt-2 text-xs text-muted-foreground">
+              <span className="font-mono">{detail.sha.slice(0, 7)}</span>
+              <span className="mx-1.5 text-muted-foreground/40">·</span>
+              <span>{detail.author}</span>
+              <span className="mx-1.5 text-muted-foreground/40">·</span>
+              <span>{new Date(detail.date).toLocaleString()}</span>
+              <span className="mx-1.5 text-muted-foreground/40">·</span>
+              <span className="tabular-nums">
+                {detail.files.length} {detail.files.length === 1 ? 'file' : 'files'}
+              </span>
+            </div>
+          </div>
+
+          <div className="space-y-3">
+            {detail.files.map((f) => (
+              <FileDiff key={f.path} file={f} defaultExpanded={false} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/components/git-repo/file-diff.tsx
+++ b/dashboard/src/components/git-repo/file-diff.tsx
@@ -1,0 +1,178 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useTheme } from 'next-themes';
+import { IconChevronDown, IconChevronRight, IconCircleDot } from '@tabler/icons-react';
+import { cn } from '@/lib/utils';
+import type { DiffFile, FileStatus } from './types';
+import { parsePatch, languageFromPath } from './diff-parser';
+import { highlightLine } from './highlighter';
+
+interface FileDiffProps {
+  file: DiffFile;
+  defaultExpanded?: boolean;
+}
+
+const STATUS_LABEL: Record<FileStatus, string> = {
+  added: 'added',
+  modified: 'modified',
+  deleted: 'deleted',
+  renamed: 'renamed',
+  copied: 'copied',
+  other: 'changed',
+};
+
+const STATUS_CLASSES: Record<FileStatus, string> = {
+  added: 'bg-emerald-500/10 text-emerald-700 dark:text-emerald-300 border-emerald-500/30',
+  modified: 'bg-amber-500/10 text-amber-700 dark:text-amber-300 border-amber-500/30',
+  deleted: 'bg-red-500/10 text-red-700 dark:text-red-300 border-red-500/30',
+  renamed: 'bg-blue-500/10 text-blue-700 dark:text-blue-300 border-blue-500/30',
+  copied: 'bg-blue-500/10 text-blue-700 dark:text-blue-300 border-blue-500/30',
+  other: 'bg-muted text-muted-foreground border-border',
+};
+
+export function FileDiff({ file, defaultExpanded = true }: FileDiffProps) {
+  const [expanded, setExpanded] = useState(defaultExpanded);
+  const { resolvedTheme } = useTheme();
+  const theme: 'github-dark' | 'github-light' =
+    resolvedTheme === 'dark' ? 'github-dark' : 'github-light';
+
+  const hunks = expanded ? parsePatch(file.patch) : [];
+  const lang = languageFromPath(file.path);
+
+  return (
+    <div className="rounded-xl border bg-card overflow-hidden">
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2 border-b bg-muted/30 hover:bg-muted/50 transition-colors text-left"
+      >
+        {expanded ? (
+          <IconChevronDown size={14} className="text-muted-foreground shrink-0" />
+        ) : (
+          <IconChevronRight size={14} className="text-muted-foreground shrink-0" />
+        )}
+        <span className="font-mono text-[12.5px] truncate flex-1">
+          {file.oldPath && file.oldPath !== file.path ? (
+            <>
+              <span className="text-muted-foreground">{file.oldPath}</span>
+              <span className="mx-1 text-muted-foreground/60">→</span>
+              {file.path}
+            </>
+          ) : (
+            file.path
+          )}
+        </span>
+        <span
+          className={cn(
+            'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-wider',
+            STATUS_CLASSES[file.status],
+          )}
+        >
+          {STATUS_LABEL[file.status]}
+        </span>
+        <span className="text-[11px] tabular-nums text-emerald-600/90 dark:text-emerald-400/90">
+          +{file.additions}
+        </span>
+        <span className="text-[11px] tabular-nums text-red-600/90 dark:text-red-400/90">
+          −{file.deletions}
+        </span>
+      </button>
+
+      {expanded && (
+        <div>
+          {file.binary ? (
+            <div className="px-3 py-4 text-xs text-muted-foreground flex items-center gap-2">
+              <IconCircleDot size={12} />
+              Binary file — no diff preview
+            </div>
+          ) : hunks.length === 0 ? (
+            <div className="px-3 py-4 text-xs text-muted-foreground">
+              No textual diff (file may be too large or empty).
+            </div>
+          ) : (
+            <div className="font-mono text-[12.5px] leading-[1.45]">
+              {hunks.map((hunk, hi) => (
+                <div key={hi}>
+                  <div className="px-3 py-1 bg-muted/40 text-[11px] text-muted-foreground border-y">
+                    {hunk.header}
+                  </div>
+                  {hunk.lines.map((line, li) => (
+                    <DiffLineRow
+                      key={`${hi}-${li}`}
+                      type={line.type}
+                      content={line.content}
+                      oldNum={line.oldNum}
+                      newNum={line.newNum}
+                      lang={lang}
+                      theme={theme}
+                    />
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface DiffLineRowProps {
+  type: 'add' | 'del' | 'context' | 'header' | 'meta';
+  content: string;
+  oldNum: number | null;
+  newNum: number | null;
+  lang: string;
+  theme: 'github-dark' | 'github-light';
+}
+
+function DiffLineRow({ type, content, oldNum, newNum, lang, theme }: DiffLineRowProps) {
+  const [highlighted, setHighlighted] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    if (type === 'meta') {
+      setHighlighted(null);
+      return;
+    }
+    highlightLine(content, lang, theme).then((html) => {
+      if (!cancelled) setHighlighted(html);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [content, lang, theme, type]);
+
+  const bg =
+    type === 'add'
+      ? 'bg-emerald-500/[0.08]'
+      : type === 'del'
+        ? 'bg-red-500/[0.08]'
+        : '';
+  const marker = type === 'add' ? '+' : type === 'del' ? '−' : ' ';
+  const markerColor =
+    type === 'add'
+      ? 'text-emerald-600 dark:text-emerald-400'
+      : type === 'del'
+        ? 'text-red-600 dark:text-red-400'
+        : 'text-muted-foreground/40';
+
+  return (
+    <div className={cn('flex', bg)}>
+      <span className="select-none w-10 shrink-0 text-right pr-1 text-[10.5px] tabular-nums text-muted-foreground/60 border-r border-border/40">
+        {oldNum ?? ''}
+      </span>
+      <span className="select-none w-10 shrink-0 text-right pr-1 text-[10.5px] tabular-nums text-muted-foreground/60 border-r border-border/40">
+        {newNum ?? ''}
+      </span>
+      <span className={cn('select-none w-5 shrink-0 text-center', markerColor)}>{marker}</span>
+      <pre className="flex-1 whitespace-pre overflow-x-auto px-2 py-0">
+        {highlighted !== null ? (
+          <code dangerouslySetInnerHTML={{ __html: highlighted }} />
+        ) : (
+          <code>{content}</code>
+        )}
+      </pre>
+    </div>
+  );
+}

--- a/dashboard/src/components/git-repo/highlighter.ts
+++ b/dashboard/src/components/git-repo/highlighter.ts
@@ -1,0 +1,73 @@
+'use client';
+
+import type { Highlighter, BundledLanguage } from 'shiki';
+
+const SUPPORTED_LANGS: BundledLanguage[] = [
+  'typescript',
+  'tsx',
+  'javascript',
+  'jsx',
+  'json',
+  'css',
+  'scss',
+  'html',
+  'markdown',
+  'mdx',
+  'bash',
+  'python',
+  'ruby',
+  'go',
+  'rust',
+  'java',
+  'c',
+  'cpp',
+  'yaml',
+  'toml',
+  'sql',
+  'xml',
+  'docker',
+];
+
+let highlighterPromise: Promise<Highlighter> | null = null;
+
+export async function getHighlighter(): Promise<Highlighter> {
+  if (!highlighterPromise) {
+    highlighterPromise = import('shiki').then((shiki) =>
+      shiki.createHighlighter({
+        themes: ['github-dark', 'github-light'],
+        langs: SUPPORTED_LANGS,
+      }),
+    );
+  }
+  return highlighterPromise;
+}
+
+export function isSupportedLang(lang: string): lang is BundledLanguage {
+  return (SUPPORTED_LANGS as string[]).includes(lang);
+}
+
+export async function highlightLine(
+  line: string,
+  lang: string,
+  theme: 'github-dark' | 'github-light',
+): Promise<string> {
+  if (!isSupportedLang(lang) || !line) return escapeHtml(line);
+  const h = await getHighlighter();
+  try {
+    const html = h.codeToHtml(line, { lang, theme });
+    const inner = html.match(/<code[^>]*>([\s\S]*?)<\/code>/);
+    if (!inner) return escapeHtml(line);
+    return inner[1].replace(/<\/?span class="line"[^>]*>/g, '');
+  } catch {
+    return escapeHtml(line);
+  }
+}
+
+function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/dashboard/src/components/git-repo/status-card.tsx
+++ b/dashboard/src/components/git-repo/status-card.tsx
@@ -1,0 +1,172 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  IconArrowUp,
+  IconArrowDown,
+  IconRefresh,
+  IconExternalLink,
+  IconCircleCheck,
+  IconAlertTriangle,
+} from '@tabler/icons-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import type { GitStatus, CommitSummary } from './types';
+
+interface StatusCardProps {
+  status: GitStatus | null;
+  commits: CommitSummary[];
+  onFetched: () => void;
+}
+
+function relativeTime(iso: string | null): string {
+  if (!iso) return 'never';
+  const then = new Date(iso).getTime();
+  const now = Date.now();
+  const sec = Math.round((now - then) / 1000);
+  if (sec < 60) return `${sec}s ago`;
+  const min = Math.round(sec / 60);
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.round(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.round(hr / 24);
+  return `${day}d ago`;
+}
+
+function githubCompareUrl(remoteUrl: string | null, branch: string): string | null {
+  if (!remoteUrl) return null;
+  const m = remoteUrl.match(/github\.com[:/]([^/]+)\/([^/.]+)(?:\.git)?$/);
+  if (!m) return null;
+  const [, owner, repo] = m;
+  return `https://github.com/${owner}/${repo}/compare/main...${encodeURIComponent(branch)}`;
+}
+
+export function StatusCard({ status, commits, onFetched }: StatusCardProps) {
+  const [fetching, setFetching] = useState(false);
+
+  async function handleFetch() {
+    setFetching(true);
+    try {
+      await fetch('/api/git/fetch', { method: 'POST' });
+    } catch {
+      // silent
+    }
+    setFetching(false);
+    onFetched();
+  }
+
+  if (!status) {
+    return <div className="h-32 rounded-xl border bg-card/50 animate-pulse" />;
+  }
+
+  const totalFiles = commits.reduce((acc, c) => acc + c.filesChanged, 0);
+  const totalInsertions = commits.reduce((acc, c) => acc + c.insertions, 0);
+  const totalDeletions = commits.reduce((acc, c) => acc + c.deletions, 0);
+  const ready = status.ahead > 0 && status.behind === 0;
+  const compareUrl = githubCompareUrl(status.upstreamRemoteUrl, status.branch);
+
+  return (
+    <div className="rounded-xl border bg-card p-4 space-y-3">
+      <div className="flex flex-wrap items-center gap-3">
+        <div className="flex items-center gap-2">
+          <AheadBadge ahead={status.ahead} />
+          <BehindBadge behind={status.behind} />
+        </div>
+
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-xs text-muted-foreground">
+            Last fetched <span className="text-foreground/80">{relativeTime(status.lastFetchedAt)}</span>
+            <span className="mx-1.5 text-muted-foreground/40">·</span>
+            <span className="font-mono">{status.upstream}</span>
+          </span>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleFetch}
+            disabled={fetching}
+            className="gap-1.5"
+          >
+            <IconRefresh size={14} className={cn(fetching && 'animate-spin')} />
+            {fetching ? 'Fetching...' : 'Fetch upstream'}
+          </Button>
+        </div>
+      </div>
+
+      <div className="border-t pt-3 flex flex-wrap items-center gap-3 text-sm">
+        {ready ? (
+          <div className="flex items-center gap-2 text-emerald-600 dark:text-emerald-400">
+            <IconCircleCheck size={16} />
+            <span>
+              Looks ready —{' '}
+              <span className="tabular-nums font-medium">{status.ahead}</span>{' '}
+              {status.ahead === 1 ? 'commit' : 'commits'},{' '}
+              <span className="tabular-nums font-medium">{totalFiles}</span>{' '}
+              {totalFiles === 1 ? 'file' : 'files'} changed
+              {' '}
+              (<span className="tabular-nums text-emerald-600/90 dark:text-emerald-400/90">+{totalInsertions}</span>
+              {' '}
+              <span className="tabular-nums text-red-600/90 dark:text-red-400/90">−{totalDeletions}</span>)
+            </span>
+          </div>
+        ) : status.behind > 0 ? (
+          <div className="flex items-center gap-2 text-amber-600 dark:text-amber-400">
+            <IconAlertTriangle size={16} />
+            <span>
+              Branch is <span className="tabular-nums font-medium">{status.behind}</span>{' '}
+              {status.behind === 1 ? 'commit' : 'commits'} behind{' '}
+              <span className="font-mono">{status.upstream}</span> — rebase or merge before opening a PR
+            </span>
+          </div>
+        ) : (
+          <div className="text-muted-foreground">No commits ahead of {status.upstream}</div>
+        )}
+
+        {compareUrl && (
+          <a
+            href={compareUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="ml-auto inline-flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Open compare on GitHub
+            <IconExternalLink size={12} />
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function AheadBadge({ ahead }: { ahead: number }) {
+  const active = ahead > 0;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium tabular-nums transition-colors',
+        active
+          ? 'border-emerald-500/30 bg-emerald-500/10 text-emerald-700 dark:text-emerald-300'
+          : 'border-border bg-muted/30 text-muted-foreground',
+      )}
+    >
+      <IconArrowUp size={12} />
+      {ahead} ahead
+    </span>
+  );
+}
+
+function BehindBadge({ behind }: { behind: number }) {
+  const active = behind > 0;
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5 text-xs font-medium tabular-nums transition-colors',
+        active
+          ? 'border-amber-500/30 bg-amber-500/10 text-amber-700 dark:text-amber-300'
+          : 'border-border bg-muted/30 text-muted-foreground',
+      )}
+    >
+      <IconArrowDown size={12} />
+      {behind} behind
+    </span>
+  );
+}

--- a/dashboard/src/components/git-repo/types.ts
+++ b/dashboard/src/components/git-repo/types.ts
@@ -1,0 +1,47 @@
+export interface GitBranches {
+  branches: string[];
+  current: string;
+}
+
+export interface GitStatus {
+  branch: string;
+  upstream: string;
+  upstreamRemoteUrl: string | null;
+  ahead: number;
+  behind: number;
+  lastFetchedAt: string | null;
+}
+
+export interface CommitSummary {
+  sha: string;
+  shortSha: string;
+  subject: string;
+  author: string;
+  authorEmail: string;
+  date: string;
+  filesChanged: number;
+  insertions: number;
+  deletions: number;
+}
+
+export type FileStatus = 'added' | 'modified' | 'deleted' | 'renamed' | 'copied' | 'other';
+
+export interface DiffFile {
+  path: string;
+  oldPath: string | null;
+  status: FileStatus;
+  additions: number;
+  deletions: number;
+  binary: boolean;
+  patch: string;
+}
+
+export interface CommitDetail {
+  sha: string;
+  subject: string;
+  body: string;
+  author: string;
+  authorEmail: string;
+  date: string;
+  files: DiffFile[];
+}

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   IconClock,
   IconTarget,
   IconMessages,
+  IconGitBranch,
 } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
@@ -49,12 +50,16 @@ const navItems: NavItem[] = [
   { label: 'Knowledge Base', href: '/knowledge-base', icon: IconBook2, section: 'intel' },
   { label: 'Experiments', href: '/experiments', icon: IconFlask, section: 'intel' },
   { label: 'Skills', href: '/skills', icon: IconPuzzle, section: 'intel' },
+
+  // Other
+  { label: 'Git Repo', href: '/git-repo', icon: IconGitBranch, section: 'other' },
 ];
 
 const sectionLabels: Record<string, string> = {
   core: '',
   ops: 'Operations',
   intel: 'Intelligence',
+  other: 'Other',
 };
 
 interface SidebarProps {
@@ -92,7 +97,7 @@ export function Sidebar({
   }
 
   // Group items by section
-  const sections = ['core', 'ops', 'intel'];
+  const sections = ['core', 'ops', 'intel', 'other'];
 
   return (
     <aside className="flex h-screen w-56 shrink-0 flex-col border-r bg-card/50">


### PR DESCRIPTION
## Summary

Adds a Git repository management page to the dashboard showing branch status, ahead/behind upstream counts, and per-commit diffs.

- **git-repo page**: shows current branch, ahead/behind count vs upstream, and commit list
- **api/git/* routes**: status, commits, per-commit diff, branches, remote fetch
- **git-repo components**: branch-picker, commit-list, diff-viewer, file-diff, diff-parser, highlighter, status-card
- **sidebar.tsx**: adds "Git Repo" nav item under a new "Other" section
- **dashboard/package.json**: adds shiki ^4.0.2 dependency for syntax-highlighted diffs

## Test plan

- [ ] Open /git-repo, confirm current branch and ahead/behind count display
- [ ] Click a commit, confirm diff renders with syntax highlighting
- [ ] Switch branches via branch picker
- [ ] Trigger remote fetch, confirm behind count updates

## Demo video
https://github.com/user-attachments/assets/8f56fa67-7761-4e3e-bf66-e28b97e46219