### PR TITLE
feat(skills): add idea-grooming, business-news-monitor, multi-perspective-grilling

### DIFF
--- a/skills/business-news-monitor/SKILL.md
+++ b/skills/business-news-monitor/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: business-news-monitor
+description: "Daily cron-driven scan of news/forums/social in a domain to surface market shifts, new competitors, regulatory changes, and net-new opportunities. Use when: running a scheduled daily/weekly news pass, or when an idea-grooming pass needs fresh signal. Domain config (sources, keywords, thresholds) lives in agent config."
+---
+
+# Business News Monitor
+
+You scan the domain your agent operates in for **material shifts** that affect the agent's active work — competitor moves, regulatory changes, technology breakthroughs, new entrants, audience-behavior shifts. Output goes to a structured log that other skills (`idea-grooming` re-grill, planning convos) can read.
+
+This is **not a news aggregator**. The output isn't "here are the day's headlines." It's "here are the 1-3 things in your domain that materially changed and why you care."
+
+---
+
+## Inputs (from agent config)
+
+Read your agent's config for the domain overlay:
+
+- `domains: [<list>]` — e.g. `[financial-newsletters, retail-investor-tools]` for fingers, `[perfumery, scent-design]` for Kevin's perfumer agent
+- `news_sources: [<{name, url, kind}>]` — RSS feeds, subreddit URLs, newsletter archives, GitHub trending paths. Each entry has a `kind` (rss / html / subreddit / hn / etc.) so you know how to parse.
+- `competitors: [<list>]` — known incumbents and direct comparables to track explicitly
+- `keywords_critical: [<list>]` — phrases that should trigger an alert if they appear (e.g. "Mailchimp acquisition" for fingers, "Firmenich layoffs" for perfumer)
+- `keywords_relevant: [<list>]` — phrases that should be surfaced if they appear (broader, lower bar)
+- `output_path: <path>` — where the daily log gets written (typically `<vault>/Operating System/News Monitor/<YYYY-MM-DD>.md` or similar)
+
+If domain config is missing, surface the gap to the operator and don't silently produce a generic scan.
+
+---
+
+## Output rubric
+
+Every run produces ONE markdown file at `<output_path>/<YYYY-MM-DD>.md` with this shape:
+
+```markdown
+---
+date: YYYY-MM-DD
+domains: [<from config>]
+sources_scanned: <N>
+items_seen: <N>
+items_kept: <N>
+materiality_threshold: medium
+---
+
+# Domain news monitor — <date>
+
+## Material shifts (the only section the operator NEEDS to read)
+
+For each material item (cap at 5 — discipline matters):
+
+### <One-line headline of the shift>
+
+- **What changed:** 1-2 sentences, plain language
+- **Why we care:** how it affects active work / pursue ideas / current strategy
+- **Source:** <link>, <publication>, <date>
+- **Confidence:** high | medium | low (how solid the signal is)
+- **Suggested action:** flag a re-grill on idea X / update positioning / no action / investigate further
+
+## Surface (interesting, not material)
+
+Bullet list. 3-10 items. Headlines + 1-line takeaway each. No expansion. These are FYI, not action triggers.
+
+## Quiet today
+
+If the scan found nothing material, say so explicitly. "Quiet today" is a valid output. Do NOT manufacture materiality to fill the section.
+
+## Sources scanned
+
+Inline list of every source visited + count of items pulled. Lets the operator audit coverage.
+```
+
+---
+
+## Materiality test
+
+For every candidate item, ask:
+1. **Does it affect a current pursue idea or active work?** If yes → material.
+2. **Does it match a `keywords_critical` keyword?** If yes → material.
+3. **Does it represent a new competitor entering the space?** If yes → material.
+4. **Does it represent a regulatory or platform change (Apple, Mailchimp, Anthropic, etc.) that touches our stack?** If yes → material.
+5. **Does it surface a net-new opportunity (new audience, new tech enabling X, new market emerging)?** If yes → material.
+
+Otherwise → surface (not material).
+
+**Hard cap: 5 material items per day.** If the day genuinely has more than 5 material shifts, that's worth a Telegram alert to the operator separately — drop the rest into surface.
+
+---
+
+## Anti-patterns (don't do)
+
+- Don't surface yesterday's news. Each item must be net-new since the last run.
+- Don't paraphrase headlines. Quote the source headline verbatim, then add the "what changed" interpretation.
+- Don't make predictions. ("This will lead to X" is out of scope.) Stick to what changed and why we care.
+- Don't pad. If only 2 things are material, output 2 items. Empty padding is noise.
+- Don't paste raw source content. Parse, summarize, link. The output should be skimmable in 60 seconds.
+
+---
+
+## Cron pattern
+
+Suggested cadence per domain:
+
+- **Fast-moving domains** (financial markets, AI, crypto): daily, weekday morning before the operator's first session
+- **Slow-moving domains** (perfumery, brand strategy, niche B2B): 2x/week
+
+Cadence lives in the agent's cron config, not here. This skill just defines how the scan runs once invoked.
+
+---
+
+## Cross-skill links
+
+- Material items with `Suggested action: flag a re-grill on idea X` should trigger `idea-grooming` to re-run on that idea
+- The output log is also read by `multi-perspective-grilling` when generating new perspectives on existing strategy

--- a/skills/idea-grooming/SKILL.md
+++ b/skills/idea-grooming/SKILL.md
@@ -1,0 +1,185 @@
+---
+name: idea-grooming
+description: "Pressure-test a captured idea against an objective rubric and write a structured analysis back into the source file. Use when: a new idea drops into an Ideas/ inbox (manual or cron-watched), or when re-grilling an existing groomed idea against fresh market data."
+---
+
+# Idea Grooming
+
+You evaluate captured ideas against a rubric and write the analysis **back into the source file in place**. The original capture stays at the top, untouched. Frontmatter flips from `status: raw` to `status: groomed` and gets the structured fields populated.
+
+This skill is domain-agnostic — the rubric works for financial newsletters, perfumery products, fitness apps, AI tools, anything. **Domain customization** (which questions to emphasize, what counts as novelty in this space, what comparables to surface) lives in the **agent's config**, not in this skill. Read your `config.json` or domain-specific notes for that overlay.
+
+---
+
+## Inputs
+
+A markdown file at a path the operator provides (typically `<vault>/Ideas/<idea>.md`). The file follows the canonical template:
+
+```yaml
+---
+title: <one-line idea title>
+status: raw
+created: YYYY-MM-DD
+groomed:
+captured_by: <sam | quint | other>
+tags: []
+originality_score:
+market_size:
+manual_burden:
+verdict:
+folder_promoted: false
+---
+
+# <Title>
+
+## Original capture
+<verbatim source>
+
+## Originality
+*(empty — you fill)*
+
+## Market potential
+*(empty — you fill)*
+
+## Moats
+## Barriers
+## Scaling vulnerabilities
+## Manual burden
+## Verdict
+```
+
+If a file you're asked to groom doesn't have the frontmatter shell, add it. Don't refuse the work just because the format is off.
+
+---
+
+## Posture (read this every time)
+
+- **Ground every claim in something concrete.** "There's clearly demand" is not a claim. "Stratechery has 30k+ paid subs at $120/yr in this exact category" is.
+- **Default to skepticism.** Most ideas are average. Originality is rare; mark `originality_score: 2` if that's the truth.
+- **Surface disagreement.** If two parts of the analysis tension (huge market BUT massive moats already in place), say so.
+- **No flattery.** If verdict is `kill`, write the kill reason cleanly. The whole point of grooming is sharper thinking, not validation.
+- **Write the body in plain language.** This is read by humans, not by other agents. No bureaucratese.
+
+---
+
+## Section-by-section rubric
+
+### Originality (1-5)
+
+- **1** — exists at scale, undifferentiated copy
+- **2** — exists, this version has a small twist
+- **3** — meaningful differentiation in a crowded space
+- **4** — genuinely new angle in a known category
+- **5** — new category, no obvious comparable
+
+Always name the closest 2-3 comparables explicitly. If there are none, that's a flag — most "original" ideas just have unfindable competition, not zero.
+
+### Market potential
+
+Three reads:
+- **Who buys/uses** — name the persona, not "people who want X"
+- **Demand signal** — what's already paying for nearby goods? Search trends? Subreddit activity? Conference floor density?
+- **Size band** — `small` (<$10M TAM, lifestyle), `mid` ($10M–$1B, real business), `large` ($1B–$50B, venture-scale), `massive` ($50B+, generational)
+
+Pick the band you can defend. If you'd cringe at a partner reading your defense, drop a band.
+
+### Moats
+
+For each defensible advantage, mark it:
+- **Data** — proprietary data accumulating with use
+- **Distribution** — owned audience, established channel
+- **Brand** — recognized name worth a premium
+- **Network** — value increases with users
+- **Switching cost** — pain to leave, not just inertia
+- **Regulatory** — license/compliance barrier
+- **Talent** — rare skill concentrated here
+- **IP** — patents, copyright, trade secret
+
+For each: **load-bearing** (would actually defend in a price war) or **weak** (sounds defensible, isn't). Don't list a moat if it's weak — say "no real moat" honestly.
+
+### Barriers
+
+What would actually stop us from shipping v1?
+- **Tech** — does it exist, is it ours to build, do we have skills
+- **Capital** — burn rate to MVP
+- **Distribution** — how do customers find this
+- **Regulation** — license/compliance to operate
+- **Talent** — who has to be hired
+- **Customer trust** — does the audience believe a 2-person op can deliver
+
+Rank by which would ACTUALLY stop us. Customer trust often beats tech.
+
+### Scaling vulnerabilities
+
+What breaks between MVP and 10x / 100x / 1000x:
+- Manual-ops bottleneck (does someone have to touch every customer)
+- Unit economics (cost curve flat or flipping negative at scale)
+- Support burden (who answers tickets at 1k users)
+- Compliance scope (regulation tightens at audience size)
+- Vendor lock-in (Mailchimp limits, API rate limits, etc.)
+
+For each: at what scale does this bite? Day 1, 100 users, 10k users?
+
+### Manual burden
+
+Honest labor estimate:
+- **low** — <2 hr/week to operate at MVP scale
+- **med** — 2–15 hr/week
+- **high** — 15+ hr/week, requires a hire to scale
+
+Be specific about WHERE the burden sits — content production, customer success, ops, content review. AI helps where it's actually generative; not where it's review/judgment.
+
+### Verdict
+
+- **pursue** — passes on all dimensions OR strong enough on 2-3 to justify exploring deeper. Add 1-3 concrete next moves.
+- **park** — promising but blocked by timing, capital, or another priority. Add a "revisit when X" condition.
+- **kill** — fails core dimension (no moat AND no market AND no originality). Add the one-line kill reason.
+- **needs-more** — analysis genuinely can't conclude with available info. Add what to learn.
+
+---
+
+## Promotion rule (single file → folder)
+
+Promote a `.md` to a folder (`<idea-name>/Index.md` + `Notes/` + `References/` + `Open Questions.md`) when ALL true:
+- `verdict: pursue`
+- 3+ distinct work threads (e.g. tech build + brand work + customer dev + legal review)
+- The single-file structure is becoming hard to reason about
+
+Set `folder_promoted: true` in frontmatter when you do this. Move the original file to become `Index.md` in the new folder.
+
+---
+
+## Domain overlay (read agent config)
+
+Before grooming, check your agent's config for domain-specific signals:
+- `domains: [<list>]` — what spaces this agent works in (financial, perfumery, fitness, ai-communities, etc.)
+- `comparables_seed: [<list>]` — known companies/products in this space the rubric should consider
+- `market_signals: [<list>]` — things that count as demand evidence in this domain
+- `kill_dimensions: [<list>]` — domain-specific dealbreakers (e.g. "regulated advice without a license" for financial)
+
+If your agent has no domain config, run the rubric domain-agnostic and surface in the verdict that no domain context was loaded.
+
+---
+
+## Output
+
+You write the analysis **back into the source file in place**:
+1. Update frontmatter: `status: groomed`, `groomed: <today's date>`, fill `originality_score`, `market_size`, `manual_burden`, `verdict`, populate `tags` if useful
+2. Fill each section body in the rubric order above
+3. If verdict is `pursue` and 3+ work threads emerge, also do the promotion (move file to folder, create subfolders)
+4. Don't touch the `## Original capture` section — that's the historical record
+
+Confirm completion in the way your agent normally confirms work (Telegram message to operator, log entry, etc.).
+
+---
+
+## Re-grilling (cron pattern)
+
+When run on a schedule against existing `status: groomed` + `verdict: pursue` ideas:
+- Re-read the file
+- Check for fresh news/market shifts in the domain (use the `business-news-monitor` skill output if available)
+- If the original analysis still holds → update `groomed` date only
+- If something material has shifted (new competitor, regulation change, market shrinkage) → append a `## Re-grill <date>` section noting the shift + impact on verdict
+- If verdict needs to change → update frontmatter + add the re-grill section explaining why
+
+Don't rewrite the original analysis — append. The trail is part of the value.

--- a/skills/multi-perspective-grilling/SKILL.md
+++ b/skills/multi-perspective-grilling/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: multi-perspective-grilling
+description: "Pressure-test a plan, idea, or active strategy by walking it through a fixed roster of distinct skeptical perspectives. Use when: a decision feels too settled to be safe, an idea passed grooming and needs a second-order stress test, or a recurring weekly review wants fresh angles. Personas defined here, domain customization in agent config."
+---
+
+# Multi-Perspective Grilling
+
+You take a target (an idea, a plan, an active strategy, a draft) and run it through a **rotating roster of skeptical perspectives**. Each perspective has its own posture, set of questions, and failure modes it's looking for. The output is the union of every perspective's pushback, filtered by your judgment for which pushbacks are actually load-bearing.
+
+This is **not "give me three opinions"**. It's a structured grilling where each persona is sharp in a specific direction — the financial-analyst is looking for unit-economics fragility, the historian is looking for "this exact thing failed in 2014 because Y", the contrarian VC is looking for "why isn't a smarter team already doing this." Different personas catch different bugs.
+
+---
+
+## Inputs
+
+- **Target**: path to the markdown file or a verbatim text block to grill
+- **Mode**: one of `single-pass` (run all personas in one prompt, one synthesis), `rotating` (one persona per scheduled run, output appends), `tournament` (each persona runs independently, you summarize)
+- **Persona set**: which personas to invoke — defaults to the canonical roster below; agent config can override or extend
+
+Read your agent's config for:
+- `personas_default: [<list>]` — which personas to use when the operator doesn't specify
+- `personas_<domain>: [<list>]` — domain-specific persona overrides (e.g. for financial: `[financial-analyst, market-historian, contrarian-vc, compliance-officer]`; for perfumery: `[perfumer-master, retail-buyer, regulatory-fda, niche-blogger]`)
+
+---
+
+## Canonical persona roster
+
+The skill ships with these personas defined. Each is a posture + a set of pressure questions. Domain configs can swap in domain-specific replacements.
+
+### Financial Analyst
+
+- Posture: trained to spot unit-economics fragility, hidden customer-acquisition costs, churn assumptions that don't survive contact with reality
+- Pressure questions: "What's CAC over LTV at year 1 vs year 3?" "Where does the cost curve bend negative?" "What's the realistic churn at month 6?" "Show me the sensitivity to a 20% price drop."
+
+### Market Historian
+
+- Posture: pattern-matches against past attempts in adjacent spaces; default skepticism around "this time it's different"
+- Pressure questions: "Who tried this in 2015 / 2008 / 1999, and what killed them?" "What's the analogue from a different industry where the same dynamic played out?" "What did the survivors do that the failures didn't?"
+
+### Contrarian VC
+
+- Posture: trained on "why isn't a smarter team already doing this"; looks for the trade you're making with second-order effects
+- Pressure questions: "If this is so obvious, why isn't [established player] already shipping it?" "What does the smartest version of this look like, and how does ours compare?" "Where's the hidden trade — what are we giving up that we don't realize?"
+
+### Customer
+
+- Posture: lives in the user's chair; asks the questions the user actually asks
+- Pressure questions: "Why do I care?" "What did I have to do BEFORE this existed, and is the new thing actually less work?" "Why should I trust you (a 2-person op) over [incumbent]?" "How does this fail me on a Tuesday?"
+
+### Compliance/Regulator
+
+- Posture: paid to find the regulatory gotcha; default to "if you have to ask whether this is legal, it isn't yet"
+- Pressure questions: "What licenses does this require?" "What's the failure mode if a regulator audits in year 2?" "Where do you cross from editorial to advice to recommendation?" "What disclosures are missing?"
+
+### Pessimist Engineer
+
+- Posture: spent 20 years debugging production at scale; assumes the happy path doesn't exist
+- Pressure questions: "What breaks at 10x scale?" "What's the SLO and who's on call?" "What's the data-loss exposure?" "What dependencies have we just bet the company on?"
+
+(Domain configs can add: `perfumer-master`, `niche-blogger`, `regulatory-fda`, `accessibility-advocate`, etc.)
+
+---
+
+## Modes
+
+### `single-pass`
+
+Run all personas in one prompt. Output one synthesis section per persona, then a final "Operator decision points" section listing the top 3-5 pressure points across all personas that the operator should actually act on.
+
+Use when: an idea is fresh and we want a thorough first pressure-test.
+
+### `rotating`
+
+One persona per run. Cron-driven, e.g. financial-analyst Monday, market-historian Wednesday, contrarian-VC Friday. Output appends to the target file (or a sibling Grilling Log) with date + persona + their pressure points.
+
+Use when: ongoing pressure-test cadence, want fresh angles over time without overloading the operator.
+
+### `tournament`
+
+Each persona runs in its own independent invocation. Outputs are then synthesized into a single "What broke under grilling" doc with: most-common pressure points (multiple personas hit), unique-but-load-bearing pressure points (only one persona hit but it's serious), pressure points to dismiss (one persona raised, doesn't survive scrutiny).
+
+Use when: a major decision is on the table and you want maximum coverage with internal cross-validation.
+
+---
+
+## Output rubric
+
+For each persona run, write:
+
+```markdown
+### <Persona name> — <YYYY-MM-DD>
+
+**Posture:** <one line>
+
+**Pressure points raised:**
+1. <Pressure point in plain English. Specific, not generic.>
+2. ...
+
+**Strongest single objection:** <the one the operator should think hardest about>
+
+**Verdict from this perspective:** strong / has-concerns / fragile / doesn't-survive
+```
+
+Single-pass + tournament modes add a final synthesis:
+
+```markdown
+## Synthesis
+
+**Pressure points raised by 2+ personas (high confidence):**
+- ...
+
+**Unique pressure points worth taking seriously:**
+- ...
+
+**Pressure points to dismiss:**
+- ...
+
+**Operator decision points (top 3):**
+1. ...
+2. ...
+3. ...
+```
+
+---
+
+## Posture across all personas
+
+- **Each persona stays in character.** The financial analyst doesn't soften because the market historian made a kill point; they each surface what they see from their vantage.
+- **Specificity > generality.** "Customer acquisition will be hard" is filler. "If you're trying to convert DIY Money's existing 12k podcast listeners to paid newsletter subs, the historical conversion ceiling for podcast→email→paid is 2-4% which gives you 240-480 paid subs at $X — does that math close?" is a pressure point.
+- **Don't manufacture pressure.** If the financial analyst genuinely sees no fragility, say "no material concerns from this angle" and move on. Padding personas with weak objections is worse than a short output.
+- **Surface tension between personas.** If the contrarian VC says "no one's doing this because the regulatory cost is too high" but the compliance officer says "the regulatory cost is overstated, here's the precedent" — say so. The operator's job is to resolve the tension; yours is to surface it.
+
+---
+
+## Cross-skill links
+
+- Pressure points raised by a grilling pass on a `pursue` idea may trigger the `idea-grooming` skill to re-run with the new info baked in
+- The `business-news-monitor` skill output is a critical input to the `market-historian` and `contrarian-vc` personas — read the latest log before grilling


### PR DESCRIPTION
## Summary

Three domain-agnostic skills for running an objective business-review apparatus across multiple agents/contexts. Each agent loads what it needs; per-agent config carries the domain overlay (financial vs perfumery vs fitness vs ai-communities).

## Why

The grooming/grilling/news-monitoring patterns get reinvented per agent today. This factors them into shared skills so improvements propagate to every loading agent, and adds the missing critical-skeptic apparatus (multi-perspective grilling) that wasn't in the existing skill set.

## Skills

### \`idea-grooming\`
Pressure-tests a captured idea against an objective rubric, writes structured analysis back into the source file in place. Original capture stays untouched at top; frontmatter flips \`raw → groomed\`.

Section scoring: originality (1-5 with required comparables), market sizing (small/mid/large/massive bands), moats (load-bearing vs weak per category), barriers (ranked by what would actually stop us), scaling vulnerabilities (10x/100x/1000x), manual burden, verdict (pursue/park/kill/needs-more). Promotion rule moves single-file ideas to subfolder when \`pursue\` + 3+ work threads.

Domain overlay (\`comparables_seed\`, \`market_signals\`, \`kill_dimensions\`) lives in agent config.

### \`business-news-monitor\`
Daily/weekly cron-driven scan of news/forums/social in a domain. Materiality-gated (5-item hard cap), structured output for cross-skill consumption.

Materiality test: affects active work / matches critical keyword / new competitor / regulatory or platform shift / net-new opportunity. Output is the 1-3 things that materially changed and why we care — explicitly NOT a headline aggregator.

Sources, keywords, competitors live in agent config.

### \`multi-perspective-grilling\`
Pressure-tests a target through a roster of distinct skeptical perspectives. Six canonical personas: Financial Analyst, Market Historian, Contrarian VC, Customer, Compliance/Regulator, Pessimist Engineer. Each persona has a posture + specific pressure questions; outputs filtered by load-bearing concern.

Three modes: \`single-pass\` (all personas in one prompt), \`rotating\` (one persona per cron run), \`tournament\` (independent runs, synthesized).

## Cross-skill links

- \`business-news-monitor\` material items can trigger \`idea-grooming\` re-runs on affected pursue-status ideas
- \`multi-perspective-grilling\` reads the latest \`business-news-monitor\` log when invoking \`market-historian\` and \`contrarian-vc\` personas

## Test plan

- [ ] Skills load via \`cortextos bus list-skills\` from an agent's session
- [ ] An agent with \`comparables_seed\` config in config.json grooms an Ideas/ file and surfaces those comparables in the originality section
- [ ] Multi-perspective grilling in \`single-pass\` mode produces one output section per persona + one synthesis section
- [ ] business-news-monitor with empty config surfaces the missing-config gap rather than producing a generic scan