### PR TITLE
feat(cli): cortextos update — opt-in framework update with confirmation

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import { goalsCommand } from './goals.js';
 import { setupCommand } from './setup.js';
 import { spawnWorkerCommand, terminateWorkerCommand, listWorkersCommand, injectWorkerCommand } from './workers.js';
 import { importAgentCommand } from './import-agent.js';
+import { updateCommand } from './update.js';
 
 const program = new Command();
 
@@ -58,6 +59,7 @@ program.addCommand(terminateWorkerCommand);
 program.addCommand(listWorkersCommand);
 program.addCommand(injectWorkerCommand);
 program.addCommand(importAgentCommand);
+program.addCommand(updateCommand);
 
 // crash-alert: SessionEnd hook — cross-platform replacement for crash-alert.sh
 const crashAlertCommand = new Command('crash-alert')

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,128 @@
+/**
+ * `ascendops update` — customer-friendly opt-in update mechanism MVP.
+ *
+ * Wraps the existing `cortextos bus check-upstream` machinery with a
+ * confirmation prompt before applying. Per David's directive (locked
+ * 2026-05): the customer must opt in to each apply; updates do NOT run
+ * automatically. The daily 06:23 ET cron only CHECKS (no --apply); this
+ * command is how the customer hits "yes" when there's something to pull.
+ *
+ * Flow:
+ *   1. Run check-upstream in dry-run mode (--apply NOT set).
+ *   2. Pretty-print the result:
+ *      - up_to_date: print a one-liner, exit 0
+ *      - error: print error + hint, exit 1 (preserves operator awareness)
+ *      - updates_available: print commit count + diff stat, prompt y/N
+ *   3. On y, re-invoke check-upstream with --apply, print result, exit.
+ *   4. On N or anything else, exit 0 without applying.
+ *
+ * Flags:
+ *   --yes / -y       skip the confirmation prompt (for scripted use)
+ *   --check          only check; never apply (alias for the daily cron)
+ */
+import { Command } from 'commander';
+import { createInterface, type Interface } from 'readline';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { checkUpstream } from '../bus/metrics.js';
+
+function rl(): Interface {
+  return createInterface({ input: process.stdin, output: process.stdout });
+}
+
+function ask(iface: Interface, question: string): Promise<string> {
+  return new Promise(resolve => iface.question(question, answer => resolve(answer.trim())));
+}
+
+function findFrameworkRoot(): string {
+  const candidates = [
+    process.env.CTX_FRAMEWORK_ROOT,
+    process.env.CORTEXTOS_DIR,
+    process.env.CTX_PROJECT_ROOT,
+    process.cwd(),
+    join(homedir(), 'cortextos'),
+  ].filter(Boolean) as string[];
+  for (const c of candidates) {
+    if (existsSync(join(c, 'package.json'))) {
+      // Verify it's actually cortextos (not a random package.json).
+      try {
+        const pkg = JSON.parse(require('fs').readFileSync(join(c, 'package.json'), 'utf-8'));
+        if (pkg.name === 'cortextos' || pkg.name === 'ascendops') return c;
+      } catch { /* ignore */ }
+    }
+  }
+  // Fall back to process.cwd anyway — let checkUpstream surface the not-a-repo error.
+  return process.cwd();
+}
+
+interface UpdateOptions {
+  yes?: boolean;
+  check?: boolean;
+}
+
+async function runUpdate(opts: UpdateOptions): Promise<void> {
+  const frameworkRoot = findFrameworkRoot();
+
+  // Step 1: check (no apply).
+  const status = checkUpstream(frameworkRoot, { apply: false }) as any;
+
+  if (status.status === 'error') {
+    console.error(`Error: ${status.error}`);
+    if (status.hint) console.error(`  Hint: ${status.hint}`);
+    process.exit(1);
+  }
+
+  if (status.status === 'up_to_date') {
+    console.log('Already up to date — no upstream changes available.');
+    process.exit(0);
+  }
+
+  // Updates available.
+  const commitCount = status.commitCount ?? '?';
+  const diffStat = status.diffStat || '';
+  console.log('');
+  console.log(`Upstream updates available: ${commitCount} commit(s) behind.`);
+  if (diffStat) console.log(`  ${diffStat}`);
+  console.log('');
+
+  if (opts.check) {
+    console.log('--check mode — exiting without applying.');
+    process.exit(0);
+  }
+
+  let confirmed = !!opts.yes;
+  if (!confirmed) {
+    const iface = rl();
+    try {
+      const answer = await ask(iface, 'Apply the upstream updates now? [y/N]: ');
+      confirmed = answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+    } finally {
+      iface.close();
+    }
+  }
+
+  if (!confirmed) {
+    console.log('Aborted — no updates applied. Re-run when ready.');
+    process.exit(0);
+  }
+
+  console.log('');
+  console.log('Applying upstream updates...');
+  const applied = checkUpstream(frameworkRoot, { apply: true }) as any;
+  console.log(JSON.stringify(applied, null, 2));
+
+  if (applied.status === 'error') {
+    process.exit(1);
+  }
+  if (applied.status === 'applied') {
+    console.log('');
+    console.log('Updates applied. You may need to: cortextos stop && cortextos start');
+  }
+}
+
+export const updateCommand = new Command('update')
+  .description('Check for and (with confirmation) apply framework updates from upstream')
+  .option('-y, --yes', 'Skip the confirmation prompt (apply without asking)')
+  .option('--check', 'Only check — never apply, even with --yes')
+  .action(runUpdate);


### PR DESCRIPTION
## Summary

MVP for the customer-facing framework update command. Wraps the existing `checkUpstream()` in `src/bus/metrics.ts` with a confirmation prompt so a customer can run a one-liner without needing to know the bus subcommand or git internals. Per locked design: updates are **opt-in**, never auto.

```
$ cortextos update            # check + prompt before apply
$ cortextos update --yes      # apply if updates exist, no prompt
$ cortextos update --check    # check only, never apply
```

## Behavior

| Status | Output | Exit |
|---|---|---|
| `up_to_date` | "Already up to date — no upstream changes available." | 0 |
| `error` | Error + hint (e.g. "no upstream remote configured. Hint: Run: git remote add upstream <url>") | 1 |
| `updates_available` + `--check` | Commit count + diff stat + "--check mode — exiting" | 0 |
| `updates_available` + `--yes` | Apply immediately, print result | 0 (if applied) / 1 (if apply errored) |
| `updates_available` + no flag | Print summary + prompt `y/N`, apply on `y`, skip on `N` or anything else | 0 |

## Smoke (live, this repo)

```
$ cortextos update --check
Already up to date — no upstream changes available.
```

(That's the only path exercisable in a clean worktree right now; the
updates_available + apply paths inherit their behavior from
`checkUpstream()` which already has test coverage in the bus metrics
unit suite.)

## Test plan

- [x] `cortextos update --help` lists the command + flags
- [x] `cortextos update --check` returns up_to_date on a clean worktree
- [ ] Unit tests for the prompt + flag-handling logic — deferred to a small follow-up PR (mocking `readline`, `checkUpstream`, and `process.exit` is non-trivial and out of scope for this MVP commit)
- [ ] Customer-friendly `ascendops update` alias — pending once `src/cli/ascendops.ts` lands upstream (currently lives only on the noogalabs fork chain)

## Out of scope

- `ascendops` binary alias (fork-only file today)
- Update-channel selection (e.g. "stable" vs "edge")
- Auto-apply mode (intentionally not built — David's lock: opt-in only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)