### PR TITLE
fix(telegram+daemon): suppress local_file in photo + auto-recover image-poison crashes

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -376,7 +376,80 @@ export class AgentProcess {
 
   // --- Private methods ---
 
+  /**
+   * Read the tail of this agent's stdout.log without loading the whole file.
+   * Used by handleExit() to inspect recent output for known-crash signatures
+   * (e.g. the image-poison API 400 pattern) so it can decide whether the
+   * exit is a real crash or a recoverable upstream artifact.
+   *
+   * Returns an empty string if the log doesn't exist or can't be read.
+   */
+  private tailStdoutLog(maxBytes: number): string {
+    const logPath = join(this.env.ctxRoot, 'logs', this.name, 'stdout.log');
+    try {
+      if (!existsSync(logPath)) return '';
+      const stats = statSync(logPath);
+      const start = Math.max(0, stats.size - maxBytes);
+      const len = stats.size - start;
+      // Synchronous read of the tail; small and bounded so the cost is fine
+      // even in the exit handler.
+      const fd = require('fs').openSync(logPath, 'r');
+      try {
+        const buf = Buffer.alloc(len);
+        const read = require('fs').readSync(fd, buf, 0, len, start);
+        return buf.toString('utf-8', 0, read);
+      } finally {
+        require('fs').closeSync(fd);
+      }
+    } catch {
+      return '';
+    }
+  }
+
+  /**
+   * Match the API 400 image-poison signature in recent stdout.
+   *
+   * Two variants observed in Anthropic's Messages API responses:
+   *   `API Error: 400 messages.N.content.M.image.source.base64.data: Image format image/<fmt> not supported`
+   *   `API Error: 400 ... image.source.base64.data: ...`
+   *
+   * Matching the prefix `image.source.base64` is robust to wording changes
+   * in Anthropic's error string; matching `image format image/<fmt>` is the
+   * confirmed exact wording today and gives a second signal. Either is enough.
+   */
+  private detectImagePoisonCrash(recentOutput: string): boolean {
+    if (!recentOutput) return false;
+    if (recentOutput.includes('API Error: 400') && recentOutput.includes('image.source.base64')) {
+      return true;
+    }
+    if (/image format image\/[a-z]+ not supported/i.test(recentOutput)) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   * Write the `.force-fresh` marker that AgentProcess.shouldContinue() reads
+   * on the next start() to force a fresh Claude Code session (no --continue).
+   * Used by the image-poison auto-recovery in handleExit().
+   */
+  private armForceFresh(reason: string): void {
+    try {
+      const stateDir = join(this.env.ctxRoot, 'state', this.name);
+      ensureDir(stateDir);
+      const markerPath = join(stateDir, '.force-fresh');
+      writeFileSync(markerPath, `${new Date().toISOString()} ${reason}\n`, 'utf-8');
+    } catch (err) {
+      this.log(`Failed to arm .force-fresh marker: ${err}`);
+    }
+  }
+
   private handleExit(exitCode: number): void {
+    // Capture last 16KB of the agent's stdout BEFORE nulling pty.
+    // Used by the image-poison auto-recovery check below — reads the log
+    // file so this works even if the PTY buffer has already been GC'd.
+    const recentOutput = this.tailStdoutLog(16384);
+
     this.pty = null;
     this.clearSessionTimer();
 
@@ -417,6 +490,42 @@ export class AgentProcess {
     // awaiting. Either flag short-circuits crash recovery.
     if (this.stopRequested || this.stopping) {
       this.stopRequested = false;
+      return;
+    }
+
+    // Image-poison auto-recovery (companion to PR #446's photo-injection fix).
+    //
+    // Claude Code crashes with `API Error: 400 messages.N.content.M.image.source.base64.data:
+    // Image format image/<fmt> not supported` when conversation history holds a
+    // base64-encoded image whose claimed media_type does not match the actual
+    // bytes. The poison is permanent: every `--continue` restart reloads the
+    // same conversation history and re-hits the same 400, so the agent
+    // crash-loops until it exhausts max_crashes_per_day and the daemon halts.
+    //
+    // PR #446 fixed the source by suppressing the `local_file:` line from
+    // photo injections so Claude Code no longer auto-attaches new images.
+    // That covers FUTURE messages. This block covers agents that ALREADY
+    // have a poisoned context from before the source fix: detect the 400
+    // signature in the recent stdout, write `.force-fresh` so the next start
+    // discards the saved conversation, and respawn WITHOUT charging the
+    // crash counter — the agent didn't malfunction, an old upstream artifact
+    // did.
+    //
+    // Exit is always code 0 in this failure mode (Claude Code surfaces the
+    // 400 to the user then exits cleanly), so we gate on both exit code and
+    // the error signature to avoid false positives that would skip a real
+    // crash counter increment.
+    if (exitCode === 0 && this.detectImagePoisonCrash(recentOutput)) {
+      this.log('Image-poison crash detected (API 400, unsupported image format). Arming .force-fresh and restarting without counting against max_crashes_per_day.');
+      this.armForceFresh('image-poison auto-recovery');
+      this.appendCrashToRestartsLog(exitCode, 5000, 'IMAGE_POISON_RECOVERY');
+      this.status = 'crashed';
+      this.notifyStatusChange();
+      setTimeout(() => {
+        if (this.status === 'crashed') {
+          this.start().catch(err => this.log(`Image-poison restart failed: ${err}`));
+        }
+      }, 5000);
       return;
     }
 
@@ -678,7 +787,7 @@ export class AgentProcess {
   private appendCrashToRestartsLog(
     exitCode: number,
     backoffMs: number,
-    kind: 'CRASH' | 'HALTED',
+    kind: 'CRASH' | 'HALTED' | 'IMAGE_POISON_RECOVERY',
   ): void {
     try {
       const logDir = join(this.env.ctxRoot, 'logs', this.name);
@@ -687,7 +796,9 @@ export class AgentProcess {
       const details =
         kind === 'HALTED'
           ? `exit_code=${exitCode} crash_count=${this.crashCount} max_crashes=${this.maxCrashesPerDay}`
-          : `exit_code=${exitCode} crash_count=${this.crashCount} backoff_s=${backoffMs / 1000}`;
+          : kind === 'IMAGE_POISON_RECOVERY'
+            ? `exit_code=${exitCode} backoff_s=${backoffMs / 1000} (not counted toward max_crashes)`
+            : `exit_code=${exitCode} crash_count=${this.crashCount} backoff_s=${backoffMs / 1000}`;
       const logLine = `[${timestamp}] ${kind}: ${details}\n`;
       appendFileSync(join(logDir, 'restarts.log'), logLine, 'utf-8');
     } catch {

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -303,7 +303,12 @@ ${lastSentCtx}Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
 
   /**
    * Format a Telegram photo message for injection.
-   * Matches bash fast-checker.sh format.
+   *
+   * The raw image path is intentionally NOT injected into the agent message:
+   * claude-code auto-attaches local image files referenced by path in user
+   * input, which triggers `API Error: 400 image/png not supported` and wedges
+   * the session permanently (force-fresh is the only recovery). The file
+   * remains on disk at `imagePath` for a future vision-pre-call to consume.
    */
   static formatTelegramPhotoMessage(
     from: string,
@@ -311,12 +316,15 @@ ${lastSentCtx}Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     caption: string,
     imagePath: string,
   ): string {
+    // imagePath is reserved for a future vision-side-channel that produces a
+    // text description; currently unused here to prevent auto-attach crash.
+    void imagePath;
     return `=== TELEGRAM PHOTO from ${from} (chat_id:${chatId}) ===
 caption:
 \`\`\`
 ${caption}
 \`\`\`
-local_file: ${imagePath}
+[image attached — local path suppressed to prevent claude-code auto-attach crash; vision pre-call not yet wired]
 Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
 
 `;

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -698,7 +698,7 @@ describe('FastChecker', () => {
   });
 
   describe('formatTelegramPhotoMessage', () => {
-    it('formats photo message with caption and local_file', () => {
+    it('formats photo message with caption and a suppressed-path marker', () => {
       const result = FastChecker.formatTelegramPhotoMessage(
         'Alice',
         '123456789',
@@ -709,15 +709,22 @@ describe('FastChecker', () => {
       expect(result).toContain('=== TELEGRAM PHOTO from Alice (chat_id:123456789) ===');
       expect(result).toContain('caption:');
       expect(result).toContain('Check this out');
-      expect(result).toContain('local_file: /tmp/telegram-images/20260403_abc12345678.jpg');
+      expect(result).toContain('[image attached');
       expect(result).toContain("cortextos bus send-telegram 123456789 '<your reply>'");
     });
 
-    it('formats photo message with empty caption', () => {
-      const result = FastChecker.formatTelegramPhotoMessage('Alice', '999', '', '/tmp/photo.jpg');
+    it('does not leak the raw image path (auto-attach crash guard)', () => {
+      const result = FastChecker.formatTelegramPhotoMessage(
+        'Alice',
+        '999',
+        '',
+        '/tmp/telegram-images/20260403_abc12345678.jpg',
+      );
 
       expect(result).toContain('=== TELEGRAM PHOTO from Alice (chat_id:999) ===');
-      expect(result).toContain('local_file: /tmp/photo.jpg');
+      expect(result).not.toContain('/tmp/telegram-images/20260403_abc12345678.jpg');
+      expect(result).not.toContain('.jpg');
+      expect(result).not.toMatch(/local_file:\s*\//);
     });
   });
 


### PR DESCRIPTION
## Summary

Two coupled fixes for the same recurring failure mode: cortextOS agents silently crash-loop when their conversation history contains a poisoned image attachment.

**Source fix** (commit 1 — original PR scope): suppress the `local_file:` path from photo injections in `FastChecker.formatTelegramPhotoMessage`. Without this, Claude Code reads the file Telegram delivered, base64-encodes it for Anthropic with a media_type that doesn't match the bytes, and Anthropic rejects with `API Error: 400 ... image format image/<fmt> not supported`. The agent exits clean (code 0) and the bad reference stays in conversation history, so every `--continue` restart re-crashes.

**Retroactive fix** (commit 2 — new in this update): detect that exact 400 signature in the agent's recent stdout after exit, auto-write `.force-fresh`, and respawn without counting against `max_crashes_per_day`. Closes the gap where agents poisoned BEFORE the source fix shipped will keep crash-looping until they hit the daily limit and the daemon halts them.

## Why both

Real failure mode observed in production:
1. User sends a screenshot via Telegram → agent receives it → injection includes `local_file: /path/to/screenshot.jpg`
2. Claude Code auto-reads the file, base64-encodes it for Anthropic
3. Media-type stamping bug somewhere in the pipeline labels it `image/png` when the bytes don't match
4. Anthropic returns HTTP 400 `image format image/png not supported`
5. Agent exits code 0 (clean)
6. Daemon counts as a crash, restarts with `--continue`
7. Saved conversation history still contains the poisoned base64 → instant re-crash
8. After 3-4 cycles, max_crashes_per_day trips and daemon halts the agent

Source fix alone (commit 1) prevents NEW poisoning. It doesn't help an agent that already has a bad image in saved history — that agent has to be manually `.force-fresh`'d, which an operator can only do if they know to look for the specific 400 signature in logs.

Retroactive fix (commit 2) makes the daemon self-healing for this specific failure mode.

## Changes

### Commit 1 — `fast-checker.ts` (original)
- `formatTelegramPhotoMessage`: replace `local_file: ${imagePath}` with `[image attached — local path suppressed to prevent claude-code auto-attach crash; vision pre-call not yet wired]`
- Note added in source: imagePath stays in the signature for a future vision-side-channel that produces a text description, currently unused

### Commit 2 — `agent-process.ts` (new)
- `handleExit`: read last 16KB of stdout.log via new `tailStdoutLog` helper
- New `detectImagePoisonCrash`: returns true when recent output contains `API Error: 400` + `image.source.base64`, OR the literal `image format image/<fmt> not supported`
- New `armForceFresh`: writes `.force-fresh` marker to state dir
- New path in `handleExit`: when exit code 0 + image-poison signature detected, log `IMAGE_POISON_RECOVERY` and respawn after 5s WITHOUT incrementing `crashCount`
- `appendCrashToRestartsLog` accepts new `IMAGE_POISON_RECOVERY` kind, formatted distinctly so operators can grep for it in audit logs

## Test plan

- [x] Manual: send a problematic screenshot to an agent → confirm new fast-checker injection omits local_file path
- [x] Manual: pre-poison an agent's conversation with a bad image, restart → confirm handleExit detects, arms force-fresh, respawns fresh (no `--continue`), crash count unchanged
- [x] Manual: trigger an unrelated crash (e.g. PTY error) → confirm normal CRASH path still increments counter
- [x] Unit: existing `fast-checker.test.ts` updated for the new format

Tested in production across 9 cortextOS agents that had been collectively hitting this bug 4-6 times per day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)