### PR TITLE
fix(daemon): kill false-positive crash detection — no-unlink markers + first-heartbeat clear

### DIFF
--- a/src/bus/heartbeat.ts
+++ b/src/bus/heartbeat.ts
@@ -1,7 +1,37 @@
-import { readdirSync, readFileSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import type { Heartbeat, BusPaths } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+
+/**
+ * SessionEnd-hook end-type markers (see src/hooks/hook-crash-alert.ts). A
+ * restart writes one of these; the crash-alert hook reads it WITHOUT consuming
+ * it, because one restart fires the hook twice and both firings must classify
+ * from the same marker. clearEndMarkers is the marker's primary cleanup: an
+ * agent that is updating its heartbeat is genuinely alive in its post-restart
+ * session — any pending end-marker is therefore stale and is removed here, so
+ * it cannot misclassify a later genuine crash. The hook's own TTL is only the
+ * backstop for a start that fails before ever heartbeating.
+ */
+const END_TYPE_MARKERS = [
+  '.restart-planned',
+  '.session-refresh',
+  '.user-restart',
+  '.user-disable',
+  '.user-stop',
+  '.daemon-crashed',
+  '.daemon-stop',
+];
+
+/** Remove any SessionEnd-hook end-type markers from an agent's state dir. */
+export function clearEndMarkers(stateDir: string): void {
+  for (const file of END_TYPE_MARKERS) {
+    const p = join(stateDir, file);
+    if (existsSync(p)) {
+      try { unlinkSync(p); } catch { /* ignore — best-effort cleanup */ }
+    }
+  }
+}
 
 /**
  * Update heartbeat for the current agent.
@@ -34,6 +64,12 @@ export function updateHeartbeat(
     join(paths.stateDir, 'heartbeat.json'),
     JSON.stringify(heartbeat),
   );
+
+  // The agent is alive in its (post-restart) session — clear any stale
+  // SessionEnd markers so the crash-alert hook cannot misclassify a later
+  // genuine crash as a planned restart. This is the primary marker cleanup;
+  // the hook's TTL is the failed-start backstop.
+  clearEndMarkers(paths.stateDir);
 }
 
 /**

--- a/src/bus/heartbeat.ts
+++ b/src/bus/heartbeat.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, existsSync, unlinkSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, unlinkSync, statSync } from 'fs';
 import { join } from 'path';
 import type { Heartbeat, BusPaths } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
@@ -8,10 +8,10 @@ import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
  * restart writes one of these; the crash-alert hook reads it WITHOUT consuming
  * it, because one restart fires the hook twice and both firings must classify
  * from the same marker. clearEndMarkers is the marker's primary cleanup: an
- * agent that is updating its heartbeat is genuinely alive in its post-restart
- * session — any pending end-marker is therefore stale and is removed here, so
- * it cannot misclassify a later genuine crash. The hook's own TTL is only the
- * backstop for a start that fails before ever heartbeating.
+ * agent updating its heartbeat is genuinely alive in its post-restart session,
+ * so a pending end-marker is stale and is removed here — but only once it is
+ * past the grace window below. The hook's TTL is the backstop for a start that
+ * fails before ever heartbeating.
  */
 const END_TYPE_MARKERS = [
   '.restart-planned',
@@ -23,13 +23,38 @@ const END_TYPE_MARKERS = [
   '.daemon-stop',
 ];
 
-/** Remove any SessionEnd-hook end-type markers from an agent's state dir. */
-export function clearEndMarkers(stateDir: string): void {
+/**
+ * A marker younger than this is left alone by clearEndMarkers — it may belong
+ * to a restart still in flight. The hazard: the post-restart session can reach
+ * its first heartbeat before the dying restart's SECOND SessionEnd firing
+ * lands (firing#2 is typically 13-22s after firing#1, but not hard-bounded).
+ * Without a grace window, that heartbeat would wipe the marker and firing#2
+ * would classify `crash` — the exact false positive this whole change exists
+ * to kill, reintroduced under a narrower window.
+ *
+ * The grace makes that race negligible, not mathematically zero: a firing#2
+ * delayed past 120s under heavy load could still miss the marker. That is the
+ * same bounded residual as the hook's TTL and is accepted. The window is sized
+ * generously on the TTL's cost asymmetry — too tight reopens the FP; too loose
+ * only delays cleanup harmlessly (the heartbeat clears it on a later pass, and
+ * the 300s hook TTL backstops). 120s clears any plausible firing#2 delay while
+ * staying well under the TTL.
+ */
+const MARKER_CLEAR_GRACE_MS = 120_000; // 2 minutes
+
+/**
+ * Remove SessionEnd-hook end-type markers from an agent's state dir, skipping
+ * any marker younger than MARKER_CLEAR_GRACE_MS (an in-flight restart whose
+ * second hook firing may not have landed yet). `nowMs` is injectable for tests.
+ */
+export function clearEndMarkers(stateDir: string, nowMs: number = Date.now()): void {
   for (const file of END_TYPE_MARKERS) {
     const p = join(stateDir, file);
-    if (existsSync(p)) {
-      try { unlinkSync(p); } catch { /* ignore — best-effort cleanup */ }
-    }
+    if (!existsSync(p)) continue;
+    try {
+      if (nowMs - statSync(p).mtimeMs < MARKER_CLEAR_GRACE_MS) continue; // in-flight — leave it
+      unlinkSync(p);
+    } catch { /* ignore — best-effort cleanup */ }
   }
 }
 
@@ -65,10 +90,12 @@ export function updateHeartbeat(
     JSON.stringify(heartbeat),
   );
 
-  // The agent is alive in its (post-restart) session — clear any stale
-  // SessionEnd markers so the crash-alert hook cannot misclassify a later
-  // genuine crash as a planned restart. This is the primary marker cleanup;
-  // the hook's TTL is the failed-start backstop.
+  // The agent is alive in its (post-restart) session — clear stale SessionEnd
+  // markers so the crash-alert hook cannot misclassify a later genuine crash
+  // as a planned restart. Markers inside the grace window are left in place
+  // (an in-flight restart's second hook firing may not have landed); they are
+  // cleared on a later heartbeat. This is the primary marker cleanup; the
+  // hook's TTL is the failed-start backstop.
   clearEndMarkers(paths.stateDir);
 }
 

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -277,6 +277,23 @@ export class AgentProcess {
    */
   async sessionRefresh(): Promise<void> {
     this.log('Session refresh (--continue restart)');
+    // Write .session-refresh marker so the SessionEnd crash-alert hook
+    // (src/hooks/hook-crash-alert.ts) classifies the imminent PTY exit as a
+    // session refresh rather than a crash. The hook's marker handler +
+    // quiet-suppression set + message switch were all wired for this type,
+    // but no writer existed — every --continue rollover at the session-time
+    // cap surfaced as a false-positive 'crash' on chief/analyst + the
+    // crashes.log file.
+    try {
+      const paths = resolvePaths(this.name, this.env.instanceId, this.env.org);
+      writeFileSync(
+        join(paths.stateDir, '.session-refresh'),
+        'session-time-cap rollover\n',
+        'utf-8',
+      );
+    } catch (err) {
+      this.log(`Failed to write .session-refresh marker: ${err}`);
+    }
     await this.stop();
     await this.start();
     this.log('Session refreshed');

--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -149,11 +149,28 @@ function shouldSuppressDedup(stateDir: string, endType: string): boolean {
 }
 
 /**
+ * A restart marker is valid for the hook only while younger than this. A
+ * single restart fires the SessionEnd hook TWICE (~13-22s apart); the marker
+ * must survive both firings. The daemon's first-post-restart heartbeat is the
+ * primary clear (see updateHeartbeat in src/bus/heartbeat.ts). This TTL is
+ * only the BACKSTOP for a failed start that never heartbeats: a marker older
+ * than the TTL is treated as stale, ignored, and lazy-unlinked, so it cannot
+ * misclassify a genuine crash arbitrarily far in the future.
+ *
+ * Sized generously on a deliberate cost asymmetry: a TTL too tight re-exposes
+ * the exact false-positive bug (it would ignore the marker at a slow
+ * firing#2); a TTL too generous only widens the bounded failed-start
+ * false-negative window — which the heartbeat-staleness monitor catches as a
+ * secondary path anyway. 300s clears any plausible firing#2 delay.
+ */
+const MARKER_TTL_MS = 300_000; // 5 minutes
+
+/**
  * Read the hook's stdin JSON payload. Claude Code pipes a JSON object to
  * SessionEnd hooks containing `session_id` (the ending session's id) plus
  * other event fields. Mirrors the stdin-read in hook-context-status.ts.
- * Returns {} on any failure — callers treat a missing session_id as
- * "cannot dedup" and fall through to normal processing (FP-safe).
+ * Returns {} on any failure. The session_id is recorded in crashes.log for
+ * audit; it is not used for classification.
  */
 async function readHookInput(): Promise<{ session_id?: string }> {
   const chunks: Buffer[] = [];
@@ -171,41 +188,49 @@ async function readHookInput(): Promise<{ session_id?: string }> {
 }
 
 /**
- * Dedup a SessionEnd hook firing by session_id.
+ * Classify a SessionEnd from the state markers, returning the marker-derived
+ * end type + reason — WITHOUT consuming the marker.
  *
- * A single restart fires the SessionEnd hook TWICE for the SAME logical
- * session-end (~13-17s apart): once from the dying PTY, once from the next
- * PTY's fresh-launch cleanup. crashes.log writes one line per hook *firing*,
- * so the second firing — which finds no marker (the first consumed it) — is
- * logged as a false `type=crash reason=none`.
+ * Why no-consume: a single restart fires the SessionEnd hook TWICE for one
+ * logical session-end (~13-22s apart) — once from the dying PTY, once from
+ * the next PTY's fresh-launch cleanup. Every restart path writes exactly ONE
+ * hook-recognized marker. The previous code unlinked the marker on the first
+ * firing, so the second firing found nothing and was logged as a false
+ * `type=crash reason=none` — the FP pairs in crashes.log. Leaving the marker
+ * in place lets BOTH firings classify correctly. The marker is cleared by the
+ * daemon's first-post-restart heartbeat (the successor session is genuinely
+ * up by then), with the TTL above as the failed-start backstop.
  *
- * session_id is a hard identity signal: both firings carry the ended
- * session's id; a real crash carries a distinct id. If a SessionEnd for this
- * exact session_id was already processed, this firing is the duplicate and
- * the caller should no-op entirely.
+ * A marker older than MARKER_TTL_MS is treated as stale: ignored (so it
+ * cannot misclassify a later genuine crash) and lazy-unlinked here.
  *
- * Records the session_id on a first sighting BEFORE the caller does any
- * further work, so a mid-processing failure still leaves the duplicate
- * firing suppressible. An empty session_id (older Claude Code, or hook
- * invoked without stdin) returns duplicate=false — we cannot dedup, so we
- * fall through to normal processing: a possible FP beats suppressing a
- * possible real crash.
+ * Returns { endType: 'crash' } when no fresh marker is present.
  */
-export function checkAndRecordSession(
+export function classifyFromMarkers(
   stateDir: string,
-  sessionId: string,
-): { duplicate: boolean } {
-  if (!sessionId) return { duplicate: false };
-  const lastSessionFile = join(stateDir, '.crash_last_session');
-  let lastSession = '';
-  try {
-    lastSession = readFileSync(lastSessionFile, 'utf-8').trim();
-  } catch { /* no prior session recorded */ }
-  if (lastSession === sessionId) return { duplicate: true };
-  try {
-    writeFileSync(lastSessionFile, sessionId, 'utf-8');
-  } catch { /* ignore — worst case the duplicate firing is not suppressed */ }
-  return { duplicate: false };
+  markers: { file: string; type: string }[],
+  nowMs: number = Date.now(),
+): { endType: string; reason: string } {
+  for (const marker of markers) {
+    const markerPath = join(stateDir, marker.file);
+    if (!existsSync(markerPath)) continue;
+    let ageMs = 0;
+    try {
+      ageMs = nowMs - statSync(markerPath).mtimeMs;
+    } catch { /* unreadable mtime — treat as fresh, fall through to classify */ }
+    if (ageMs > MARKER_TTL_MS) {
+      // Stale: the first-heartbeat clear evidently never fired (failed
+      // start). Do not classify from it — lazy-unlink and keep looking.
+      try { unlinkSync(markerPath); } catch { /* ignore */ }
+      continue;
+    }
+    let reason = '';
+    try {
+      reason = readFileSync(markerPath, 'utf-8').trim();
+    } catch { /* ignore */ }
+    return { endType: marker.type, reason };
+  }
+  return { endType: 'crash', reason: '' };
 }
 
 async function main(): Promise<void> {
@@ -220,20 +245,16 @@ async function main(): Promise<void> {
   mkdirSync(stateDir, { recursive: true });
   mkdirSync(logDir, { recursive: true });
 
-  // Dedup by session_id — see checkAndRecordSession. The duplicate firing of
-  // a restart no-ops here: no crashes.log line, no alert, no crash-count
-  // increment. A real crash always carries a new id and is always processed.
+  // session_id is recorded in crashes.log for audit only — not used to
+  // classify. (An earlier iteration deduped firings by session_id; that was
+  // wrong — the two firings of one restart carry DIFFERENT session_ids, one
+  // real session + one ephemeral. The fix is marker-handling, not id-dedup.)
   const hookInput = await readHookInput();
   const sessionId = typeof hookInput.session_id === 'string' ? hookInput.session_id : '';
-  if (checkAndRecordSession(stateDir, sessionId).duplicate) {
-    return;
-  }
 
-  // Determine end type from state markers (written by other parts of the system
-  // before the Claude Code session exits).
-  let endType = 'crash';
-  let reason = '';
-
+  // Determine end type from state markers (written by other parts of the
+  // system before the Claude Code session exits). Markers are NOT consumed
+  // here — see classifyFromMarkers for why (restart fires this hook twice).
   const markers = [
     { file: '.restart-planned', type: 'planned-restart' },
     { file: '.session-refresh', type: 'session-refresh' },
@@ -247,17 +268,9 @@ async function main(): Promise<void> {
     { file: '.daemon-stop', type: 'daemon-stop' },
   ];
 
-  for (const marker of markers) {
-    const markerPath = join(stateDir, marker.file);
-    if (existsSync(markerPath)) {
-      endType = marker.type;
-      try {
-        reason = readFileSync(markerPath, 'utf-8').trim();
-        unlinkSync(markerPath);
-      } catch { /* ignore */ }
-      break;
-    }
-  }
+  const classified = classifyFromMarkers(stateDir, markers);
+  let endType = classified.endType;
+  let reason = classified.reason;
 
   // If no marker matched but the stdout tail shows a rate-limit signature,
   // reclassify as rate-limited. Prevents the 30-minute 🚨 CRASH buzz storm

--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -148,6 +148,66 @@ function shouldSuppressDedup(stateDir: string, endType: string): boolean {
   return false;
 }
 
+/**
+ * Read the hook's stdin JSON payload. Claude Code pipes a JSON object to
+ * SessionEnd hooks containing `session_id` (the ending session's id) plus
+ * other event fields. Mirrors the stdin-read in hook-context-status.ts.
+ * Returns {} on any failure — callers treat a missing session_id as
+ * "cannot dedup" and fall through to normal processing (FP-safe).
+ */
+async function readHookInput(): Promise<{ session_id?: string }> {
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve) => {
+    process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
+    process.stdin.on('end', resolve);
+    process.stdin.on('error', resolve);
+    setTimeout(resolve, 1500); // don't block forever
+  });
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Dedup a SessionEnd hook firing by session_id.
+ *
+ * A single restart fires the SessionEnd hook TWICE for the SAME logical
+ * session-end (~13-17s apart): once from the dying PTY, once from the next
+ * PTY's fresh-launch cleanup. crashes.log writes one line per hook *firing*,
+ * so the second firing — which finds no marker (the first consumed it) — is
+ * logged as a false `type=crash reason=none`.
+ *
+ * session_id is a hard identity signal: both firings carry the ended
+ * session's id; a real crash carries a distinct id. If a SessionEnd for this
+ * exact session_id was already processed, this firing is the duplicate and
+ * the caller should no-op entirely.
+ *
+ * Records the session_id on a first sighting BEFORE the caller does any
+ * further work, so a mid-processing failure still leaves the duplicate
+ * firing suppressible. An empty session_id (older Claude Code, or hook
+ * invoked without stdin) returns duplicate=false — we cannot dedup, so we
+ * fall through to normal processing: a possible FP beats suppressing a
+ * possible real crash.
+ */
+export function checkAndRecordSession(
+  stateDir: string,
+  sessionId: string,
+): { duplicate: boolean } {
+  if (!sessionId) return { duplicate: false };
+  const lastSessionFile = join(stateDir, '.crash_last_session');
+  let lastSession = '';
+  try {
+    lastSession = readFileSync(lastSessionFile, 'utf-8').trim();
+  } catch { /* no prior session recorded */ }
+  if (lastSession === sessionId) return { duplicate: true };
+  try {
+    writeFileSync(lastSessionFile, sessionId, 'utf-8');
+  } catch { /* ignore — worst case the duplicate firing is not suppressed */ }
+  return { duplicate: false };
+}
+
 async function main(): Promise<void> {
   const agentName = process.env.CTX_AGENT_NAME;
   const instanceId = process.env.CTX_INSTANCE_ID || 'default';
@@ -159,6 +219,15 @@ async function main(): Promise<void> {
 
   mkdirSync(stateDir, { recursive: true });
   mkdirSync(logDir, { recursive: true });
+
+  // Dedup by session_id — see checkAndRecordSession. The duplicate firing of
+  // a restart no-ops here: no crashes.log line, no alert, no crash-count
+  // increment. A real crash always carries a new id and is always processed.
+  const hookInput = await readHookInput();
+  const sessionId = typeof hookInput.session_id === 'string' ? hookInput.session_id : '';
+  if (checkAndRecordSession(stateDir, sessionId).duplicate) {
+    return;
+  }
 
   // Determine end type from state markers (written by other parts of the system
   // before the Claude Code session exits).
@@ -235,8 +304,11 @@ async function main(): Promise<void> {
   } catch { /* ignore */ }
 
   // Always log to crashes.log — we want visibility even when alerts are muted.
+  // session_id is recorded so the session_id dedup above is auditable after
+  // the fact: a duplicate-firing FP, if one ever slips through, is provable
+  // by two crashes.log lines sharing a session value.
   const timestamp = new Date().toISOString();
-  const logLine = `${timestamp} type=${endType} reason=${reason || 'none'} last_task=${lastTask}\n`;
+  const logLine = `${timestamp} type=${endType} reason=${reason || 'none'} session=${sessionId || 'unknown'} last_task=${lastTask}\n`;
   try {
     appendFileSync(join(logDir, 'crashes.log'), logLine);
   } catch { /* ignore */ }

--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -149,19 +149,24 @@ function shouldSuppressDedup(stateDir: string, endType: string): boolean {
 }
 
 /**
- * A restart marker is valid for the hook only while younger than this. A
- * single restart fires the SessionEnd hook TWICE (~13-22s apart); the marker
- * must survive both firings. The daemon's first-post-restart heartbeat is the
- * primary clear (see updateHeartbeat in src/bus/heartbeat.ts). This TTL is
- * only the BACKSTOP for a failed start that never heartbeats: a marker older
- * than the TTL is treated as stale, ignored, and lazy-unlinked, so it cannot
- * misclassify a genuine crash arbitrarily far in the future.
+ * A restart marker is valid for the hook only while younger than this. The TTL
+ * budget runs from when the marker is WRITTEN — which is inside sessionRefresh
+ * BEFORE `await stop()` — to the LAST hook firing it must still classify, i.e.
+ * firing#2. So the budget must cover: stop()'s PTY-exit wait + the inter-firing
+ * gap. The inter-firing gap is ~13-22s typical; stop() is normally fast but is
+ * NOT bounded — BUG-011 exists precisely because PTY exit can hang. 300s is
+ * sized to absorb a slow stop() on top of the firing gap, not just the gap.
  *
- * Sized generously on a deliberate cost asymmetry: a TTL too tight re-exposes
- * the exact false-positive bug (it would ignore the marker at a slow
- * firing#2); a TTL too generous only widens the bounded failed-start
- * false-negative window — which the heartbeat-staleness monitor catches as a
- * secondary path anyway. 300s clears any plausible firing#2 delay.
+ * The daemon's post-restart heartbeat is the primary clear (see updateHeartbeat
+ * in src/bus/heartbeat.ts). This TTL is the BACKSTOP for a failed start that
+ * never heartbeats: a marker older than the TTL is treated as stale, ignored,
+ * and lazy-unlinked, so it cannot misclassify a genuine crash arbitrarily far
+ * in the future.
+ *
+ * Sized on a deliberate cost asymmetry: a TTL too tight re-exposes the exact
+ * false-positive bug (it would ignore the marker at a slow firing#2); a TTL too
+ * generous only widens the bounded failed-start false-negative window — which
+ * the heartbeat-staleness monitor catches as a secondary path anyway.
  */
 const MARKER_TTL_MS = 300_000; // 5 minutes
 
@@ -175,10 +180,15 @@ const MARKER_TTL_MS = 300_000; // 5 minutes
 async function readHookInput(): Promise<{ session_id?: string }> {
   const chunks: Buffer[] = [];
   await new Promise<void>((resolve) => {
+    // Fallback so a stdin that never ends can't hang the hook. unref()'d and
+    // cleared on a clean end/error so the timer never keeps the process alive
+    // past its work — without this the hook lingers up to 1.5s after it is done.
+    const timer = setTimeout(resolve, 1500);
+    timer.unref?.();
+    const finish = () => { clearTimeout(timer); resolve(); };
     process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
-    process.stdin.on('end', resolve);
-    process.stdin.on('error', resolve);
-    setTimeout(resolve, 1500); // don't block forever
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
   });
   try {
     return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
@@ -317,9 +327,10 @@ async function main(): Promise<void> {
   } catch { /* ignore */ }
 
   // Always log to crashes.log — we want visibility even when alerts are muted.
-  // session_id is recorded so the session_id dedup above is auditable after
-  // the fact: a duplicate-firing FP, if one ever slips through, is provable
-  // by two crashes.log lines sharing a session value.
+  // session_id is recorded purely for audit (there is no session_id dedup —
+  // an earlier iteration tried that and it was removed). If a duplicate-firing
+  // FP ever slips through, two crashes.log lines sharing a session value make
+  // it provable after the fact.
   const timestamp = new Date().toISOString();
   const logLine = `${timestamp} type=${endType} reason=${reason || 'none'} session=${sessionId || 'unknown'} last_task=${lastTask}\n`;
   try {

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -253,17 +253,21 @@ describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
     const ap = new AgentProcess('alice', mockEnv, {});
     await ap.start();
 
-    vi.spyOn(ap, 'stop').mockResolvedValue();
+    const stopSpy = vi.spyOn(ap, 'stop').mockResolvedValue();
     vi.spyOn(ap, 'start').mockResolvedValue();
     fsMocks.writeFileSync.mockReset();
 
     await ap.sessionRefresh();
 
-    const sessionRefreshWrites = fsMocks.writeFileSync.mock.calls.filter(
+    const writeIdx = fsMocks.writeFileSync.mock.calls.findIndex(
       (call) => String(call[0]).endsWith('.session-refresh'),
     );
-    expect(sessionRefreshWrites).toHaveLength(1);
-    expect(String(sessionRefreshWrites[0][0])).toBe('/tmp/test-ctx/state/alice/.session-refresh');
+    expect(writeIdx).toBeGreaterThanOrEqual(0);
+    expect(String(fsMocks.writeFileSync.mock.calls[writeIdx][0])).toBe('/tmp/test-ctx/state/alice/.session-refresh');
+    // The marker must be written BEFORE stop() — a SessionEnd hook firing as
+    // the PTY dies must already see the marker, or it classifies a false crash.
+    const markerWriteOrder = fsMocks.writeFileSync.mock.invocationCallOrder[writeIdx];
+    expect(markerWriteOrder).toBeLessThan(stopSpy.mock.invocationCallOrder[0]);
   });
 });
 

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../../src/bus/reminders.js', () => ({
 }));
 
 vi.mock('../../../src/utils/paths.js', () => ({
-  resolvePaths: vi.fn().mockReturnValue({}),
+  resolvePaths: vi.fn().mockReturnValue({ stateDir: '/tmp/test-ctx/state/alice' }),
 }));
 
 const fsMocks = {
@@ -247,6 +247,23 @@ describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
     const stopOrder = stopSpy.mock.invocationCallOrder[0];
     const startOrder = startSpy.mock.invocationCallOrder[0];
     expect(stopOrder).toBeLessThan(startOrder);
+  });
+
+  it('sessionRefresh() writes .session-refresh marker before stop (false-crash FP fix)', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    vi.spyOn(ap, 'stop').mockResolvedValue();
+    vi.spyOn(ap, 'start').mockResolvedValue();
+    fsMocks.writeFileSync.mockReset();
+
+    await ap.sessionRefresh();
+
+    const sessionRefreshWrites = fsMocks.writeFileSync.mock.calls.filter(
+      (call) => String(call[0]).endsWith('.session-refresh'),
+    );
+    expect(sessionRefreshWrites).toHaveLength(1);
+    expect(String(sessionRefreshWrites[0][0])).toBe('/tmp/test-ctx/state/alice/.session-refresh');
   });
 });
 

--- a/tests/unit/hooks/hook-crash-alert.test.ts
+++ b/tests/unit/hooks/hook-crash-alert.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -8,7 +8,8 @@ vi.mock('child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
 
-import { readMaxCrashesPerDay, notifyAgents, checkAndRecordSession } from '../../../src/hooks/hook-crash-alert';
+import { readMaxCrashesPerDay, notifyAgents, classifyFromMarkers } from '../../../src/hooks/hook-crash-alert';
+import { clearEndMarkers } from '../../../src/bus/heartbeat';
 
 describe('readMaxCrashesPerDay', () => {
   let tmp: string;
@@ -146,42 +147,84 @@ describe('notifyAgents', () => {
   });
 });
 
-describe('checkAndRecordSession', () => {
+describe('classifyFromMarkers', () => {
   let tmp: string;
+  const MARKERS = [
+    { file: '.restart-planned', type: 'planned-restart' },
+    { file: '.session-refresh', type: 'session-refresh' },
+    { file: '.user-restart', type: 'user-restart' },
+    { file: '.user-stop', type: 'user-stop' },
+  ];
 
   beforeEach(() => {
-    tmp = mkdtempSync(join(tmpdir(), 'crashalert-session-'));
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-markers-'));
   });
 
   afterEach(() => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it('first sighting of a session_id is not a duplicate', () => {
-    expect(checkAndRecordSession(tmp, 'sess-aaa').duplicate).toBe(false);
+  it('no marker present → endType crash', () => {
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('crash');
   });
 
-  it('second firing for the SAME session_id is a duplicate', () => {
-    // First firing — the dying PTY's SessionEnd.
-    expect(checkAndRecordSession(tmp, 'sess-aaa').duplicate).toBe(false);
-    // Second firing — the next PTY's fresh-launch cleanup, same session-end.
-    expect(checkAndRecordSession(tmp, 'sess-aaa').duplicate).toBe(true);
+  it('fresh marker → classified by type, with its reason', () => {
+    writeFileSync(join(tmp, '.restart-planned'), 'planned reboot', 'utf-8');
+    const r = classifyFromMarkers(tmp, MARKERS);
+    expect(r.endType).toBe('planned-restart');
+    expect(r.reason).toBe('planned reboot');
   });
 
-  it('a new session_id after one was recorded is not a duplicate (real crash path)', () => {
-    checkAndRecordSession(tmp, 'sess-aaa');
-    // A genuine later crash is a different session — must always be processed.
-    expect(checkAndRecordSession(tmp, 'sess-bbb').duplicate).toBe(false);
+  it('does NOT consume the marker — both firings of a restart see it', () => {
+    writeFileSync(join(tmp, '.session-refresh'), 'rollover', 'utf-8');
+    // Firing #1 — the dying PTY's SessionEnd.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh');
+    // Firing #2 — the next PTY's fresh-launch cleanup. Marker must still be
+    // there: this is the FP that the old unlink-on-read code produced.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh');
+    expect(existsSync(join(tmp, '.session-refresh'))).toBe(true);
   });
 
-  it('empty session_id is never a duplicate (cannot dedup → FP-safe fall-through)', () => {
-    expect(checkAndRecordSession(tmp, '').duplicate).toBe(false);
-    // An empty id must not be recorded, so it cannot later swallow a real end.
-    expect(checkAndRecordSession(tmp, '').duplicate).toBe(false);
+  it('marker older than the TTL → treated as stale: ignored AND lazy-unlinked', () => {
+    const markerPath = join(tmp, '.restart-planned');
+    writeFileSync(markerPath, 'stale planned restart', 'utf-8');
+    // Simulate a marker whose first-heartbeat clear never fired (failed
+    // start): classify with a "now" well past the 5-minute TTL.
+    const farFuture = Date.now() + 10 * 60 * 1000;
+    const r = classifyFromMarkers(tmp, MARKERS, farFuture);
+    expect(r.endType).toBe('crash'); // stale marker must NOT mask a real crash
+    expect(existsSync(markerPath)).toBe(false); // lazy-unlinked
   });
 
-  it('records the session_id to .crash_last_session for cross-process dedup', () => {
-    checkAndRecordSession(tmp, 'sess-ccc');
-    expect(readFileSync(join(tmp, '.crash_last_session'), 'utf-8').trim()).toBe('sess-ccc');
+  it('first matching marker wins (precedence order preserved)', () => {
+    writeFileSync(join(tmp, '.restart-planned'), 'planned', 'utf-8');
+    writeFileSync(join(tmp, '.user-stop'), 'stopped', 'utf-8');
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('planned-restart');
+  });
+});
+
+describe('clearEndMarkers (via heartbeat)', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-clear-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('a heartbeat removes every pending end-type marker', () => {
+    for (const f of ['.restart-planned', '.session-refresh', '.user-restart', '.user-stop', '.daemon-stop']) {
+      writeFileSync(join(tmp, f), 'x', 'utf-8');
+    }
+    clearEndMarkers(tmp);
+    for (const f of ['.restart-planned', '.session-refresh', '.user-restart', '.user-stop', '.daemon-stop']) {
+      expect(existsSync(join(tmp, f))).toBe(false);
+    }
+  });
+
+  it('is a no-op when no markers are present', () => {
+    expect(() => clearEndMarkers(tmp)).not.toThrow();
   });
 });

--- a/tests/unit/hooks/hook-crash-alert.test.ts
+++ b/tests/unit/hooks/hook-crash-alert.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -8,7 +8,7 @@ vi.mock('child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
 
-import { readMaxCrashesPerDay, notifyAgents } from '../../../src/hooks/hook-crash-alert';
+import { readMaxCrashesPerDay, notifyAgents, checkAndRecordSession } from '../../../src/hooks/hook-crash-alert';
 
 describe('readMaxCrashesPerDay', () => {
   let tmp: string;
@@ -143,5 +143,45 @@ describe('notifyAgents', () => {
     })).not.toThrow();
     // Second recipient still attempted
     expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('checkAndRecordSession', () => {
+  let tmp: string;
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-session-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('first sighting of a session_id is not a duplicate', () => {
+    expect(checkAndRecordSession(tmp, 'sess-aaa').duplicate).toBe(false);
+  });
+
+  it('second firing for the SAME session_id is a duplicate', () => {
+    // First firing — the dying PTY's SessionEnd.
+    expect(checkAndRecordSession(tmp, 'sess-aaa').duplicate).toBe(false);
+    // Second firing — the next PTY's fresh-launch cleanup, same session-end.
+    expect(checkAndRecordSession(tmp, 'sess-aaa').duplicate).toBe(true);
+  });
+
+  it('a new session_id after one was recorded is not a duplicate (real crash path)', () => {
+    checkAndRecordSession(tmp, 'sess-aaa');
+    // A genuine later crash is a different session — must always be processed.
+    expect(checkAndRecordSession(tmp, 'sess-bbb').duplicate).toBe(false);
+  });
+
+  it('empty session_id is never a duplicate (cannot dedup → FP-safe fall-through)', () => {
+    expect(checkAndRecordSession(tmp, '').duplicate).toBe(false);
+    // An empty id must not be recorded, so it cannot later swallow a real end.
+    expect(checkAndRecordSession(tmp, '').duplicate).toBe(false);
+  });
+
+  it('records the session_id to .crash_last_session for cross-process dedup', () => {
+    checkAndRecordSession(tmp, 'sess-ccc');
+    expect(readFileSync(join(tmp, '.crash_last_session'), 'utf-8').trim()).toBe('sess-ccc');
   });
 });

--- a/tests/unit/hooks/hook-crash-alert.test.ts
+++ b/tests/unit/hooks/hook-crash-alert.test.ts
@@ -205,6 +205,7 @@ describe('classifyFromMarkers', () => {
 
 describe('clearEndMarkers (via heartbeat)', () => {
   let tmp: string;
+  const ALL = ['.restart-planned', '.session-refresh', '.user-restart', '.user-stop', '.daemon-stop'];
 
   beforeEach(() => {
     tmp = mkdtempSync(join(tmpdir(), 'crashalert-clear-'));
@@ -214,17 +215,61 @@ describe('clearEndMarkers (via heartbeat)', () => {
     rmSync(tmp, { recursive: true, force: true });
   });
 
-  it('a heartbeat removes every pending end-type marker', () => {
-    for (const f of ['.restart-planned', '.session-refresh', '.user-restart', '.user-stop', '.daemon-stop']) {
-      writeFileSync(join(tmp, f), 'x', 'utf-8');
-    }
+  it('a post-grace heartbeat removes every pending end-type marker', () => {
+    for (const f of ALL) writeFileSync(join(tmp, f), 'x', 'utf-8');
+    // nowMs well past the grace window — the markers are no longer in-flight.
+    clearEndMarkers(tmp, Date.now() + 10 * 60 * 1000);
+    for (const f of ALL) expect(existsSync(join(tmp, f))).toBe(false);
+  });
+
+  it('leaves a fresh (within-grace) marker in place — an in-flight restart', () => {
+    for (const f of ALL) writeFileSync(join(tmp, f), 'x', 'utf-8');
+    // nowMs ≈ marker mtime → every marker is within the grace window.
     clearEndMarkers(tmp);
-    for (const f of ['.restart-planned', '.session-refresh', '.user-restart', '.user-stop', '.daemon-stop']) {
-      expect(existsSync(join(tmp, f))).toBe(false);
-    }
+    for (const f of ALL) expect(existsSync(join(tmp, f))).toBe(true);
   });
 
   it('is a no-op when no markers are present', () => {
     expect(() => clearEndMarkers(tmp)).not.toThrow();
+  });
+});
+
+describe('marker lifecycle (classify → clearEndMarkers → classify)', () => {
+  let tmp: string;
+  const MARKERS = [
+    { file: '.restart-planned', type: 'planned-restart' },
+    { file: '.session-refresh', type: 'session-refresh' },
+    { file: '.user-restart', type: 'user-restart' },
+    { file: '.user-stop', type: 'user-stop' },
+  ];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-lifecycle-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('both restart firings classify, a post-grace heartbeat clears, then a real crash classifies as crash', () => {
+    writeFileSync(join(tmp, '.restart-planned'), 'planned reboot', 'utf-8');
+    // Firing #1 and #2 of the dying restart — both must see the marker.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('planned-restart');
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('planned-restart');
+    // Post-restart session heartbeats past the grace window → marker cleared.
+    clearEndMarkers(tmp, Date.now() + 10 * 60 * 1000);
+    expect(existsSync(join(tmp, '.restart-planned'))).toBe(false);
+    // A genuine crash AFTER the clear must classify as crash — not be masked.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('crash');
+  });
+
+  it('a heartbeat DURING the in-flight restart (within grace) does NOT wipe the marker — firing#2 still classifies', () => {
+    // This is the Finding-1 race: a fast-booting successor heartbeats before
+    // the dying restart's second SessionEnd firing lands.
+    writeFileSync(join(tmp, '.session-refresh'), 'rollover', 'utf-8');
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh'); // firing #1
+    clearEndMarkers(tmp); // successor's first heartbeat — marker still within grace
+    expect(existsSync(join(tmp, '.session-refresh'))).toBe(true);
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh'); // firing #2 — no false crash
   });
 });


### PR DESCRIPTION
## Problem

A restart fires the Claude Code `SessionEnd` hook **twice** for one logical
session-end (~13-22s apart — once from the dying PTY, once from the next PTY's
fresh-launch cleanup). The crash-alert hook consumed (`unlinkSync` + `break`)
**one marker per firing**. Every restart path writes exactly **one**
hook-recognized marker, so firing #1 classified correctly and unlinked it, and
firing #2 found nothing → logged a false `type=crash reason=none`. Those are the
FP pairs in `crashes.log`; the daemon then treated them as real crashes.

It is **marker arithmetic**, not `session_id`: 1 marker consumed per firing, 2
firings, 1 marker supplied. Affected paths (all write 1 marker): `hard-restart`,
`soft-restart`, `soft-restart-all`, `--continue` rollover, `cortextos restart`,
daemon `stopAll`. (`self-restart` writes 2 and never FP'd — which is why an
early self-restart repro didn't reproduce the bug.)

## Fix

Path-agnostic, no time-window in the hot path:

1. **Hook no longer consumes markers** (`classifyFromMarkers` in
   `hook-crash-alert.ts`): reads + classifies, leaves the marker. Both firings —
   and any N firings — now classify identically. This makes the fix **immune to
   Claude Code's actual firing count**, which is the uncertainty that
   disqualified the claim-count candidate.
2. **Daemon clears markers on the first post-restart heartbeat**
   (`clearEndMarkers` in `heartbeat.ts`): an agent updating its heartbeat is
   genuinely alive in its successor session, so any pending marker is stale.
   This is the **primary** cleanup and is ordering-clean (the heartbeat is
   written inside the new session, after both firings).
3. **`MARKER_TTL_MS = 300s` mtime backstop**: covers the one case the heartbeat
   clear can't — a start that fails before ever heartbeating. A marker older
   than the TTL is ignored (so it can't mask a later genuine crash) and
   lazy-unlinked. 300s is sized on a deliberate cost asymmetry: too-tight
   re-exposes the exact FP; too-generous only widens a bounded failed-start FN
   that the heartbeat-staleness monitor catches anyway.

Also keeps the `session=` field in the `crashes.log` line (from `6bd4f92`) for
audit — a duplicate-firing FP, if one ever slips through, stays provable.

### Superseded approach

`6bd4f92` deduped firings by `session_id`. A controlled restart proved the two
firings carry **different** `session_id`s (one real long-lived session, one
ephemeral) — so id-novelty cannot distinguish a duplicate firing from a real
crash. That commit's Part A is replaced here; its Part B (`session=` logging) is
kept.

## Verification

- **Unit** — 19 `hook-crash-alert` tests + 2 `clearEndMarkers` tests: no-consume
  (both firings see the marker), stale-TTL ignore + lazy-unlink, precedence,
  heartbeat clears every marker. Full suite: 1667 passed.
- **End-to-end against the compiled `dist/hooks/hook-crash-alert.js`** — drove
  the real two-firings sequence: planned-restart path (3 firings → 3×
  `planned-restart`, **0 crash**, marker survived), `--continue` rollover /
  `.session-refresh` path (2 firings → 2× `session-refresh`, **0 crash**),
  post-clear genuine crash → correctly `type=crash` (no false negative).

Pre-merge verification is controlled (compiled-artifact + unit). Live-PTY
rollover confirmation is covered-by-mechanism and will be confirmed post-deploy
via fleet telemetry (markers present, no `crashes.log` crash entries).

## Known accepted residual / future hardening

**This PR knowingly accepts one residual.** Any marker-based scheme has an
irreducible false-**negative** window = the restart's firing-span (~30-60s
normal, ~TTL worst case for a failed start) — within that window a genuine crash
could be masked by a still-present restart marker. This is accepted because the
heartbeat-staleness monitor is a secondary detection path for it, and because
the alternative (this PR's status quo) is the far worse false-**positive**
storm.

Driving the FN window to zero needs **process-exit-code classification** (a
clean exit 0 during a known restart vs. a non-zero crash). That is **scoped out
of this PR** and is the designated next hardening step — not a blocker for this
merge.

## CI note

grandamenium CI runs currently complete in `action_required` with **zero jobs
executed** across all recent PRs (org Actions gated/exhausted). This PR is **not
set to auto-merge** — it needs a maintainer to unblock CI and merge manually.



---

## Triangle round-trip — `7f32046` → `3faca36`

Re-review (Walter 5-area + boss-diff) returned YELLOW; this commit closes all 5
findings in one round-trip:

- **F1 (headline race)** — `clearEndMarkers` wiped *all* markers on every
  heartbeat, so a successor that heartbeats before the dying restart's firing#2
  would reintroduce the FP under a narrower window. It now skips markers younger
  than `MARKER_CLEAR_GRACE_MS` (120s) — the in-flight marker survives all
  firings; a later heartbeat clears it; the 300s TTL backstops. Race is now
  negligible, not zero (a firing#2 delayed past the grace reopens it narrowly) —
  same bounded, accepted residual class as the TTL.
- **F4** — added 3-actor lifecycle tests (`classify → clearEndMarkers →
  classify`), including the F1 race; the agent-process test now asserts the
  `.session-refresh` write *precedes* `stop()` via `invocationCallOrder`.
- **F2** — TTL docstring now states the 300s budget covers marker-write →
  firing#2 *including* `stop()`'s PTY-exit wait.
- **F3** — `readHookInput`'s 1.5s fallback timer is `unref()`'d and cleared on
  clean stdin end/error; the hook no longer lingers past its work.
- **F5** — reworded the stale `crashes.log` comment referencing the removed
  `session_id` dedup.
