### PR TITLE
fix(cli): wire up cortextos update apply path + field-name parity (#421)

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -24,6 +24,7 @@ import { goalsCommand } from './goals.js';
 import { setupCommand } from './setup.js';
 import { spawnWorkerCommand, terminateWorkerCommand, listWorkersCommand, injectWorkerCommand } from './workers.js';
 import { importAgentCommand } from './import-agent.js';
+import { updateCommand } from './update.js';
 
 const program = new Command();
 
@@ -58,6 +59,7 @@ program.addCommand(terminateWorkerCommand);
 program.addCommand(listWorkersCommand);
 program.addCommand(injectWorkerCommand);
 program.addCommand(importAgentCommand);
+program.addCommand(updateCommand);
 
 // crash-alert: SessionEnd hook — cross-platform replacement for crash-alert.sh
 const crashAlertCommand = new Command('crash-alert')

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,5 +1,5 @@
 /**
- * `ascendops update` — customer-friendly opt-in update mechanism MVP.
+ * `cortextos update` — customer-friendly opt-in update mechanism MVP.
  *
  * Wraps the existing `cortextos bus check-upstream` machinery with a
  * confirmation prompt before applying. Per David's directive (locked
@@ -79,8 +79,8 @@ async function runUpdate(opts: UpdateOptions): Promise<void> {
   }
 
   // Updates available.
-  const commitCount = status.commitCount ?? '?';
-  const diffStat = status.diffStat || '';
+  const commitCount = status.commits ?? '?';
+  const diffStat = status.diff_stat || '';
   console.log('');
   console.log(`Upstream updates available: ${commitCount} commit(s) behind.`);
   if (diffStat) console.log(`  ${diffStat}`);
@@ -109,6 +109,10 @@ async function runUpdate(opts: UpdateOptions): Promise<void> {
 
   console.log('');
   console.log('Applying upstream updates...');
+  // checkUpstream's apply path gates on CORTEXTOS_CONFIRM_UPSTREAM_MERGE — the
+  // customer's interactive `y` (or --yes flag) IS that confirmation, so set it
+  // here before calling. Without this, apply short-circuits with a refusal.
+  process.env.CORTEXTOS_CONFIRM_UPSTREAM_MERGE = 'yes';
   const applied = checkUpstream(frameworkRoot, { apply: true }) as any;
   console.log(JSON.stringify(applied, null, 2));
 

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,128 @@
+/**
+ * `ascendops update` — customer-friendly opt-in update mechanism MVP.
+ *
+ * Wraps the existing `cortextos bus check-upstream` machinery with a
+ * confirmation prompt before applying. Per David's directive (locked
+ * 2026-05): the customer must opt in to each apply; updates do NOT run
+ * automatically. The daily 06:23 ET cron only CHECKS (no --apply); this
+ * command is how the customer hits "yes" when there's something to pull.
+ *
+ * Flow:
+ *   1. Run check-upstream in dry-run mode (--apply NOT set).
+ *   2. Pretty-print the result:
+ *      - up_to_date: print a one-liner, exit 0
+ *      - error: print error + hint, exit 1 (preserves operator awareness)
+ *      - updates_available: print commit count + diff stat, prompt y/N
+ *   3. On y, re-invoke check-upstream with --apply, print result, exit.
+ *   4. On N or anything else, exit 0 without applying.
+ *
+ * Flags:
+ *   --yes / -y       skip the confirmation prompt (for scripted use)
+ *   --check          only check; never apply (alias for the daily cron)
+ */
+import { Command } from 'commander';
+import { createInterface, type Interface } from 'readline';
+import { existsSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { checkUpstream } from '../bus/metrics.js';
+
+function rl(): Interface {
+  return createInterface({ input: process.stdin, output: process.stdout });
+}
+
+function ask(iface: Interface, question: string): Promise<string> {
+  return new Promise(resolve => iface.question(question, answer => resolve(answer.trim())));
+}
+
+function findFrameworkRoot(): string {
+  const candidates = [
+    process.env.CTX_FRAMEWORK_ROOT,
+    process.env.CORTEXTOS_DIR,
+    process.env.CTX_PROJECT_ROOT,
+    process.cwd(),
+    join(homedir(), 'cortextos'),
+  ].filter(Boolean) as string[];
+  for (const c of candidates) {
+    if (existsSync(join(c, 'package.json'))) {
+      // Verify it's actually cortextos (not a random package.json).
+      try {
+        const pkg = JSON.parse(require('fs').readFileSync(join(c, 'package.json'), 'utf-8'));
+        if (pkg.name === 'cortextos' || pkg.name === 'ascendops') return c;
+      } catch { /* ignore */ }
+    }
+  }
+  // Fall back to process.cwd anyway — let checkUpstream surface the not-a-repo error.
+  return process.cwd();
+}
+
+interface UpdateOptions {
+  yes?: boolean;
+  check?: boolean;
+}
+
+async function runUpdate(opts: UpdateOptions): Promise<void> {
+  const frameworkRoot = findFrameworkRoot();
+
+  // Step 1: check (no apply).
+  const status = checkUpstream(frameworkRoot, { apply: false }) as any;
+
+  if (status.status === 'error') {
+    console.error(`Error: ${status.error}`);
+    if (status.hint) console.error(`  Hint: ${status.hint}`);
+    process.exit(1);
+  }
+
+  if (status.status === 'up_to_date') {
+    console.log('Already up to date — no upstream changes available.');
+    process.exit(0);
+  }
+
+  // Updates available.
+  const commitCount = status.commitCount ?? '?';
+  const diffStat = status.diffStat || '';
+  console.log('');
+  console.log(`Upstream updates available: ${commitCount} commit(s) behind.`);
+  if (diffStat) console.log(`  ${diffStat}`);
+  console.log('');
+
+  if (opts.check) {
+    console.log('--check mode — exiting without applying.');
+    process.exit(0);
+  }
+
+  let confirmed = !!opts.yes;
+  if (!confirmed) {
+    const iface = rl();
+    try {
+      const answer = await ask(iface, 'Apply the upstream updates now? [y/N]: ');
+      confirmed = answer.toLowerCase() === 'y' || answer.toLowerCase() === 'yes';
+    } finally {
+      iface.close();
+    }
+  }
+
+  if (!confirmed) {
+    console.log('Aborted — no updates applied. Re-run when ready.');
+    process.exit(0);
+  }
+
+  console.log('');
+  console.log('Applying upstream updates...');
+  const applied = checkUpstream(frameworkRoot, { apply: true }) as any;
+  console.log(JSON.stringify(applied, null, 2));
+
+  if (applied.status === 'error') {
+    process.exit(1);
+  }
+  if (applied.status === 'applied') {
+    console.log('');
+    console.log('Updates applied. You may need to: cortextos stop && cortextos start');
+  }
+}
+
+export const updateCommand = new Command('update')
+  .description('Check for and (with confirmation) apply framework updates from upstream')
+  .option('-y, --yes', 'Skip the confirmation prompt (apply without asking)')
+  .option('--check', 'Only check — never apply, even with --yes')
+  .action(runUpdate);


### PR DESCRIPTION
## Summary

Replacement PR for #421 — original work by @noogalabs, co-authored fixes from cortext-designer sandbox review.

Cortext-designer caught three regressions in #421's apply flow that typecheck + build all passed cleanly through:

1. **HIGH**: \`runUpdate()\` called \`checkUpstream(..., { apply: true })\` without first setting \`CORTEXTOS_CONFIRM_UPSTREAM_MERGE='yes'\`. Inner gate at \`metrics.ts:422-428\` short-circuited, returning refusal JSON. Customer's interactive \`y\` (or scripted \`--yes\`) IS the confirmation — wrapper now sets the env var before the apply call.
2. **MED**: \`status.commitCount\` / \`status.diffStat\` were read but \`checkUpstream\` returns \`commits\` / \`diff_stat\`. The 'Upstream updates available: ? commit(s) behind.' line hid scope.
3. **LOW**: JSDoc header said 'ascendops update'; registered binary is 'cortextos update'.

## Test plan

- [x] \`npm run build\` (clean, 98ms)
- [ ] cortext-designer TC3 (interactive \`y\`) — re-running on this HEAD
- [ ] cortext-designer TC4 (\`--yes\` scripted) — re-running on this HEAD
- [ ] cortext-designer TC4b (apply with already-confirmed env) — was the workaround that confirmed root cause

Closes #421.

Co-Authored-By: noogalabs <noogalabs@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)