### PR TITLE
feat(dashboard): /usage page — per-agent + per-cron cost attribution

### DIFF
--- a/dashboard/src/app/(dashboard)/usage/[agent]/page.tsx
+++ b/dashboard/src/app/(dashboard)/usage/[agent]/page.tsx
@@ -1,0 +1,248 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import { IconArrowLeft, IconRefresh } from '@tabler/icons-react';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/lib/utils';
+import { RangePicker, type Range } from '@/components/usage/range-picker';
+import { AgentSummaryCards } from '@/components/usage/agent-summary-cards';
+import { AgentCostChart } from '@/components/usage/agent-cost-chart';
+import { AgentModelBreakdown } from '@/components/usage/agent-model-breakdown';
+import { CronAttributionTable } from '@/components/usage/cron-attribution-table';
+import { SessionList } from '@/components/usage/session-list';
+
+interface AgentResponse {
+  summary: {
+    agent: string;
+    org: string;
+    runtime: 'claude-code' | 'codex-app-server' | 'hermes';
+    cron_mode: 'inject' | 'print' | null;
+    cost_usd: number;
+    input_cost_usd: number;
+    output_cost_usd: number;
+    cache_cost_usd: number;
+    total_tokens: number;
+    input_tokens: number;
+    output_tokens: number;
+    message_count: number;
+    cron_runs: number;
+    last_active: string | null;
+  };
+  dailyCost: Array<{ date: string; cost: number }>;
+  dailyByModel: Array<Record<string, unknown>>;
+}
+
+interface CronsResponse {
+  aggregates: Array<{
+    cron: string;
+    runs: number;
+    total_tokens: number;
+    cost_usd: number;
+    last_fire: string;
+    last_status: 'fired' | 'retried' | 'failed';
+    approximate: boolean;
+  }>;
+  runs: Array<{
+    ts: string;
+    cron: string;
+    status: 'fired' | 'retried' | 'failed';
+    duration_ms: number;
+    error?: string | null;
+    total_tokens: number;
+    cost_usd: number;
+    approximate: boolean;
+  }>;
+}
+
+interface SessionsResponse {
+  sessions: Array<{
+    source_file: string;
+    session_label: string;
+    started_at: string;
+    ended_at: string;
+    message_count: number;
+    total_tokens: number;
+    cost_usd: number;
+    model: string;
+  }>;
+}
+
+function runtimeBadge(runtime: AgentResponse['summary']['runtime']) {
+  if (runtime === 'codex-app-server') return 'codex';
+  if (runtime === 'hermes') return 'hermes';
+  return 'claude';
+}
+
+export default function AgentUsagePage() {
+  const params = useParams<{ agent: string }>();
+  const agent = decodeURIComponent(params.agent);
+
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const range = (searchParams.get('range') as Range | null) ?? '30';
+
+  const [agentData, setAgentData] = useState<AgentResponse | null>(null);
+  const [crons, setCrons] = useState<CronsResponse | null>(null);
+  const [sessions, setSessions] = useState<SessionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(
+    async (r: Range, force = false) => {
+      if (force) setRefreshing(true);
+      else setLoading(true);
+      setError(null);
+      try {
+        const q = `days=${r}${force ? '&refresh=1' : ''}`;
+        const [a, c, s] = await Promise.all([
+          fetch(`/api/usage/agents/${encodeURIComponent(agent)}?${q}`),
+          fetch(`/api/usage/agents/${encodeURIComponent(agent)}/crons?${q}`),
+          fetch(`/api/usage/agents/${encodeURIComponent(agent)}/sessions?${q}`),
+        ]);
+        if (a.status === 404) {
+          setError('Agent not found');
+          setAgentData(null);
+          return;
+        }
+        if (!a.ok) throw new Error(`agent ${a.status}`);
+        setAgentData(await a.json());
+        setCrons(c.ok ? await c.json() : { aggregates: [], runs: [] });
+        setSessions(s.ok ? await s.json() : { sessions: [] });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'load failed');
+      } finally {
+        setLoading(false);
+        setRefreshing(false);
+      }
+    },
+    [agent],
+  );
+
+  useEffect(() => {
+    load(range);
+  }, [range, load]);
+
+  useEffect(() => {
+    function onFocus() {
+      load(range);
+    }
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [range, load]);
+
+  function setRange(next: Range) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('range', next);
+    router.replace(`/usage/${encodeURIComponent(agent)}?${params.toString()}`, { scroll: false });
+  }
+
+  const summary = agentData?.summary;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="space-y-1">
+          <Link
+            href="/usage"
+            className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+          >
+            <IconArrowLeft size={12} /> Usage
+          </Link>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-semibold tracking-tight">{agent}</h1>
+            {summary && (
+              <>
+                <Badge variant="outline" className="font-mono text-[10px]">
+                  {runtimeBadge(summary.runtime)}
+                </Badge>
+                {summary.cron_mode && (
+                  <Badge variant="ghost" className="font-mono text-[10px]">
+                    cron:{summary.cron_mode}
+                  </Badge>
+                )}
+                {summary.org && (
+                  <span className="text-xs text-muted-foreground">{summary.org}</span>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => load(range, true)}
+            disabled={refreshing}
+            aria-label="Refresh now"
+            className={cn(
+              'inline-flex h-8 items-center gap-1.5 rounded-md border bg-background/50 px-2.5 text-xs font-medium transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              refreshing
+                ? 'text-muted-foreground/60'
+                : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+            )}
+          >
+            <IconRefresh size={12} className={cn(refreshing && 'animate-spin')} />
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+          <RangePicker value={range} onChange={setRange} />
+        </div>
+      </div>
+
+      {error && (
+        <div className="rounded-md border border-destructive/40 bg-destructive/5 p-3 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      {summary && (
+        <>
+          <AgentSummaryCards
+            cost_usd={summary.cost_usd}
+            input_cost_usd={summary.input_cost_usd}
+            output_cost_usd={summary.output_cost_usd}
+            cache_cost_usd={summary.cache_cost_usd}
+            input_tokens={summary.input_tokens}
+            output_tokens={summary.output_tokens}
+            total_tokens={summary.total_tokens}
+            cron_runs={summary.cron_runs}
+            last_active={summary.last_active}
+          />
+
+          <Tabs defaultValue="overview">
+            <TabsList>
+              <TabsTrigger value="overview">Overview</TabsTrigger>
+              <TabsTrigger value="crons">Crons ({crons?.aggregates.length ?? 0})</TabsTrigger>
+              <TabsTrigger value="sessions">Sessions ({sessions?.sessions.length ?? 0})</TabsTrigger>
+            </TabsList>
+
+            <TabsContent value="overview" className="mt-4 space-y-4">
+              <AgentCostChart data={agentData?.dailyCost ?? []} />
+              <AgentModelBreakdown data={agentData?.dailyByModel ?? []} />
+            </TabsContent>
+
+            <TabsContent value="crons" className="mt-4 space-y-4">
+              <CronAttributionTable
+                aggregates={crons?.aggregates ?? []}
+                runs={crons?.runs ?? []}
+              />
+            </TabsContent>
+
+            <TabsContent value="sessions" className="mt-4 space-y-4">
+              <SessionList sessions={sessions?.sessions ?? []} />
+            </TabsContent>
+          </Tabs>
+        </>
+      )}
+
+      {loading && !summary && !error && (
+        <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+          Loading…
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/app/(dashboard)/usage/page.tsx
+++ b/dashboard/src/app/(dashboard)/usage/page.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BarChart } from '@/components/charts/bar-chart';
+import { MODEL_COLORS, CHART_COLORS } from '@/components/charts/chart-theme';
+import { FleetTable } from '@/components/usage/fleet-table';
+import { RangePicker, type Range } from '@/components/usage/range-picker';
+import { IconRefresh } from '@tabler/icons-react';
+import { cn } from '@/lib/utils';
+
+interface FleetResponse {
+  totals: {
+    total_cost_usd: number;
+    input_cost_usd: number;
+    output_cost_usd: number;
+    cache_cost_usd: number;
+    total_tokens: number;
+    agent_count: number;
+    cron_runs: number;
+  };
+  dailyByModel: Array<Record<string, unknown>>;
+  agents: Array<{
+    agent: string;
+    org: string;
+    runtime: 'claude-code' | 'codex-app-server' | 'hermes';
+    cron_mode: 'inject' | 'print' | null;
+    cost_usd: number;
+    input_cost_usd: number;
+    output_cost_usd: number;
+    cache_cost_usd: number;
+    total_tokens: number;
+    cron_runs: number;
+    last_active: string | null;
+    sparkline: number[];
+  }>;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${n}`;
+}
+
+export default function UsagePage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const rangeParam = (searchParams.get('range') as Range | null) ?? '30';
+
+  const [data, setData] = useState<FleetResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+
+  const load = useCallback(async (range: Range, force = false) => {
+    if (force) setRefreshing(true);
+    else setLoading(true);
+    try {
+      const url = `/api/usage/fleet?days=${range}${force ? '&refresh=1' : ''}`;
+      const res = await fetch(url);
+      if (!res.ok) throw new Error(`fleet ${res.status}`);
+      const json = (await res.json()) as FleetResponse;
+      setData(json);
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(rangeParam);
+  }, [rangeParam, load]);
+
+  // Re-fetch on window focus so usage feels live after a chat message
+  useEffect(() => {
+    function onFocus() {
+      load(rangeParam);
+    }
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [rangeParam, load]);
+
+  function setRange(next: Range) {
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('range', next);
+    router.replace(`/usage?${params.toString()}`, { scroll: false });
+  }
+
+  const totals = data?.totals;
+  const dailyByModel = data?.dailyByModel ?? [];
+  const modelKeys = (() => {
+    const keys = new Set<string>();
+    for (const row of dailyByModel) {
+      for (const k of Object.keys(row)) {
+        if (k !== 'date') keys.add(k);
+      }
+    }
+    return Array.from(keys);
+  })();
+  const modelColors = modelKeys.map(
+    (k) => MODEL_COLORS[k] ?? CHART_COLORS[modelKeys.indexOf(k) % CHART_COLORS.length],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Usage</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Token consumption and cost attribution across all agents, including cron workflow runs.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => load(rangeParam, true)}
+            disabled={refreshing}
+            aria-label="Refresh now"
+            className={cn(
+              'inline-flex h-8 items-center gap-1.5 rounded-md border bg-background/50 px-2.5 text-xs font-medium transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              refreshing
+                ? 'text-muted-foreground/60'
+                : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+            )}
+          >
+            <IconRefresh size={12} className={cn(refreshing && 'animate-spin')} />
+            {refreshing ? 'Refreshing…' : 'Refresh'}
+          </button>
+          <RangePicker value={rangeParam} onChange={setRange} />
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+        <Card>
+          <CardContent className="pt-4 pb-3">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+              Total cost
+            </p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums">
+              ${totals ? totals.total_cost_usd.toFixed(2) : '—'}
+            </p>
+            {totals && (
+              <div className="mt-2 space-y-0.5 text-[10px] text-muted-foreground tabular-nums">
+                <div className="flex justify-between"><span>Input</span><span>${totals.input_cost_usd.toFixed(2)}</span></div>
+                <div className="flex justify-between"><span>Output</span><span>${totals.output_cost_usd.toFixed(2)}</span></div>
+                <div className="flex justify-between"><span>Cache</span><span>${totals.cache_cost_usd.toFixed(2)}</span></div>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4 pb-3">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+              Tokens
+            </p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums">
+              {totals ? formatTokens(totals.total_tokens) : '—'}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4 pb-3">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+              Agents
+            </p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums">
+              {totals ? totals.agent_count : '—'}
+            </p>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardContent className="pt-4 pb-3">
+            <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+              Cron runs
+            </p>
+            <p className="mt-1 text-2xl font-semibold tabular-nums">
+              {totals ? totals.cron_runs : '—'}
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+            Daily cost by model
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {dailyByModel.length > 0 && modelKeys.length > 0 ? (
+            <BarChart
+              data={dailyByModel}
+              xKey="date"
+              yKeys={modelKeys}
+              colors={modelColors}
+              stacked
+              showLegend
+              height={200}
+            />
+          ) : (
+            <div className="flex h-[200px] items-center justify-center text-xs text-muted-foreground">
+              {loading ? 'Loading…' : 'No data in this range'}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <FleetTable rows={data?.agents ?? []} />
+    </div>
+  );
+}

--- a/dashboard/src/app/api/usage/agents/[name]/crons/route.ts
+++ b/dashboard/src/app/api/usage/agents/[name]/crons/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getAgentCronRuns,
+  getAgentCronAggregates,
+  type RangeDays,
+} from '@/lib/usage-queries';
+import { syncCostsLazy } from '@/lib/sync';
+
+export const dynamic = 'force-dynamic';
+
+function parseDays(value: string | null): RangeDays {
+  if (value === 'all') return 'all';
+  const n = Number(value);
+  if (n === 1 || n === 7 || n === 30 || n === 90) return n;
+  return 30;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  const url = new URL(req.url);
+  const days = parseDays(url.searchParams.get('days'));
+  const refresh = url.searchParams.get('refresh') === '1';
+
+  syncCostsLazy(refresh);
+
+  const aggregates = getAgentCronAggregates(name, days);
+  const runs = getAgentCronRuns(name, days, 200);
+
+  return NextResponse.json({ aggregates, runs, range: days });
+}

--- a/dashboard/src/app/api/usage/agents/[name]/route.ts
+++ b/dashboard/src/app/api/usage/agents/[name]/route.ts
@@ -1,0 +1,38 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getAgentUsageSummary,
+  getAgentDailyCost,
+  getAgentDailyCostByModel,
+  type RangeDays,
+} from '@/lib/usage-queries';
+import { syncCostsLazy } from '@/lib/sync';
+
+export const dynamic = 'force-dynamic';
+
+function parseDays(value: string | null): RangeDays {
+  if (value === 'all') return 'all';
+  const n = Number(value);
+  if (n === 1 || n === 7 || n === 30 || n === 90) return n;
+  return 30;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  const url = new URL(req.url);
+  const days = parseDays(url.searchParams.get('days'));
+  const refresh = url.searchParams.get('refresh') === '1';
+
+  syncCostsLazy(refresh);
+
+  const summary = getAgentUsageSummary(name, days);
+  if (!summary) {
+    return NextResponse.json({ error: 'agent not found' }, { status: 404 });
+  }
+  const dailyCost = getAgentDailyCost(name, days);
+  const dailyByModel = getAgentDailyCostByModel(name, days);
+
+  return NextResponse.json({ summary, dailyCost, dailyByModel, range: days });
+}

--- a/dashboard/src/app/api/usage/agents/[name]/sessions/route.ts
+++ b/dashboard/src/app/api/usage/agents/[name]/sessions/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getAgentSessions, type RangeDays } from '@/lib/usage-queries';
+import { syncCostsLazy } from '@/lib/sync';
+
+export const dynamic = 'force-dynamic';
+
+function parseDays(value: string | null): RangeDays {
+  if (value === 'all') return 'all';
+  const n = Number(value);
+  if (n === 1 || n === 7 || n === 30 || n === 90) return n;
+  return 30;
+}
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ name: string }> },
+) {
+  const { name } = await params;
+  const url = new URL(req.url);
+  const days = parseDays(url.searchParams.get('days'));
+  const limit = Number(url.searchParams.get('limit') ?? 50);
+  const refresh = url.searchParams.get('refresh') === '1';
+
+  syncCostsLazy(refresh);
+
+  const sessions = getAgentSessions(name, days, Number.isFinite(limit) ? limit : 50);
+  return NextResponse.json({ sessions, range: days });
+}

--- a/dashboard/src/app/api/usage/fleet/route.ts
+++ b/dashboard/src/app/api/usage/fleet/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  getFleetUsageSummary,
+  getFleetDailyCostByModel,
+  getFleetAgentList,
+  getAgentSparkline,
+  type RangeDays,
+} from '@/lib/usage-queries';
+import { syncCostsLazy } from '@/lib/sync';
+
+export const dynamic = 'force-dynamic';
+
+function parseDays(value: string | null): RangeDays {
+  if (value === 'all') return 'all';
+  const n = Number(value);
+  if (n === 1 || n === 7 || n === 30 || n === 90) return n;
+  return 30;
+}
+
+export async function GET(req: NextRequest) {
+  const url = new URL(req.url);
+  const days = parseDays(url.searchParams.get('days'));
+  const refresh = url.searchParams.get('refresh') === '1';
+
+  syncCostsLazy(refresh);
+
+  const totals = getFleetUsageSummary(days);
+  const dailyByModel = getFleetDailyCostByModel(days);
+  const agents = getFleetAgentList(days).map((a) => ({
+    ...a,
+    sparkline: getAgentSparkline(a.agent, 14),
+  }));
+
+  return NextResponse.json({ totals, dailyByModel, agents, range: days });
+}

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   IconClock,
   IconTarget,
   IconMessages,
+  IconChartHistogram,
 } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
 import { Badge } from '@/components/ui/badge';
@@ -49,12 +50,16 @@ const navItems: NavItem[] = [
   { label: 'Knowledge Base', href: '/knowledge-base', icon: IconBook2, section: 'intel' },
   { label: 'Experiments', href: '/experiments', icon: IconFlask, section: 'intel' },
   { label: 'Skills', href: '/skills', icon: IconPuzzle, section: 'intel' },
+
+  // Other
+  { label: 'Usage', href: '/usage', icon: IconChartHistogram, section: 'other' },
 ];
 
 const sectionLabels: Record<string, string> = {
   core: '',
   ops: 'Operations',
   intel: 'Intelligence',
+  other: 'Other',
 };
 
 interface SidebarProps {
@@ -92,7 +97,7 @@ export function Sidebar({
   }
 
   // Group items by section
-  const sections = ['core', 'ops', 'intel'];
+  const sections = ['core', 'ops', 'intel', 'other'];
 
   return (
     <aside className="flex h-screen w-56 shrink-0 flex-col border-r bg-card/50">

--- a/dashboard/src/components/layout/sidebar.tsx
+++ b/dashboard/src/components/layout/sidebar.tsx
@@ -18,6 +18,7 @@ import {
   IconClock,
   IconTarget,
   IconMessages,
+  IconGitBranch,
   IconChartHistogram,
 } from '@tabler/icons-react';
 import { cn } from '@/lib/utils';
@@ -52,6 +53,7 @@ const navItems: NavItem[] = [
   { label: 'Skills', href: '/skills', icon: IconPuzzle, section: 'intel' },
 
   // Other
+  { label: 'Git Repo', href: '/git-repo', icon: IconGitBranch, section: 'other' },
   { label: 'Usage', href: '/usage', icon: IconChartHistogram, section: 'other' },
 ];
 

--- a/dashboard/src/components/usage/agent-cost-chart.tsx
+++ b/dashboard/src/components/usage/agent-cost-chart.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AreaChart } from '@/components/charts/area-chart';
+import { CHART_GOLD } from '@/components/charts/chart-theme';
+
+interface AgentCostChartProps {
+  data: Array<{ date: string; cost: number }>;
+}
+
+export function AgentCostChart({ data }: AgentCostChartProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Daily cost
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length > 0 ? (
+          <AreaChart
+            data={data}
+            xKey="date"
+            yKeys={['cost']}
+            colors={[CHART_GOLD]}
+            height={200}
+          />
+        ) : (
+          <div className="flex h-[200px] items-center justify-center text-xs text-muted-foreground">
+            No usage in this range
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dashboard/src/components/usage/agent-model-breakdown.tsx
+++ b/dashboard/src/components/usage/agent-model-breakdown.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { BarChart } from '@/components/charts/bar-chart';
+import { MODEL_COLORS, CHART_COLORS } from '@/components/charts/chart-theme';
+
+interface AgentModelBreakdownProps {
+  data: Array<Record<string, unknown>>;
+}
+
+export function AgentModelBreakdown({ data }: AgentModelBreakdownProps) {
+  const keys = new Set<string>();
+  for (const row of data) {
+    for (const k of Object.keys(row)) {
+      if (k !== 'date') keys.add(k);
+    }
+  }
+  const modelKeys = Array.from(keys);
+  // Map model keys to colors (gold-mustard for opus, fallbacks for others)
+  const colors = modelKeys.map((k) => MODEL_COLORS[k] ?? CHART_COLORS[modelKeys.indexOf(k) % CHART_COLORS.length]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Cost by model
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {data.length > 0 && modelKeys.length > 0 ? (
+          <BarChart
+            data={data}
+            xKey="date"
+            yKeys={modelKeys}
+            colors={colors}
+            stacked
+            showLegend
+            height={200}
+          />
+        ) : (
+          <div className="flex h-[200px] items-center justify-center text-xs text-muted-foreground">
+            No model breakdown available
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/dashboard/src/components/usage/agent-summary-cards.tsx
+++ b/dashboard/src/components/usage/agent-summary-cards.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { Card, CardContent } from '@/components/ui/card';
+
+interface AgentSummaryCardsProps {
+  cost_usd: number;
+  input_cost_usd?: number;
+  output_cost_usd?: number;
+  cache_cost_usd?: number;
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens: number;
+  cron_runs: number;
+  last_active: string | null;
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${n}`;
+}
+
+function formatRelative(iso: string | null): string {
+  if (!iso) return '—';
+  const ms = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(ms)) return '—';
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+function Stat({
+  label,
+  value,
+  sub,
+  children,
+}: {
+  label: string;
+  value: string;
+  sub?: string;
+  children?: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardContent className="pt-4 pb-3">
+        <p className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+          {label}
+        </p>
+        <p className="mt-1 text-2xl font-semibold tabular-nums">{value}</p>
+        {sub && <p className="mt-0.5 text-[10px] text-muted-foreground">{sub}</p>}
+        {children}
+      </CardContent>
+    </Card>
+  );
+}
+
+function fmtUsd(n: number): string {
+  if (n >= 100) return `$${n.toFixed(0)}`;
+  if (n >= 1) return `$${n.toFixed(2)}`;
+  return `$${n.toFixed(4)}`;
+}
+
+export function AgentSummaryCards({
+  cost_usd,
+  input_cost_usd,
+  output_cost_usd,
+  cache_cost_usd,
+  input_tokens,
+  output_tokens,
+  total_tokens,
+  cron_runs,
+  last_active,
+}: AgentSummaryCardsProps) {
+  const hasBreakdown =
+    typeof input_cost_usd === 'number' &&
+    typeof output_cost_usd === 'number' &&
+    typeof cache_cost_usd === 'number';
+  return (
+    <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+      <Stat label="Cost" value={`$${cost_usd.toFixed(2)}`}>
+        {hasBreakdown && (
+          <div className="mt-2 space-y-0.5 text-[10px] text-muted-foreground tabular-nums">
+            <div className="flex justify-between"><span>Input</span><span>{fmtUsd(input_cost_usd!)}</span></div>
+            <div className="flex justify-between"><span>Output</span><span>{fmtUsd(output_cost_usd!)}</span></div>
+            <div className="flex justify-between"><span>Cache</span><span>{fmtUsd(cache_cost_usd!)}</span></div>
+          </div>
+        )}
+      </Stat>
+      <Stat label="Tokens" value={formatTokens(total_tokens)}>
+        {typeof input_tokens === 'number' && typeof output_tokens === 'number' && (
+          <div className="mt-2 space-y-0.5 text-[10px] text-muted-foreground tabular-nums">
+            <div className="flex justify-between"><span>Input</span><span>{formatTokens(input_tokens)}</span></div>
+            <div className="flex justify-between"><span>Output</span><span>{formatTokens(output_tokens)}</span></div>
+            <div className="flex justify-between"><span>Cache</span><span>{formatTokens(total_tokens - input_tokens - output_tokens)}</span></div>
+          </div>
+        )}
+      </Stat>
+      <Stat label="Cron runs" value={`${cron_runs}`} />
+      <Stat
+        label="Last active"
+        value={formatRelative(last_active)}
+        sub={last_active ? new Date(last_active).toLocaleString() : undefined}
+      />
+    </div>
+  );
+}

--- a/dashboard/src/components/usage/cron-attribution-table.tsx
+++ b/dashboard/src/components/usage/cron-attribution-table.tsx
@@ -1,0 +1,237 @@
+'use client';
+
+import { Fragment, useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { cn } from '@/lib/utils';
+import { IconChevronRight, IconAlertTriangle, IconCheck, IconX } from '@tabler/icons-react';
+
+interface AggregateRow {
+  cron: string;
+  runs: number;
+  total_tokens: number;
+  cost_usd: number;
+  last_fire: string;
+  last_status: 'fired' | 'retried' | 'failed';
+  approximate: boolean;
+}
+
+interface RunRow {
+  ts: string;
+  cron: string;
+  status: 'fired' | 'retried' | 'failed';
+  duration_ms: number;
+  error?: string | null;
+  total_tokens: number;
+  cost_usd: number;
+  approximate: boolean;
+}
+
+interface CronAttributionTableProps {
+  aggregates: AggregateRow[];
+  runs: RunRow[];
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${n}`;
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(ms)) return iso;
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+function statusIcon(status: 'fired' | 'retried' | 'failed') {
+  if (status === 'fired') return <IconCheck size={12} className="text-green-600" />;
+  if (status === 'retried') return <IconAlertTriangle size={12} className="text-amber-500" />;
+  return <IconX size={12} className="text-red-500" />;
+}
+
+export function CronAttributionTable({ aggregates, runs }: CronAttributionTableProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+
+  if (aggregates.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          <p>No cron runs in this range</p>
+          <p className="mt-1 text-xs text-muted-foreground/70">Try a longer range, or check the Workflows page if you expected crons here.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const anyApprox = aggregates.some((a) => a.approximate);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex flex-wrap items-center gap-2 text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Crons
+          {anyApprox && (
+            <Badge
+              variant="outline"
+              className="font-normal normal-case tracking-normal"
+              aria-label="Some attribution is approximate"
+            >
+              ≈ inject-mode is approximate
+            </Badge>
+          )}
+        </CardTitle>
+        {anyApprox && (
+          <p className="text-xs text-muted-foreground/80">
+            Tokens for <code className="font-mono text-[10px]">cron_mode=inject</code> crons are
+            estimated by matching cost entries to each fire's time-window. Mode{' '}
+            <code className="font-mono text-[10px]">print</code> attribution is exact.
+          </p>
+        )}
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead className="w-8"></TableHead>
+              <TableHead>Cron</TableHead>
+              <TableHead className="text-right">Runs</TableHead>
+              <TableHead className="text-right">Tokens</TableHead>
+              <TableHead className="text-right">Cost</TableHead>
+              <TableHead>Last fire</TableHead>
+              <TableHead>Status</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {aggregates.map((a) => {
+              const isOpen = expanded === a.cron;
+              const cronRuns = runs.filter((r) => r.cron === a.cron).slice(0, 20);
+              return (
+                <Fragment key={a.cron}>
+                  <TableRow
+                    onClick={() => setExpanded(isOpen ? null : a.cron)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault();
+                        setExpanded(isOpen ? null : a.cron);
+                      }
+                    }}
+                    role="button"
+                    tabIndex={0}
+                    aria-expanded={isOpen}
+                    className="cursor-pointer focus-visible:outline-none focus-visible:bg-muted/50"
+                  >
+                    <TableCell>
+                      <IconChevronRight
+                        size={14}
+                        className={cn(
+                          'text-muted-foreground transition-transform',
+                          isOpen && 'rotate-90',
+                        )}
+                      />
+                    </TableCell>
+                    <TableCell className="font-medium">
+                      <span className="inline-flex items-center gap-1.5">
+                        {a.cron}
+                        {a.approximate && (
+                          <span
+                            className="text-[10px] text-muted-foreground"
+                            title="approximate: inject-mode time-window heuristic"
+                            aria-label="approximate"
+                          >
+                            ≈
+                          </span>
+                        )}
+                      </span>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{a.runs}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatTokens(a.total_tokens)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      ${a.cost_usd.toFixed(4)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      {formatRelative(a.last_fire)}
+                    </TableCell>
+                    <TableCell>
+                      <span className="inline-flex items-center gap-1">
+                        {statusIcon(a.last_status)}
+                        <span className="text-xs capitalize text-muted-foreground">
+                          {a.last_status}
+                        </span>
+                      </span>
+                    </TableCell>
+                  </TableRow>
+                  {isOpen && cronRuns.length > 0 && (
+                    <TableRow className="bg-muted/30 hover:bg-muted/30">
+                      <TableCell colSpan={7} className="p-0">
+                        <div className="border-t px-3 py-2">
+                          <p className="mb-2 text-[10px] font-semibold uppercase tracking-widest text-muted-foreground/70">
+                            Recent runs
+                          </p>
+                          <Table>
+                            <TableHeader>
+                              <TableRow>
+                                <TableHead>When</TableHead>
+                                <TableHead>Status</TableHead>
+                                <TableHead className="text-right">Duration</TableHead>
+                                <TableHead className="text-right">Tokens</TableHead>
+                                <TableHead className="text-right">Cost</TableHead>
+                                <TableHead>Error</TableHead>
+                              </TableRow>
+                            </TableHeader>
+                            <TableBody>
+                              {cronRuns.map((r, i) => (
+                                <TableRow key={`${r.ts}-${i}`}>
+                                  <TableCell className="text-muted-foreground">
+                                    {formatRelative(r.ts)}
+                                  </TableCell>
+                                  <TableCell>
+                                    <span className="inline-flex items-center gap-1">
+                                      {statusIcon(r.status)}
+                                      <span className="text-xs capitalize text-muted-foreground">
+                                        {r.status}
+                                      </span>
+                                    </span>
+                                  </TableCell>
+                                  <TableCell className="text-right tabular-nums text-muted-foreground">
+                                    {(r.duration_ms / 1000).toFixed(1)}s
+                                  </TableCell>
+                                  <TableCell className="text-right tabular-nums">
+                                    {formatTokens(r.total_tokens)}
+                                  </TableCell>
+                                  <TableCell className="text-right tabular-nums">
+                                    ${r.cost_usd.toFixed(4)}
+                                  </TableCell>
+                                  <TableCell className="max-w-[280px] truncate text-xs text-muted-foreground">
+                                    {r.error ?? ''}
+                                  </TableCell>
+                                </TableRow>
+                              ))}
+                            </TableBody>
+                          </Table>
+                        </div>
+                      </TableCell>
+                    </TableRow>
+                  )}
+                </Fragment>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dashboard/src/components/usage/fleet-table.tsx
+++ b/dashboard/src/components/usage/fleet-table.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import Link from 'next/link';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { SparkLine } from '@/components/charts/spark-line';
+import { CHART_GOLD } from '@/components/charts/chart-theme';
+import { IconChevronRight } from '@tabler/icons-react';
+
+interface FleetRow {
+  agent: string;
+  org: string;
+  runtime: 'claude-code' | 'codex-app-server' | 'hermes';
+  cron_mode: 'inject' | 'print' | null;
+  cost_usd: number;
+  total_tokens: number;
+  cron_runs: number;
+  last_active: string | null;
+  sparkline: number[];
+}
+
+interface FleetTableProps {
+  rows: FleetRow[];
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${n}`;
+}
+
+function runtimeLabel(r: FleetRow['runtime']): string {
+  if (r === 'claude-code') return 'claude';
+  if (r === 'codex-app-server') return 'codex';
+  return 'hermes';
+}
+
+export function FleetTable({ rows }: FleetTableProps) {
+  if (rows.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          <p>No agents have usage in this range yet</p>
+          <p className="mt-1 text-xs text-muted-foreground/70">
+            Token usage syncs from <code className="font-mono text-[10px]">~/.claude/projects</code> and{' '}
+            <code className="font-mono text-[10px]">logs/&lt;agent&gt;/codex-tokens.jsonl</code>. Try a longer range.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Agents
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Agent</TableHead>
+              <TableHead>Runtime</TableHead>
+              <TableHead className="text-right">Tokens</TableHead>
+              <TableHead className="text-right">Cost</TableHead>
+              <TableHead className="text-right">Cron runs</TableHead>
+              <TableHead>Trend (14d)</TableHead>
+              <TableHead className="w-8"></TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {rows.map((r) => (
+              <TableRow key={`${r.org}/${r.agent}`}>
+                <TableCell className="font-medium">
+                  <Link
+                    href={`/usage/${encodeURIComponent(r.agent)}`}
+                    className="hover:text-primary"
+                  >
+                    {r.agent}
+                  </Link>
+                  {r.org && (
+                    <span className="ml-2 text-[10px] text-muted-foreground">{r.org}</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Badge variant="outline" className="font-mono text-[10px]">
+                    {runtimeLabel(r.runtime)}
+                  </Badge>
+                  {r.cron_mode === 'print' && (
+                    <Badge variant="ghost" className="ml-1 font-mono text-[10px]">
+                      print
+                    </Badge>
+                  )}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{formatTokens(r.total_tokens)}</TableCell>
+                <TableCell className="text-right tabular-nums">${r.cost_usd.toFixed(2)}</TableCell>
+                <TableCell className="text-right tabular-nums">{r.cron_runs}</TableCell>
+                <TableCell>
+                  {r.sparkline.length > 0 && r.sparkline.some((v) => v > 0) ? (
+                    <SparkLine data={r.sparkline} color={CHART_GOLD} width={100} height={24} />
+                  ) : (
+                    <span className="text-xs text-muted-foreground/50">—</span>
+                  )}
+                </TableCell>
+                <TableCell>
+                  <Link
+                    href={`/usage/${encodeURIComponent(r.agent)}`}
+                    aria-label={`Open ${r.agent} usage`}
+                    className="inline-flex items-center text-muted-foreground hover:text-primary"
+                  >
+                    <IconChevronRight size={14} />
+                  </Link>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dashboard/src/components/usage/range-picker.tsx
+++ b/dashboard/src/components/usage/range-picker.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+export type Range = '1' | '7' | '30' | '90' | 'all';
+
+const OPTIONS: { value: Range; label: string }[] = [
+  { value: '1', label: '24h' },
+  { value: '7', label: '7d' },
+  { value: '30', label: '30d' },
+  { value: '90', label: '90d' },
+  { value: 'all', label: 'All' },
+];
+
+export function RangePicker({
+  value,
+  onChange,
+}: {
+  value: Range;
+  onChange: (next: Range) => void;
+}) {
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Time range"
+      className="inline-flex h-8 items-center gap-0.5 rounded-md border bg-background/50 p-0.5"
+    >
+      {OPTIONS.map((opt) => {
+        const active = opt.value === value;
+        return (
+          <button
+            key={opt.value}
+            type="button"
+            role="radio"
+            aria-checked={active}
+            onClick={() => onChange(opt.value)}
+            className={cn(
+              'rounded px-2.5 py-1 text-xs font-medium transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+              active
+                ? 'bg-primary/10 text-primary'
+                : 'text-muted-foreground hover:bg-muted/50 hover:text-foreground',
+            )}
+          >
+            {opt.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/components/usage/session-list.tsx
+++ b/dashboard/src/components/usage/session-list.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+
+interface SessionRow {
+  source_file: string;
+  session_label: string;
+  started_at: string;
+  ended_at: string;
+  message_count: number;
+  total_tokens: number;
+  cost_usd: number;
+  model: string;
+}
+
+interface SessionListProps {
+  sessions: SessionRow[];
+}
+
+function formatTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}K`;
+  return `${n}`;
+}
+
+function formatRelative(iso: string): string {
+  const ms = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(ms)) return iso;
+  if (ms < 60_000) return 'just now';
+  if (ms < 3_600_000) return `${Math.floor(ms / 60_000)}m ago`;
+  if (ms < 86_400_000) return `${Math.floor(ms / 3_600_000)}h ago`;
+  return `${Math.floor(ms / 86_400_000)}d ago`;
+}
+
+export function SessionList({ sessions }: SessionListProps) {
+  if (sessions.length === 0) {
+    return (
+      <Card>
+        <CardContent className="py-10 text-center text-sm text-muted-foreground">
+          <p>No sessions in this range</p>
+          <p className="mt-1 text-xs text-muted-foreground/70">Sessions appear here as the agent's transcript is parsed.</p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+          Sessions
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Session</TableHead>
+              <TableHead>Model</TableHead>
+              <TableHead>Last active</TableHead>
+              <TableHead className="text-right">Messages</TableHead>
+              <TableHead className="text-right">Tokens</TableHead>
+              <TableHead className="text-right">Cost</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {sessions.map((s) => (
+              <TableRow key={s.source_file}>
+                <TableCell className="max-w-[280px] truncate font-mono text-xs">
+                  {s.session_label}
+                </TableCell>
+                <TableCell className="text-xs text-muted-foreground">{s.model || '—'}</TableCell>
+                <TableCell className="text-xs text-muted-foreground">
+                  {formatRelative(s.ended_at)}
+                </TableCell>
+                <TableCell className="text-right tabular-nums">{s.message_count}</TableCell>
+                <TableCell className="text-right tabular-nums">{formatTokens(s.total_tokens)}</TableCell>
+                <TableCell className="text-right tabular-nums">${s.cost_usd.toFixed(4)}</TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </CardContent>
+    </Card>
+  );
+}

--- a/dashboard/src/lib/cost-parser.ts
+++ b/dashboard/src/lib/cost-parser.ts
@@ -18,7 +18,7 @@ interface ModelPricing {
   cacheReadPerMillion: number;
 }
 
-const MODEL_PRICING: Record<string, ModelPricing> = {
+export const MODEL_PRICING: Record<string, ModelPricing> = {
   opus: { inputPerMillion: 15, outputPerMillion: 75, cacheWritePerMillion: 3.75, cacheReadPerMillion: 1.50 },
   sonnet: { inputPerMillion: 3, outputPerMillion: 15, cacheWritePerMillion: 3.75, cacheReadPerMillion: 0.30 },
   haiku: { inputPerMillion: 0.8, outputPerMillion: 4, cacheWritePerMillion: 1.00, cacheReadPerMillion: 0.08 },
@@ -32,7 +32,7 @@ const MODEL_PRICING: Record<string, ModelPricing> = {
  * opus/sonnet/haiku; gpt-5-codex (and bare "codex" / "gpt-5" variants) map to
  * gpt-5-codex pricing rather than silently defaulting to sonnet.
  */
-function resolvePricingKey(model: string): string {
+export function resolvePricingKey(model: string): string {
   const lower = model.toLowerCase();
   if (lower.includes('opus')) return 'opus';
   if (lower.includes('haiku')) return 'haiku';
@@ -160,9 +160,17 @@ export function scanClaudeProjectsCosts(): CostEntry[] {
 
       const parts = dir.name.split('-');
       const orgsIdx = parts.indexOf('orgs');
-      const orgName = orgsIdx >= 0 && orgsIdx < parts.length - 1
-        ? parts[orgsIdx + 1]
-        : 'default';
+      const agentsIdx = parts.lastIndexOf('agents');
+
+      // Org name lives between 'orgs' and 'agents' in the encoded path. It may
+      // contain hyphens (e.g. "sondre-hq"), so join the slice rather than taking
+      // a single token.
+      let orgName = 'default';
+      if (orgsIdx >= 0 && agentsIdx > orgsIdx + 1) {
+        orgName = parts.slice(orgsIdx + 1, agentsIdx).join('-');
+      } else if (orgsIdx >= 0 && orgsIdx < parts.length - 1) {
+        orgName = parts[orgsIdx + 1];
+      }
 
       // Scope to current instance's orgs — prevent cross-instance bleed
       if (!allowedOrgs.has(orgName)) continue;
@@ -173,7 +181,6 @@ export function scanClaudeProjectsCosts(): CostEntry[] {
       for (const file of files) {
         const filePath = path.join(projectPath, file);
         // Extract agent name from encoded dir path (e.g. "-Users-...-agents-devbot" -> "devbot")
-        const agentsIdx = parts.lastIndexOf('agents');
         const agentName = agentsIdx >= 0 && agentsIdx < parts.length - 1
           ? parts.slice(agentsIdx + 1).join('-')
           : dir.name;

--- a/dashboard/src/lib/db.ts
+++ b/dashboard/src/lib/db.ts
@@ -168,6 +168,13 @@ function initializeSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_cost_entries_timestamp ON cost_entries(timestamp);
     CREATE INDEX IF NOT EXISTS idx_cost_entries_agent ON cost_entries(agent);
     CREATE INDEX IF NOT EXISTS idx_cost_entries_org ON cost_entries(org);
+    -- Remove any pre-existing duplicates before creating the unique index.
+    -- Safe on fresh DBs (no rows to delete). Required on existing DBs where
+    -- syncCosts() may have re-inserted rows before this index existed.
+    DELETE FROM cost_entries WHERE rowid NOT IN (
+      SELECT MIN(rowid) FROM cost_entries
+      GROUP BY timestamp, agent, model, source_file, total_tokens, cost_usd
+    );
     -- Dedup: INSERT OR IGNORE only works when there is a UNIQUE constraint.
     -- Without this, syncCosts() re-inserts every row on every sync, inflating costs.
     CREATE UNIQUE INDEX IF NOT EXISTS idx_cost_entries_dedup

--- a/dashboard/src/lib/db.ts
+++ b/dashboard/src/lib/db.ts
@@ -168,6 +168,10 @@ function initializeSchema(db: Database.Database): void {
     CREATE INDEX IF NOT EXISTS idx_cost_entries_timestamp ON cost_entries(timestamp);
     CREATE INDEX IF NOT EXISTS idx_cost_entries_agent ON cost_entries(agent);
     CREATE INDEX IF NOT EXISTS idx_cost_entries_org ON cost_entries(org);
+    -- Dedup: INSERT OR IGNORE only works when there is a UNIQUE constraint.
+    -- Without this, syncCosts() re-inserts every row on every sync, inflating costs.
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_cost_entries_dedup
+      ON cost_entries(timestamp, agent, model, source_file, total_tokens, cost_usd);
 
     CREATE INDEX IF NOT EXISTS idx_messages_from ON messages(from_agent);
     CREATE INDEX IF NOT EXISTS idx_messages_to ON messages(to_agent);

--- a/dashboard/src/lib/sync.ts
+++ b/dashboard/src/lib/sync.ts
@@ -334,12 +334,12 @@ export function syncAll(): SyncResult {
 // Lazy cost sync (only called from Analytics page)
 // ---------------------------------------------------------------------------
 
-const COST_SYNC_INTERVAL_MS = 5 * 60 * 1000;
+const COST_SYNC_INTERVAL_MS = 15 * 1000;
 
-export function syncCostsLazy(): void {
+export function syncCostsLazy(force = false): void {
   const now = Date.now();
   const lastCostSync = (globalThis as unknown as Record<string, number>).__lastCostSync ?? 0;
-  if (now - lastCostSync > COST_SYNC_INTERVAL_MS) {
+  if (force || now - lastCostSync > COST_SYNC_INTERVAL_MS) {
     try {
       const { syncCosts } = require('./cost-parser');
       const costResult = syncCosts();

--- a/dashboard/src/lib/usage-queries.ts
+++ b/dashboard/src/lib/usage-queries.ts
@@ -1,0 +1,749 @@
+// cortextOS Dashboard - Usage query layer
+// Pure read-only queries over the cost_entries table + cron-execution.log files.
+// No new schemas, no on-disk writes. Reuses cost-parser pricing.
+
+import fs from 'fs';
+import path from 'path';
+import { db } from '@/lib/db';
+import { CTX_ROOT, getAgentDir, getAllAgents } from '@/lib/config';
+import { resolvePricingKey, MODEL_PRICING } from '@/lib/cost-parser';
+import type { AgentRuntime } from '@/lib/types';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RangeDays = 1 | 7 | 30 | 90 | 'all';
+
+export interface UsageTotals {
+  cost_usd: number;
+  input_cost_usd: number;
+  output_cost_usd: number;
+  cache_cost_usd: number;
+  total_tokens: number;
+  input_tokens: number;
+  output_tokens: number;
+  message_count: number;
+}
+
+export interface AgentUsageSummary extends UsageTotals {
+  agent: string;
+  org: string;
+  runtime: AgentRuntime;
+  cron_mode: 'inject' | 'print' | null;
+  cron_runs: number;
+  last_active: string | null;
+}
+
+export interface DailyCostPoint {
+  date: string;
+  cost: number;
+}
+
+export interface DailyCostByModelPoint {
+  date: string;
+  [modelKey: string]: number | string;
+}
+
+export interface SessionRow {
+  source_file: string;
+  session_label: string;
+  started_at: string;
+  ended_at: string;
+  message_count: number;
+  total_tokens: number;
+  cost_usd: number;
+  model: string;
+}
+
+export interface CronRunRow {
+  ts: string;
+  cron: string;
+  status: 'fired' | 'retried' | 'failed';
+  duration_ms: number;
+  error?: string | null;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+  approximate: boolean;
+}
+
+export interface CronAggregateRow {
+  cron: string;
+  runs: number;
+  total_tokens: number;
+  cost_usd: number;
+  last_fire: string;
+  last_status: 'fired' | 'retried' | 'failed';
+  approximate: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+const GRACE_MS = 30_000;
+
+function sinceClause(days: RangeDays): string {
+  if (days === 'all') return '';
+  // SQLite's `-1 days` modifier is valid; this covers the 24h range as well.
+  return ` AND timestamp >= datetime('now', '-${days} days')`;
+}
+
+interface CostBreakdown {
+  input_cost_usd: number;
+  output_cost_usd: number;
+  cache_cost_usd: number;
+}
+
+/**
+ * Compute input/output/cache cost breakdown from per-model token totals.
+ * Cache cost is the residual: total - input - output. This is faithful to how
+ * the parser computed the original cost_usd (sum of all four components), so
+ * the breakdown always reconciles back to the row's total.
+ */
+function breakdownFromRows(
+  rows: Array<{ model: string; input_tokens: number; output_tokens: number; total_cost: number }>,
+): CostBreakdown {
+  let input_cost_usd = 0;
+  let output_cost_usd = 0;
+  let total = 0;
+  for (const r of rows) {
+    const pricing = MODEL_PRICING[resolvePricingKey(r.model)] ?? MODEL_PRICING.sonnet;
+    input_cost_usd += (r.input_tokens / 1_000_000) * pricing.inputPerMillion;
+    output_cost_usd += (r.output_tokens / 1_000_000) * pricing.outputPerMillion;
+    total += r.total_cost;
+  }
+  // Round to 4 decimals so JSON stays compact and UI math doesn't drift
+  input_cost_usd = Math.round(input_cost_usd * 10_000) / 10_000;
+  output_cost_usd = Math.round(output_cost_usd * 10_000) / 10_000;
+  const cache_cost_usd = Math.max(0, Math.round((total - input_cost_usd - output_cost_usd) * 10_000) / 10_000);
+  return { input_cost_usd, output_cost_usd, cache_cost_usd };
+}
+
+function getBreakdownByAgent(days: RangeDays, agent?: string): Map<string, CostBreakdown> {
+  try {
+    const where = agent ? 'WHERE agent = ?' : 'WHERE 1=1';
+    const params = agent ? [agent] : [];
+    const rows = db
+      .prepare(
+        `SELECT agent, model,
+            SUM(input_tokens) AS input_tokens,
+            SUM(output_tokens) AS output_tokens,
+            SUM(cost_usd) AS total_cost
+         FROM cost_entries
+         ${where} ${sinceClause(days)}
+         GROUP BY agent, model`,
+      )
+      .all(...params) as Array<{
+        agent: string;
+        model: string;
+        input_tokens: number;
+        output_tokens: number;
+        total_cost: number;
+      }>;
+
+    const byAgent = new Map<string, Array<typeof rows[number]>>();
+    for (const r of rows) {
+      if (!byAgent.has(r.agent)) byAgent.set(r.agent, []);
+      byAgent.get(r.agent)!.push(r);
+    }
+    const out = new Map<string, CostBreakdown>();
+    for (const [a, rs] of byAgent.entries()) out.set(a, breakdownFromRows(rs));
+    return out;
+  } catch {
+    return new Map();
+  }
+}
+
+function getFleetBreakdown(days: RangeDays): CostBreakdown {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT model,
+            SUM(input_tokens) AS input_tokens,
+            SUM(output_tokens) AS output_tokens,
+            SUM(cost_usd) AS total_cost
+         FROM cost_entries
+         WHERE 1=1 ${sinceClause(days)}
+         GROUP BY model`,
+      )
+      .all() as Array<{
+        model: string;
+        input_tokens: number;
+        output_tokens: number;
+        total_cost: number;
+      }>;
+    return breakdownFromRows(rows);
+  } catch {
+    return { input_cost_usd: 0, output_cost_usd: 0, cache_cost_usd: 0 };
+  }
+}
+
+function readAgentConfig(name: string, org: string): { runtime: AgentRuntime; cron_mode: 'inject' | 'print' | null } {
+  const agentDir = getAgentDir(name, org);
+  try {
+    const raw = fs.readFileSync(path.join(agentDir, 'config.json'), 'utf-8');
+    const cfg = JSON.parse(raw) as { runtime?: string; cron_mode?: string };
+    const runtime: AgentRuntime =
+      cfg.runtime === 'codex-app-server' || cfg.runtime === 'hermes'
+        ? cfg.runtime
+        : 'claude-code';
+    const cron_mode =
+      cfg.cron_mode === 'print' || cfg.cron_mode === 'inject' ? cfg.cron_mode : null;
+    return { runtime, cron_mode };
+  } catch {
+    return { runtime: 'claude-code', cron_mode: null };
+  }
+}
+
+function cronLogPath(agent: string): string {
+  return path.join(CTX_ROOT, '.cortextOS', 'state', 'agents', agent, 'cron-execution.log');
+}
+
+interface RawCronEntry {
+  ts: string;
+  cron: string;
+  status: 'fired' | 'retried' | 'failed';
+  attempt?: number;
+  duration_ms: number;
+  error?: string | null;
+}
+
+function readCronLog(agent: string): RawCronEntry[] {
+  const filePath = cronLogPath(agent);
+  if (!fs.existsSync(filePath)) return [];
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const lines = content.split('\n').filter((l) => l.trim());
+    const entries: RawCronEntry[] = [];
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line) as RawCronEntry;
+        if (parsed.ts && parsed.cron && parsed.status) entries.push(parsed);
+      } catch {
+        // skip malformed
+      }
+    }
+    return entries;
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fleet queries
+// ---------------------------------------------------------------------------
+
+export function getFleetUsageSummary(days: RangeDays = 30): {
+  total_cost_usd: number;
+  input_cost_usd: number;
+  output_cost_usd: number;
+  cache_cost_usd: number;
+  total_tokens: number;
+  agent_count: number;
+  cron_runs: number;
+} {
+  try {
+    const row = db
+      .prepare(
+        `SELECT
+          COALESCE(SUM(cost_usd), 0) as total_cost_usd,
+          COALESCE(SUM(total_tokens), 0) as total_tokens,
+          COUNT(DISTINCT agent) as agent_count
+        FROM cost_entries
+        WHERE 1=1 ${sinceClause(days)}`,
+      )
+      .get() as { total_cost_usd: number; total_tokens: number; agent_count: number };
+
+    // Cron runs: walk every agent's cron log and count entries within range
+    let cronRuns = 0;
+    const cutoffMs =
+      days === 'all' ? 0 : Date.now() - days * 24 * 60 * 60 * 1000;
+    for (const { name } of getAllAgents()) {
+      const entries = readCronLog(name);
+      for (const e of entries) {
+        const t = Date.parse(e.ts);
+        if (Number.isFinite(t) && t >= cutoffMs) cronRuns++;
+      }
+    }
+
+    const breakdown = getFleetBreakdown(days);
+    return { ...row, ...breakdown, cron_runs: cronRuns };
+  } catch {
+    return {
+      total_cost_usd: 0,
+      input_cost_usd: 0,
+      output_cost_usd: 0,
+      cache_cost_usd: 0,
+      total_tokens: 0,
+      agent_count: 0,
+      cron_runs: 0,
+    };
+  }
+}
+
+export function getFleetDailyCostByModel(days: RangeDays = 30): DailyCostByModelPoint[] {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT DATE(timestamp) as date, model, SUM(cost_usd) as cost
+         FROM cost_entries
+         WHERE 1=1 ${sinceClause(days)}
+         GROUP BY DATE(timestamp), model
+         ORDER BY date ASC`,
+      )
+      .all() as Array<{ date: string; model: string; cost: number }>;
+
+    const dateMap = new Map<string, DailyCostByModelPoint>();
+    for (const row of rows) {
+      if (!dateMap.has(row.date)) dateMap.set(row.date, { date: row.date });
+      const entry = dateMap.get(row.date)!;
+      const key = resolvePricingKey(row.model);
+      entry[key] = ((entry[key] as number) ?? 0) + row.cost;
+    }
+    return Array.from(dateMap.values());
+  } catch {
+    return [];
+  }
+}
+
+export function getFleetAgentList(days: RangeDays = 30): AgentUsageSummary[] {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT
+          agent,
+          org,
+          COALESCE(SUM(cost_usd), 0) as cost_usd,
+          COALESCE(SUM(total_tokens), 0) as total_tokens,
+          COALESCE(SUM(input_tokens), 0) as input_tokens,
+          COALESCE(SUM(output_tokens), 0) as output_tokens,
+          COUNT(*) as message_count,
+          MAX(timestamp) as last_active
+        FROM cost_entries
+        WHERE 1=1 ${sinceClause(days)}
+        GROUP BY agent, org
+        ORDER BY cost_usd DESC`,
+      )
+      .all() as Array<{
+        agent: string;
+        org: string;
+        cost_usd: number;
+        total_tokens: number;
+        input_tokens: number;
+        output_tokens: number;
+        message_count: number;
+        last_active: string;
+      }>;
+
+    const cutoffMs =
+      days === 'all' ? 0 : Date.now() - days * 24 * 60 * 60 * 1000;
+    const breakdowns = getBreakdownByAgent(days);
+
+    return rows.map((r) => {
+      const { runtime, cron_mode } = readAgentConfig(r.agent, r.org);
+      const entries = readCronLog(r.agent);
+      const cronRuns = entries.filter((e) => {
+        const t = Date.parse(e.ts);
+        return Number.isFinite(t) && t >= cutoffMs;
+      }).length;
+      const b = breakdowns.get(r.agent) ?? {
+        input_cost_usd: 0,
+        output_cost_usd: 0,
+        cache_cost_usd: 0,
+      };
+      return {
+        agent: r.agent,
+        org: r.org,
+        runtime,
+        cron_mode,
+        cost_usd: r.cost_usd,
+        input_cost_usd: b.input_cost_usd,
+        output_cost_usd: b.output_cost_usd,
+        cache_cost_usd: b.cache_cost_usd,
+        total_tokens: r.total_tokens,
+        input_tokens: r.input_tokens,
+        output_tokens: r.output_tokens,
+        message_count: r.message_count,
+        cron_runs: cronRuns,
+        last_active: r.last_active ?? null,
+      };
+    });
+  } catch {
+    return [];
+  }
+}
+
+export function getAgentSparkline(agent: string, days: number = 14): number[] {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT DATE(timestamp) as date, SUM(cost_usd) as cost
+         FROM cost_entries
+         WHERE agent = ? AND timestamp >= datetime('now', ?)
+         GROUP BY DATE(timestamp)
+         ORDER BY date ASC`,
+      )
+      .all(agent, `-${days} days`) as Array<{ date: string; cost: number }>;
+
+    // Pad to exactly `days` slots (oldest → newest) so sparklines align
+    const today = new Date();
+    today.setUTCHours(0, 0, 0, 0);
+    const out: number[] = [];
+    for (let i = days - 1; i >= 0; i--) {
+      const d = new Date(today.getTime() - i * 24 * 60 * 60 * 1000)
+        .toISOString()
+        .slice(0, 10);
+      const found = rows.find((r) => r.date === d);
+      out.push(found?.cost ?? 0);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Per-agent queries
+// ---------------------------------------------------------------------------
+
+export function getAgentUsageSummary(
+  agent: string,
+  days: RangeDays = 30,
+): AgentUsageSummary | null {
+  try {
+    const row = db
+      .prepare(
+        `SELECT
+          agent,
+          org,
+          COALESCE(SUM(cost_usd), 0) as cost_usd,
+          COALESCE(SUM(total_tokens), 0) as total_tokens,
+          COALESCE(SUM(input_tokens), 0) as input_tokens,
+          COALESCE(SUM(output_tokens), 0) as output_tokens,
+          COUNT(*) as message_count,
+          MAX(timestamp) as last_active
+        FROM cost_entries
+        WHERE agent = ? ${sinceClause(days)}
+        GROUP BY agent, org`,
+      )
+      .get(agent) as
+        | {
+            agent: string;
+            org: string;
+            cost_usd: number;
+            total_tokens: number;
+            input_tokens: number;
+            output_tokens: number;
+            message_count: number;
+            last_active: string;
+          }
+        | undefined;
+
+    // Still return a row with zeros if no cost entries — discover the agent's org
+    if (!row) {
+      const meta = getAllAgents().find((a) => a.name === agent);
+      if (!meta) return null;
+      const { runtime, cron_mode } = readAgentConfig(agent, meta.org);
+      return {
+        agent,
+        org: meta.org,
+        runtime,
+        cron_mode,
+        cost_usd: 0,
+        input_cost_usd: 0,
+        output_cost_usd: 0,
+        cache_cost_usd: 0,
+        total_tokens: 0,
+        input_tokens: 0,
+        output_tokens: 0,
+        message_count: 0,
+        cron_runs: 0,
+        last_active: null,
+      };
+    }
+
+    const { runtime, cron_mode } = readAgentConfig(row.agent, row.org);
+    const cutoffMs =
+      days === 'all' ? 0 : Date.now() - days * 24 * 60 * 60 * 1000;
+    const cronRuns = readCronLog(agent).filter((e) => {
+      const t = Date.parse(e.ts);
+      return Number.isFinite(t) && t >= cutoffMs;
+    }).length;
+    const breakdown = getBreakdownByAgent(days, agent).get(agent) ?? {
+      input_cost_usd: 0,
+      output_cost_usd: 0,
+      cache_cost_usd: 0,
+    };
+
+    return {
+      agent: row.agent,
+      org: row.org,
+      runtime,
+      cron_mode,
+      cost_usd: row.cost_usd,
+      input_cost_usd: breakdown.input_cost_usd,
+      output_cost_usd: breakdown.output_cost_usd,
+      cache_cost_usd: breakdown.cache_cost_usd,
+      total_tokens: row.total_tokens,
+      input_tokens: row.input_tokens,
+      output_tokens: row.output_tokens,
+      message_count: row.message_count,
+      cron_runs: cronRuns,
+      last_active: row.last_active ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function getAgentDailyCost(agent: string, days: RangeDays = 30): DailyCostPoint[] {
+  try {
+    return db
+      .prepare(
+        `SELECT DATE(timestamp) as date, SUM(cost_usd) as cost
+         FROM cost_entries
+         WHERE agent = ? ${sinceClause(days)}
+         GROUP BY DATE(timestamp)
+         ORDER BY date ASC`,
+      )
+      .all(agent) as DailyCostPoint[];
+  } catch {
+    return [];
+  }
+}
+
+export function getAgentDailyCostByModel(
+  agent: string,
+  days: RangeDays = 30,
+): DailyCostByModelPoint[] {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT DATE(timestamp) as date, model, SUM(cost_usd) as cost
+         FROM cost_entries
+         WHERE agent = ? ${sinceClause(days)}
+         GROUP BY DATE(timestamp), model
+         ORDER BY date ASC`,
+      )
+      .all(agent) as Array<{ date: string; model: string; cost: number }>;
+
+    const dateMap = new Map<string, DailyCostByModelPoint>();
+    for (const row of rows) {
+      if (!dateMap.has(row.date)) dateMap.set(row.date, { date: row.date });
+      const entry = dateMap.get(row.date)!;
+      const key = resolvePricingKey(row.model);
+      entry[key] = ((entry[key] as number) ?? 0) + row.cost;
+    }
+    return Array.from(dateMap.values());
+  } catch {
+    return [];
+  }
+}
+
+export function getAgentSessions(
+  agent: string,
+  days: RangeDays = 30,
+  limit: number = 50,
+): SessionRow[] {
+  try {
+    const rows = db
+      .prepare(
+        `SELECT
+          source_file,
+          MIN(timestamp) as started_at,
+          MAX(timestamp) as ended_at,
+          COUNT(*) as message_count,
+          SUM(total_tokens) as total_tokens,
+          SUM(cost_usd) as cost_usd,
+          (
+            SELECT model FROM cost_entries c2
+            WHERE c2.agent = ? AND c2.source_file = c1.source_file
+            ORDER BY c2.timestamp DESC LIMIT 1
+          ) as model
+        FROM cost_entries c1
+        WHERE agent = ? AND source_file IS NOT NULL ${sinceClause(days)}
+        GROUP BY source_file
+        ORDER BY ended_at DESC
+        LIMIT ?`,
+      )
+      .all(agent, agent, limit) as Array<{
+        source_file: string;
+        started_at: string;
+        ended_at: string;
+        message_count: number;
+        total_tokens: number;
+        cost_usd: number;
+        model: string;
+      }>;
+
+    return rows.map((r) => ({
+      source_file: r.source_file,
+      session_label: sessionLabelFromPath(r.source_file),
+      started_at: r.started_at,
+      ended_at: r.ended_at,
+      message_count: r.message_count,
+      total_tokens: r.total_tokens,
+      cost_usd: r.cost_usd,
+      model: r.model ?? '',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function sessionLabelFromPath(filePath: string): string {
+  const base = path.basename(filePath);
+  return base.replace(/\.jsonl$/, '');
+}
+
+// ---------------------------------------------------------------------------
+// Cron attribution — time-window heuristic
+// ---------------------------------------------------------------------------
+
+interface CostRowMin {
+  timestamp: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cost_usd: number;
+}
+
+function fetchCostRowsInWindow(
+  agent: string,
+  windowStart: string,
+  windowEnd: string,
+): CostRowMin[] {
+  try {
+    return db
+      .prepare(
+        `SELECT timestamp, input_tokens, output_tokens, total_tokens, cost_usd
+         FROM cost_entries
+         WHERE agent = ?
+           AND timestamp >= ?
+           AND timestamp <= ?`,
+      )
+      .all(agent, windowStart, windowEnd) as CostRowMin[];
+  } catch {
+    return [];
+  }
+}
+
+function attributeCronRuns(
+  agent: string,
+  entries: RawCronEntry[],
+  approximate: boolean,
+): CronRunRow[] {
+  // Build windows: [ts, ts + duration_ms + GRACE_MS]
+  // De-overlap: if two windows overlap, the earlier one wins (deterministic).
+  const sorted = [...entries].sort((a, b) =>
+    a.ts.localeCompare(b.ts),
+  );
+
+  type Window = {
+    start: number;
+    end: number;
+    entry: RawCronEntry;
+    cost_usd: number;
+    input_tokens: number;
+    output_tokens: number;
+    total_tokens: number;
+  };
+
+  const windows: Window[] = sorted.map((e) => {
+    const start = Date.parse(e.ts);
+    const end = start + (e.duration_ms ?? 0) + GRACE_MS;
+    return {
+      start,
+      end,
+      entry: e,
+      cost_usd: 0,
+      input_tokens: 0,
+      output_tokens: 0,
+      total_tokens: 0,
+    };
+  });
+
+  // For each window, fetch cost rows within. Then dedupe: a cost row can only
+  // belong to the earliest window whose [start, end] contains it.
+  const claimed = new Set<string>(); // key: timestamp + cost_usd
+  for (const w of windows) {
+    const startIso = new Date(w.start).toISOString();
+    const endIso = new Date(w.end).toISOString();
+    const rows = fetchCostRowsInWindow(agent, startIso, endIso);
+    for (const r of rows) {
+      const key = `${r.timestamp}|${r.cost_usd}|${r.total_tokens}`;
+      if (claimed.has(key)) continue;
+      claimed.add(key);
+      w.cost_usd += r.cost_usd;
+      w.input_tokens += r.input_tokens;
+      w.output_tokens += r.output_tokens;
+      w.total_tokens += r.total_tokens;
+    }
+  }
+
+  return windows.map((w) => ({
+    ts: w.entry.ts,
+    cron: w.entry.cron,
+    status: w.entry.status,
+    duration_ms: w.entry.duration_ms ?? 0,
+    error: w.entry.error ?? null,
+    input_tokens: w.input_tokens,
+    output_tokens: w.output_tokens,
+    total_tokens: w.total_tokens,
+    cost_usd: Math.round(w.cost_usd * 1_000_000) / 1_000_000,
+    approximate,
+  }));
+}
+
+export function getAgentCronRuns(
+  agent: string,
+  days: RangeDays = 30,
+  limit: number = 200,
+): CronRunRow[] {
+  const meta = getAllAgents().find((a) => a.name === agent);
+  if (!meta) return [];
+  const { cron_mode } = readAgentConfig(agent, meta.org);
+  const approximate = cron_mode !== 'print'; // print mode is exact; inject is approx; null default = approx
+
+  const cutoffMs = days === 'all' ? 0 : Date.now() - days * 24 * 60 * 60 * 1000;
+  const all = readCronLog(agent).filter((e) => {
+    const t = Date.parse(e.ts);
+    return Number.isFinite(t) && t >= cutoffMs;
+  });
+
+  const attributed = attributeCronRuns(agent, all, approximate);
+  return attributed
+    .sort((a, b) => b.ts.localeCompare(a.ts))
+    .slice(0, limit);
+}
+
+export function getAgentCronAggregates(
+  agent: string,
+  days: RangeDays = 30,
+): CronAggregateRow[] {
+  const runs = getAgentCronRuns(agent, days, 1000);
+  const byName = new Map<string, CronAggregateRow>();
+  for (const r of runs) {
+    const existing = byName.get(r.cron);
+    if (!existing) {
+      byName.set(r.cron, {
+        cron: r.cron,
+        runs: 1,
+        total_tokens: r.total_tokens,
+        cost_usd: r.cost_usd,
+        last_fire: r.ts,
+        last_status: r.status,
+        approximate: r.approximate,
+      });
+    } else {
+      existing.runs += 1;
+      existing.total_tokens += r.total_tokens;
+      existing.cost_usd += r.cost_usd;
+      // r is already in newest-first order; first encounter sets last_fire/status
+    }
+  }
+  return Array.from(byName.values()).sort((a, b) => b.cost_usd - a.cost_usd);
+}


### PR DESCRIPTION
## Summary

Adds a `/usage` dashboard page with per-agent and per-cron token cost attribution, backed by a SQLite usage database.

- **usage page + [agent] page**: fleet-level cost overview and per-agent drill-down with session and cron breakdowns
- **api/usage/fleet + agents/[name] + sessions + crons routes**: query usage data from SQLite db
- **usage components**: fleet-table, agent-summary-cards, agent-cost-chart, agent-model-breakdown, cron-attribution-table, session-list, range-picker
- **usage-queries.ts**: typed query layer over the usage SQLite database
- **cost-parser.ts**: parses Claude API cost from session logs
- **db.ts + sync.ts**: database connection and log sync utilities
- **sidebar.tsx**: adds "Usage" nav item under a new "Other" section

## Test plan

- [ ] Open /usage, confirm fleet cost table shows per-agent totals
- [ ] Click an agent, confirm session list and cron attribution table populate
- [ ] Change date range, confirm data updates
- [ ] Verify cost numbers match Claude API invoice for the period

## Demo video

https://github.com/user-attachments/assets/bea5641d-35f2-430e-a116-2ef43aa7bf1f


