### PR TITLE
feat(telegram): add CTX_WHISPER_LANG env for transcription language

### DIFF
--- a/src/telegram/transcribe.ts
+++ b/src/telegram/transcribe.ts
@@ -9,6 +9,11 @@
  * Disable entirely with CTX_TELEGRAM_NO_TRANSCRIBE=1.
  * Override binaries / model with CTX_WHISPER_BIN, CTX_FFMPEG_BIN,
  * CTX_WHISPER_MODEL.
+ * Override transcription language with CTX_WHISPER_LANG (passed via
+ * whisper-cli's `-l` flag). Default is 'auto' (auto-detect). Note: `.en`
+ * models (e.g. ggml-tiny.en.bin) are English-only — the lang flag has no
+ * effect there. Use a multilingual model (no `.en` suffix) for non-English
+ * audio.
  */
 import { spawn } from 'child_process';
 import * as fs from 'fs';
@@ -24,6 +29,10 @@ function resolveModelPath(): string {
 
 function resolveBin(envVar: string, fallback: string): string {
   return process.env[envVar] || fallback;
+}
+
+function resolveLang(): string {
+  return process.env.CTX_WHISPER_LANG || 'auto';
 }
 
 export interface TranscribeOptions {
@@ -47,6 +56,7 @@ export async function transcribeVoice(
   const modelPath = opts.modelPath || resolveModelPath();
   const ffmpegBin = resolveBin('CTX_FFMPEG_BIN', 'ffmpeg');
   const whisperBin = resolveBin('CTX_WHISPER_BIN', 'whisper-cli');
+  const lang = resolveLang();
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
   if (!fs.existsSync(modelPath)) {
@@ -68,7 +78,7 @@ export async function transcribeVoice(
   try {
     const whisper = await runProcess(
       whisperBin,
-      ['-m', modelPath, '-f', wavPath, '-nt', '-np'],
+      ['-m', modelPath, '-f', wavPath, '-l', lang, '-nt', '-np'],
       timeoutMs,
       true,
     );


### PR DESCRIPTION
Closes #427.

## Summary

Adds a `CTX_WHISPER_LANG` env var (default `auto`) that is forwarded to `whisper-cli` via its `-l` flag, so operators can pin the transcription language for Telegram voice notes.

## Motivation

Today `transcribeVoice` calls whisper-cli without `-l`. On multilingual models that yields auto-detection (often wrong on short / mixed-language utterances); on `.en` models the call is implicitly English-only. There is no way to pin the language short of replacing the binary.

Concrete case: cortextos running in a German Telegram setup transcribes German voice notes as nonsense English when the default `.en` model is in place, and is brittle even with a multilingual model. The fix is to pin the language — but the framework offers no knob.

## Change

- New helper \`resolveLang()\` returning \`process.env.CTX_WHISPER_LANG || 'auto'\`.
- Whisper invocation extended from \`-m … -f … -nt -np\` to \`-m … -f … -l \$lang -nt -np\`.
- JSDoc header updated to document the new env var and the \`.en\`-model caveat.

Total change: 11 added / 1 removed in \`src/telegram/transcribe.ts\`. No new dependencies, no other files touched.

## Backwards compatibility

Non-breaking:

- Default \`auto\` reproduces today's behaviour for multilingual models.
- \`.en\` models continue to ignore the flag (whisper.cpp's documented behaviour: language flag is no-op for English-only models).
- No change to default model selection in \`scripts/install-whisper-model.sh\`.

## Tests

\`tests/unit/telegram/transcribe.test.ts\` already covers the null-fallback paths and still passes (7/7). Happy to add a mock-binary test asserting that \`-l\` reaches whisper-cli if you'd prefer that in the same PR.

\`\`\`
$ npx vitest run tests/unit/telegram/transcribe.test.ts
 Test Files  1 passed (1)
      Tests  7 passed (7)
\`\`\`

\`npx tsc --noEmit\` is clean.

## Test plan

- [x] Existing transcribe tests pass
- [x] Typecheck clean
- [ ] Manual: voice note with multilingual model + \`CTX_WHISPER_LANG=de\` returns German transcript
- [ ] Manual: unset \`CTX_WHISPER_LANG\` reproduces previous behaviour