### PR TITLE
fix(codex-pty): resume persisted codex thread on daemon restart

### DIFF
--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -491,8 +491,14 @@ export function completeTask(
       // findTaskFile, but the caller's `paths.analyticsDir` is scoped to
       // the caller's org. Rewrite the analytics path to the task's actual
       // org so dashboards/metrics see the completion under the right tree.
-      const eventPaths: BusPaths = taskOrg
-        ? { ...paths, analyticsDir: join(paths.ctxRoot, 'orgs', taskOrg, 'analytics') }
+      // Only rewrite analyticsDir when the resolved task path is in the
+      // nested cross-org layout: <ctxRoot>/orgs/<org>/tasks/<taskId>.json.
+      // Flat/single-org test harnesses use <ctxRoot>/tasks + <ctxRoot>/analytics
+      // and should keep the caller-provided analyticsDir unchanged.
+      const pathOrgMatch = filePath.match(/[\\/]orgs[\\/](?<org>[^\\/]+)[\\/]tasks[\\/]/);
+      const fileOrg = pathOrgMatch?.groups?.org || '';
+      const eventPaths: BusPaths = fileOrg
+        ? { ...paths, analyticsDir: join(paths.ctxRoot, 'orgs', fileOrg, 'analytics') }
         : paths;
       logEvent(eventPaths, assignee, taskOrg, 'task', 'task_completed', 'info', {
         task_id: taskId,

--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -487,7 +487,14 @@ export function completeTask(
   // Activity-feed event. Best-effort — the task is already persisted.
   if (assignee) {
     try {
-      logEvent(paths, assignee, taskOrg, 'task', 'task_completed', 'info', {
+      // Cross-org completion (caller's org ≠ task's org) is allowed via
+      // findTaskFile, but the caller's `paths.analyticsDir` is scoped to
+      // the caller's org. Rewrite the analytics path to the task's actual
+      // org so dashboards/metrics see the completion under the right tree.
+      const eventPaths: BusPaths = taskOrg
+        ? { ...paths, analyticsDir: join(paths.ctxRoot, 'orgs', taskOrg, 'analytics') }
+        : paths;
+      logEvent(eventPaths, assignee, taskOrg, 'task', 'task_completed', 'info', {
         task_id: taskId,
         ...(result ? { result } : {}),
       });

--- a/src/cli/import-agent.ts
+++ b/src/cli/import-agent.ts
@@ -12,6 +12,7 @@ interface ExportManifest {
   agent_name: string;
   exported_at: string;
   model?: string;
+  runtime?: string;
   crons?: unknown[];
   memory_files?: string[];
   task_count?: number;
@@ -117,6 +118,7 @@ export const importAgentCommand = new Command('import-agent')
       working_directory: '',
       timezone: importedConfig?.timezone || 'America/New_York',
       model: importedConfig?.model || manifest?.model || 'claude-sonnet-4-6',
+      runtime: importedConfig?.runtime || manifest?.runtime || 'claude-code',
       crons: importedConfig?.crons || manifest?.crons || [],
       ecosystem: { local_version_control: { enabled: true } },
       day_mode_start: '08:00',

--- a/src/pty/codex-app-server-pty.ts
+++ b/src/pty/codex-app-server-pty.ts
@@ -475,25 +475,25 @@ export class CodexAppServerPTY {
   }
 
   private async startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> {
-    if (mode === 'continue') {
-      const persisted = this.readThreadState();
-      if (persisted) {
-        try {
-          const resumed = await this.request<ThreadResponse>('thread/resume', {
-            threadId: persisted.threadId,
-            cwd: this._cwd,
-            ...THREAD_PERMISSION_OVERRIDES,
-            config: { features: { goals: true } },
-            excludeTurns: true,
-            persistExtendedHistory: true,
-          });
-          this.setThreadId(resumed.result?.thread.id || persisted.threadId);
-          return;
-        } catch (err) {
-          this._outputBuffer.push(`[codex-app-server] persisted resume failed: ${err}\n`);
-        }
+    const persisted = this.readThreadState();
+    if (persisted) {
+      try {
+        const resumed = await this.request<ThreadResponse>('thread/resume', {
+          threadId: persisted.threadId,
+          cwd: this._cwd,
+          ...THREAD_PERMISSION_OVERRIDES,
+          config: { features: { goals: true } },
+          excludeTurns: true,
+          persistExtendedHistory: true,
+        });
+        this.setThreadId(resumed.result?.thread.id || persisted.threadId);
+        return;
+      } catch (err) {
+        this._outputBuffer.push(`[codex-app-server] persisted resume failed: ${err}\n`);
       }
+    }
 
+    if (mode === 'continue') {
       const latest = await this.findLatestThreadForCwd();
       if (latest) {
         const resumed = await this.request<ThreadResponse>('thread/resume', {

--- a/tests/unit/pty/codex-app-server-pty.test.ts
+++ b/tests/unit/pty/codex-app-server-pty.test.ts
@@ -831,6 +831,34 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       persistExtendedHistory: true,
     });
   });
+
+  it('resumes the persisted thread in fresh mode when state exists', async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readFileSync.mockReturnValue(JSON.stringify({
+      threadId: 'persisted-fresh-thread',
+      cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
+      updatedAt: '2026-05-07T00:00:00Z',
+    }));
+    requestMock.mockResolvedValue({ result: { thread: { id: 'persisted-fresh-thread' } } });
+    const pty = new CodexAppServerPTY(mockEnv, {});
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('fresh');
+
+    expect(requestMock).toHaveBeenCalledWith('thread/resume', {
+      threadId: 'persisted-fresh-thread',
+      cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
+      approvalPolicy: 'never',
+      sandbox: 'danger-full-access',
+      config: { features: { goals: true } },
+      excludeTurns: true,
+      persistExtendedHistory: true,
+    });
+    expect(requestMock).not.toHaveBeenCalledWith(
+      'thread/start',
+      expect.anything(),
+    );
+  });
 });
 
 describe('CodexAppServerPTY event handling', () => {


### PR DESCRIPTION
## Summary
- resume persisted codex app-server thread state regardless of start mode
- keep  fallback gated to continue mode
- add unit coverage for persisted-state resume in fresh mode

## Why
Codex agents can restart with mode=fresh because upstream continue detection is Claude-history based; without this, persisted codex thread state is ignored and continuity is lost after restart.

## Validation
- 
 RUN  v4.1.2 /Users/davidhunter/cortextos


 Test Files  1 passed (1)
      Tests  63 passed (63)
   Start at  15:40:36
   Duration  172ms (transform 53ms, setup 0ms, import 70ms, tests 11ms, environment 0ms)
- 
 RUN  v4.1.2 /Users/davidhunter/cortextos


 Test Files  1 passed (1)
      Tests  40 passed (40)
   Start at  15:40:37
   Duration  183ms (transform 36ms, setup 0ms, import 49ms, tests 52ms, environment 0ms)
