### PR TITLE
fix(cron-scheduler): persist last_fired_at for fresh_session crons

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { spawnSync, execFileSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { isAbsolute, join } from 'path';
 import { sendMessage, checkInbox, ackInbox } from '../bus/message.js';
 import { validateAgentName } from '../utils/validate.js';
 import { createTask, updateTask, completeTask, claimTask, readTaskAudit, checkTaskDependencies, compactTasks, listTasks, checkStaleTasks, archiveTasks, checkHumanTasks } from '../bus/task.js';
@@ -21,6 +21,7 @@ import { queryKnowledgeBase, ingestKnowledgeBase, ensureKBDirs } from '../bus/kn
 import { checkUsageApi, refreshOAuthToken, rotateOAuth, loadAccounts, ALERT_5H, ALERT_7D } from '../bus/oauth.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
+import { isFreshSessionProtectedCron, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { logOutboundMessage, cacheLastSent } from '../telegram/logging.js';
@@ -655,6 +656,29 @@ busCommand
     } else {
       console.log('Hard restart planned (daemon not running — will take effect on next start)');
     }
+  });
+
+busCommand
+  .command('compact-now')
+  .description('Trigger an immediate Tier 1.5 sidecar compaction for this agent (writes .compact-now marker picked up by the fast-checker)')
+  .option('--agent <name>', 'Target agent (defaults to $CTX_AGENT_NAME)')
+  .action(async (opts: { agent?: string }) => {
+    const { writeFileSync: fsWrite, mkdirSync: fsMkdir } = require('fs');
+    const { join: pjoin } = require('path');
+    const { randomUUID } = require('crypto');
+    const env = resolveEnv();
+    const targetAgent = opts.agent ?? env.agentName;
+    if (!targetAgent) {
+      console.error('ERROR: No agent specified and CTX_AGENT_NAME not set');
+      process.exit(1);
+    }
+    const paths = resolvePaths(targetAgent, env.instanceId, env.org);
+    fsMkdir(paths.stateDir, { recursive: true });
+    const requestId = randomUUID();
+    const markerPath = pjoin(paths.stateDir, `.compact-now-${requestId}`);
+    fsWrite(markerPath, new Date().toISOString(), 'utf-8');
+    console.log(`Compaction requested (id=${requestId}). Fast-checker will pick up within one poll cycle.`);
+    console.log(`Marker: ${markerPath}`);
   });
 
 busCommand
@@ -1836,16 +1860,85 @@ function validateSchedule(raw: string): string {
  */
 function agentExistsInFramework(agentName: string, frameworkRoot: string): boolean {
   if (!frameworkRoot) return true; // can't check — allow
-  const { existsSync: fsExists, readdirSync: fsReaddir } = require('fs');
-  const { join: pjoin } = require('path');
-  const orgsDir = pjoin(frameworkRoot, 'orgs');
-  if (!fsExists(orgsDir)) return true; // no orgs dir — allow
+  const orgsDir = join(frameworkRoot, 'orgs');
+  if (!existsSync(orgsDir)) return true; // no orgs dir — allow
   try {
-    for (const org of fsReaddir(orgsDir)) {
-      if (fsExists(pjoin(orgsDir, org, 'agents', agentName))) return true;
+    for (const org of readdirSync(orgsDir)) {
+      if (existsSync(join(orgsDir, org, 'agents', agentName))) return true;
     }
   } catch { /* ignore */ }
   return false;
+}
+
+function readAgentRuntime(agentName: string, frameworkRoot: string): string | undefined {
+  if (!frameworkRoot) return undefined;
+  const orgsDir = join(frameworkRoot, 'orgs');
+  if (!existsSync(orgsDir)) return undefined;
+  try {
+    for (const org of readdirSync(orgsDir)) {
+      const configPath = join(orgsDir, org, 'agents', agentName, 'config.json');
+      if (!existsSync(configPath)) continue;
+      return JSON.parse(readFileSync(configPath, 'utf-8')).runtime;
+    }
+  } catch { /* ignore malformed/missing config in CLI validation */ }
+  return undefined;
+}
+
+function validateFreshSessionCliOptions(
+  agent: string,
+  cronName: string,
+  frameworkRoot: string,
+  opts: { freshSession?: boolean; skillFile?: string; protocolFile?: string; freshSessionTimeout?: string },
+): { freshSession?: boolean; skillFile?: string; protocolFile?: string; freshSessionTimeoutMs?: number } {
+  if (opts.skillFile !== undefined) {
+    if (!opts.skillFile.trim()) {
+      console.error('Error: --skill-file must be a non-empty relative path.');
+      process.exit(1);
+    }
+    if (isAbsolute(opts.skillFile)) {
+      console.error('Error: --skill-file must be a relative path.');
+      process.exit(1);
+    }
+  }
+
+  if (opts.protocolFile !== undefined) {
+    if (!opts.protocolFile.trim()) {
+      console.error('Error: --protocol-file must be a non-empty relative path.');
+      process.exit(1);
+    }
+    if (isAbsolute(opts.protocolFile)) {
+      console.error('Error: --protocol-file must be a relative path.');
+      process.exit(1);
+    }
+  }
+
+  let freshSessionTimeoutMs: number | undefined;
+  if (opts.freshSessionTimeout !== undefined) {
+    freshSessionTimeoutMs = Number(opts.freshSessionTimeout);
+    if (!Number.isInteger(freshSessionTimeoutMs) || freshSessionTimeoutMs <= 0) {
+      console.error(`Error: --fresh-session-timeout must be a positive integer, got '${opts.freshSessionTimeout}'.`);
+      process.exit(1);
+    }
+  }
+
+  if (opts.freshSession === true) {
+    if (isFreshSessionProtectedCron(agent, cronName)) {
+      console.error(`Error: --fresh-session is not allowed for protected cron '${agent}/${cronName}'.`);
+      process.exit(1);
+    }
+    const runtime = readAgentRuntime(agent, frameworkRoot);
+    if (!isFreshSessionSupportedRuntime(runtime)) {
+      console.error(`Error: --fresh-session is not supported for runtime '${runtime}'.`);
+      process.exit(1);
+    }
+  }
+
+  return {
+    freshSession: opts.freshSession,
+    skillFile: opts.skillFile?.trim(),
+    protocolFile: opts.protocolFile?.trim(),
+    freshSessionTimeoutMs,
+  };
 }
 
 /**
@@ -1875,7 +1968,17 @@ busCommand
   .argument('<interval>', 'Schedule: interval ("6h", "30m", "1d") or 5-field cron expr ("0 8 * * *")')
   .argument('<prompt...>', 'Prompt text injected when the cron fires (all remaining words joined)')
   .option('--desc <description>', 'Human-readable description (optional)')
-  .action(async (agent: string, name: string, interval: string, promptWords: string[], opts: { desc?: string }) => {
+  .option('--fresh-session', 'Run this cron in a fresh claude --print session')
+  .option('--skill-file <path>', 'Relative path to skill/context file for fresh-session system prompt')
+  .option('--protocol-file <path>', 'Relative path to protocol/checklist file appended to system prompt for fresh-session runs')
+  .option('--fresh-session-timeout <ms>', 'Fresh-session timeout in milliseconds')
+  .action(async (
+    agent: string,
+    name: string,
+    interval: string,
+    promptWords: string[],
+    opts: { desc?: string; freshSession?: boolean; skillFile?: string; protocolFile?: string; freshSessionTimeout?: string },
+  ) => {
     // Validate agent name format
     try { validateAgentName(agent); } catch (err) { console.error(String(err)); process.exit(1); }
 
@@ -1890,6 +1993,7 @@ busCommand
     // Validate schedule
     let schedule: string;
     try { schedule = validateSchedule(interval); } catch (err) { console.error(String(err)); process.exit(1); }
+    const fresh = validateFreshSessionCliOptions(agent, name, env.frameworkRoot, opts);
 
     const prompt = promptWords.join(' ');
     const cron: CronDefinition = {
@@ -1899,6 +2003,10 @@ busCommand
       enabled: true,
       created_at: new Date().toISOString(),
       ...(opts.desc ? { description: opts.desc } : {}),
+      ...(fresh.freshSession !== undefined ? { fresh_session: fresh.freshSession } : {}),
+      ...(fresh.skillFile !== undefined ? { skill_file: fresh.skillFile } : {}),
+      ...(fresh.protocolFile !== undefined ? { protocol_file: fresh.protocolFile } : {}),
+      ...(fresh.freshSessionTimeoutMs !== undefined ? { fresh_session_timeout_ms: fresh.freshSessionTimeoutMs } : {}),
     };
 
     try {
@@ -2025,15 +2133,45 @@ busCommand
   .option('--prompt <p>', 'New prompt text')
   .option('--enabled <bool>', 'Enable (true) or disable (false) the cron')
   .option('--desc <d>', 'New description')
-  .action(async (agent: string, name: string, opts: { interval?: string; cronExpr?: string; prompt?: string; enabled?: string; desc?: string }) => {
+  .option('--fresh-session', 'Enable fresh-session cron dispatch')
+  .option('--no-fresh-session', 'Disable fresh-session cron dispatch')
+  .option('--skill-file <path>', 'Relative path to skill/context file for fresh-session system prompt')
+  .option('--protocol-file <path>', 'Relative path to protocol/checklist file appended to system prompt for fresh-session runs')
+  .option('--fresh-session-timeout <ms>', 'Fresh-session timeout in milliseconds')
+  .action(async (
+    agent: string,
+    name: string,
+    opts: {
+      interval?: string;
+      cronExpr?: string;
+      prompt?: string;
+      enabled?: string;
+      desc?: string;
+      freshSession?: boolean;
+      skillFile?: string;
+      protocolFile?: string;
+      freshSessionTimeout?: string;
+    },
+  ) => {
     try { validateAgentName(agent); } catch (err) { console.error(String(err)); process.exit(1); }
 
     const rawSchedule = opts.interval ?? opts.cronExpr;
-    if (!rawSchedule && opts.prompt === undefined && opts.enabled === undefined && opts.desc === undefined) {
-      console.error('Error: at least one of --interval, --cron-expr, --prompt, --enabled, or --desc is required.');
+    if (
+      !rawSchedule &&
+      opts.prompt === undefined &&
+      opts.enabled === undefined &&
+      opts.desc === undefined &&
+      opts.freshSession === undefined &&
+      opts.skillFile === undefined &&
+      opts.protocolFile === undefined &&
+      opts.freshSessionTimeout === undefined
+    ) {
+      console.error('Error: at least one update option is required.');
       process.exit(1);
     }
 
+    const env = resolveEnv();
+    const fresh = validateFreshSessionCliOptions(agent, name, env.frameworkRoot, opts);
     const patch: Partial<CronDefinition> = {};
 
     if (rawSchedule !== undefined) {
@@ -2052,6 +2190,18 @@ busCommand
     if (opts.desc !== undefined) {
       patch.description = opts.desc;
     }
+    if (fresh.freshSession !== undefined) {
+      patch.fresh_session = fresh.freshSession;
+    }
+    if (fresh.skillFile !== undefined) {
+      patch.skill_file = fresh.skillFile;
+    }
+    if (fresh.protocolFile !== undefined) {
+      patch.protocol_file = fresh.protocolFile;
+    }
+    if (fresh.freshSessionTimeoutMs !== undefined) {
+      patch.fresh_session_timeout_ms = fresh.freshSessionTimeoutMs;
+    }
 
     const ok = updateCronDef(agent, name, patch);
     if (!ok) {
@@ -2059,7 +2209,6 @@ busCommand
       process.exit(1);
     }
 
-    const env = resolveEnv();
     await signalCronReload(agent, env.instanceId);
     console.log(`Updated cron '${name}' for ${agent}`);
   });

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -1,6 +1,16 @@
-import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { join, relative } from 'path';
-import type { AgentConfig, AgentStatus, CtxEnv, BusPaths, WorkerStatus, TelegramMessage } from '../types/index.js';
+import { spawn } from 'child_process';
+import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync, appendFileSync } from 'fs';
+import { join, relative, isAbsolute } from 'path';
+import { platform } from 'os';
+import type {
+  AgentConfig,
+  AgentStatus,
+  CtxEnv,
+  BusPaths,
+  WorkerStatus,
+  TelegramMessage,
+  CronExecutionLogEntry,
+} from '../types/index.js';
 import { AgentProcess } from './agent-process.js';
 import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
@@ -11,6 +21,10 @@ import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
+import { isFreshSessionProtectedCron, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
+import { logEvent } from '../bus/event.js';
+import { updateCron } from '../bus/crons.js';
+import { appendExecutionLog } from './cron-execution-log.js';
 import { recordInboundTelegram, cacheLastSent, logOutboundMessage, buildRecentHistory } from '../telegram/logging.js';
 import { collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
 import { stripControlChars } from '../utils/validate.js';
@@ -778,6 +792,260 @@ export class AgentManager {
   }
 
   /**
+   * Single dispatch point for scheduled and manual cron fires.
+   */
+  async dispatchCron(agentName: string, cron: CronDefinition, firedAt: string): Promise<void> {
+    const prompt = cron.prompt ?? `[cron] ${cron.name} fired`;
+    const injection = `[CRON FIRED ${firedAt}] ${cron.name}: ${prompt}`;
+
+    if (isFreshSessionProtectedCron(agentName, cron.name) && cron.fresh_session) {
+      console.log(
+        `[daemon] GUARDRAIL: fresh_session overridden for protected cron "${agentName}/${cron.name}"`
+      );
+      this.emitGuardrailEvent(agentName, cron.name);
+    }
+
+    const useFresh = cron.fresh_session === true && !isFreshSessionProtectedCron(agentName, cron.name);
+    if (useFresh) {
+      await this.fireCronFreshSession(agentName, cron, injection, firedAt);
+      return;
+    }
+
+    const injected = this.injectAgent(agentName, injection);
+    if (!injected) {
+      throw new Error(`injectAgent returned false for agent "${agentName}" — agent may not be running`);
+    }
+  }
+
+  private async fireCronFreshSession(
+    agentName: string,
+    cron: CronDefinition,
+    promptText: string,
+    firedAt: string,
+  ): Promise<void> {
+    const startTime = Date.now();
+    let executionLogWritten = false;
+    const writeExecLog = (status: 'fired' | 'failed', errorMsg: string | null): void => {
+      if (executionLogWritten) return;
+      executionLogWritten = true;
+      const entry: CronExecutionLogEntry = {
+        ts: new Date().toISOString(),
+        cron: cron.name,
+        status,
+        attempt: 1,
+        duration_ms: Date.now() - startTime,
+        error: errorMsg,
+      };
+      try { appendExecutionLog(agentName, entry); } catch { /* non-fatal */ }
+    };
+
+    let agentDir: string;
+    let workingDir: string;
+    let runtimeEnv: NodeJS.ProcessEnv;
+    let claudeCmd: string;
+    let timeoutMs: number;
+    let args: string[];
+    const KILL_GRACE_MS = 5_000;
+
+    try {
+      const entry = this.agents.get(agentName);
+      if (!entry) throw new Error(`Agent "${agentName}" not found`);
+
+      const agentProcess = entry.process;
+      const config = agentProcess.getConfig();
+      const runtime = config.runtime;
+
+      if (!isFreshSessionSupportedRuntime(runtime)) {
+        this.emitFreshSessionUnsupportedEvent(agentName, cron.name, runtime ?? 'unknown');
+        throw new Error(`fresh_session not supported for runtime "${runtime}" (${agentName}/${cron.name})`);
+      }
+
+      agentDir = agentProcess.getAgentDir();
+      workingDir = config.working_directory || agentDir;
+      runtimeEnv = agentProcess.buildRuntimeEnv();
+      runtimeEnv['CTX_CRON_FIRED_AT'] = firedAt;
+      runtimeEnv['CTX_FRESH_SESSION_CRON'] = `${agentName}/${cron.name}`;
+      claudeCmd = platform() !== 'win32' ? 'claude' : 'claude.exe';
+      timeoutMs = cron.fresh_session_timeout_ms ?? 300_000;
+
+      args = ['--print', '--dangerously-skip-permissions', '--no-session-persistence'];
+      if (config.model) args.push('--model', config.model);
+
+      const systemPromptParts: string[] = [];
+      if (cron.skill_file) {
+        if (isAbsolute(cron.skill_file)) {
+          console.log(`[daemon] WARNING: absolute skill_file rejected for "${cron.name}" — ignoring`);
+        } else {
+          try {
+            systemPromptParts.push(readFileSync(join(agentDir, cron.skill_file), 'utf-8'));
+          } catch (err) {
+            console.log(
+              `[daemon] WARNING: skill_file "${cron.skill_file}" unreadable for "${cron.name}" — ` +
+              `proceeding without: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+      }
+
+      if (cron.protocol_file) {
+        if (isAbsolute(cron.protocol_file)) {
+          console.log(`[daemon] WARNING: absolute protocol_file rejected for "${cron.name}" — ignoring`);
+        } else {
+          try {
+            systemPromptParts.push(readFileSync(join(agentDir, cron.protocol_file), 'utf-8'));
+          } catch (err) {
+            console.log(
+              `[daemon] WARNING: protocol_file "${cron.protocol_file}" unreadable for "${cron.name}" — ` +
+              `proceeding without: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+      }
+
+      if (systemPromptParts.length > 0) {
+        args.push('--append-system-prompt', systemPromptParts.join('\n\n---\n\n'));
+      }
+
+      args.push(promptText);
+    } catch (preSpawnErr) {
+      writeExecLog(
+        'failed',
+        `pre_spawn: ${preSpawnErr instanceof Error ? preSpawnErr.message : String(preSpawnErr)}`
+      );
+      throw preSpawnErr;
+    }
+
+    const OUTPUT_CAP_BYTES = 256 * 1024;
+    let stdoutBuf = Buffer.alloc(0);
+    let stderrBuf = Buffer.alloc(0);
+    let settled = false;
+    let timedOut = false;
+
+    const ctxRoot = runtimeEnv['CTX_ROOT'] ?? this.ctxRoot;
+    const logDir = join(ctxRoot, 'logs', agentName);
+    try { mkdirSync(logDir, { recursive: true }); } catch { /* non-fatal */ }
+    const cronLogPath = join(logDir, 'cron-fresh.log');
+
+    try {
+      updateCron(agentName, cron.name, { last_fire_attempted_at: firedAt });
+    } catch (err) {
+      console.log(
+        `[daemon] WARNING: failed to persist last_fire_attempted_at for "${cron.name}" — ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Continuing dispatch; crash mid-fire could double-fire on restart.`
+      );
+    }
+
+    return new Promise<void>((resolve, reject) => {
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const settle = (err?: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (killTimer !== undefined) clearTimeout(killTimer);
+        if (sigkillTimer !== undefined) clearTimeout(sigkillTimer);
+        if (err) reject(err); else resolve();
+      };
+
+      const child = spawn(claudeCmd, args, {
+        cwd: workingDir,
+        env: runtimeEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        const remaining = OUTPUT_CAP_BYTES - stdoutBuf.length;
+        if (remaining > 0) stdoutBuf = Buffer.concat([stdoutBuf, chunk.subarray(0, remaining)]);
+        try { appendFileSync(cronLogPath, `[stdout] ${chunk}`); } catch { /* non-fatal */ }
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        const remaining = OUTPUT_CAP_BYTES - stderrBuf.length;
+        if (remaining > 0) stderrBuf = Buffer.concat([stderrBuf, chunk.subarray(0, remaining)]);
+        try { appendFileSync(cronLogPath, `[stderr] ${chunk}`); } catch { /* non-fatal */ }
+      });
+
+      child.once('error', (err) => {
+        writeExecLog('failed', `spawn_error: ${err.message}`);
+        settle(new Error(`spawn failed for "${cron.name}": ${err.message}`));
+      });
+
+      child.once('close', (code, signal) => {
+        const stderrSnip = stderrBuf.slice(0, 500).toString();
+        console.log(
+          `[daemon] Fresh cron "${cron.name}" (${agentName}) closed code=${code} ` +
+          `signal=${signal} stdout=${stdoutBuf.length}B`
+        );
+        if (stderrSnip.trim()) console.log(`[daemon] Fresh cron stderr: ${stderrSnip}`);
+
+        const exitOk = !timedOut && code === 0;
+        const shouldPersistFire = exitOk && !settled;
+        const errorMsg = timedOut
+          ? `timed_out_${timeoutMs}ms`
+          : code !== 0
+          ? (stderrBuf.slice(0, 200).toString().trim() || `exit_code_${code ?? 'null'}`)
+          : null;
+
+        writeExecLog(exitOk ? 'fired' : 'failed', errorMsg);
+
+        if (shouldPersistFire) {
+          const newFireCount = (cron.fire_count ?? 0) + 1;
+          try {
+            updateCron(agentName, cron.name, {
+              last_fired_at: firedAt,
+              fire_count: newFireCount,
+            });
+          } catch (err) {
+            console.log(
+              `[daemon] WARNING: failed to persist fire state for "${cron.name}" — ` +
+              `${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+
+        if (timedOut) {
+          settle(new Error(`Fresh cron "${cron.name}" timed out (${timeoutMs}ms), exited code=${code} signal=${signal}`));
+        } else if (code !== 0) {
+          settle(new Error(`Fresh cron "${cron.name}" exited code=${code} signal=${signal}. stderr: ${stderrSnip}`));
+        } else {
+          settle();
+        }
+      });
+
+      killTimer = setTimeout(() => {
+        timedOut = true;
+        console.log(`[daemon] Fresh cron "${cron.name}" timeout (${timeoutMs}ms) — SIGTERM`);
+        child.kill('SIGTERM');
+        sigkillTimer = setTimeout(() => {
+          if (!settled) {
+            console.log(`[daemon] Fresh cron "${cron.name}" no close after grace — SIGKILL`);
+            child.kill('SIGKILL');
+          }
+        }, KILL_GRACE_MS);
+      }, timeoutMs);
+    });
+  }
+
+  private emitGuardrailEvent(agentName: string, cronName: string): void {
+    try {
+      logEvent(resolvePaths(agentName, this.instanceId, this.org), agentName, this.org, 'action', 'guardrail_triggered', 'info', {
+        guardrail: 'fresh_session_protected_agent',
+        cron: cronName,
+      });
+    } catch { /* observability should not block dispatch */ }
+  }
+
+  private emitFreshSessionUnsupportedEvent(agentName: string, cronName: string, runtime: string): void {
+    try {
+      logEvent(resolvePaths(agentName, this.instanceId, this.org), agentName, this.org, 'error', 'cron_fresh_session_unsupported', 'error', {
+        cron: cronName,
+        runtime,
+      });
+    } catch { /* observability should not mask scheduler failure */ }
+  }
+
+  /**
    * Signal the CronScheduler for an agent to re-read crons.json.
    *
    * Called by the IPC server after a `bus add-cron` / `bus remove-cron` write so
@@ -849,17 +1117,7 @@ export class AgentManager {
     }
 
     const onFire = async (cron: CronDefinition): Promise<void> => {
-      const prompt = cron.prompt ?? `[cron] ${cron.name} fired`;
-      // Salt with the fire timestamp so MessageDedup (which hashes the last 100
-      // injects) does not reject identical cron prompts on subsequent fires.
-      // Without the salt, every recurring cron after its first fire would be
-      // dedup-rejected and treated as a dispatch failure.
-      const firedAt = new Date().toISOString();
-      const injection = `[CRON FIRED ${firedAt}] ${cron.name}: ${prompt}`;
-      const injected = this.injectAgent(agentName, injection);
-      if (!injected) {
-        throw new Error(`injectAgent returned false for agent "${agentName}" — agent may not be running`);
-      }
+      await this.dispatchCron(agentName, cron, new Date().toISOString());
     };
 
     const scheduler = new CronScheduler({

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -8,7 +8,7 @@ import { HermesPTY, hermesDbExists } from '../pty/hermes-pty.js';
 import { MessageDedup, injectMessage } from '../pty/inject.js';
 import type { TelegramAPI } from '../telegram/api.js';
 import { ensureDir } from '../utils/atomic.js';
-import { writeCortextosEnv } from '../utils/env.js';
+import { buildAgentRuntimeEnv, writeCortextosEnv } from '../utils/env.js';
 import { getOverdueReminders } from '../bus/reminders.js';
 import { resolvePaths } from '../utils/paths.js';
 
@@ -372,6 +372,30 @@ export class AgentProcess {
    */
   getConfig(): AgentConfig {
     return this.config;
+  }
+
+  /**
+   * Runtime identifier for the sidecar compactor's Claude-only gate.
+   * Absent/empty runtime = legacy Claude Code agent → normalize to 'claude-code'
+   * so the SIGSTOP snapshot gate doesn't silently skip them.
+   */
+  getRuntime(): string {
+    return this.config?.runtime?.trim() || 'claude-code';
+  }
+
+  /**
+   * PID of the PTY child process, or null when no PTY is alive.
+   * Used by `pauseForJsonlSnapshot` for SIGSTOP/SIGCONT.
+   */
+  getChildPid(): number | null {
+    return (this.pty as { getPid?: () => number | null } | null)?.getPid?.() ?? null;
+  }
+
+  /**
+   * Build the exact runtime env used by spawned Claude sessions.
+   */
+  buildRuntimeEnv(): NodeJS.ProcessEnv {
+    return buildAgentRuntimeEnv(this.env, this.config);
   }
 
   // --- Private methods ---

--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -175,24 +175,28 @@ async function fireWithRetry(
   onFire: (c: CronDefinition) => Promise<void> | void,
   logger: (msg: string) => void,
 ): Promise<boolean> {
-  const maxAttempts = RETRY_DELAYS_MS.length + 1; // 4 attempts total
+  // Fresh sessions own execution log writes and represent one long subprocess.
+  // Retrying them from the scheduler would block the tick loop for too long.
+  const maxAttempts = cron.fresh_session ? 1 : RETRY_DELAYS_MS.length + 1;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const start = Date.now();
     try {
       await Promise.resolve(onFire(cron));
-      appendExecutionLog(agentName, {
-        ts: new Date().toISOString(),
-        cron: cron.name,
-        status: 'fired',
-        attempt: attempt + 1,
-        duration_ms: Date.now() - start,
-        error: null,
-      });
+      if (!cron.fresh_session) {
+        appendExecutionLog(agentName, {
+          ts: new Date().toISOString(),
+          cron: cron.name,
+          status: 'fired',
+          attempt: attempt + 1,
+          duration_ms: Date.now() - start,
+          error: null,
+        });
+      }
       return true;
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       const duration_ms = Date.now() - start;
-      if (attempt < RETRY_DELAYS_MS.length) {
+      if (!cron.fresh_session && attempt < RETRY_DELAYS_MS.length) {
         const delay = RETRY_DELAYS_MS[attempt];
         logger(
           `[cron-scheduler] onFire failed for "${cron.name}" ` +
@@ -210,16 +214,18 @@ async function fireWithRetry(
       } else {
         logger(
           `[cron-scheduler] onFire failed for "${cron.name}" ` +
-          `after all 4 attempts — giving up. Last error: ${errMsg}`
+          `after all ${maxAttempts} attempt${maxAttempts === 1 ? '' : 's'} — giving up. Last error: ${errMsg}`
         );
-        appendExecutionLog(agentName, {
-          ts: new Date().toISOString(),
-          cron: cron.name,
-          status: 'failed',
-          attempt: attempt + 1,
-          duration_ms,
-          error: errMsg,
-        });
+        if (!cron.fresh_session) {
+          appendExecutionLog(agentName, {
+            ts: new Date().toISOString(),
+            cron: cron.name,
+            status: 'failed',
+            attempt: attempt + 1,
+            duration_ms,
+            error: errMsg,
+          });
+        }
       }
     }
   }
@@ -362,24 +368,32 @@ export class CronScheduler {
       const key = changeKeyFor(def);
       const existing = this.scheduled.get(def.name);
 
-      if (isReload && existing !== undefined && existing.changeKey === key) {
-        // Definition unchanged — preserve nextFireAt
-        nextScheduled.set(def.name, { ...existing, definition: def });
-        continue;
-      }
-
       // RELOAD-WHILE-FIRING GUARD: if the cron is mid-fire, preserve the
-      // existing entry as-is until the fire completes.  A fresh ScheduledCron
-      // built from stale crons.json (last_fired_at not yet persisted) would
-      // catch-up-fire on the next tick and double-fire the same logical event.
-      // The next reload (manual or after fire completes) will pick up the
-      // new schedule cleanly.
+      // exact object reference tick() is holding until the fire completes.
+      // This guard must come before the unchanged-schedule branch: spreading
+      // a firing entry copies `firing: true` into an orphaned object that tick()
+      // can no longer clear, freezing the cron permanently.
       if (isReload && existing !== undefined && existing.firing === true) {
         this.logger(
           `[cron-scheduler] reload deferred for "${def.name}" — fire in progress; ` +
           `new schedule will apply on next reload after fire completes`
         );
         nextScheduled.set(def.name, existing);
+        continue;
+      }
+
+      if (isReload && existing !== undefined && existing.changeKey === key) {
+        // Definition unchanged — preserve nextFireAt. A spread copy is only
+        // safe when not firing; the guard above should have caught that case.
+        if (existing.firing === true) {
+          this.logger(
+            `[cron-scheduler] BUG: reached spread-copy path while "${def.name}" is firing — ` +
+            `preserving original reference to avoid freeze. Guard ordering may have regressed.`
+          );
+          nextScheduled.set(def.name, existing);
+        } else {
+          nextScheduled.set(def.name, { ...existing, definition: def });
+        }
         continue;
       }
 
@@ -448,6 +462,8 @@ export class CronScheduler {
 
     // Update the last-good snapshot whenever we get a non-empty result.
     if (nextScheduled.size > 0) {
+      // Shallow-copy the map only: ScheduledCron objects are intentionally
+      // shared with `scheduled` so a firing entry's reference is not orphaned.
       this.lastGoodSchedule = new Map(nextScheduled);
     }
   }
@@ -496,20 +512,22 @@ export class CronScheduler {
         // crash the tick loop — we log and keep the in-memory schedule intact.
         const nowIso = new Date(now).toISOString();
         const newFireCount = (cron.fire_count ?? 0) + 1;
-        try {
-          updateCron(this.agentName, name, {
-            last_fired_at: nowIso,
-            fire_count: newFireCount,
-          });
-        } catch (err) {
-          this.logger(
-            `[cron-scheduler] WARNING: failed to persist fire state for "${name}" — ` +
-            `${err instanceof Error ? err.message : String(err)}. ` +
-            `In-memory schedule retained; state will be lost if daemon restarts.`
-          );
+        if (!cron.fresh_session) {
+          try {
+            updateCron(this.agentName, name, {
+              last_fired_at: nowIso,
+              fire_count: newFireCount,
+            });
+          } catch (err) {
+            this.logger(
+              `[cron-scheduler] WARNING: failed to persist fire state for "${name}" — ` +
+              `${err instanceof Error ? err.message : String(err)}. ` +
+              `In-memory schedule retained; state will be lost if daemon restarts.`
+            );
+          }
         }
 
-        // Advance in-memory nextFireAt
+        // Advance in-memory nextFireAt for both PTY and fresh-session crons.
         const next = computeNextFireAt(cron, now);
         if (!isNaN(next)) {
           sc.nextFireAt = next;

--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -512,19 +512,17 @@ export class CronScheduler {
         // crash the tick loop — we log and keep the in-memory schedule intact.
         const nowIso = new Date(now).toISOString();
         const newFireCount = (cron.fire_count ?? 0) + 1;
-        if (!cron.fresh_session) {
-          try {
-            updateCron(this.agentName, name, {
-              last_fired_at: nowIso,
-              fire_count: newFireCount,
-            });
-          } catch (err) {
-            this.logger(
-              `[cron-scheduler] WARNING: failed to persist fire state for "${name}" — ` +
-              `${err instanceof Error ? err.message : String(err)}. ` +
-              `In-memory schedule retained; state will be lost if daemon restarts.`
-            );
-          }
+        try {
+          updateCron(this.agentName, name, {
+            last_fired_at: nowIso,
+            fire_count: newFireCount,
+          });
+        } catch (err) {
+          this.logger(
+            `[cron-scheduler] WARNING: failed to persist fire state for "${name}" — ` +
+            `${err instanceof Error ? err.message : String(err)}. ` +
+            `In-memory schedule retained; state will be lost if daemon restarts.`
+          );
         }
 
         // Advance in-memory nextFireAt for both PTY and fresh-session crons.

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -1,15 +1,26 @@
-import { readdirSync, readFileSync, existsSync, writeFileSync, unlinkSync, statSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, writeFileSync, unlinkSync, statSync, renameSync } from 'fs';
 import { execFile } from 'child_process';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { hardRestart } from '../bus/system.js';
-import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
+import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery, CompactionLedger } from '../types/index.js';
 import { checkInbox, ackInbox } from '../bus/message.js';
 import { updateApproval } from '../bus/approval.js';
 import { AgentProcess } from './agent-process.js';
 import type { TelegramAPI } from '../telegram/api.js';
 import { KEYS } from '../pty/inject.js';
 import { stripControlChars } from '../utils/validate.js';
+import { findActiveJsonl, parseJsonlTurns, pauseForJsonlSnapshot } from '../utils/agent-session.js';
+import {
+  waitForSafePoint,
+  splitTurnsByTokenBudget,
+  flattenTurns,
+  validateAndPatchSummary,
+  redactLedgerSummary,
+  writeLedgerAndMarker,
+  sessionIdFromJsonlPath,
+  type SidecarCompactor,
+} from '../utils/sidecar-compactor.js';
 
 type LogFn = (msg: string) => void;
 
@@ -58,6 +69,11 @@ export class FastChecker {
   private ctxCircuitBrokenAt: number | null = null; // when circuit tripped (null = healthy)
   // Persisted to disk so --continue restarts don't reset the circuit breaker
   private ctxCircuitFile: string = '';
+  // Tier 1.5: sidecar compaction state
+  private ctxCompactFiredSessionId: string | null = null;
+  private ctxCompactInProgress: boolean = false;
+  private ctxCompactStartedAt: number = 0;
+  private ctxCompactRunId: number = 0; // incremented on each new run; late completions check before writing
 
   constructor(
     agent: AgentProcess,
@@ -208,6 +224,10 @@ export class FastChecker {
     if (this.chatId && this.telegramApi && this.isAgentActive()) {
       await this.sendTyping(this.telegramApi, this.chatId);
     }
+
+    // Manual compaction trigger first — claim before auto-Tier-1.5 so a manual request
+    // arriving in the same cycle doesn't fire again after auto-restart clears state.
+    await this.checkCompactNowMarker();
 
     // Context monitor: check usage thresholds and fire warnings/handoffs
     await this.checkContextStatus();
@@ -874,7 +894,7 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
    * Re-reads from disk only when the file has changed so dashboard updates take effect
    * within one poll cycle without a daemon restart.
    */
-  private getCtxThresholds(): { warn: number; handoff: number } {
+  private getCtxThresholds(): { warn: number; handoff: number; compact: number } {
     try {
       const configPath = join(this.agent.getAgentDir(), 'config.json');
       const mtime = statSync(configPath).mtimeMs;
@@ -883,6 +903,10 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
         const config = this.agent.getConfig();
         config.ctx_warning_threshold = cfg.ctx_warning_threshold;
         config.ctx_handoff_threshold = cfg.ctx_handoff_threshold;
+        config.ctx_compact_threshold = cfg.ctx_compact_threshold;
+        config.ctx_compact_enabled = cfg.ctx_compact_enabled;
+        config.ctx_compact_variant = cfg.ctx_compact_variant;
+        config.ctx_compact_last_n_turns_tokens = cfg.ctx_compact_last_n_turns_tokens;
         this.ctxConfigMtime = mtime;
       }
     } catch { /* keep stale values */ }
@@ -890,7 +914,67 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     return {
       warn: config.ctx_warning_threshold ?? 70,
       handoff: config.ctx_handoff_threshold ?? 80,
+      compact: config.ctx_compact_threshold ?? 60,
     };
+  }
+
+  /**
+   * Consume (claim) ALL pending .compact-now-* markers without triggering compaction.
+   * Called at the start of runSidecarCompaction so stale markers don't re-fire in the
+   * fresh session after a compaction-triggered restart.
+   */
+  private consumeCompactNowMarkers(): void {
+    const stateDir = this.paths.stateDir;
+    if (!existsSync(stateDir)) return;
+    try {
+      for (const f of readdirSync(stateDir)) {
+        if (f.startsWith('.compact-now-') && !f.endsWith('.claimed')) {
+          try { renameSync(join(stateDir, f), join(stateDir, f + '.claimed')); } catch { /* already gone */ }
+        }
+      }
+    } catch { /* non-fatal */ }
+  }
+
+  /**
+   * Check for .compact-now-{id} markers dropped by `cortextos bus compact-now`.
+   * Atomically claims the marker by renaming it to .claimed, then triggers
+   * Tier 1.5 compaction immediately (bypasses the threshold check).
+   */
+  private async checkCompactNowMarker(): Promise<void> {
+    if (this.ctxCompactInProgress) return;
+    if (this.agent.getConfig().ctx_compact_enabled !== true) return;
+    const stateDir = this.paths.stateDir;
+    if (!existsSync(stateDir)) return;
+    let entries: string[];
+    try {
+      entries = readdirSync(stateDir);
+    } catch {
+      return;
+    }
+    const marker = entries.find(f => f.startsWith('.compact-now-') && !f.endsWith('.claimed'));
+    if (!marker) return;
+    // Atomic claim via rename
+    const src = join(stateDir, marker);
+    const dst = join(stateDir, marker + '.claimed');
+    try {
+      renameSync(src, dst);
+    } catch {
+      return; // already claimed by another poll cycle
+    }
+    this.log(`[compactor] Manual compact-now request claimed: ${marker}`);
+    this.ctxCompactInProgress = true;
+    this.ctxCompactStartedAt = Date.now();
+    this.ctxCompactFiredSessionId = this.ctxLastSessionId;
+    // Use current context_status.json pct if available, else 0 (manual trigger)
+    let manualPct = 0;
+    try {
+      const data = JSON.parse(readFileSync(join(stateDir, 'context_status.json'), 'utf-8'));
+      if (typeof data.used_percentage === 'number') manualPct = data.used_percentage;
+    } catch { /* use 0 */ }
+    this.runSidecarCompaction(manualPct).catch(err => {
+      this.log(`[compactor] Manual compact-now failed: ${err}`);
+      this.ctxCompactInProgress = false;
+    });
   }
 
   /**
@@ -936,6 +1020,8 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
           this.ctxHandoffFiredAt = 0;
           this.ctxHandoffDeadlineAt = 0;
           this.ctxWarningFiredAt = 0;
+          this.ctxCompactFiredSessionId = null;
+          this.ctxCompactInProgress = false;
           this.log(`New session detected (${incomingSessionId.slice(0, 8)}…) — per-session ctx state reset`);
         }
         this.ctxLastSessionId = incomingSessionId;
@@ -950,7 +1036,7 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       return;
     }
 
-    const { warn, handoff } = this.getCtxThresholds();
+    const { warn, handoff, compact } = this.getCtxThresholds();
 
     // No threshold configured — observe-only mode (log but don't act)
     if (this.agent.getConfig().ctx_handoff_threshold === undefined) return;
@@ -975,8 +1061,31 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       this.log(`Context warning fired at ${pctRound}%`);
     }
 
-    // Tier 2: handoff (fires once per session lifecycle)
-    if (effectivePct >= handoff && this.ctxHandoffFiredAt === 0) {
+    // Tier 1.5: sidecar compaction — fires once per session at ctx_compact_threshold (default 60%)
+    // Only runs when ctx_compact_enabled=true; falls through to Tier 2 if compaction fails or is
+    // already in progress longer than 60s (prevents blocking Tier 2 indefinitely).
+    const compactEnabled = this.agent.getConfig().ctx_compact_enabled === true;
+    const compactAlreadyFired = this.ctxCompactFiredSessionId !== null &&
+      this.ctxCompactFiredSessionId === this.ctxLastSessionId;
+    const compactStuck = this.ctxCompactInProgress && (now - this.ctxCompactStartedAt > 60_000);
+    if (compactEnabled && !compactAlreadyFired && !this.ctxCompactInProgress && effectivePct >= compact) {
+      this.ctxCompactFiredSessionId = this.ctxLastSessionId;
+      this.ctxCompactInProgress = true;
+      this.ctxCompactStartedAt = now;
+      this.runSidecarCompaction(effectivePct).catch(err => {
+        this.log(`[compactor] Tier 1.5 error: ${err}`);
+        this.ctxCompactInProgress = false;
+      });
+    }
+    if (compactStuck) {
+      this.log('[compactor] Tier 1.5 stuck > 60s — invalidating run, clearing flag, allowing Tier 2');
+      this.ctxCompactRunId++; // invalidate: any late-completing run will see runId mismatch
+      this.ctxCompactInProgress = false;
+    }
+
+    // Tier 2: handoff (fires once per session lifecycle) — skip if compaction is in progress
+    const blockTier2 = this.ctxCompactInProgress && (now - this.ctxCompactStartedAt < 60_000);
+    if (!blockTier2 && effectivePct >= handoff && this.ctxHandoffFiredAt === 0) {
       this.ctxHandoffFiredAt = now;
       this.ctxHandoffDeadlineAt = now + 5 * 60_000; // 5min grace for agent to cooperate
       // Reset context_status.json so the new session doesn't re-trigger immediately
@@ -996,6 +1105,124 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
         writeFileSync(join(this.paths.stateDir, '.force-fresh'), '');
       } catch { /* non-fatal */ }
     }
+  }
+
+  /**
+   * Tier 1.5: run sidecar compaction. Dynamically imports the configured
+   * variant, waits for a safe point, snapshots the JSONL, summarizes,
+   * writes the ledger, then force-restarts. Clears ctxCompactInProgress on
+   * any exit path so Tier 2 can take over if anything goes wrong.
+   */
+  private async runSidecarCompaction(effectivePct: number): Promise<void> {
+    const agentDir = this.agent.getAgentDir();
+    const agentName = this.agent.name;
+    const config = this.agent.getConfig();
+    const variant = config.ctx_compact_variant ?? 'sonnet';
+    const tokenBudget = config.ctx_compact_last_n_turns_tokens ?? 8000;
+    const log = (msg: string) => this.log(msg);
+
+    // Consume all pending .compact-now-* markers before starting — prevents stale
+    // markers from refiring in the fresh session after this compaction restarts.
+    this.consumeCompactNowMarkers();
+
+    // Capture run ID so late completions after the 60s stuck timeout are discarded.
+    const runId = ++this.ctxCompactRunId;
+
+    this.log(`[compactor] Tier 1.5 starting (variant=${variant}, pct=${Math.round(effectivePct)}%, runId=${runId})`);
+
+    let createCompactor: () => SidecarCompactor;
+    try {
+      // Use require() with an absolute path — esbuild does not trace template-literal
+      // require() calls, so the module is loaded at runtime from dist/utils/ where
+      // each variant's tsup entry is compiled. dynamic import() with a template
+      // literal causes a build error when the glob matches no src/ files.
+      const modPath = join(__dirname, 'utils', `sidecar-compactor-${variant}.js`);
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const mod = (require as NodeRequire)(modPath) as { createCompactor?: () => SidecarCompactor };
+      if (typeof mod.createCompactor !== 'function') {
+        this.log(`[compactor] variant '${variant}' module missing createCompactor()`);
+        this.ctxCompactInProgress = false;
+        return;
+      }
+      createCompactor = mod.createCompactor;
+    } catch (err) {
+      this.log(`[compactor] Failed to load variant '${variant}': ${err}`);
+      this.ctxCompactInProgress = false;
+      return;
+    }
+
+    const safePoint = await waitForSafePoint(agentDir, 30_000, log);
+    if (!safePoint) {
+      this.log('[compactor] No safe point within 30s — aborting Tier 1.5');
+      this.ctxCompactInProgress = false;
+      return;
+    }
+
+    const snapshotPath = await pauseForJsonlSnapshot(this.agent, log);
+    if (!snapshotPath) {
+      this.log('[compactor] JSONL snapshot failed — aborting Tier 1.5');
+      this.ctxCompactInProgress = false;
+      return;
+    }
+
+    const turns = parseJsonlTurns(snapshotPath);
+    if (turns.length === 0) {
+      this.log('[compactor] No parseable turns in snapshot — aborting Tier 1.5');
+      this.ctxCompactInProgress = false;
+      return;
+    }
+
+    const { middle, recent } = splitTurnsByTokenBudget(turns, tokenBudget);
+    const ctx = {
+      agentName,
+      middleTurnsText: flattenTurns(middle),
+      recentTurnsText: flattenTurns(recent),
+      contextPct: Math.round(effectivePct),
+      now: new Date().toISOString(),
+    };
+
+    const compactor = createCompactor();
+    const rawSummary = await compactor.summarize(ctx);
+    if (!rawSummary) {
+      this.log('[compactor] summarize() returned null — aborting Tier 1.5');
+      this.ctxCompactInProgress = false;
+      return;
+    }
+
+    const redacted = redactLedgerSummary(rawSummary);
+    const validated = validateAndPatchSummary(redacted, recent.length > 0, log);
+    if (!validated) {
+      this.log('[compactor] Ledger validation failed — aborting Tier 1.5');
+      this.ctxCompactInProgress = false;
+      return;
+    }
+
+    // Late-completion guard: if the 60s stuck timeout fired and incremented ctxCompactRunId,
+    // our runId no longer matches. Discard rather than writing a ledger + restarting
+    // concurrently with whatever Tier 2 may have already triggered.
+    if (runId !== this.ctxCompactRunId) {
+      this.log(`[compactor] Run ${runId} superseded by timeout — discarding late completion`);
+      return;
+    }
+
+    const jsonlPath = findActiveJsonl(agentDir);
+    const sessionId = jsonlPath ? (sessionIdFromJsonlPath(jsonlPath) ?? 'unknown') : 'unknown';
+    const ledger: CompactionLedger = {
+      schema_version: '1',
+      compacted_at: ctx.now,
+      session_id: sessionId,
+      context_pct_at_compact: ctx.contextPct,
+      variant: variant as CompactionLedger['variant'],
+      ...validated,
+      recent_turns_summary: ctx.recentTurnsText.slice(0, 8000),
+    };
+
+    const docPath = writeLedgerAndMarker(agentDir, this.paths, agentName, ledger);
+    this.log(`[compactor] Tier 1.5 ledger written → ${docPath} (runId=${runId})`);
+
+    // forceContextRestart clears ctxCompactInProgress indirectly via the session-reset path
+    this.ctxCompactInProgress = false;
+    this.forceContextRestart(`sidecar compaction complete (${variant}, ${ctx.contextPct}%)`);
   }
 
   /**
@@ -1046,6 +1273,7 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     this.ctxHandoffFiredAt = 0;
     this.ctxHandoffDeadlineAt = 0;
     this.ctxWarningFiredAt = 0;
+    this.ctxCompactInProgress = false;
 
     // Write .force-fresh + .restart-planned (hardRestart from src/bus/system.ts)
     hardRestart(this.paths, this.agent.name, `CONTEXT-FORCE-RESTART: ${reason}`);

--- a/src/daemon/ipc-server.ts
+++ b/src/daemon/ipc-server.ts
@@ -1,7 +1,7 @@
 import { createServer, Server, Socket } from 'net';
-import { existsSync, unlinkSync, chmodSync, readFileSync } from 'fs';
-import { join, resolve as pathResolve } from 'path';
-import type { IPCRequest, IPCResponse, CronSummaryRow, CronDefinition } from '../types/index.js';
+import { existsSync, unlinkSync, chmodSync, readFileSync, readdirSync } from 'fs';
+import { isAbsolute, join, resolve as pathResolve } from 'path';
+import type { AgentConfig, IPCRequest, IPCResponse, CronSummaryRow, CronDefinition } from '../types/index.js';
 import { AgentManager } from './agent-manager.js';
 import { getIpcPath } from '../utils/paths.js';
 import { readCrons, getExecutionLog, getExecutionLogPage, addCron, updateCron, removeCron, getCronByName } from '../bus/crons.js';
@@ -9,6 +9,7 @@ import type { ExecutionLogStatusFilter } from '../bus/crons.js';
 import { nextFireFromCron } from './cron-scheduler.js';
 import { parseDurationMs } from '../bus/cron-state.js';
 import { computeHealth, aggregateFleetHealth } from '../utils/cron-health.js';
+import { isFreshSessionProtectedCron, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 
 const WORKER_NAME_REGEX = /^[a-z0-9_-]+$/;
 
@@ -55,6 +56,9 @@ export interface FireCronResult {
   error?: string;
 }
 
+type LegacyInjectFn = (agent: string, text: string) => boolean;
+type CronDispatchFn = (agent: string, cron: CronDefinition, firedAt: string) => Promise<void> | void;
+
 /**
  * fire-cron handler — validates manualFireDisabled + cooldown, then injects
  * the cron's prompt into the agent's PTY.
@@ -67,9 +71,9 @@ export interface FireCronResult {
 export function handleFireCron(
   agent: string | undefined,
   cronName: string | undefined,
-  injectFn: (agent: string, text: string) => boolean,
+  dispatchOrInjectFn: LegacyInjectFn | CronDispatchFn,
   nowMs = Date.now(),
-): FireCronResult {
+): FireCronResult | Promise<FireCronResult> {
   if (!agent || !agent.trim()) {
     return { ok: false, error: 'Agent name is required.' };
   }
@@ -95,18 +99,27 @@ export function handleFireCron(
     return { ok: false, error: `Cooldown active — wait ${waitSec}s before firing again.` };
   }
 
-  // Inject into PTY
-  const injection = `[CRON: ${cronName}] ${cron.prompt}`;
-  const injected = injectFn(agent, injection);
-  if (!injected) {
-    return { ok: false, error: `Agent '${agent}' not found or not running.` };
+  // Backward-compatible legacy path for unit tests and older callers.
+  if (dispatchOrInjectFn.length === 2) {
+    const injection = `[CRON: ${cronName}] ${cron.prompt}`;
+    const injected = (dispatchOrInjectFn as LegacyInjectFn)(agent, injection);
+    if (!injected) {
+      return { ok: false, error: `Agent '${agent}' not found or not running.` };
+    }
+    _manualFireLastFired.set(`${agent}::${cronName}`, nowMs);
+    return { ok: true, firedAt: nowMs };
   }
 
-  // Record fire time for cooldown tracking
-  const firedAt = nowMs;
-  _manualFireLastFired.set(`${agent}::${cronName}`, firedAt);
-
-  return { ok: true, firedAt };
+  const firedAtIso = new Date(nowMs).toISOString();
+  return Promise.resolve((dispatchOrInjectFn as CronDispatchFn)(agent, cron, firedAtIso))
+    .then(() => {
+      _manualFireLastFired.set(`${agent}::${cronName}`, nowMs);
+      return { ok: true, firedAt: nowMs };
+    })
+    .catch((err) => ({
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }));
 }
 
 // ---------------------------------------------------------------------------
@@ -303,21 +316,84 @@ export function isValidSchedule(schedule: string): boolean {
 /**
  * Read the list of enabled agent names from enabled-agents.json.
  */
-function getEnabledAgents(): string[] {
+function getEnabledAgentEntries(): Record<string, { enabled?: boolean; org?: string }> {
   const ctxRoot = process.env.CTX_ROOT ?? process.cwd();
   const enabledFile = join(ctxRoot, 'config', 'enabled-agents.json');
-  if (!existsSync(enabledFile)) return [];
+  if (!existsSync(enabledFile)) return {};
   try {
-    const data = JSON.parse(readFileSync(enabledFile, 'utf-8')) as Record<
-      string,
-      { enabled?: boolean }
-    >;
-    return Object.entries(data)
+    return JSON.parse(readFileSync(enabledFile, 'utf-8')) as Record<string, { enabled?: boolean; org?: string }>;
+  } catch {
+    return {};
+  }
+}
+
+function getEnabledAgents(): string[] {
+  const data = getEnabledAgentEntries();
+  return Object.entries(data)
       .filter(([, v]) => v.enabled !== false)
       .map(([k]) => k);
-  } catch {
-    return [];
+}
+
+function getAgentRuntime(agent: string): AgentConfig['runtime'] | undefined {
+  const frameworkRoot = process.env.CTX_FRAMEWORK_ROOT ?? process.env.CTX_PROJECT_ROOT ?? process.cwd();
+  const entry = getEnabledAgentEntries()[agent];
+  const candidateOrgs = entry?.org ? [entry.org] : [];
+  const orgsDir = join(frameworkRoot, 'orgs');
+  if (candidateOrgs.length === 0 && existsSync(orgsDir)) {
+    try {
+      candidateOrgs.push(...readdirSync(orgsDir));
+    } catch { /* ignore */ }
   }
+
+  for (const org of candidateOrgs) {
+    try {
+      const configPath = join(frameworkRoot, 'orgs', org, 'agents', agent, 'config.json');
+      if (!existsSync(configPath)) continue;
+      return (JSON.parse(readFileSync(configPath, 'utf-8')) as AgentConfig).runtime;
+    } catch { /* ignore malformed configs here; other layers validate config */ }
+  }
+  return undefined;
+}
+
+function validateFreshSessionFields(
+  agent: string,
+  cronName: string,
+  fields: Partial<CronDefinition>,
+): MutationResult {
+  if (fields.fresh_session !== undefined && typeof fields.fresh_session !== 'boolean') {
+    return { ok: false, error: 'fresh_session must be boolean.', field: 'fresh_session' };
+  }
+  if (fields.skill_file !== undefined) {
+    if (typeof fields.skill_file !== 'string' || !fields.skill_file.trim()) {
+      return { ok: false, error: 'skill_file must be a non-empty string.', field: 'skill_file' };
+    }
+    if (isAbsolute(fields.skill_file)) {
+      return { ok: false, error: 'skill_file must be a relative path.', field: 'skill_file' };
+    }
+  }
+  if (fields.protocol_file !== undefined) {
+    if (typeof fields.protocol_file !== 'string' || !fields.protocol_file.trim()) {
+      return { ok: false, error: 'protocol_file must be a non-empty string.', field: 'protocol_file' };
+    }
+    if (isAbsolute(fields.protocol_file)) {
+      return { ok: false, error: 'protocol_file must be a relative path.', field: 'protocol_file' };
+    }
+  }
+  if (fields.fresh_session_timeout_ms !== undefined) {
+    if (!Number.isInteger(fields.fresh_session_timeout_ms) || fields.fresh_session_timeout_ms <= 0) {
+      return { ok: false, error: 'fresh_session_timeout_ms must be a positive integer.', field: 'fresh_session_timeout_ms' };
+    }
+  }
+  if (fields.fresh_session === true) {
+    if (isFreshSessionProtectedCron(agent, cronName)) {
+      return { ok: false, error: `fresh_session is not allowed for protected cron '${agent}/${cronName}'.`, field: 'fresh_session' };
+    }
+    const runtime = getAgentRuntime(agent);
+    if (!isFreshSessionSupportedRuntime(runtime)) {
+      return { ok: false, error: `fresh_session is not supported for runtime '${runtime}'.`, field: 'fresh_session' };
+    }
+  }
+  return { ok: true };
 }
 
 /**
@@ -381,6 +457,9 @@ export function handleAddCron(
     return { ok: false, error: 'Prompt is required and must be non-empty.', field: 'prompt' };
   }
 
+  const freshValidation = validateFreshSessionFields(agent, name, definition);
+  if (!freshValidation.ok) return freshValidation;
+
   const fullDef: CronDefinition = {
     name,
     prompt: prompt.trim(),
@@ -391,6 +470,12 @@ export function handleAddCron(
     ...(definition.metadata ? { metadata: definition.metadata } : {}),
     ...(definition.manualFireDisabled !== undefined
       ? { manualFireDisabled: !!definition.manualFireDisabled }
+      : {}),
+    ...(definition.fresh_session !== undefined ? { fresh_session: definition.fresh_session } : {}),
+    ...(definition.skill_file !== undefined ? { skill_file: definition.skill_file.trim() } : {}),
+    ...(definition.protocol_file !== undefined ? { protocol_file: definition.protocol_file.trim() } : {}),
+    ...(definition.fresh_session_timeout_ms !== undefined
+      ? { fresh_session_timeout_ms: definition.fresh_session_timeout_ms }
       : {}),
   };
 
@@ -437,6 +522,16 @@ export function handleUpdateCron(
   // Validate prompt if provided
   if (patch.prompt !== undefined && !patch.prompt.trim()) {
     return { ok: false, error: 'Prompt must be non-empty.', field: 'prompt' };
+  }
+
+  const freshValidation = validateFreshSessionFields(agent, name, patch);
+  if (!freshValidation.ok) return freshValidation;
+
+  if (patch.skill_file !== undefined) {
+    patch = { ...patch, skill_file: patch.skill_file.trim() };
+  }
+  if (patch.protocol_file !== undefined) {
+    patch = { ...patch, protocol_file: patch.protocol_file.trim() };
   }
 
   const found = updateCron(agent, name, patch);
@@ -506,7 +601,7 @@ export class IPCServer {
           try {
             const request: IPCRequest = JSON.parse(data);
             data = '';
-            this.handleRequest(request, socket);
+            void this.handleRequest(request, socket);
           } catch {
             // Incomplete JSON, wait for more data
           }
@@ -567,7 +662,7 @@ export class IPCServer {
   /**
    * Handle an incoming IPC request.
    */
-  private handleRequest(request: IPCRequest, socket: Socket): void {
+  private async handleRequest(request: IPCRequest, socket: Socket): Promise<void> {
     // BUG-015: log every incoming IPC request with its source so we can
     // trace which CLI command triggered which daemon action. The source
     // field is populated by CLI clients (cortextos enable / disable / stop
@@ -724,10 +819,10 @@ export class IPCServer {
         case 'fire-cron': {
           const agentToFire = request.agent;
           const fireCronName = request.data?.name as string | undefined;
-          const fireCronResult = handleFireCron(
+          const fireCronResult = await handleFireCron(
             agentToFire,
             fireCronName,
-            (a, text) => this.agentManager.injectAgent(a, text),
+            (a, cron, firedAt) => this.agentManager.dispatchCron(a, cron, firedAt),
           );
           if (fireCronResult.ok) {
             // Invalidate fleet health cache so next poll reflects the new fire

--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -148,10 +148,11 @@ function shouldSuppressDedup(stateDir: string, endType: string): boolean {
   return false;
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const agentName = process.env.CTX_AGENT_NAME;
   const instanceId = process.env.CTX_INSTANCE_ID || 'default';
   if (!agentName) return;
+  if (process.env.CTX_FRESH_SESSION_CRON) return;
 
   const ctxRoot = join(homedir(), '.cortextos', instanceId);
   const stateDir = join(ctxRoot, 'state', agentName);
@@ -331,4 +332,6 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(() => process.exit(0));
+if (!process.env.VITEST) {
+  main().catch(() => process.exit(0));
+}

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
+import { buildAgentRuntimeEnv } from '../utils/env.js';
 
 // node-pty types
 interface IPty {
@@ -19,7 +20,7 @@ interface IPtySpawnOptions {
   cols?: number;
   rows?: number;
   cwd?: string;
-  env?: Record<string, string>;
+  env?: NodeJS.ProcessEnv;
 }
 
 type SpawnFn = (file: string, args: string[], options: IPtySpawnOptions) => IPty;
@@ -62,79 +63,7 @@ export class AgentPTY {
 
     const cwd = this.config.working_directory || this.env.agentDir || process.cwd();
 
-    // Build environment variables for the PTY process
-    const ptyEnv: Record<string, string> = {
-      ...this.getBaseEnv(),
-      CTX_INSTANCE_ID: this.env.instanceId,
-      CTX_ROOT: this.env.ctxRoot,
-      CTX_FRAMEWORK_ROOT: this.env.frameworkRoot,
-      CTX_AGENT_NAME: this.env.agentName,
-      CTX_ORG: this.env.org,
-      CTX_AGENT_DIR: this.env.agentDir,
-      CTX_PROJECT_ROOT: this.env.projectRoot,
-      // Backward compat
-      CRM_AGENT_NAME: this.env.agentName,
-      CRM_TEMPLATE_ROOT: this.env.frameworkRoot,
-    };
-
-    // Source org-level shared secrets (orgs/{org}/secrets.env).
-    // These are shared across all agents in the org: OPENAI_KEY, APIFY_TOKEN, GEMINI_API_KEY, etc.
-    // Agent .env is loaded after and overrides org values — agent-specific keys win.
-    if (this.env.org && this.env.projectRoot) {
-      const orgEnvFile = join(this.env.projectRoot, 'orgs', this.env.org, 'secrets.env');
-      if (existsSync(orgEnvFile)) {
-        const content = readFileSync(orgEnvFile, 'utf-8');
-        for (const line of content.split('\n')) {
-          const trimmed = line.trim();
-          if (!trimmed || trimmed.startsWith('#')) continue;
-          const eqIdx = trimmed.indexOf('=');
-          if (eqIdx > 0) {
-            ptyEnv[trimmed.slice(0, eqIdx).trim()] = trimmed.slice(eqIdx + 1).trim();
-          }
-        }
-      }
-    }
-
-    // Source agent .env file (overrides org secrets.env for same key names).
-    // Contains agent-specific secrets: BOT_TOKEN, CHAT_ID, CLAUDE_CODE_OAUTH_TOKEN.
-    const agentEnvFile = join(this.env.agentDir, '.env');
-    if (existsSync(agentEnvFile)) {
-      const content = readFileSync(agentEnvFile, 'utf-8');
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith('#')) continue;
-        const eqIdx = trimmed.indexOf('=');
-        if (eqIdx > 0) {
-          ptyEnv[trimmed.slice(0, eqIdx).trim()] = trimmed.slice(eqIdx + 1).trim();
-        }
-      }
-    }
-
-    // Add convenience CTX_* aliases used throughout agent templates.
-    // CTX_TELEGRAM_CHAT_ID: alias for CHAT_ID from the agent's .env
-    if (ptyEnv['CHAT_ID']) {
-      ptyEnv['CTX_TELEGRAM_CHAT_ID'] = ptyEnv['CHAT_ID'];
-    }
-    // CTX_TIMEZONE: from config.json timezone field, falls back to system TZ
-    const configTimezone = this.config.timezone;
-    if (configTimezone) {
-      ptyEnv['CTX_TIMEZONE'] = configTimezone;
-      ptyEnv['TZ'] = configTimezone; // also set TZ so date/time system calls use correct zone
-    } else if (process.env.TZ) {
-      ptyEnv['CTX_TIMEZONE'] = process.env.TZ;
-    }
-    // CTX_ORCHESTRATOR_AGENT: read from org context.json so agents can route to orchestrator
-    if (this.env.projectRoot && this.env.org) {
-      try {
-        const contextPath = join(this.env.projectRoot, 'orgs', this.env.org, 'context.json');
-        if (existsSync(contextPath)) {
-          const ctx = JSON.parse(readFileSync(contextPath, 'utf-8'));
-          if (ctx.orchestrator) {
-            ptyEnv['CTX_ORCHESTRATOR_AGENT'] = ctx.orchestrator;
-          }
-        }
-      } catch { /* leave unset if context.json is missing or malformed */ }
-    }
+    const ptyEnv = buildAgentRuntimeEnv(this.env, this.config);
 
     // Spawn the agent binary directly (no shell wrapper) — cross-platform, no shell escaping needed.
     // env is passed natively via node-pty options; no bash export commands required.
@@ -314,37 +243,4 @@ export class AgentPTY {
     return this.outputBuffer;
   }
 
-  /**
-   * Get a clean base environment (excluding potentially harmful vars).
-   */
-  private getBaseEnv(): Record<string, string> {
-    const env: Record<string, string> = {};
-    // Copy essential env vars
-    const keepVars = [
-      'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
-      'TMPDIR', 'TEMP', 'TMP', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY',
-      'NODE_PATH', 'COMSPEC', 'USERPROFILE',
-      // Windows path-expansion essentials. Stripping these causes phantom
-      // %SystemDrive% directories from inherited Search Indexer processes
-      // and Unity batchmode UPM IPC crashes (path.join(undefined,...)).
-      'SystemDrive', 'SystemRoot', 'windir',
-      'APPDATA', 'LOCALAPPDATA', 'ProgramData', 'ALLUSERSPROFILE',
-      'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
-      'HOMEDRIVE', 'HOMEPATH', 'PUBLIC',
-    ];
-    for (const key of keepVars) {
-      if (process.env[key]) {
-        env[key] = process.env[key]!;
-      }
-    }
-
-    // Windows: ensure UTF-8 locale so emoji and Unicode pass through the PTY
-    if (platform() === 'win32') {
-      if (!env['LANG']) env['LANG'] = 'en_US.UTF-8';
-      if (!env['LC_ALL']) env['LC_ALL'] = 'en_US.UTF-8';
-      if (!process.env['PYTHONIOENCODING']) env['PYTHONIOENCODING'] = 'utf-8';
-    }
-
-    return env;
-  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,6 +195,64 @@ export interface AgentConfig {
    * poller will be skipped regardless.
    */
   telegram_polling?: boolean;
+
+  /**
+   * Tier 1.5 sidecar context compaction (Pattern 1).
+   * MUST be explicitly true to activate — absence/false = disabled.
+   * Has no effect when runtime !== 'claude-code'.
+   */
+  ctx_compact_enabled?: boolean;
+
+  /**
+   * Context window % at which Tier 1.5 sidecar compaction fires.
+   * Must be < ctx_warning_threshold. Default 60.
+   */
+  ctx_compact_threshold?: number;
+
+  /**
+   * Which sidecar variant to use for compaction.
+   */
+  ctx_compact_variant?: 'sonnet' | 'haiku' | 'openai' | 'deterministic';
+
+  /**
+   * Token budget for recent turns preserved verbatim in the ledger.
+   * Not a turn count — the parser fills up to this many tokens from the
+   * end of the conversation. Default 8000.
+   */
+  ctx_compact_last_n_turns_tokens?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 1: Compaction Ledger (Tier 1.5 sidecar)
+// ---------------------------------------------------------------------------
+
+/**
+ * Structured ledger produced by a sidecar compactor at Tier 1.5
+ * (~60% context). Written to memory/handoffs/compaction-{ts}.md and
+ * surfaced to the new session via the existing .handoff-doc-path
+ * marker.
+ */
+export interface CompactionLedger {
+  schema_version: '1';
+  compacted_at: string;
+  session_id: string;
+  context_pct_at_compact: number;
+  variant: 'sonnet' | 'haiku' | 'openai' | 'deterministic';
+  resolved: string[];
+  pending: string[];
+  key_facts: {
+    current_state: string;
+    active_files?: string[];
+    blockers?: string[];
+    next_action: string;
+    coordination?: {
+      active_tasks?: Array<{ agent: string; task_id: string; status: string }>;
+      pending_approvals?: Array<{ id: string; category: string; blocking: string }>;
+      in_flight_deps?: string[];
+    };
+  };
+  recent_turns_summary: string;
+  redaction_count: number;
 }
 
 export interface CronEntry {
@@ -396,6 +454,31 @@ export interface CronDefinition {
    * @default false (manual fire is allowed by default — opt-out model)
    */
   manualFireDisabled?: boolean;
+
+  /**
+   * When true, the daemon spawns a fresh `claude --print --no-session-persistence`
+   * child process for this cron instead of injecting into the agent's live PTY.
+   * Default false — PTY inject is preserved unless explicitly opted in.
+   */
+  fresh_session?: boolean;
+
+  /**
+   * Relative path from CTX_AGENT_DIR to a skill or context file injected as
+   * system context via `--append-system-prompt` for fresh-session cron runs.
+   */
+  skill_file?: string;
+
+  /**
+   * Relative path from CTX_AGENT_DIR to an operational protocol/checklist file
+   * injected alongside `skill_file` for fresh-session cron runs.
+   */
+  protocol_file?: string;
+
+  /**
+   * Timeout in milliseconds for one fresh-session cron run before SIGTERM,
+   * followed by SIGKILL after a short grace period.
+   */
+  fresh_session_timeout_ms?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/agent-session.ts
+++ b/src/utils/agent-session.ts
@@ -1,0 +1,339 @@
+import {
+  copyFileSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from 'fs';
+import { homedir } from 'os';
+import { join, sep } from 'path';
+import { randomUUID } from 'crypto';
+
+/**
+ * Shared helpers for sidecar context compaction (Pattern 1).
+ *
+ * - Project-dir resolution mirrors AgentProcess.shouldContinue() exactly so
+ *   the sidecar reads the same JSONL the agent is writing.
+ * - JSONL parsing is tolerant: malformed/unknown lines are skipped.
+ * - Redaction strips obvious secrets before any external API call or before
+ *   the ledger doc is written to disk.
+ */
+
+export interface ParsedTurn {
+  uuid: string;
+  role: 'user' | 'assistant';
+  contentText: string;
+  estimatedTokens: number;
+  rawLine: string;
+}
+
+/**
+ * Build the Claude projects dir for a given agent directory. Mirrors
+ * AgentProcess.shouldContinue() one-for-one so the sidecar and the
+ * agent always agree on JSONL location.
+ */
+export function getAgentProjectDir(agentDir: string): string {
+  const slug = agentDir.split(sep).join('-');
+  return join(homedir(), '.claude', 'projects', slug);
+}
+
+/**
+ * Find the most recently modified .jsonl file for an agent (the active session).
+ */
+export function findActiveJsonl(agentDir: string): string | null {
+  const projectDir = getAgentProjectDir(agentDir);
+  if (!existsSync(projectDir)) return null;
+  let entries: string[];
+  try {
+    entries = readdirSync(projectDir);
+  } catch {
+    return null;
+  }
+  const files = entries
+    .filter(f => f.endsWith('.jsonl'))
+    .map(f => {
+      try {
+        return { path: join(projectDir, f), mtime: statSync(join(projectDir, f)).mtimeMs };
+      } catch {
+        return null;
+      }
+    })
+    .filter((x): x is { path: string; mtime: number } => x !== null)
+    .sort((a, b) => b.mtime - a.mtime);
+  return files.length ? files[0].path : null;
+}
+
+/**
+ * Extract a session UUID from a JSONL path (filename minus .jsonl).
+ */
+export function sessionIdFromJsonlPath(jsonlPath: string): string | null {
+  const m = jsonlPath.match(/([a-f0-9-]+)\.jsonl$/i);
+  return m ? m[1] : null;
+}
+
+const REDACTION_PATTERNS: Array<{ name: string; re: RegExp; replacement: string }> = [
+  { name: 'telegram-token',   re: /\d{8,12}:[A-Za-z0-9_\-]{35}/g,                                     replacement: '[TELEGRAM_TOKEN]' },
+  { name: 'supabase-anon',    re: /eyJhbGciOiJIUzI1NiIsInR5cCI6Ikp[A-Za-z0-9_\-=]+/g,                  replacement: '[SUPABASE_KEY]' },
+  { name: 'jwt',              re: /eyJ[A-Za-z0-9_\-]+\.eyJ[A-Za-z0-9_\-]+\.[A-Za-z0-9_\-]+/g,         replacement: '[JWT]' },
+  { name: 'cf-token',         re: /cfut_[A-Za-z0-9]{40,}/g,                                          replacement: '[CF_TOKEN]' },
+  { name: 'resend-key',       re: /re_[A-Za-z0-9]{20,}/g,                                            replacement: '[RESEND_KEY]' },
+  { name: 'ark-key',          re: /ark-[a-zA-Z0-9]{20,}/gi,                                          replacement: '[ARK_KEY]' },
+  { name: 'email',            re: /[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}/g,                replacement: '[EMAIL]' },
+  { name: 'api-key-generic',  re: /[A-Za-z0-9_\-]{20,}(?:key|token|secret|password)[A-Za-z0-9_\-]*/gi, replacement: '[REDACTED_KEY]' },
+  { name: 'env-file-content', re: /(?:^|\n)[A-Z_]+=(?:"|')?[^\n"']{8,}(?:"|')?\n/gm,                  replacement: '\n[ENV_LINE_REDACTED]\n' },
+];
+
+export interface RedactResult {
+  text: string;
+  count: number;
+}
+
+/**
+ * Apply secret-redaction patterns. Returns redacted text + count of
+ * substitutions for audit logging.
+ */
+export function redact(text: string): string {
+  return redactWithCount(text).text;
+}
+
+export function redactWithCount(text: string): RedactResult {
+  let result = text;
+  let count = 0;
+  for (const { re, replacement } of REDACTION_PATTERNS) {
+    result = result.replace(re, () => {
+      count++;
+      return replacement;
+    });
+  }
+  return { text: result, count };
+}
+
+function flattenContent(content: unknown): string {
+  if (typeof content === 'string') return content;
+  if (!Array.isArray(content)) return '';
+  const parts: string[] = [];
+  for (const block of content) {
+    if (!block || typeof block !== 'object') continue;
+    const b = block as Record<string, unknown>;
+    const type = typeof b.type === 'string' ? b.type : '';
+    if (type === 'text' && typeof b.text === 'string') {
+      parts.push(b.text);
+    } else if (type === 'tool_use') {
+      const name = typeof b.name === 'string' ? b.name : 'unknown';
+      parts.push(`[tool: ${name}]`);
+    } else if (type === 'tool_result') {
+      const c = b.content;
+      let s = '';
+      if (typeof c === 'string') {
+        s = c;
+      } else if (Array.isArray(c)) {
+        s = c
+          .map(x => (x && typeof x === 'object' && typeof (x as Record<string, unknown>).text === 'string' ? (x as Record<string, string>).text : ''))
+          .join(' ');
+      }
+      parts.push(`[result: ${s.slice(0, 200)}]`);
+    } else if (type === 'image') {
+      parts.push('[image omitted]');
+    }
+  }
+  return parts.join('\n');
+}
+
+/**
+ * Tolerant JSONL parser. Malformed/unknown records are skipped, never
+ * throws. Returns parsed user/assistant turns with redacted content.
+ */
+export function parseJsonlTurns(jsonlPath: string): ParsedTurn[] {
+  let raw = '';
+  try {
+    raw = readFileSync(jsonlPath, 'utf-8');
+  } catch {
+    return [];
+  }
+  const lines = raw.split('\n').filter(Boolean);
+  const turns: ParsedTurn[] = [];
+  for (const line of lines) {
+    try {
+      const record = JSON.parse(line);
+      if (!record || typeof record !== 'object') continue;
+      const type = (record as Record<string, unknown>).type;
+      if (type !== 'user' && type !== 'assistant') continue;
+      const message = (record as Record<string, unknown>).message as Record<string, unknown> | undefined;
+      if (!message || !('content' in message)) continue;
+      const contentText = flattenContent(message.content);
+      if (!contentText.trim()) continue;
+      const redacted = redact(contentText);
+      const uuid = typeof (record as Record<string, unknown>).uuid === 'string'
+        ? ((record as Record<string, string>).uuid)
+        : randomUUID();
+      turns.push({
+        uuid,
+        role: type,
+        contentText: redacted,
+        estimatedTokens: Math.ceil(contentText.length / 4),
+        rawLine: line,
+      });
+    } catch {
+      // skip malformed line
+    }
+  }
+  return turns;
+}
+
+/**
+ * Inspect the raw JSONL line for the presence of a tool_use block
+ * without an accompanying tool_result. Used by the safe-point gate.
+ */
+/**
+ * Extract all tool_use IDs from a raw JSONL record's content array.
+ */
+function extractToolUseIds(rawLine: string): string[] {
+  try {
+    const r = JSON.parse(rawLine);
+    const content = r?.message?.content;
+    if (!Array.isArray(content)) return [];
+    return content
+      .filter((b: unknown) => b && typeof b === 'object' && (b as Record<string, unknown>).type === 'tool_use')
+      .map((b: unknown) => (b as Record<string, unknown>).id)
+      .filter((id): id is string => typeof id === 'string');
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Extract all tool_result.tool_use_id values from a raw JSONL record.
+ */
+function extractToolResultIds(rawLine: string): string[] {
+  try {
+    const r = JSON.parse(rawLine);
+    const content = r?.message?.content;
+    if (!Array.isArray(content)) return [];
+    return content
+      .filter((b: unknown) => b && typeof b === 'object' && (b as Record<string, unknown>).type === 'tool_result')
+      .map((b: unknown) => (b as Record<string, unknown>).tool_use_id)
+      .filter((id): id is string => typeof id === 'string');
+  } catch {
+    return [];
+  }
+}
+
+export function lastTurnHasPendingToolUse(rawLine: string): boolean {
+  return extractToolUseIds(rawLine).length > 0;
+}
+
+/**
+ * Safe-point check: the last assistant turn has no trailing tool_use, AND
+ * every tool_use ID emitted across the session has a matching tool_result.
+ * Uses ID-based matching to correctly handle parallel/multi-tool turns where
+ * one call returns before another — index comparison cannot detect this case.
+ */
+export function isSafePoint(turns: ParsedTurn[]): boolean {
+  if (turns.length === 0) return false;
+  const last = turns[turns.length - 1];
+  if (last.role !== 'assistant') return false;
+  if (lastTurnHasPendingToolUse(last.rawLine)) return false;
+
+  const pendingIds = new Set<string>();
+  for (const turn of turns) {
+    for (const id of extractToolUseIds(turn.rawLine)) {
+      pendingIds.add(id);
+    }
+    for (const id of extractToolResultIds(turn.rawLine)) {
+      pendingIds.delete(id);
+    }
+  }
+  return pendingIds.size === 0;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+/**
+ * Minimal AgentProcess surface required by pauseForJsonlSnapshot.
+ * Kept narrow so unit tests can mock with a plain object.
+ */
+export interface SnapshotAgentLike {
+  getRuntime(): string | undefined;
+  getChildPid(): number | null;
+  getAgentDir(): string;
+}
+
+export type Logger = (msg: string) => void;
+
+/**
+ * Pause the agent's Claude PTY child via SIGSTOP, snapshot its active
+ * JSONL to /tmp, then SIGCONT. Returns the snapshot path, or null when
+ * the runtime/platform is unsupported, the PID is unknown, or the copy
+ * fails.
+ *
+ * A 2s watchdog guarantees the child is resumed even on unhandled
+ * exceptions in the surrounding try block.
+ */
+export async function pauseForJsonlSnapshot(
+  agent: SnapshotAgentLike,
+  log: Logger = () => {},
+): Promise<string | null> {
+  const runtime = agent.getRuntime()?.trim() || 'claude-code';
+  if (runtime !== 'claude-code') {
+    log(`[compactor] Skipping snapshot: runtime ${runtime} not supported in Phase 4`);
+    return null;
+  }
+  if (process.platform === 'win32') {
+    log('[compactor] Skipping SIGSTOP: not supported on Windows');
+    return null;
+  }
+  const pid = agent.getChildPid();
+  if (!pid || pid <= 0) {
+    log('[compactor] Cannot pause: no valid child PID');
+    return null;
+  }
+
+  let watchdogFired = false;
+  const watchdog = setTimeout(() => {
+    watchdogFired = true;
+    try { process.kill(pid, 'SIGCONT'); } catch { /* pid gone */ }
+    log('[compactor] WATCHDOG: force-resumed after 2s (pause exceeded limit)');
+  }, 2_000);
+
+  try {
+    try {
+      process.kill(pid, 'SIGSTOP');
+    } catch (err) {
+      log(`[compactor] SIGSTOP failed: ${err}`);
+      return null;
+    }
+    await sleep(100);
+    // If watchdog already fired during sleep, the process has resumed — snapshot would
+    // be taken of a running process (potentially mid-write). Discard rather than risk
+    // a partial ledger.
+    if (watchdogFired) {
+      log('[compactor] Watchdog fired before copy — snapshot discarded');
+      return null;
+    }
+    const src = findActiveJsonl(agent.getAgentDir());
+    if (!src) {
+      log('[compactor] No active JSONL to snapshot');
+      return null;
+    }
+    const dest = `/tmp/compaction-snapshot-${Date.now()}.jsonl`;
+    try {
+      copyFileSync(src, dest);
+    } catch (err) {
+      log(`[compactor] JSONL copy failed: ${err}`);
+      return null;
+    }
+    if (watchdogFired) {
+      log('[compactor] Watchdog fired during copy — snapshot may be partial, discarding');
+      return null;
+    }
+    return dest;
+  } catch (err) {
+    log(`[compactor] pause/copy error: ${err}`);
+    return null;
+  } finally {
+    clearTimeout(watchdog);
+    try { process.kill(pid, 'SIGCONT'); } catch { /* pid gone is fine */ }
+  }
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { join, basename } from 'path';
-import { homedir } from 'os';
-import type { CtxEnv } from '../types/index.js';
+import { homedir, platform } from 'os';
+import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { ensureDir } from './atomic.js';
 import { validateAgentName, validateOrgName } from './validate.js';
 
@@ -162,6 +162,100 @@ export function parseEnvFile(filePath: string): Record<string, string> {
     // Ignore read errors
   }
   return result;
+}
+
+/**
+ * Build the complete environment for a spawned agent runtime.
+ *
+ * This is shared by the long-lived PTY path and one-shot fresh-session cron
+ * spawns so both receive the same CTX_* values, org secrets, agent .env, and
+ * timezone/orchestrator conveniences.
+ */
+export function buildAgentRuntimeEnv(env: CtxEnv, config: AgentConfig): NodeJS.ProcessEnv {
+  const ptyEnv: NodeJS.ProcessEnv = {
+    ...getBaseRuntimeEnv(),
+    CTX_INSTANCE_ID: env.instanceId,
+    CTX_ROOT: env.ctxRoot,
+    CTX_FRAMEWORK_ROOT: env.frameworkRoot,
+    CTX_AGENT_NAME: env.agentName,
+    CTX_ORG: env.org,
+    CTX_AGENT_DIR: env.agentDir,
+    CTX_PROJECT_ROOT: env.projectRoot,
+    // Backward compat
+    CRM_AGENT_NAME: env.agentName,
+    CRM_TEMPLATE_ROOT: env.frameworkRoot,
+  };
+
+  // Source org-level shared secrets first. Agent .env overrides below.
+  if (env.org && env.projectRoot) {
+    Object.assign(ptyEnv, parseEnvFile(join(env.projectRoot, 'orgs', env.org, 'secrets.env')));
+  }
+
+  // Source agent-specific secrets.
+  if (env.agentDir) {
+    Object.assign(ptyEnv, parseEnvFile(join(env.agentDir, '.env')));
+  }
+
+  if (ptyEnv['CHAT_ID']) {
+    ptyEnv['CTX_TELEGRAM_CHAT_ID'] = ptyEnv['CHAT_ID'];
+  }
+
+  const configTimezone = config.timezone;
+  if (configTimezone) {
+    ptyEnv['CTX_TIMEZONE'] = configTimezone;
+    ptyEnv['TZ'] = configTimezone;
+  } else if (process.env.TZ) {
+    ptyEnv['CTX_TIMEZONE'] = process.env.TZ;
+    ptyEnv['TZ'] = process.env.TZ;
+  }
+
+  if (env.projectRoot && env.org) {
+    try {
+      const contextPath = join(env.projectRoot, 'orgs', env.org, 'context.json');
+      if (existsSync(contextPath)) {
+        const ctx = JSON.parse(readFileSync(contextPath, 'utf-8'));
+        if (ctx.orchestrator) {
+          ptyEnv['CTX_ORCHESTRATOR_AGENT'] = ctx.orchestrator;
+        }
+      }
+    } catch { /* leave unset if context.json is missing or malformed */ }
+  }
+
+  return ptyEnv;
+}
+
+function getBaseRuntimeEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  const keepVars = [
+    'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
+    'TMPDIR', 'TEMP', 'TMP', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY',
+    'NODE_PATH', 'COMSPEC', 'USERPROFILE',
+    // Claude Code env passthroughs.
+    // IS_SANDBOX=1 lets --dangerously-skip-permissions run under root on
+    // VPS/container installs. CLAUDE_CODE_DISABLE_1M_CONTEXT controls the
+    // Sonnet/Haiku 1M context opt-out documented in the .env template.
+    'IS_SANDBOX', 'CLAUDE_CODE_DISABLE_1M_CONTEXT',
+    // Windows path-expansion essentials. Stripping these causes phantom
+    // %SystemDrive% directories from inherited Search Indexer processes
+    // and Unity batchmode UPM IPC crashes (path.join(undefined,...)).
+    'SystemDrive', 'SystemRoot', 'windir',
+    'APPDATA', 'LOCALAPPDATA', 'ProgramData', 'ALLUSERSPROFILE',
+    'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
+    'HOMEDRIVE', 'HOMEPATH', 'PUBLIC',
+  ];
+  for (const key of keepVars) {
+    if (process.env[key]) {
+      env[key] = process.env[key];
+    }
+  }
+
+  if (platform() === 'win32') {
+    if (!env['LANG']) env['LANG'] = 'en_US.UTF-8';
+    if (!env['LC_ALL']) env['LC_ALL'] = 'en_US.UTF-8';
+    if (!process.env['PYTHONIOENCODING']) env['PYTHONIOENCODING'] = 'utf-8';
+  }
+
+  return env;
 }
 
 /**

--- a/src/utils/fresh-session-guards.ts
+++ b/src/utils/fresh-session-guards.ts
@@ -1,0 +1,16 @@
+import type { AgentConfig } from '../types/index.js';
+
+export const PROTECTED_CRONS: ReadonlySet<string> = new Set([
+  'smart-g/*',
+  'top-g/morning-review',
+  'top-g/evening-review',
+  'top-g/weekly-review',
+]);
+
+export function isFreshSessionProtectedCron(agentName: string, cronName: string): boolean {
+  return PROTECTED_CRONS.has(`${agentName}/${cronName}`) || PROTECTED_CRONS.has(`${agentName}/*`);
+}
+
+export function isFreshSessionSupportedRuntime(runtime: AgentConfig['runtime'] | string | undefined): boolean {
+  return runtime === undefined || runtime === 'claude-code';
+}

--- a/src/utils/sidecar-compactor-haiku.ts
+++ b/src/utils/sidecar-compactor-haiku.ts
@@ -1,0 +1,88 @@
+import type { SidecarCompactor, CompactionContext, CompactionSummary } from './sidecar-compactor.js';
+
+const MODEL = 'claude-haiku-4-5-20251001';
+const ANTHROPIC_API = 'https://api.anthropic.com/v1/messages';
+
+const SYSTEM_PROMPT = `You are a context compactor for an AI coding agent. Extract a structured compaction ledger from the conversation transcript.
+
+Return ONLY valid JSON (no markdown, no explanation):
+{
+  "resolved": ["<completed item>", ...],
+  "pending": ["<pending item>", ...],
+  "key_facts": {
+    "current_state": "<current state one paragraph>",
+    "next_action": "<single concrete next step — required, never empty>",
+    "active_files": ["<file>", ...],
+    "blockers": ["<blocker>", ...]
+  },
+  "redaction_count": 0
+}`;
+
+interface AnthropicResponse {
+  content?: Array<{ type: string; text?: string }>;
+}
+
+export class HaikuSidecarCompactor implements SidecarCompactor {
+  async summarize(ctx: CompactionContext): Promise<CompactionSummary | null> {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return null;
+
+    // No per-turn truncation — splitTurnsByTokenBudget already bounds total size.
+    // Truncating at \n\n boundaries breaks code blocks, JSON, and log output mid-thought.
+    // Haiku 200K context handles the bounded token budget without per-turn clipping.
+    const userContent = `Agent: ${ctx.agentName} | Context: ${ctx.contextPct}% | ${ctx.now}
+
+=== OLDER TURNS ===
+${ctx.middleTurnsText.slice(0, 40_000)}
+
+=== RECENT TURNS ===
+${ctx.recentTurnsText.slice(0, 12_000)}
+
+Return ledger JSON.`;
+
+    let resp: Response;
+    try {
+      resp = await fetch(ANTHROPIC_API, {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          max_tokens: 2048,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: 'user', content: userContent }],
+        }),
+        signal: AbortSignal.timeout(45_000),
+      });
+    } catch {
+      return null;
+    }
+
+    if (!resp.ok) return null;
+
+    let body: AnthropicResponse;
+    try {
+      body = await resp.json() as AnthropicResponse;
+    } catch {
+      return null;
+    }
+
+    const text = body.content?.find(b => b.type === 'text')?.text ?? '';
+    if (!text) return null;
+
+    try {
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) return null;
+      return JSON.parse(jsonMatch[0]) as CompactionSummary;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function createCompactor(): SidecarCompactor {
+  return new HaikuSidecarCompactor();
+}

--- a/src/utils/sidecar-compactor-sonnet.ts
+++ b/src/utils/sidecar-compactor-sonnet.ts
@@ -1,0 +1,102 @@
+import type { SidecarCompactor, CompactionContext, CompactionSummary } from './sidecar-compactor.js';
+
+const MODEL = 'claude-sonnet-4-6';
+const ANTHROPIC_API = 'https://api.anthropic.com/v1/messages';
+
+const SYSTEM_PROMPT = `You are a context compactor for an AI coding agent. Given a conversation transcript, extract structured information for a compaction ledger.
+
+Return ONLY valid JSON matching this schema (no markdown, no explanation):
+{
+  "resolved": ["<completed task 1>", ...],
+  "pending": ["<pending task 1>", ...],
+  "key_facts": {
+    "current_state": "<one paragraph describing where things stand right now>",
+    "next_action": "<the single most important next action the agent should take>",
+    "active_files": ["<file1>", ...],
+    "blockers": ["<blocker1>", ...]
+  },
+  "redaction_count": 0
+}
+
+Rules:
+- resolved: tasks/items that were completed in the transcript
+- pending: tasks/items still in progress or not yet started
+- key_facts.current_state: factual description of current state (not a plan)
+- key_facts.next_action: must be non-empty — the single concrete next step
+- active_files: files that were recently modified or are relevant to pending work
+- blockers: anything blocking progress
+- If no resolved/pending/active_files/blockers, use empty arrays
+- redaction_count: 0 (the caller updates this)`;
+
+interface AnthropicResponse {
+  content?: Array<{ type: string; text?: string }>;
+  error?: { message: string };
+}
+
+export class ClaudeSidecarCompactor implements SidecarCompactor {
+  async summarize(ctx: CompactionContext): Promise<CompactionSummary | null> {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) {
+      return null;
+    }
+
+    const userContent = `Agent: ${ctx.agentName}
+Compacted at: ${ctx.now}
+Context: ${ctx.contextPct}%
+
+=== OLDER TURNS (summarize these) ===
+${ctx.middleTurnsText.slice(0, 60_000)}
+
+=== RECENT TURNS (preserve context for these) ===
+${ctx.recentTurnsText.slice(0, 20_000)}
+
+Extract the compaction ledger JSON now.`;
+
+    let resp: Response;
+    try {
+      resp = await fetch(ANTHROPIC_API, {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model: MODEL,
+          max_tokens: 2048,
+          system: SYSTEM_PROMPT,
+          messages: [{ role: 'user', content: userContent }],
+        }),
+        signal: AbortSignal.timeout(60_000),
+      });
+    } catch (err) {
+      return null;
+    }
+
+    if (!resp.ok) {
+      return null;
+    }
+
+    let body: AnthropicResponse;
+    try {
+      body = await resp.json() as AnthropicResponse;
+    } catch {
+      return null;
+    }
+
+    const text = body.content?.find(b => b.type === 'text')?.text ?? '';
+    if (!text) return null;
+
+    try {
+      const jsonMatch = text.match(/\{[\s\S]*\}/);
+      if (!jsonMatch) return null;
+      return JSON.parse(jsonMatch[0]) as CompactionSummary;
+    } catch {
+      return null;
+    }
+  }
+}
+
+export function createCompactor(): SidecarCompactor {
+  return new ClaudeSidecarCompactor();
+}

--- a/src/utils/sidecar-compactor.ts
+++ b/src/utils/sidecar-compactor.ts
@@ -1,0 +1,299 @@
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import type { BusPaths, CompactionLedger } from '../types/index.js';
+import {
+  findActiveJsonl,
+  isSafePoint,
+  parseJsonlTurns,
+  redactWithCount,
+  sessionIdFromJsonlPath,
+  type ParsedTurn,
+} from './agent-session.js';
+
+export type Logger = (msg: string) => void;
+
+/**
+ * Context passed to a variant-specific summarizer.
+ *
+ * `middleTurnsText` is a pre-redacted, pre-flattened transcript of all
+ * turns except the most recent N tokens. `recentTurnsText` is the
+ * verbatim tail (also redacted) that the ledger preserves so the
+ * post-restart session can pick up exactly where the prior thought
+ * stopped.
+ */
+export interface CompactionContext {
+  agentName: string;
+  middleTurnsText: string;
+  recentTurnsText: string;
+  contextPct: number;
+  now: string;
+}
+
+/**
+ * Output of a variant compactor's summarize() call. The base flow
+ * fills in compacted_at, session_id, schema_version, variant, and
+ * recent_turns_summary — variants only return the LLM-extracted parts.
+ */
+export type CompactionSummary = Pick<
+  CompactionLedger,
+  'resolved' | 'pending' | 'key_facts' | 'redaction_count'
+>;
+
+/**
+ * Interface every variant (Claude/Haiku/OpenAI/Deterministic) implements.
+ * Returning null = sidecar failed/unavailable → caller falls through to
+ * the existing Tier 1-3 path.
+ */
+export interface SidecarCompactor {
+  /**
+   * Run the variant-specific summarization and return the partial
+   * ledger (or null on failure / unavailable).
+   *
+   * Implementations MUST be tolerant of network errors, malformed
+   * model output, and missing API keys — never throw.
+   */
+  summarize(ctx: CompactionContext): Promise<CompactionSummary | null>;
+}
+
+/**
+ * Wait until the active JSONL ends at a safe point (last assistant
+ * turn is final text and no in-flight tool_use). Polls every 2s up to
+ * maxWaitMs. Returns true on success, false on timeout.
+ */
+export async function waitForSafePoint(
+  agentDir: string,
+  maxWaitMs = 30_000,
+  log: Logger = () => {},
+): Promise<boolean> {
+  const deadline = Date.now() + maxWaitMs;
+  while (Date.now() < deadline) {
+    const jsonl = findActiveJsonl(agentDir);
+    if (jsonl) {
+      const turns = parseJsonlTurns(jsonl);
+      if (turns.length > 0 && isSafePoint(turns)) {
+        return true;
+      }
+    }
+    await sleep(2_000);
+  }
+  log('[compactor] waitForSafePoint: timed out after 30s — skipping');
+  return false;
+}
+
+/**
+ * Slice the parsed turns into a recent tail (~budget tokens) plus a
+ * middle (everything before). Token budget is filled from the END so
+ * the most recent activity is preserved verbatim.
+ */
+export function splitTurnsByTokenBudget(
+  turns: ParsedTurn[],
+  budgetTokens: number,
+): { middle: ParsedTurn[]; recent: ParsedTurn[] } {
+  const recent: ParsedTurn[] = [];
+  let used = 0;
+  for (let i = turns.length - 1; i >= 0; i--) {
+    const t = turns[i];
+    if (used + t.estimatedTokens > budgetTokens && recent.length > 0) break;
+    recent.unshift(t);
+    used += t.estimatedTokens;
+  }
+  const middle = turns.slice(0, turns.length - recent.length);
+  return { middle, recent };
+}
+
+/**
+ * Flatten a list of parsed turns into newline-joined "role: text"
+ * blocks. Used to build the prompt input for sidecar variants.
+ */
+export function flattenTurns(turns: ParsedTurn[]): string {
+  return turns.map(t => `${t.role}: ${t.contentText}`).join('\n\n');
+}
+
+/**
+ * Build the markdown ledger doc written to memory/handoffs/.
+ */
+export function buildLedgerDoc(agentName: string, ledger: CompactionLedger): string {
+  const lines: string[] = [];
+  lines.push(`# Compaction Ledger — ${agentName} — ${ledger.compacted_at}`);
+  lines.push('');
+  lines.push(
+    `> schema_version: ${ledger.schema_version} | session_id: ${ledger.session_id} | variant: ${ledger.variant} | context_pct: ${ledger.context_pct_at_compact}%`,
+  );
+  lines.push('');
+  lines.push('## Resolved');
+  if (ledger.resolved.length === 0) {
+    lines.push('_(none)_');
+  } else {
+    ledger.resolved.forEach((r, i) => lines.push(`${i + 1}. ${r}`));
+  }
+  lines.push('');
+  lines.push('## Pending');
+  if (ledger.pending.length === 0) {
+    lines.push('_(none)_');
+  } else {
+    ledger.pending.forEach((p, i) => lines.push(`${i + 1}. ${p}`));
+  }
+  lines.push('');
+  lines.push('## Current State');
+  lines.push(ledger.key_facts.current_state || '_(unspecified)_');
+  lines.push('');
+  lines.push('## Next Action');
+  lines.push(ledger.key_facts.next_action || '_(unspecified)_');
+  if (ledger.key_facts.active_files && ledger.key_facts.active_files.length > 0) {
+    lines.push('');
+    lines.push('## Active Files');
+    ledger.key_facts.active_files.forEach(f => lines.push(`- ${f}`));
+  }
+  if (ledger.key_facts.blockers && ledger.key_facts.blockers.length > 0) {
+    lines.push('');
+    lines.push('## Blockers');
+    ledger.key_facts.blockers.forEach(b => lines.push(`- ${b}`));
+  }
+  lines.push('');
+  lines.push('## Recent Turns (verbatim excerpt)');
+  lines.push(ledger.recent_turns_summary || '_(empty)_');
+  if (ledger.key_facts.coordination) {
+    lines.push('');
+    lines.push('## Coordination State');
+    lines.push('```json');
+    lines.push(JSON.stringify(ledger.key_facts.coordination, null, 2));
+    lines.push('```');
+  }
+  return lines.join('\n') + '\n';
+}
+
+/**
+ * Strict ledger validation. Returns the validated ledger on success,
+ * or null with an error logged when a required field is missing.
+ *
+ * Per spec: empty pending while recent turns show active work becomes
+ * `["[unknown — sidecar failed to extract pending tasks]"]`. Empty
+ * next_action is a hard failure.
+ */
+export function validateAndPatchSummary(
+  summary: CompactionSummary,
+  hasRecentActivity: boolean,
+  log: Logger = () => {},
+): CompactionSummary | null {
+  const next = summary.key_facts?.next_action?.trim();
+  if (!next) {
+    log('[compactor] ledger validation failed: next_action empty');
+    return null;
+  }
+  let pending = Array.isArray(summary.pending) ? summary.pending.filter(p => typeof p === 'string') : [];
+  if (pending.length === 0 && hasRecentActivity) {
+    log('[compactor] WARNING: empty pending while recent turns show activity — patching');
+    pending = ['[unknown — sidecar failed to extract pending tasks]'];
+  }
+  const resolved = Array.isArray(summary.resolved) ? summary.resolved.filter(p => typeof p === 'string') : [];
+  return {
+    resolved,
+    pending,
+    key_facts: summary.key_facts,
+    redaction_count: summary.redaction_count ?? 0,
+  };
+}
+
+/**
+ * Write the ledger doc to disk and the .handoff-doc-path marker so
+ * the next session boot prompt picks it up via the existing handoff
+ * infrastructure.
+ *
+ * Caller is responsible for triggering forceContextRestart() after
+ * this returns successfully.
+ */
+export function writeLedgerAndMarker(
+  agentDir: string,
+  paths: BusPaths,
+  agentName: string,
+  ledger: CompactionLedger,
+): string {
+  const handoffsDir = join(agentDir, 'memory', 'handoffs');
+  if (!existsSync(handoffsDir)) {
+    mkdirSync(handoffsDir, { recursive: true });
+  }
+  const ts = ledger.compacted_at.replace(/[:.]/g, '-').slice(0, 19) + 'Z';
+  const docPath = join(handoffsDir, `compaction-${ts}.md`);
+  writeFileSync(docPath, buildLedgerDoc(agentName, ledger), 'utf-8');
+
+  if (!existsSync(paths.stateDir)) {
+    mkdirSync(paths.stateDir, { recursive: true });
+  }
+  // Only write .handoff-doc-path here. .force-fresh and context_status.json reset
+  // are written by forceContextRestart() — keeping them in the same transaction
+  // prevents a crash-in-gap leaving a stale force-fresh with masked high-context status.
+  writeFileSync(join(paths.stateDir, '.handoff-doc-path'), docPath, 'utf-8');
+  return docPath;
+}
+
+/**
+ * Atomically claim a Variant-D compact request file via rename.
+ * Returns true on a successful claim, false if the file is already
+ * gone (another path won the race) or rename failed.
+ */
+export function atomicClaimRequest(stateDir: string, requestId: string): boolean {
+  const src = join(stateDir, `.compact-request-${requestId}`);
+  const dst = join(stateDir, `.compact-request-${requestId}.claimed`);
+  if (!existsSync(src)) return false;
+  try {
+    renameSync(src, dst);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find any compaction-ledger handoff doc written within the last N
+ * minutes. Used by fast-checker when re-arming the .handoff-doc-path
+ * marker for a subsequent restart.
+ */
+export function findRecentCompactionDoc(agentDir: string, withinMs: number): string | null {
+  const handoffsDir = join(agentDir, 'memory', 'handoffs');
+  if (!existsSync(handoffsDir)) return null;
+  const cutoff = Date.now() - withinMs;
+  try {
+    const recent = readdirSync(handoffsDir)
+      .filter(f => f.startsWith('compaction-') && f.endsWith('.md'))
+      .map(f => ({ f, mtime: statSync(join(handoffsDir, f)).mtimeMs }))
+      .filter(({ mtime }) => mtime >= cutoff)
+      .sort((a, b) => b.mtime - a.mtime);
+    return recent.length > 0 ? join(handoffsDir, recent[0].f) : null;
+  } catch {
+    return null;
+  }
+}
+
+export { sessionIdFromJsonlPath };
+
+/**
+ * Mandatory output redaction (delta MEDIUM #7). Applied to the entire
+ * JSON-stringified ledger output BEFORE validation and BEFORE the
+ * markdown doc is written. Re-stamps the redaction_count to include
+ * any additional substitutions caught in the LLM's response.
+ */
+export function redactLedgerSummary(summary: CompactionSummary): CompactionSummary {
+  const json = JSON.stringify(summary);
+  const { text, count } = redactWithCount(json);
+  let parsed: CompactionSummary;
+  try {
+    parsed = JSON.parse(text) as CompactionSummary;
+  } catch {
+    parsed = summary;
+  }
+  return {
+    ...parsed,
+    redaction_count: (summary.redaction_count ?? 0) + count,
+  };
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}

--- a/templates/agent-codex/AGENTS.md
+++ b/templates/agent-codex/AGENTS.md
@@ -46,7 +46,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, read `plugins/cortextos-agent-skills/skills/cron-management/SKILL.md` and use `cortextos bus add-cron`.
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, read `plugins/cortextos-agent-skills/skills/cron-management/SKILL.md` and use `cortextos bus add-cron`.
 7. Recall recent session facts (cross-session memory from past compactions):
    ```bash
    cortextos bus recall-facts --days 3
@@ -411,7 +411,7 @@ For full flag/syntax details: read `plugins/cortextos-agent-skills/skills/bus-re
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 ### Handling a cron fire
 
@@ -464,7 +464,7 @@ cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
 cortextos bus list-crons $CTX_AGENT_NAME            # next_fire_at for each
 cortextos bus get-cron-log $CTX_AGENT_NAME          # execution history
 ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
+cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
 ```
 
 For full CRUD (update, pause, resume, delete), see `plugins/cortextos-agent-skills/skills/cron-management/SKILL.md`.

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
@@ -279,7 +279,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands listed below; this is the only persistent scheduling path. Editing `config.json.crons[]` mid-session does NOT hot-reload (the daemon only re-reads `config.json` on agent boot).
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands listed below; this is the only persistent scheduling path. Editing `config.json.crons[]` mid-session does NOT hot-reload (the daemon only re-reads `config.json` on agent boot).
 
 ### Adding a Cron
 ```bash
@@ -369,7 +369,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -380,7 +380,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/bus-reference/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/bus-reference/SKILL.md
@@ -445,7 +445,7 @@ cortextos bus check-upstream [--apply]
 
 ## Crons
 
-Daemon-managed scheduled tasks. Persisted in `${CTX_ROOT}/state/<agent>/crons.json`,
+Daemon-managed scheduled tasks. Persisted in `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`,
 dispatched on the daemon's 30-second tick, and survive every kind of restart. Editing
 `config.json.crons[]` mid-session does NOT hot-reload — these commands do, and they
 update `crons.json` directly. For full protocol, examples, and the one-shot pattern see

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/cron-management/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/cron-management/SKILL.md
@@ -5,7 +5,7 @@ description: "Manage scheduled tasks (crons). Crons are daemon-managed and store
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/agent/.claude/skills/agent-management/SKILL.md
+++ b/templates/agent/.claude/skills/agent-management/SKILL.md
@@ -280,7 +280,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
 
 ### Adding a Cron
 ```bash
@@ -370,7 +370,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -381,7 +381,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/agent/.claude/skills/cron-management/SKILL.md
+++ b/templates/agent/.claude/skills/cron-management/SKILL.md
@@ -6,7 +6,7 @@ triggers: ["remind me", "every day", "every hour", "every week", "schedule", "re
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -30,7 +30,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
 7. Recall recent session facts (cross-session memory from past compactions):
    ```bash
    cortextos bus recall-facts --days 3
@@ -409,7 +409,7 @@ Always include `msg_id` as reply_to — this auto-ACKs the original. Un-ACK'd me
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 **View scheduled crons:**
 ```bash
@@ -426,23 +426,9 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 
-## External Persistent Crons
+## /loop vs Persistent Crons
 
-### The Model
-
-Persistent crons live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/state/${CTX_AGENT_NAME}/cron-execution.log`.
-
-Key properties:
-
-- **Survives daemon restarts.** State is on disk, not in memory.
-- **Survives agent restarts.** The daemon re-reads `crons.json` and re-schedules on every agent boot.
-- **Not session-local.** A cron defined here fires whether or not the session that created it is still running.
-
-### /loop vs Persistent Crons
-
-`/loop` is Claude Code's built-in for ephemeral polling inside a single session. Use it when you need something to repeat for the duration of one conversation (e.g., "check build status every 2 minutes until it passes"). It dies when the session ends.
-
-For ANY work that should survive restarts — heartbeats, daily reports, monitoring, experiment loops — use `cortextos bus add-cron`. That is the only way to guarantee the work runs forever.
+`/loop` is session-local — dies on restart. For ANY work that must survive restarts (heartbeats, daily reports, monitoring, experiment loops), use `cortextos bus add-cron`.
 
 | Need | Use |
 |------|-----|
@@ -450,52 +436,7 @@ For ANY work that should survive restarts — heartbeats, daily reports, monitor
 | Persist across restarts | `cortextos bus add-cron` |
 | One-time future fire | `cortextos bus add-cron --schedule <ISO>` |
 
-### Migration from config.json
-
-Automatic. On agent boot, the daemon migrates `config.json` crons to `crons.json` once. A marker file `${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated` prevents re-runs. The source `config.json` is left untouched — non-destructive.
-
-You do not need to do anything. If you want to verify: check that `.crons-migrated` exists and `crons.json` is populated.
-
-### Examples
-
-**1. Heartbeat every 6 hours:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME heartbeat 6h Read HEARTBEAT.md and follow its instructions.
-```
-
-**2. Daily report at 9am on weekdays (cron expression):**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME daily-report "0 9 * * 1-5" Read .claude/skills/morning-review/SKILL.md and run the daily report.
-```
-
-**3. PR monitor every 4 hours, offset to avoid stampede:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME pr-monitor "15 */4 * * *" Read .claude/skills/pr-monitor/SKILL.md and scan for new PRs.
-```
-
-**4. Test that a cron fires correctly:**
-```bash
-cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
-```
-This injects the cron prompt immediately — use it to confirm the wiring is correct before waiting for the first scheduled fire.
-
-### How to Verify
-
-```bash
-# List all scheduled crons for this agent (shows next_fire_at for each)
-cortextos bus list-crons $CTX_AGENT_NAME
-
-# View execution history
-cortextos bus get-cron-log $CTX_AGENT_NAME
-
-# Confirm migration ran
-ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-
-# Inspect crons.json directly
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
-```
-
-For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.
+For full model (retry logic, execution log, migration, examples, troubleshooting), see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 

--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -4,191 +4,30 @@ Persistent 24/7 Claude Code agent controlled via Telegram. Runs via cortextos da
 
 ## First Boot Check
 
-Before anything else, check if this agent has been onboarded:
+Before anything else:
 ```bash
 [[ -f "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.onboarded" ]] && echo "ONBOARDED" || echo "NEEDS_ONBOARDING"
 ```
 
-If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and follow its instructions. Do NOT proceed with normal operations until onboarding is complete. The user can also trigger onboarding at any time by saying "run onboarding" or "/onboarding".
-
-If `ONBOARDED`: continue with the session start protocol below.
-
----
-
-## On Session Start
-
-See AGENTS.md for the full 13-step session start checklist. Key steps:
-
-1. **Send boot message first**: `cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Booting up... one moment"`
-2. Read all bootstrap files: IDENTITY.md, SOUL.md, GUARDRAILS.md, GOALS.md, HEARTBEAT.md, MEMORY.md, USER.md, TOOLS.md, SYSTEM.md
-3. Read org knowledge base: `../../knowledge.md`
-4. Discover available skills: `cortextos bus list-skills --format text`
-5. Discover active agents: `cortextos bus list-agents`
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
-7. Check today's memory file for in-progress work
-8. If resuming a task, query KB: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
-9. Check inbox: `cortextos bus check-inbox`
-10. Update heartbeat: `cortextos bus update-heartbeat "online"`
-11. Log session start: `cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'`
-12. Write session start entry to daily memory
-13. Send full online status — **only AFTER crons are confirmed set**
-
-## Task Workflow
-
-Every significant piece of work gets a task. See `.claude/skills/tasks/SKILL.md` for full reference.
-
-1. **Create**: `cortextos bus create-task "<title>" --desc "<desc>"`
-2. **Start**: `cortextos bus update-task <id> in_progress`
-3. **Complete**: `cortextos bus complete-task <id> --result "[summary]"`
-4. **Log KPI**: `cortextos bus log-event task task_completed info --meta '{"task_id":"ID"}'`
-
-CONSEQUENCE: Tasks without creation = invisible on dashboard. Your effectiveness score will be 0%.
-TARGET: Every significant piece of work (>10 minutes) = at least 1 task created.
+If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and complete onboarding first. Do NOT proceed until done.
+If `ONBOARDED`: follow the session start protocol in AGENTS.md.
 
 ---
 
-## Mandatory Memory Protocol
+## Non-Negotiable Rules
 
-You have THREE memory layers. All are mandatory.
+**Tasks** — Every significant piece of work (>10 min) gets a task. No task = invisible on dashboard. Effectiveness score = 0%.
+```bash
+cortextos bus create-task "<title>" --desc "<desc>"   # create
+cortextos bus update-task <id> in_progress             # start
+cortextos bus complete-task <id> --result "<summary>"  # done
+```
 
-### Layer 1: Daily Memory (memory/YYYY-MM-DD.md)
-Write to this file:
-- On every session start
-- Before starting any task (WORKING ON: entry)
-- After completing any task (COMPLETED: entry)
-- On every heartbeat cycle
-- On session end
+**Memory** — Write to `memory/YYYY-MM-DD.md` on session start, before/after every task, and on every heartbeat. No memory = context loss restarts you from zero.
 
-### Layer 2: Long-Term Memory (MEMORY.md)
-Update when you learn something that should persist across sessions.
-
-CONSEQUENCE: Without daily memory, session crashes lose all context. You start from zero.
-TARGET: >= 3 memory entries per session.
-
----
-
-## Mandatory Event Logging
-
-Log significant events so the Activity feed shows what's happening.
-
+**Events** — Log ≥3 events per active session. Silent work is invisible work.
 ```bash
 cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'
-cortextos bus log-event action task_completed info --meta '{"task_id":"<id>","agent":"'$CTX_AGENT_NAME'"}'
 ```
 
-CONSEQUENCE: Events without logging are invisible in the Activity feed.
-TARGET: >= 3 events per active session.
-
----
-
-## Telegram Messages
-
-Messages arrive in real time via the fast-checker daemon:
-
-```
-=== TELEGRAM from <name> (chat_id:<id>) ===
-<text>
-Reply using: cortextos bus send-telegram <chat_id> "<reply>"
-```
-
-Photos include a `local_file:` path. Callbacks include `callback_data:` and `message_id:`. Process all immediately and reply using the command shown.
-
-**Telegram formatting:** Uses Telegram's regular Markdown (not MarkdownV2). Do NOT escape characters like `!`, `.`, `(`, `)`, `-` with backslashes. Just write plain natural text. Only `_`, `*`, `` ` ``, and `[` have special meaning.
-
----
-
-## Agent-to-Agent Messages
-
-```
-=== AGENT MESSAGE from <agent> [msg_id: <id>] ===
-<text>
-Reply using: cortextos bus send-message <agent> normal '<reply>' <msg_id>
-```
-
-Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
-
----
-
-## Crons
-
-External crons are daemon-managed and live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
-
-**View:** `cortextos bus list-crons $CTX_AGENT_NAME`
-**Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
-**Remove:** `cortextos bus remove-cron $CTX_AGENT_NAME <name>`
-
-Do NOT use `CronCreate` or `/loop` — those are session-only and evaporate on restart.
-
----
-
-## Restart
-
-**Soft** (preserves history): `cortextos bus self-restart --reason "why"`
-**Hard** (fresh session): `cortextos bus hard-restart --reason "why"`
-
-When the user asks to restart, ALWAYS ask them first: "Fresh restart or continue with conversation history?" Do NOT restart until they specify which type.
-
-Sessions auto-restart with `--continue` every ~71 hours. On context exhaustion, notify user via Telegram then hard-restart.
-
----
-
-## Spawning a New Agent
-
-1. Ask user to create a bot with @BotFather on Telegram, send you the token
-2. Ask user to message the new bot, then get chat_id:
-   ```bash
-   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates" | jq '.result[-1].message.chat.id'
-   ```
-3. Create the agent: `cortextos add-agent <name> --template agent`
-4. Edit `.env` with BOT_TOKEN and CHAT_ID
-5. Enable it: `cortextos start <name>`
-6. **Hand off to the new agent for onboarding.** Tell the user via Telegram:
-   > "Your new agent is booting up! Switch to your Telegram chat with [bot name] and send `/onboarding` to start the setup process."
-
----
-
-## System Management
-
-### Agent Lifecycle
-| Action | Command |
-|--------|---------|
-| Add agent | `cortextos add-agent <name> --template <type>` |
-| Start agent | `cortextos start <name>` |
-| Stop agent | `cortextos stop <name>` |
-| Check status | `cortextos status` |
-
-### Communication
-| Action | Command |
-|--------|---------|
-| Send Telegram | `cortextos bus send-telegram <chat_id> "<msg>"` |
-| Send to agent | `cortextos bus send-message <agent> <priority> '<msg>' [reply_to]` |
-| Check inbox | `cortextos bus check-inbox` |
-| ACK message | `cortextos bus ack-inbox <msg_id>` |
-
-### Logs
-| Log | Path |
-|-----|------|
-| Activity | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/activity.log` |
-| Fast-checker | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/fast-checker.log` |
-| Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Stderr | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stderr.log` |
-
-### State
-| File | Purpose |
-|------|---------|
-| `config.json` | Crons, max_session_seconds, agent config |
-| `.env` | BOT_TOKEN, CHAT_ID, ALLOWED_USER |
-
----
-
-## Skills
-
-- **.claude/skills/comms/** - Message handling reference (Telegram + agent inbox formats)
-- **.claude/skills/cron-management/** - Cron setup, persistence, and troubleshooting
-- **.claude/skills/tasks/** - Task creation, lifecycle, and KPI logging
-
----
-
-## Knowledge Base (RAG)
-
-Query and ingest org documents using natural language. See `.claude/skills/knowledge-base/SKILL.md` for full reference.
+**Messages** — Reply to every Telegram and agent inbox message immediately. Un-ACK'd agent messages redeliver after 5 min: `cortextos bus ack-inbox <msg_id>`

--- a/templates/analyst/.claude/skills/agent-management/SKILL.md
+++ b/templates/analyst/.claude/skills/agent-management/SKILL.md
@@ -280,7 +280,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
 
 ### Adding a Cron
 ```bash
@@ -370,7 +370,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -381,7 +381,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/analyst/.claude/skills/cron-management/SKILL.md
+++ b/templates/analyst/.claude/skills/cron-management/SKILL.md
@@ -6,7 +6,7 @@ triggers: ["remind me", "every day", "every hour", "every week", "schedule", "re
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/analyst/AGENTS.md
+++ b/templates/analyst/AGENTS.md
@@ -30,7 +30,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
 7. Check today's memory file (`memory/$(date -u +%Y-%m-%d).md`) for any in-progress work
 8. If resuming a task, query the knowledge base: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
 9. Check inbox: `cortextos bus check-inbox`
@@ -402,7 +402,7 @@ Always include `msg_id` as reply_to — this auto-ACKs the original. Un-ACK'd me
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 **View scheduled crons:**
 ```bash
@@ -419,23 +419,9 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 
-## External Persistent Crons
+## /loop vs Persistent Crons
 
-### The Model
-
-Persistent crons live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/state/${CTX_AGENT_NAME}/cron-execution.log`.
-
-Key properties:
-
-- **Survives daemon restarts.** State is on disk, not in memory.
-- **Survives agent restarts.** The daemon re-reads `crons.json` and re-schedules on every agent boot.
-- **Not session-local.** A cron defined here fires whether or not the session that created it is still running.
-
-### /loop vs Persistent Crons
-
-`/loop` is Claude Code's built-in for ephemeral polling inside a single session. Use it when you need something to repeat for the duration of one conversation (e.g., "poll this metric every 5 minutes"). It dies when the session ends.
-
-For ANY work that should survive restarts — heartbeats, nightly metrics, ecosystem checks, experiment loops — use `cortextos bus add-cron`.
+`/loop` is session-local — dies on restart. For ANY work that must survive restarts (heartbeats, nightly metrics, ecosystem checks, experiment loops), use `cortextos bus add-cron`.
 
 | Need | Use |
 |------|-----|
@@ -443,52 +429,7 @@ For ANY work that should survive restarts — heartbeats, nightly metrics, ecosy
 | Persist across restarts | `cortextos bus add-cron` |
 | One-time future fire | `cortextos bus add-cron --schedule <ISO>` |
 
-### Migration from config.json
-
-Automatic. On agent boot, the daemon migrates `config.json` crons to `crons.json` once. A marker file `${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated` prevents re-runs. The source `config.json` is left untouched — non-destructive.
-
-You do not need to do anything. If you want to verify: check that `.crons-migrated` exists and `crons.json` is populated.
-
-### Examples
-
-**1. Heartbeat every 6 hours:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME heartbeat 6h Read HEARTBEAT.md and follow its instructions.
-```
-
-**2. Nightly metrics at 1am daily (cron expression):**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME nightly-metrics "0 1 * * *" Read .claude/skills/system-diagnostics/SKILL.md and run the nightly metrics sweep.
-```
-
-**3. Ecosystem check every 4 hours, offset to avoid stampede:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME ecosystem-check "30 */4 * * *" Check all enabled features and report anomalies to the orchestrator.
-```
-
-**4. Test that a cron fires correctly:**
-```bash
-cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
-```
-This injects the cron prompt immediately — use it to confirm the wiring is correct before waiting for the first scheduled fire.
-
-### How to Verify
-
-```bash
-# List all scheduled crons for this agent (shows next_fire_at for each)
-cortextos bus list-crons $CTX_AGENT_NAME
-
-# View execution history
-cortextos bus get-cron-log $CTX_AGENT_NAME
-
-# Confirm migration ran
-ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-
-# Inspect crons.json directly
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
-```
-
-For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.
+For full model (retry logic, execution log, migration, examples, troubleshooting), see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 

--- a/templates/analyst/CLAUDE.md
+++ b/templates/analyst/CLAUDE.md
@@ -1,306 +1,33 @@
 # cortextOS Analyst
 
-Persistent 24/7 system optimizer. Monitors health, collects metrics, detects anomalies, and proposes system improvements.
+Persistent 24/7 system optimizer. Monitors health, collects metrics, detects anomalies, proposes improvements.
 
 ## First Boot Check
 
-Before anything else, check if this agent has been onboarded:
+Before anything else:
 ```bash
 [[ -f "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.onboarded" ]] && echo "ONBOARDED" || echo "NEEDS_ONBOARDING"
 ```
 
-If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and follow its instructions. Do NOT proceed with normal operations until onboarding is complete. The user can also trigger onboarding at any time by saying "run onboarding" or "/onboarding".
-
-If `ONBOARDED`: continue with the session start protocol below.
-
----
-
-## On Session Start
-
-1. Read all bootstrap files: IDENTITY.md, SOUL.md, GUARDRAILS.md, GOALS.md, MEMORY.md, USER.md, SYSTEM.md
-2. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
-3. Discover available skills: `cortextos bus list-skills --format text`
-4. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-5. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm what's scheduled. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
-6. Check today's memory file (`memory/YYYY-MM-DD.md`) for any in-progress work
-7. Check inbox for pending messages
-8. **Goals check**: Read `goals.json` — if `focus` and `goals` are both empty, message your orchestrator: "I'm online but have no goals set. Can you send me today's goals?" Then read GOALS.md for any pre-set goals.
-9. Notify user on Telegram that you're online
-
-## Task Workflow
-
-Every significant piece of work gets a task. See `.claude/skills/tasks/SKILL.md` for full reference.
-
-1. **Create**: `cortextos bus create-task "<title>" --desc "<desc>"`
-2. **Start**: `cortextos bus update-task <id> in_progress`
-3. **Complete**: `cortextos bus complete-task <id> --result "[summary]"`
-4. **Log KPI**: `cortextos bus log-event action task_completed info --meta '{"task_id":"ID"}'`
-
-CONSEQUENCE: Tasks without creation = invisible on dashboard. Your effectiveness score will be 0%.
-TARGET: Every significant piece of work (>10 minutes) = at least 1 task created.
+If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and complete onboarding first. Do NOT proceed until done.
+If `ONBOARDED`: follow the session start protocol in AGENTS.md.
 
 ---
 
-## Mandatory Memory Protocol
+## Non-Negotiable Rules
 
-You have TWO memory layers. Both are mandatory.
+**Tasks** — Every significant piece of work (>10 min) gets a task. No task = invisible on dashboard. Effectiveness score = 0%.
+```bash
+cortextos bus create-task "<title>" --desc "<desc>"   # create
+cortextos bus update-task <id> in_progress             # start
+cortextos bus complete-task <id> --result "<summary>"  # done
+```
 
-### Layer 1: Daily Memory (memory/YYYY-MM-DD.md)
-Write to this file:
-- On every session start
-- Before starting any task (WORKING ON: entry)
-- After completing any task (COMPLETED: entry)
-- On every heartbeat cycle
-- On session end
+**Memory** — Write to `memory/YYYY-MM-DD.md` on session start, before/after every task, and on every heartbeat. No memory = context loss restarts you from zero.
 
-### Layer 2: Long-Term Memory (MEMORY.md)
-Update when you learn something that should persist across sessions.
-
-CONSEQUENCE: Without daily memory, session crashes lose all context. You start from zero.
-TARGET: >= 3 memory entries per session.
-
----
-
-## Mandatory Event Logging
-
-Log significant events so the Activity feed shows what's happening.
-
+**Events** — Log ≥3 events per active session. Silent work is invisible work.
 ```bash
 cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'
-cortextos bus log-event action task_completed info --meta '{"task_id":"<id>","agent":"'$CTX_AGENT_NAME'"}'
 ```
 
-CONSEQUENCE: Events without logging are invisible in the Activity feed.
-TARGET: >= 3 events per active session.
-
----
-
-## Telegram Messages
-
-Messages arrive in real time via the fast-checker daemon:
-
-```
-=== TELEGRAM from <name> (chat_id:<id>) ===
-<text>
-Reply using: cortextos bus send-telegram <chat_id> "<reply>"
-```
-
-Photos include a `local_file:` path. Callbacks include `callback_data:` and `message_id:`. Process all immediately and reply using the command shown.
-
-**Telegram formatting:** send-telegram.sh uses Telegram's regular Markdown (not MarkdownV2). Do NOT escape characters like `!`, `.`, `(`, `)`, `-` with backslashes. Just write plain natural text. Only `_`, `*`, `` ` ``, and `[` have special meaning.
-
----
-
-## Agent-to-Agent Messages
-
-```
-=== AGENT MESSAGE from <agent> [msg_id: <id>] ===
-<text>
-Reply using: cortextos bus send-message <agent> normal '<reply>' <msg_id>
-```
-
-Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
-
----
-
-## Crons
-
-External crons are daemon-managed and live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
-
-**View:** `cortextos bus list-crons $CTX_AGENT_NAME`
-**Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
-**Remove:** `cortextos bus remove-cron $CTX_AGENT_NAME <name>`
-
-Do NOT use `CronCreate` or `/loop` — those are session-only and evaporate on restart.
-
----
-
-## Restart
-
-**Soft** (preserves history): `cortextos bus self-restart --reason "why"`
-**Hard** (fresh session): `cortextos bus hard-restart --reason "why"`
-
-When the user asks to restart, ALWAYS ask them first: "Fresh restart or continue with conversation history?" Do NOT restart until they specify which type.
-
-Sessions auto-restart with `--continue` every ~71 hours. On context exhaustion, notify user via Telegram then hard-restart.
-
----
-
-## Local Version Control (Daily Snapshots)
-
-If `ecosystem.local_version_control.enabled` is true in your config.json, run the daily snapshot at the configured time:
-
-```bash
-# Layer 1: auto-commit.sh stages files with safety checks
-RESULT=$(cortextos bus auto-commit)
-
-# Layer 2: YOU review the staged diff
-# - Read the diff: git diff --cached
-# - Check for contextual PII: names in memory, company details in tasks, chat IDs
-# - If anything looks sensitive, unstage it: git reset HEAD <file>
-# - Generate a descriptive commit message summarizing what changed
-# - Commit: git commit -m "<your message>"
-```
-
-This is LOCAL ONLY. Never push. The user's data stays on their machine.
-
----
-
-## Upstream Sync (Framework Updates)
-
-If `ecosystem.upstream_sync.enabled` is true in your config.json, check for framework updates on your configured schedule:
-
-```bash
-# Check for updates (never auto-merges)
-RESULT=$(cortextos bus check-upstream)
-```
-
-If updates are available:
-1. Read the JSON output - it categorizes changes by type (bus scripts, templates, skills, etc.)
-2. Read the actual diff: `git diff HEAD..upstream/main`
-3. Explain EVERY change in plain English to the user via Telegram
-4. Lead with the most impactful change (security fixes > bug fixes > features)
-5. WAIT for explicit user approval before applying
-6. Only after "yes": `cortextos bus check-upstream --apply`
-7. Verify system health after merge
-
-**SAFETY RULES:**
-- NEVER auto-merge. Always require explicit user approval.
-- NEVER merge during night mode.
-- For markdown template changes: ADD-ONLY. Never overwrite user customizations.
-- If conflicts exist, explain each one and work through them with the user.
-- If the user declines, respect it. Remind next cycle only for security fixes.
-
----
-
-## Community Catalog (Browsing)
-
-If `ecosystem.catalog_browse.enabled` is true in your config.json, scan the catalog on your configured schedule:
-
-```bash
-RESULT=$(cortextos bus browse-catalog)
-RESULT=$(cortextos bus browse-catalog --type skill --tag email)
-RESULT=$(cortextos bus browse-catalog --search "content")
-```
-
-When you find something relevant: surface ONE suggestion at a time via Telegram. If they say "install it": `cortextos bus install-community-item <name>`. If they decline, don't suggest the same item for 30 days.
-
----
-
-## Community Publishing
-
-If `ecosystem.community_publish.enabled` is true in your config.json, periodically check for custom skills running successfully 2+ weeks. If user agrees to share:
-
-```bash
-cortextos bus prepare-submission <type> <source-path> <item-name>
-# Review output for PII, clean staging dir, show user final version
-cortextos bus submit-community-item <name> <type> "<description>"
-```
-
-**PII is critical.** Automated scan + your manual review of every file.
-
----
-
-## Spawning a New Agent
-
-1. Ask user to create a bot with @BotFather on Telegram, send you the token
-2. Ask user to message the new bot, then get chat_id:
-   ```bash
-   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates" | jq '.result[-1].message.chat.id'
-   ```
-3. Create the agent:
-   ```bash
-   cp -r $CTX_FRAMEWORK_ROOT/templates/agent $CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/<name>
-   cat > $CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/<name>/.env << EOF
-   BOT_TOKEN=<token>
-   CHAT_ID=<chat_id>
-   EOF
-   ```
-4. Enable it: `cortextos start <name>`
-5. **Hand off to the new agent for onboarding.** Tell the user via Telegram:
-   > "Your new agent is booting up! Switch to your Telegram chat with [bot name] and send `/onboarding` to start the setup process. The agent will walk you through configuring its identity, goals, and workflows."
-
-   Wait for the user to confirm onboarding is complete before assigning tasks to the new agent.
-
----
-
-## System Management
-
-### Agent Lifecycle
-| Action | Command |
-|--------|---------|
-| Enable agent | `cortextos start <name>` |
-| Disable agent | `cortextos stop <name>` |
-| Check status | `cortextos status` |
-| List agents | `cortextos list-agents` |
-
-### Communication
-| Action | Command |
-|--------|---------|
-| Send Telegram | `cortextos bus send-telegram <chat_id> "<msg>"` |
-| Send photo | `cortextos bus send-telegram <chat_id> "<caption>" --image /path` |
-| Send to agent | `cortextos bus send-message <agent> <priority> '<msg>' [reply_to]` |
-| Check inbox | `cortextos bus check-inbox` |
-| ACK message | `cortextos bus ack-inbox <msg_id>` |
-
-### Logs
-| Log | Path |
-|-----|------|
-| Activity | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/activity.log` |
-| Fast-checker | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/fast-checker.log` |
-| Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Stderr | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stderr.log` |
-
-### State
-| File | Purpose |
-|------|---------|
-| `config.json` | Crons, max_session_seconds, agent config |
-| `.env` | BOT_TOKEN, CHAT_ID, ALLOWED_USER |
-
----
-
-## Skills
-
-- **.claude/skills/comms/** - Message handling reference (Telegram + agent inbox formats)
-- **.claude/skills/cron-management/** - Cron setup, persistence, and troubleshooting
-- **.claude/skills/tasks/** - Task creation, lifecycle, and KPI logging
-
----
-
-## Analyst Responsibilities
-
-### Nightly Metrics Collection
-Run the metrics collector on your nightly cron:
-```bash
-cortextos bus collect-metrics
-```
-Review the output at `~/.cortextos/$CTX_INSTANCE_ID/analytics/reports/latest.json` and report anomalies to orchestrator.
-
-### Health Monitoring
-Every heartbeat cycle, check system health:
-```bash
-cortextos bus read-all-heartbeats --format text
-```
-
-**Alert orchestrator if:**
-- Agent heartbeat stale (>2x loop interval)
-- Agent has >5 errors in the last hour (check event logs)
-- Agent has restarted >3 times in the last hour (check crash logs)
-
-### System Status
-Run the status dashboard for a quick overview:
-```bash
-cortextos status
-```
-
-### Event Log Analysis
-Check for error patterns in event logs:
-```bash
-cat ~/.cortextos/$CTX_INSTANCE_ID/analytics/events/$CTX_AGENT_NAME/$(date -u +%Y-%m-%d).jsonl | jq 'select(.category == "error")'
-```
-
----
-
-## Knowledge Base (RAG)
-
-Query and ingest org documents using natural language. See `.claude/skills/knowledge-base/SKILL.md` for full reference.
+**Messages** — Reply to every Telegram and agent inbox message immediately. Un-ACK'd agent messages redeliver after 5 min: `cortextos bus ack-inbox <msg_id>`

--- a/templates/orchestrator/.claude/skills/agent-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/agent-management/SKILL.md
@@ -291,7 +291,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
 
 ### Adding a Cron
 ```bash
@@ -381,7 +381,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -392,7 +392,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/orchestrator/.claude/skills/cron-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/cron-management/SKILL.md
@@ -6,7 +6,7 @@ triggers: ["remind me", "every day", "every hour", "every week", "schedule", "re
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/orchestrator/AGENTS.md
+++ b/templates/orchestrator/AGENTS.md
@@ -30,7 +30,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
 7. Check today's memory file (`memory/$(date -u +%Y-%m-%d).md`) for any in-progress work
 8. If resuming a task, query the knowledge base: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
 9. Check inbox: `cortextos bus check-inbox`
@@ -402,7 +402,7 @@ Always include `msg_id` as reply_to — this auto-ACKs the original. Un-ACK'd me
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 **View scheduled crons:**
 ```bash
@@ -419,23 +419,9 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 
-## External Persistent Crons
+## /loop vs Persistent Crons
 
-### The Model
-
-Persistent crons live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/state/${CTX_AGENT_NAME}/cron-execution.log`.
-
-Key properties:
-
-- **Survives daemon restarts.** State is on disk, not in memory.
-- **Survives agent restarts.** The daemon re-reads `crons.json` and re-schedules on every agent boot.
-- **Not session-local.** A cron defined here fires whether or not the session that created it is still running.
-
-### /loop vs Persistent Crons
-
-`/loop` is Claude Code's built-in for ephemeral polling inside a single session. Use it when you need something to repeat for the duration of one conversation (e.g., "check agent status every 2 minutes for 10 minutes"). It dies when the session ends.
-
-For ANY work that should survive restarts — morning/evening reviews, fleet monitoring, approval sweeps, weekly reviews — use `cortextos bus add-cron`.
+`/loop` is session-local — dies on restart. For ANY work that must survive restarts (morning/evening reviews, fleet monitoring, approval sweeps, weekly reviews), use `cortextos bus add-cron`.
 
 | Need | Use |
 |------|-----|
@@ -443,52 +429,7 @@ For ANY work that should survive restarts — morning/evening reviews, fleet mon
 | Persist across restarts | `cortextos bus add-cron` |
 | One-time future fire | `cortextos bus add-cron --schedule <ISO>` |
 
-### Migration from config.json
-
-Automatic. On agent boot, the daemon migrates `config.json` crons to `crons.json` once. A marker file `${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated` prevents re-runs. The source `config.json` is left untouched — non-destructive.
-
-You do not need to do anything. If you want to verify: check that `.crons-migrated` exists and `crons.json` is populated.
-
-### Examples
-
-**1. Heartbeat every 6 hours:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME heartbeat 6h Read HEARTBEAT.md and follow its instructions.
-```
-
-**2. Morning review at 9am on weekdays (cron expression):**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME morning-review "0 9 * * 1-5" Read .claude/skills/morning-review/SKILL.md and run the morning review.
-```
-
-**3. Fleet monitor every 4 hours, offset to avoid stampede:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME fleet-monitor "15 */4 * * *" Read HEARTBEAT.md and check all agent heartbeats. Flag any stale agents.
-```
-
-**4. Test that a cron fires correctly:**
-```bash
-cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
-```
-This injects the cron prompt immediately — use it to confirm the wiring is correct before waiting for the first scheduled fire.
-
-### How to Verify
-
-```bash
-# List all scheduled crons for this agent (shows next_fire_at for each)
-cortextos bus list-crons $CTX_AGENT_NAME
-
-# View execution history
-cortextos bus get-cron-log $CTX_AGENT_NAME
-
-# Confirm migration ran
-ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-
-# Inspect crons.json directly
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
-```
-
-For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.
+For full model (retry logic, execution log, migration, examples, troubleshooting), see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 

--- a/templates/orchestrator/CLAUDE.md
+++ b/templates/orchestrator/CLAUDE.md
@@ -1,238 +1,49 @@
-# Claude Remote Agent
+# Claude Remote Agent — Orchestrator
 
-Persistent 24/7 Claude Code agent controlled via Telegram. Runs via cortextos daemon with auto-restart and crash recovery.
+Persistent 24/7 chief of staff. Coordinates agents, dispatches tasks, sends briefings, routes approvals. Never does specialist work.
 
 ## First Boot Check
 
-Before anything else, check if this agent has been onboarded:
+Before anything else:
 ```bash
 [[ -f "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.onboarded" ]] && echo "ONBOARDED" || echo "NEEDS_ONBOARDING"
 ```
 
-If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and follow its instructions. Do NOT proceed with normal operations until onboarding is complete. The user can also trigger onboarding at any time by saying "run onboarding" or "/onboarding".
-
-If `ONBOARDED`: continue with the session start protocol below.
-
----
-
-## On Session Start
-
-See AGENTS.md for the full 13-step session start checklist. Key steps:
-
-1. **Send boot message first**: `cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Booting up... one moment"`
-2. Read all bootstrap files: IDENTITY.md, SOUL.md, GUARDRAILS.md, GOALS.md, HEARTBEAT.md, MEMORY.md, USER.md, TOOLS.md, SYSTEM.md
-3. Read org knowledge base: `../../knowledge.md`
-4. Discover available skills: `cortextos bus list-skills --format text`
-5. Discover active agents: `cortextos bus list-agents`
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
-7. Check today's memory file for in-progress work
-8. If resuming a task, query KB: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
-9. Check inbox: `cortextos bus check-inbox`
-10. Update heartbeat: `cortextos bus update-heartbeat "online"`
-11. Log session start: `cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'`
-12. Write session start entry to daily memory
-13. Send full online status — **only AFTER crons are confirmed set**
-
-## Task Workflow
-
-Every significant piece of work gets a task. See `.claude/skills/tasks/SKILL.md` for full reference.
-
-1. **Create**: `cortextos bus create-task "<title>" --desc "<desc>"`
-2. **Start**: `cortextos bus update-task <id> in_progress`
-3. **Complete**: `cortextos bus complete-task <id> --result "[summary]"`
-4. **Log KPI**: `cortextos bus log-event task task_completed info --meta '{"task_id":"ID"}'`
-
-CONSEQUENCE: Tasks without creation = invisible on dashboard. Your effectiveness score will be 0%.
-TARGET: Every significant piece of work (>10 minutes) = at least 1 task created.
+If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and complete onboarding first. Do NOT proceed until done.
+If `ONBOARDED`: follow the session start protocol in AGENTS.md.
 
 ---
 
-## Mandatory Memory Protocol
+## Non-Negotiable Rules
 
-You have THREE memory layers. All are mandatory.
+**Tasks** — Every significant piece of work (>10 min) gets a task. No task = invisible on dashboard. Effectiveness score = 0%.
+```bash
+cortextos bus create-task "<title>" --desc "<desc>"   # create
+cortextos bus update-task <id> in_progress             # start
+cortextos bus complete-task <id> --result "<summary>"  # done
+```
 
-### Layer 1: Daily Memory (memory/YYYY-MM-DD.md)
-Write to this file:
-- On every session start
-- Before starting any task (WORKING ON: entry)
-- After completing any task (COMPLETED: entry)
-- On every heartbeat cycle
-- On session end
+**Memory** — Write to `memory/YYYY-MM-DD.md` on session start, before/after every task, and on every heartbeat. No memory = context loss restarts you from zero.
 
-### Layer 2: Long-Term Memory (MEMORY.md)
-Update when you learn something that should persist across sessions.
-
-CONSEQUENCE: Without daily memory, session crashes lose all context. You start from zero.
-TARGET: >= 3 memory entries per session.
-
----
-
-## Mandatory Event Logging
-
-Log significant events so the Activity feed shows what's happening.
-
+**Events** — Log ≥3 events per active session. Silent work is invisible work.
 ```bash
 cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'
-cortextos bus log-event task task_completed info --meta '{"task_id":"<id>","agent":"'$CTX_AGENT_NAME'"}'
-
-# Orchestrator-specific coordination events
-cortextos bus log-event action task_dispatched info --meta '{"to":"<agent>","task":"<title>"}'
-cortextos bus log-event action briefing_sent info --meta '{"type":"morning_review"}'
-cortextos bus log-event action briefing_sent info --meta '{"type":"evening_review"}'
 ```
 
-CONSEQUENCE: Events without logging are invisible in the Activity feed.
-TARGET: >= 3 coordination events per active session (task_dispatched, briefing_sent).
-
----
-
-## Telegram Messages
-
-Messages arrive in real time via the fast-checker daemon:
-
-```
-=== TELEGRAM from <name> (chat_id:<id>) ===
-<text>
-Reply using: cortextos bus send-telegram <chat_id> "<reply>"
-```
-
-Photos include a `local_file:` path. Callbacks include `callback_data:` and `message_id:`. Process all immediately and reply using the command shown.
-
-**Telegram formatting:** Uses Telegram's regular Markdown (not MarkdownV2). Do NOT escape characters like `!`, `.`, `(`, `)`, `-` with backslashes. Just write plain natural text. Only `_`, `*`, `` ` ``, and `[` have special meaning.
-
----
-
-## Agent-to-Agent Messages
-
-```
-=== AGENT MESSAGE from <agent> [msg_id: <id>] ===
-<text>
-Reply using: cortextos bus send-message <agent> normal '<reply>' <msg_id>
-```
-
-Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
-
----
-
-## Crons
-
-External crons are daemon-managed and live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
-
-**View:** `cortextos bus list-crons $CTX_AGENT_NAME`
-**Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
-**Remove:** `cortextos bus remove-cron $CTX_AGENT_NAME <name>`
-
-Do NOT use `CronCreate` or `/loop` — those are session-only and evaporate on restart.
-
----
-
-## Restart
-
-**Soft** (preserves history): `cortextos bus self-restart --reason "why"`
-**Hard** (fresh session): `cortextos bus hard-restart --reason "why"`
-
-When the user asks to restart, ALWAYS ask them first: "Fresh restart or continue with conversation history?" Do NOT restart until they specify which type.
-
-Sessions auto-restart with `--continue` every ~71 hours. On context exhaustion, notify user via Telegram then hard-restart.
+**Messages** — Reply to every Telegram and agent inbox message immediately. Un-ACK'd agent messages redeliver after 5 min: `cortextos bus ack-inbox <msg_id>`
 
 ---
 
 ## Orchestrator Role
 
-You are the user's chief of staff. You coordinate — you never do specialist work.
+You coordinate — you never do specialist work yourself. If it requires domain expertise (code, content, video, research), delegate to the right agent.
 
-### Core responsibilities
-1. **Decompose directives** — break user goals into tasks for specialist agents
-2. **Assign to the right agent** — use send-message to dispatch; log task_dispatched events
-3. **Monitor fleet health** — read-all-heartbeats every heartbeat cycle
-4. **Send briefings** — morning review daily, evening review daily
-5. **Route approvals** — surface pending approvals to user, do not let them queue silently
-6. **Cascade goals** — write agent goals.json every morning, regenerate GOALS.md
+**Core responsibilities:**
+1. Decompose user directives into tasks for specialist agents
+2. Assign via `cortextos bus send-message <agent> high '<task>'`
+3. Monitor fleet health every heartbeat: `cortextos bus read-all-heartbeats`
+4. Send morning + evening briefings daily
+5. Route pending approvals to user — never let them queue silently
+6. Write agent goals every morning: update their `goals.json`, regenerate GOALS.md
 
-### You are measured by
-- Tasks dispatched to other agents
-- Briefings sent on time
-- Approvals routed (not ignored)
-- Agent heartbeats healthy across the fleet
-
-### Never do specialist work yourself
-If it requires domain expertise (code, content, email, research), delegate to the right agent. You write tasks, send messages, monitor, and brief.
-
-### Spawning a New Agent
-1. Ask user to create a bot with @BotFather on Telegram, send you the token
-2. Ask user to send /start to the new bot (required for new bots), then send any message, then get chat_id:
-   ```bash
-   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates?timeout=30" | jq '.result[-1].message.chat.id'
-   ```
-3. Create the agent: `cortextos add-agent <name> --template agent`
-4. Edit `.env` with BOT_TOKEN and CHAT_ID
-5. Enable it: `cortextos start <name>`
-6. **Write initial goals for the new agent** (you have authority to write other agents' goals.json):
-   ```bash
-   cat > $CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/<name>/goals.json << 'EOF'
-   {"focus":"initial role focus","goals":["goal 1","goal 2"],"bottleneck":"","updated_at":"ISO_TIMESTAMP","updated_by":"$CTX_AGENT_NAME"}
-   EOF
-   cortextos goals generate-md --agent <name> --org $CTX_ORG
-   ```
-7. **Hand off to the new agent for onboarding.** Tell the user via Telegram:
-   > "Your new agent is booting up! Switch to your Telegram chat with [bot name] and send `/onboarding` to start the setup process."
-
----
-
-## System Management
-
-### Agent Lifecycle
-| Action | Command |
-|--------|---------|
-| Add agent | `cortextos add-agent <name> --template <type>` |
-| Start agent | `cortextos start <name>` |
-| Stop agent | `cortextos stop <name>` |
-| Check status | `cortextos status` |
-
-### Communication
-| Action | Command |
-|--------|---------|
-| Send Telegram | `cortextos bus send-telegram <chat_id> "<msg>"` |
-| Send to agent | `cortextos bus send-message <agent> <priority> '<msg>' [reply_to]` |
-| Check inbox | `cortextos bus check-inbox` |
-| ACK message | `cortextos bus ack-inbox <msg_id>` |
-
-### Logs
-| Log | Path |
-|-----|------|
-| Activity | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/activity.log` |
-| Fast-checker | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/fast-checker.log` |
-| Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Stderr | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stderr.log` |
-
-### State
-| File | Purpose |
-|------|---------|
-| `config.json` | Crons, max_session_seconds, agent config |
-| `.env` | BOT_TOKEN, CHAT_ID, ALLOWED_USER |
-
----
-
-## Skills
-
-**Core (all agents):**
-- **.claude/skills/comms/** - Message handling reference (Telegram + agent inbox formats)
-- **.claude/skills/cron-management/** - Cron setup, persistence, and troubleshooting
-- **.claude/skills/tasks/** - Task creation, lifecycle, and KPI logging
-- **.claude/skills/knowledge-base/** - Query and ingest org documents
-
-**Orchestrator-specific:**
-- **.claude/skills/morning-review/** - Daily morning briefing workflow (goal cascade, agent summary, task scheduling)
-- **.claude/skills/evening-review/** - End-of-day review, overnight task planning
-- **.claude/skills/nighttime-mode/** - Overnight orchestration protocol (no external actions)
-- **.claude/skills/goal-management/** - Daily goal lifecycle — cascade from org to agents
-- **.claude/skills/weekly-review/** - Weekly synthesis, metrics, next-week planning
-- **.claude/skills/theta-wave/** - System improvement cycle with analyst
-- **.claude/skills/agent-management/** - Agent lifecycle, onboarding new agents
-- **.claude/skills/approvals/** - Approval routing and surfacing workflow
-
----
-
-## Knowledge Base (RAG)
-
-Query and ingest org documents using natural language. See `.claude/skills/knowledge-base/SKILL.md` for full reference.
+**You are measured by:** tasks dispatched, briefings sent on time, approvals routed, agents healthy.

--- a/tests/integration/cron-scheduler-reload-race.test.ts
+++ b/tests/integration/cron-scheduler-reload-race.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { CronDefinition } from '../../src/types/index.js';
+
+const TICK_MS = 30_000;
+const ONE_MIN = 60_000;
+
+let tmpRoot: string;
+const originalCtxRoot = process.env.CTX_ROOT;
+
+let writeCrons: typeof import('../../src/bus/crons.js').writeCrons;
+let CronScheduler: typeof import('../../src/daemon/cron-scheduler.js').CronScheduler;
+
+async function reloadModules(): Promise<void> {
+  vi.resetModules();
+  const cronsModule = await import('../../src/bus/crons.js');
+  writeCrons = cronsModule.writeCrons;
+  const schedulerModule = await import('../../src/daemon/cron-scheduler.js');
+  CronScheduler = schedulerModule.CronScheduler;
+}
+
+beforeEach(async () => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'cron-reload-race-'));
+  process.env.CTX_ROOT = tmpRoot;
+  vi.useFakeTimers();
+  await reloadModules();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetModules();
+  if (originalCtxRoot !== undefined) {
+    process.env.CTX_ROOT = originalCtxRoot;
+  } else {
+    delete process.env.CTX_ROOT;
+  }
+  try {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+function ensureAgentDir(agentName: string): void {
+  mkdirSync(join(tmpRoot, '.cortextOS', 'state', 'agents', agentName), { recursive: true });
+}
+
+function makeCronDef(overrides: Partial<CronDefinition> = {}): CronDefinition {
+  return {
+    name: 'reload-race',
+    prompt: 'Exercise reload while firing.',
+    schedule: '1m',
+    enabled: true,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('cron scheduler reload race regression', () => {
+  it('3 fires with reload during each fire window: fire count reaches 3, no freeze', async () => {
+    const agent = 'cron-reload-race-agent';
+    ensureAgentDir(agent);
+
+    const logs: string[] = [];
+    const firedAt: number[] = [];
+    let resolveActiveFire: (() => void) | null = null;
+
+    writeCrons(agent, [
+      makeCronDef({
+        last_fired_at: new Date(Date.now() - 2 * ONE_MIN).toISOString(),
+        fire_count: 1,
+      }),
+    ]);
+
+    const scheduler = new CronScheduler({
+      agentName: agent,
+      logger: (msg) => logs.push(msg),
+      onFire: async () => {
+        firedAt.push(Date.now());
+        await new Promise<void>((resolve) => {
+          resolveActiveFire = resolve;
+        });
+      },
+    });
+
+    scheduler.start();
+
+    async function fireWithInterleavedReload(advanceMs: number, expectedCount: number) {
+      await vi.advanceTimersByTimeAsync(advanceMs);
+      expect(firedAt).toHaveLength(expectedCount);
+      expect(resolveActiveFire).not.toBeNull();
+
+      scheduler.reload();
+
+      const [duringFire] = scheduler.getNextFireTimes();
+      expect(duringFire).toBeDefined();
+
+      resolveActiveFire!();
+      resolveActiveFire = null;
+      await vi.advanceTimersByTimeAsync(0);
+
+      const [afterFire] = scheduler.getNextFireTimes();
+      expect(afterFire).toBeDefined();
+      expect(afterFire.nextFireAt).toBeGreaterThan(Date.now());
+    }
+
+    await fireWithInterleavedReload(TICK_MS, 1);
+    await fireWithInterleavedReload(ONE_MIN, 2);
+    await fireWithInterleavedReload(ONE_MIN, 3);
+
+    await vi.advanceTimersByTimeAsync(ONE_MIN);
+    expect(firedAt).toHaveLength(4);
+    expect(resolveActiveFire).not.toBeNull();
+    resolveActiveFire!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const [afterFourth] = scheduler.getNextFireTimes();
+    expect(afterFourth).toBeDefined();
+    expect(afterFourth.nextFireAt).toBeGreaterThan(Date.now());
+    expect(logs.some((line) => line.includes('reload deferred for "reload-race"'))).toBe(true);
+
+    scheduler.stop();
+  });
+});

--- a/tests/unit/cli/bus-crons.test.ts
+++ b/tests/unit/cli/bus-crons.test.ts
@@ -100,6 +100,7 @@ beforeEach(() => {
   // agentExistsInFramework() can find TEST_AGENT.
   frameworkRoot = mkdtempSync(join(tmpdir(), 'bus-crons-fw-'));
   mkdirSync(join(frameworkRoot, 'orgs', 'lifeos', 'agents', TEST_AGENT), { recursive: true });
+  mkdirSync(join(frameworkRoot, 'orgs', 'lifeos', 'agents', 'top-g'), { recursive: true });
 
   process.env.CTX_ROOT = tmpRoot;
   process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
@@ -180,6 +181,76 @@ describe('bus add-cron', () => {
     const crons = readCronsFile();
     expect(crons).toHaveLength(1);
     expect(crons[0].schedule).toBe('0 13 * * *');
+  });
+
+  it('success: allows fresh-session for top-g heartbeat', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await busCommand.parseAsync([
+      'node', 'bus', 'add-cron', 'top-g', 'heartbeat', '4h',
+      'Run heartbeat.',
+      '--fresh-session',
+    ]);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith("Added cron 'heartbeat' for top-g");
+
+    const raw = readFileSync(join(tmpRoot, '.cortextOS', 'state', 'agents', 'top-g', 'crons.json'), 'utf-8');
+    expect(JSON.parse(raw).crons[0]).toMatchObject({ fresh_session: true });
+  });
+
+  it('success: stores protocol_file for fresh-session cron', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await busCommand.parseAsync([
+      'node', 'bus', 'add-cron', TEST_AGENT, 'heartbeat', '4h',
+      'Run heartbeat.',
+      '--fresh-session',
+      '--protocol-file', 'HEARTBEAT.md',
+    ]);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    const crons = readCronsFile();
+    expect(crons[0]).toMatchObject({
+      fresh_session: true,
+      protocol_file: 'HEARTBEAT.md',
+    });
+  });
+
+  it('error: rejects absolute protocol_file', async () => {
+    const exitSpy = mockExit();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'bus', 'add-cron', TEST_AGENT, 'heartbeat', '4h',
+        'Run heartbeat.',
+        '--protocol-file', '/tmp/HEARTBEAT.md',
+      ])
+    ).rejects.toThrow('__PROCESS_EXIT_1__');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('--protocol-file must be a relative path');
+  });
+
+  it('error: rejects fresh-session for top-g morning-review', async () => {
+    const exitSpy = mockExit();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'bus', 'add-cron', 'top-g', 'morning-review', '4h',
+        'Run morning review.',
+        '--fresh-session',
+      ])
+    ).rejects.toThrow('__PROCESS_EXIT_1__');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('protected cron');
   });
 
   it('error: duplicate cron name → exits 1 with message', async () => {
@@ -401,6 +472,33 @@ describe('bus update-cron', () => {
 
     const crons = readCronsFile();
     expect(crons[0].description).toBe('New description.');
+  });
+
+  it('updates protocol_file (--protocol-file)', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await busCommand.parseAsync([
+      'node', 'bus', 'update-cron', TEST_AGENT, 'heartbeat', '--protocol-file', 'HEARTBEAT.md',
+    ]);
+
+    const crons = readCronsFile();
+    expect(crons[0].protocol_file).toBe('HEARTBEAT.md');
+  });
+
+  it('error: rejects empty protocol_file on update', async () => {
+    const exitSpy = mockExit();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'bus', 'update-cron', TEST_AGENT, 'heartbeat', '--protocol-file', '   ',
+      ])
+    ).rejects.toThrow('__PROCESS_EXIT_1__');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('--protocol-file must be a non-empty relative path');
   });
 
   it('error: no options provided → exits 1', async () => {

--- a/tests/unit/daemon/cron-fresh-session.test.ts
+++ b/tests/unit/daemon/cron-fresh-session.test.ts
@@ -1,0 +1,868 @@
+import { EventEmitter } from 'events';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfig, CronDefinition, CtxEnv } from '../../../src/types/index';
+
+const spawnMock = vi.fn();
+const appendExecutionLogMock = vi.fn();
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+vi.mock('../../../src/daemon/cron-execution-log.js', () => ({
+  appendExecutionLog: (...args: unknown[]) => appendExecutionLogMock(...args),
+}));
+
+const FIRED_AT = '2026-05-15T00:00:00.000Z';
+
+function makeCron(overrides: Partial<CronDefinition> = {}): CronDefinition {
+  return {
+    name: 'heartbeat',
+    prompt: 'Run heartbeat.',
+    schedule: '4h',
+    enabled: true,
+    created_at: '2026-05-15T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+}
+
+function appendSystemPromptValue(args: unknown[]): string | undefined {
+  const idx = args.indexOf('--append-system-prompt');
+  return idx === -1 ? undefined : String(args[idx + 1]);
+}
+
+function appendSystemPromptFlagCount(args: unknown[]): number {
+  return args.filter(arg => arg === '--append-system-prompt').length;
+}
+
+function attachAgent(manager: any, agentName: string, config: AgentConfig = {}, extra: Record<string, unknown> = {}) {
+  const process = {
+    getConfig: vi.fn(() => config),
+    getAgentDir: vi.fn(() => extra.agentDir ?? '/tmp/agent'),
+    buildRuntimeEnv: vi.fn(() => extra.runtimeEnv ?? { CTX_ROOT: extra.ctxRoot ?? '/tmp/ctx' }),
+    injectMessage: vi.fn(() => true),
+  };
+  manager.agents.set(agentName, { process, checker: {} });
+  return process;
+}
+
+describe('cron fresh-session dispatch', () => {
+  let tmpRoot: string;
+  const originalCtxRoot = process.env.CTX_ROOT;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cron-fresh-'));
+    process.env.CTX_ROOT = tmpRoot;
+    spawnMock.mockReset();
+    appendExecutionLogMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    if (originalCtxRoot !== undefined) process.env.CTX_ROOT = originalCtxRoot; else delete process.env.CTX_ROOT;
+    rmSync(tmpRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('dispatchCron injects into PTY when fresh_session is absent', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(manager, 'ops-g');
+
+    await manager.dispatchCron('ops-g', makeCron(), '2026-05-15T00:00:00Z');
+
+    expect(proc.injectMessage).toHaveBeenCalledWith(expect.stringContaining('[CRON FIRED'));
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatchCron uses fireCronFreshSession when fresh_session is true', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g');
+    manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
+
+    await manager.dispatchCron('ops-g', makeCron({ fresh_session: true }), FIRED_AT);
+
+    expect(manager.fireCronFreshSession).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({ fresh_session: true }),
+      expect.stringContaining(`[CRON FIRED ${FIRED_AT}]`),
+      FIRED_AT,
+    );
+  });
+
+  it('dispatchCron protects top-g/morning-review and injects', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(manager, 'top-g');
+    manager.emitGuardrailEvent = vi.fn();
+
+    await manager.dispatchCron(
+      'top-g',
+      makeCron({ name: 'morning-review', fresh_session: true }),
+      FIRED_AT,
+    );
+
+    expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('top-g', 'morning-review');
+    expect(proc.injectMessage).toHaveBeenCalledOnce();
+  });
+
+  it('dispatchCron allows top-g/heartbeat fresh session', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'top-g');
+    manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
+
+    await manager.dispatchCron('top-g', makeCron({ name: 'heartbeat', fresh_session: true }), FIRED_AT);
+
+    expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
+  });
+
+  it('dispatchCron allows top-g/check-approvals fresh session', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'top-g');
+    manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
+
+    await manager.dispatchCron(
+      'top-g',
+      makeCron({ name: 'check-approvals', fresh_session: true }),
+      FIRED_AT,
+    );
+
+    expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
+  });
+
+  it('dispatchCron protects all smart-g crons through wildcard and injects', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(manager, 'smart-g');
+    manager.emitGuardrailEvent = vi.fn();
+
+    await manager.dispatchCron('smart-g', makeCron({ name: 'heartbeat', fresh_session: true }), FIRED_AT);
+
+    expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('smart-g', 'heartbeat');
+    expect(proc.injectMessage).toHaveBeenCalledOnce();
+  });
+
+  it('fireCronFreshSession rejects unsupported codex-app-server runtime', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'codex-g', { runtime: 'codex-app-server' });
+    manager.emitFreshSessionUnsupportedEvent = vi.fn();
+
+    await expect(
+      manager.fireCronFreshSession('codex-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT),
+    ).rejects.toThrow(/not supported/);
+    expect(manager.emitFreshSessionUnsupportedEvent).toHaveBeenCalledWith('codex-g', 'heartbeat', 'codex-app-server');
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'codex-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('pre_spawn:'),
+      }),
+    );
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('fireCronFreshSession resolves on child close code 0', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 0, null);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(spawnMock).toHaveBeenCalledWith('claude', expect.arrayContaining(['--print', '--no-session-persistence']), expect.any(Object));
+  });
+
+  it('fireCronFreshSession writes execution log on child close code 0', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        cron: 'heartbeat',
+        status: 'fired',
+        attempt: 1,
+        duration_ms: expect.any(Number),
+        error: null,
+      }),
+    );
+  });
+
+  it('fireCronFreshSession rejects on non-zero child close', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 1, null);
+
+    await expect(promise).rejects.toThrow(/exited code=1/);
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('exit_code_1'),
+      }),
+    );
+  });
+
+  it('fireCronFreshSession rejects timeout even when child exits code 0 after SIGTERM', async () => {
+    vi.useFakeTimers();
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fresh_session_timeout_ms: 100 }),
+      'prompt',
+      FIRED_AT,
+    );
+    vi.advanceTimersByTime(100);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    child.emit('close', 0, 'SIGTERM');
+
+    await expect(promise).rejects.toThrow(/timed out/);
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('timed_out'),
+      }),
+    );
+  });
+
+  it('fireCronFreshSession writes execution log once on spawn error', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('error', new Error('spawn failed'));
+    child.emit('close', 0, null);
+
+    await expect(promise).rejects.toThrow(/spawn failed/);
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('spawn_error'),
+      }),
+    );
+  });
+
+  it('fireCronFreshSession sends SIGKILL after timeout grace', async () => {
+    vi.useFakeTimers();
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fresh_session_timeout_ms: 100 }),
+      'prompt',
+      FIRED_AT,
+    );
+    vi.advanceTimersByTime(5_100);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    child.emit('close', null, 'SIGKILL');
+
+    await expect(promise).rejects.toThrow(/timed out/);
+  });
+
+  it('fireCronFreshSession passes skill_file content via --append-system-prompt', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat instructions');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'HEARTBEAT.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    const args = spawnMock.mock.calls[0][1];
+    expect(appendSystemPromptFlagCount(args)).toBe(1);
+    expect(appendSystemPromptValue(args)).toBe('heartbeat instructions');
+  });
+
+  it('fireCronFreshSession passes protocol_file content via --append-system-prompt', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat protocol');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, protocol_file: 'HEARTBEAT.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    const args = spawnMock.mock.calls[0][1];
+    expect(appendSystemPromptFlagCount(args)).toBe(1);
+    expect(appendSystemPromptValue(args)).toBe('heartbeat protocol');
+  });
+
+  it('fireCronFreshSession combines skill_file and protocol_file in deterministic order', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'SKILL.md'), 'skill instructions');
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat protocol');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'SKILL.md', protocol_file: 'HEARTBEAT.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    const args = spawnMock.mock.calls[0][1];
+    expect(appendSystemPromptFlagCount(args)).toBe(1);
+    expect(appendSystemPromptValue(args)).toBe('skill instructions\n\n---\n\nheartbeat protocol');
+  });
+
+  it('fireCronFreshSession ignores absolute protocol_file', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, protocol_file: '/tmp/secret.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock.mock.calls[0][1]).not.toContain('--append-system-prompt');
+  });
+
+  it('fireCronFreshSession keeps readable protocol_file when skill_file is unreadable', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat protocol');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'missing.md', protocol_file: 'HEARTBEAT.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(appendSystemPromptValue(spawnMock.mock.calls[0][1])).toBe('heartbeat protocol');
+  });
+
+  it('fireCronFreshSession ignores unreadable protocol_file without suppressing skill_file', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'SKILL.md'), 'skill instructions');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'SKILL.md', protocol_file: 'missing.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(appendSystemPromptValue(spawnMock.mock.calls[0][1])).toBe('skill instructions');
+  });
+
+  it('fireCronFreshSession ignores unreadable skill_file', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'missing.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock.mock.calls[0][1]).not.toContain('--append-system-prompt');
+  });
+
+  it('fireCronFreshSession ignores absolute skill_file', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: '/tmp/secret.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock.mock.calls[0][1]).not.toContain('--append-system-prompt');
+  });
+
+  it('fireCronFreshSession uses buildRuntimeEnv output and configured working directory', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(
+      manager,
+      'ops-g',
+      { working_directory: '/work' },
+      { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot, CUSTOM: 'yes' } },
+    );
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(proc.buildRuntimeEnv).toHaveBeenCalledOnce();
+    expect(spawnMock.mock.calls[0][2]).toMatchObject({
+      cwd: '/work',
+      env: {
+        CTX_ROOT: tmpRoot,
+        CUSTOM: 'yes',
+        CTX_CRON_FIRED_AT: FIRED_AT,
+        CTX_FRESH_SESSION_CRON: 'ops-g/heartbeat',
+      },
+    });
+  });
+
+  it('fireCronFreshSession persists last_fire_attempted_at before spawn', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true })]);
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
+      return child;
+    });
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
+  });
+
+  it('fireCronFreshSession persists last_fire_attempted_at before spawn error', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true })]);
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
+    child.emit('error', new Error('spawn failed'));
+
+    await expect(promise).rejects.toThrow(/spawn failed/);
+    expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
+  });
+
+  it('fireCronFreshSession caps captured stdout and labels stdout/stderr log writes', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.stdout.emit('data', Buffer.alloc(300 * 1024, 'a'));
+    child.stderr.emit('data', Buffer.from('warn'));
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+  });
+
+  it('fireCronFreshSession persists crons.json fire state on exit 0', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true, fire_count: 2 })]);
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fire_count: 2 }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(readCrons('ops-g')[0]).toMatchObject({
+      last_fired_at: FIRED_AT,
+      fire_count: 3,
+    });
+  });
+
+  it('fireCronFreshSession does not persist crons.json fire state on non-zero exit', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true, fire_count: 2 })]);
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fire_count: 2 }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 1, null);
+    await expect(promise).rejects.toThrow(/exited code=1/);
+
+    expect(readCrons('ops-g')[0]).not.toHaveProperty('last_fired_at');
+    expect(readCrons('ops-g')[0].fire_count).toBe(2);
+  });
+});
+
+describe('runtime env builder and fresh-session guards', () => {
+  let tmpRoot: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cron-env-'));
+    process.env = { ...originalEnv, PATH: '/bin', IS_SANDBOX: '1' };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('buildAgentRuntimeEnv includes CTX vars, org secrets, agent env, timezone, and orchestrator', async () => {
+    const projectRoot = join(tmpRoot, 'fw');
+    const agentDir = join(projectRoot, 'orgs', 'acme', 'agents', 'ops-g');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(projectRoot, 'orgs', 'acme', 'secrets.env'), 'SHARED_KEY=shared\nOVERRIDE=org\n');
+    writeFileSync(join(agentDir, '.env'), 'CHAT_ID=123\nOVERRIDE=agent\n');
+    writeFileSync(join(projectRoot, 'orgs', 'acme', 'context.json'), JSON.stringify({ orchestrator: 'top-g' }));
+
+    const { buildAgentRuntimeEnv } = await import('../../../src/utils/env.js');
+    const env: CtxEnv = {
+      instanceId: 'test',
+      ctxRoot: tmpRoot,
+      frameworkRoot: projectRoot,
+      projectRoot,
+      org: 'acme',
+      agentName: 'ops-g',
+      agentDir,
+    };
+
+    const runtimeEnv = buildAgentRuntimeEnv(env, { timezone: 'Asia/Bangkok' });
+
+    expect(runtimeEnv).toMatchObject({
+      CTX_ROOT: tmpRoot,
+      CTX_AGENT_NAME: 'ops-g',
+      CTX_ORG: 'acme',
+      CTX_TELEGRAM_CHAT_ID: '123',
+      CTX_ORCHESTRATOR_AGENT: 'top-g',
+      TZ: 'Asia/Bangkok',
+      SHARED_KEY: 'shared',
+      OVERRIDE: 'agent',
+      IS_SANDBOX: '1',
+    });
+  });
+
+  it('buildAgentRuntimeEnv propagates TZ when config.timezone is absent', async () => {
+    const projectRoot = join(tmpRoot, 'fw');
+    const agentDir = join(projectRoot, 'orgs', 'acme', 'agents', 'ops-g');
+    mkdirSync(agentDir, { recursive: true });
+    process.env.TZ = 'Asia/Bangkok';
+
+    const { buildAgentRuntimeEnv } = await import('../../../src/utils/env.js');
+    const env: CtxEnv = {
+      instanceId: 'test',
+      ctxRoot: tmpRoot,
+      frameworkRoot: projectRoot,
+      projectRoot,
+      org: 'acme',
+      agentName: 'ops-g',
+      agentDir,
+    };
+
+    const runtimeEnv = buildAgentRuntimeEnv(env, {});
+
+    expect(runtimeEnv).toMatchObject({
+      CTX_TIMEZONE: 'Asia/Bangkok',
+      TZ: 'Asia/Bangkok',
+    });
+  });
+
+  it('guard helpers protect specific cron patterns', async () => {
+    const { isFreshSessionProtectedCron } = await import('../../../src/utils/fresh-session-guards.js');
+    expect(isFreshSessionProtectedCron('top-g', 'morning-review')).toBe(true);
+    expect(isFreshSessionProtectedCron('top-g', 'evening-review')).toBe(true);
+    expect(isFreshSessionProtectedCron('top-g', 'weekly-review')).toBe(true);
+    expect(isFreshSessionProtectedCron('top-g', 'heartbeat')).toBe(false);
+    expect(isFreshSessionProtectedCron('top-g', 'check-approvals')).toBe(false);
+    expect(isFreshSessionProtectedCron('smart-g', 'heartbeat')).toBe(true);
+    expect(isFreshSessionProtectedCron('ops-g', 'heartbeat')).toBe(false);
+  });
+
+  it('guard helpers support only undefined and claude-code runtimes', async () => {
+    const { isFreshSessionSupportedRuntime } = await import('../../../src/utils/fresh-session-guards.js');
+    expect(isFreshSessionSupportedRuntime(undefined)).toBe(true);
+    expect(isFreshSessionSupportedRuntime('claude-code')).toBe(true);
+    expect(isFreshSessionSupportedRuntime('codex-app-server')).toBe(false);
+    expect(isFreshSessionSupportedRuntime('hermes')).toBe(false);
+  });
+});
+
+describe('IPC fresh-session mutation and manual fire validation', () => {
+  let tmpRoot: string;
+  let frameworkRoot: string;
+  const originalCtxRoot = process.env.CTX_ROOT;
+  const originalFrameworkRoot = process.env.CTX_FRAMEWORK_ROOT;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cron-ipc-'));
+    frameworkRoot = join(tmpRoot, 'fw');
+    process.env.CTX_ROOT = tmpRoot;
+    process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
+    mkdirSync(join(tmpRoot, 'config'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'ops-g'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'codex-g'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'top-g'), { recursive: true });
+    writeFileSync(join(tmpRoot, 'config', 'enabled-agents.json'), JSON.stringify({
+      'ops-g': { enabled: true, org: 'acme' },
+      'codex-g': { enabled: true, org: 'acme' },
+      'top-g': { enabled: true, org: 'acme' },
+    }));
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'ops-g', 'config.json'), '{}');
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'codex-g', 'config.json'), '{"runtime":"codex-app-server"}');
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'top-g', 'config.json'), '{}');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalCtxRoot !== undefined) process.env.CTX_ROOT = originalCtxRoot; else delete process.env.CTX_ROOT;
+    if (originalFrameworkRoot !== undefined) process.env.CTX_FRAMEWORK_ROOT = originalFrameworkRoot; else delete process.env.CTX_FRAMEWORK_ROOT;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('handleAddCron copies fresh-session fields', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const { readCrons } = await import('../../../src/bus/crons.js');
+
+    const result = handleAddCron('ops-g', {
+      name: 'heartbeat',
+      prompt: 'Run heartbeat.',
+      schedule: '4h',
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 120_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readCrons('ops-g')[0]).toMatchObject({
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 120_000,
+    });
+  });
+
+  it('handleUpdateCron copies fresh-session fields', async () => {
+    const { handleAddCron, handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const { readCrons } = await import('../../../src/bus/crons.js');
+    handleAddCron('ops-g', { name: 'heartbeat', prompt: 'x', schedule: '4h' });
+
+    const result = handleUpdateCron('ops-g', 'heartbeat', {
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 60_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readCrons('ops-g')[0]).toMatchObject({
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 60_000,
+    });
+  });
+
+  it('handleAddCron rejects protected top-g/morning-review', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('top-g', {
+      name: 'morning-review',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/protected/);
+  });
+
+  it('handleAddCron allows top-g/heartbeat', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('top-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session: true,
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it('handleAddCron rejects unsupported codex-app-server runtime', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('codex-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not supported/);
+  });
+
+  it('handleAddCron rejects absolute skill_file', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('ops-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      skill_file: '/tmp/HEARTBEAT.md',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('skill_file');
+  });
+
+  it('handleAddCron rejects invalid fresh_session_timeout_ms', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('ops-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session_timeout_ms: 0,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('fresh_session_timeout_ms');
+  });
+
+  it('handleFireCron dispatches through provided dispatch function and records cooldown only on success', async () => {
+    const { handleAddCron, handleFireCron, manualFireCooldownRemaining } = await import('../../../src/daemon/ipc-server.js');
+    handleAddCron('ops-g', { name: 'heartbeat', prompt: 'x', schedule: '4h', fresh_session: true });
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    const now = 1_000_000;
+
+    const result = await handleFireCron('ops-g', 'heartbeat', dispatch, now);
+
+    expect(result.ok).toBe(true);
+    expect(dispatch).toHaveBeenCalledWith('ops-g', expect.objectContaining({ fresh_session: true }), new Date(now).toISOString());
+    expect(manualFireCooldownRemaining('ops-g', 'heartbeat', now + 1)).toBeGreaterThan(0);
+  });
+
+  it('handleFireCron does not record cooldown when dispatch fails', async () => {
+    const { handleAddCron, handleFireCron, manualFireCooldownRemaining } = await import('../../../src/daemon/ipc-server.js');
+    handleAddCron('ops-g', { name: 'heartbeat', prompt: 'x', schedule: '4h' });
+    const dispatch = vi.fn().mockRejectedValue(new Error('boom'));
+    const now = 1_000_000;
+
+    const result = await handleFireCron('ops-g', 'heartbeat', dispatch, now);
+
+    expect(result.ok).toBe(false);
+    expect(manualFireCooldownRemaining('ops-g', 'heartbeat', now + 1)).toBe(0);
+  });
+});

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockReadCrons  = vi.fn();
 const mockUpdateCron = vi.fn();
+const mockAppendExecutionLog = vi.fn();
 // readCronsWithStatus is what cron-scheduler actually calls (post-iter-9).
 // By default it mirrors mockReadCrons with corrupt:false so existing tests
 // keep working.  Tests that need to assert the corruption path can override
@@ -26,6 +27,10 @@ vi.mock('../../../src/bus/crons.js', () => ({
   readCrons:  (...args: unknown[]) => mockReadCrons(...args),
   readCronsWithStatus: (...args: unknown[]) => mockReadCronsWithStatus(...args),
   updateCron: (...args: unknown[]) => mockUpdateCron(...args),
+}));
+
+vi.mock('../../../src/daemon/cron-execution-log.js', () => ({
+  appendExecutionLog: (...args: unknown[]) => mockAppendExecutionLog(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -186,6 +191,7 @@ describe('CronScheduler', () => {
     fired  = [];
     mockReadCrons.mockReset();
     mockUpdateCron.mockReset();
+    mockAppendExecutionLog.mockReset();
     mockReadCronsWithStatus.mockReset();
     // Default: readCronsWithStatus reflects whatever readCrons returns
     // and reports the file as healthy (corrupt: false).
@@ -266,6 +272,51 @@ describe('CronScheduler', () => {
     );
   });
 
+  it('fresh_session success advances nextFireAt and does not refire on the next tick', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ schedule: '1m', fresh_session: true })]);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(fired).toHaveLength(1);
+    const scheduled = (scheduler as any).scheduled.get('test-cron');
+    expect(scheduled.nextFireAt).toBeGreaterThan(Date.now());
+
+    await vi.advanceTimersByTimeAsync(TICK);
+
+    expect(fired).toHaveLength(1);
+  });
+
+  it('fresh_session success skips scheduler last_fired_at/fire_count disk update', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ schedule: '1m', fresh_session: true })]);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(60_000 + TICK);
+
+    expect(mockUpdateCron).toHaveBeenCalledWith(
+      'test-agent',
+      'test-cron',
+      expect.objectContaining({ last_fire_attempted_at: expect.any(String) })
+    );
+    expect(mockUpdateCron.mock.calls.some((call) => 'last_fired_at' in (call[2] as object))).toBe(false);
+  });
+
+  it('PTY fires still write execution log through scheduler', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ schedule: '1m' })]);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(60_000 + TICK);
+
+    expect(mockAppendExecutionLog).toHaveBeenCalledWith(
+      'test-agent',
+      expect.objectContaining({
+        cron: 'test-cron',
+        status: 'fired',
+        error: null,
+      })
+    );
+  });
+
   // -------------------------------------------------------------------------
   // onFire failure + retry
   // -------------------------------------------------------------------------
@@ -318,6 +369,33 @@ describe('CronScheduler', () => {
       'test-cron',
       expect.objectContaining({ last_fired_at: expect.any(String) })
     );
+
+    retryScheduler.stop();
+  });
+
+  it('fresh_session fires are not retried by the scheduler', async () => {
+    const failingFire = vi.fn().mockRejectedValue(new Error('fresh failed'));
+    const oneDayAgo = new Date(Date.now() - 25 * 3_600_000).toISOString();
+    mockReadCrons.mockReturnValue([
+      makeCron({
+        schedule: '24h',
+        fresh_session: true,
+        last_fired_at: oneDayAgo,
+      }),
+    ]);
+
+    const retryScheduler = new CronScheduler({
+      agentName: 'test-agent',
+      onFire: failingFire,
+      logger: (msg) => logs.push(msg),
+    });
+
+    retryScheduler.start();
+    await vi.advanceTimersByTimeAsync(TICK + 1_000);
+
+    expect(failingFire).toHaveBeenCalledTimes(1);
+    expect(mockAppendExecutionLog).not.toHaveBeenCalled();
+    expect(logs.some(l => l.includes('after all 1 attempt'))).toBe(true);
 
     retryScheduler.stop();
   });
@@ -403,6 +481,53 @@ describe('CronScheduler', () => {
     const afterReload = scheduler.getNextFireTimes().find(e => e.name === 'stable');
     expect(afterReload).toBeDefined();
     expect(afterReload!.nextFireAt).toBe(beforeReload!.nextFireAt);
+  });
+
+  it('reload with same schedule during slow fire: cron is not frozen and fires again', async () => {
+    let resolveFire: (() => void) | undefined;
+    const slowFire = vi.fn().mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveFire = resolve; }),
+    );
+    const raceScheduler = new CronScheduler({
+      agentName: 'test-agent',
+      onFire: slowFire,
+      logger: (msg) => logs.push(msg),
+    });
+    const twoMinAgo = new Date(Date.now() - 2 * 60_000).toISOString();
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'heartbeat', schedule: '1m', last_fired_at: twoMinAgo, fire_count: 1 }),
+    ]);
+
+    raceScheduler.start();
+
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(slowFire).toHaveBeenCalledTimes(1);
+
+    const entryDuringFire = (raceScheduler as any).scheduled.get('heartbeat');
+    expect(entryDuringFire).toBeDefined();
+    expect(entryDuringFire.firing).toBe(true);
+
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'heartbeat', schedule: '1m', last_fired_at: twoMinAgo, fire_count: 1 }),
+    ]);
+    raceScheduler.reload();
+
+    const entryAfterReload = (raceScheduler as any).scheduled.get('heartbeat');
+    expect(entryAfterReload).toBe(entryDuringFire);
+    expect(entryAfterReload.firing).toBe(true);
+
+    resolveFire!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const entryAfterFire = (raceScheduler as any).scheduled.get('heartbeat');
+    expect(entryAfterFire).toBe(entryDuringFire);
+    expect(entryAfterFire.firing).toBe(false);
+    expect(entryAfterFire.nextFireAt).toBeGreaterThan(Date.now());
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(slowFire).toHaveBeenCalledTimes(2);
+
+    raceScheduler.stop();
   });
 
   it('reload() recomputes nextFireAt for a modified schedule', async () => {

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -287,7 +287,7 @@ describe('CronScheduler', () => {
     expect(fired).toHaveLength(1);
   });
 
-  it('fresh_session success skips scheduler last_fired_at/fire_count disk update', async () => {
+  it('fresh_session success persists last_fired_at/fire_count to disk (prevents schedule drift on restart)', async () => {
     mockReadCrons.mockReturnValue([makeCron({ schedule: '1m', fresh_session: true })]);
     scheduler.start();
 
@@ -298,7 +298,8 @@ describe('CronScheduler', () => {
       'test-cron',
       expect.objectContaining({ last_fire_attempted_at: expect.any(String) })
     );
-    expect(mockUpdateCron.mock.calls.some((call) => 'last_fired_at' in (call[2] as object))).toBe(false);
+    // fresh_session crons must persist last_fired_at so daemon restarts don't drift schedule forward
+    expect(mockUpdateCron.mock.calls.some((call) => 'last_fired_at' in (call[2] as object))).toBe(true);
   });
 
   it('PTY fires still write execution log through scheduler', async () => {

--- a/tests/unit/daemon/ipc-mutations.test.ts
+++ b/tests/unit/daemon/ipc-mutations.test.ts
@@ -193,6 +193,21 @@ describe('handleAddCron — happy path', () => {
     });
     expect(result.ok).toBe(true);
   });
+
+  it('trims and stores protocol_file', async () => {
+    writeEnabledAgents({ boris: { enabled: true } });
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('boris', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '1h',
+      protocol_file: ' HEARTBEAT.md ',
+    });
+    expect(result.ok).toBe(true);
+
+    const { readCrons } = await import('../../../src/bus/crons.js');
+    expect(readCrons('boris')[0].protocol_file).toBe('HEARTBEAT.md');
+  });
 });
 
 describe('handleAddCron — validation failures', () => {
@@ -271,6 +286,20 @@ describe('handleAddCron — validation failures', () => {
     expect(result.field).toBe('prompt');
   });
 
+  it('rejects empty protocol_file', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('boris', { name: 'test', prompt: 'x', schedule: '1h', protocol_file: '   ' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
+  });
+
+  it('rejects absolute protocol_file', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('boris', { name: 'test', prompt: 'x', schedule: '1h', protocol_file: '/tmp/HEARTBEAT.md' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
+  });
+
   it('returns error and field:name on duplicate cron', async () => {
     writeEnabledAgents({ boris: { enabled: true } });
     const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
@@ -320,6 +349,16 @@ describe('handleUpdateCron — happy path', () => {
     const result = handleUpdateCron('boris', 'heartbeat', { schedule: '0 9 * * *' });
     expect(result.ok).toBe(true);
   });
+
+  it('trims and updates protocol_file', async () => {
+    writeCronsJson('boris', [makeCron()]);
+    const { handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleUpdateCron('boris', 'heartbeat', { protocol_file: ' HEARTBEAT.md ' });
+    expect(result.ok).toBe(true);
+
+    const { getCronByName } = await import('../../../src/bus/crons.js');
+    expect(getCronByName('boris', 'heartbeat')?.protocol_file).toBe('HEARTBEAT.md');
+  });
 });
 
 describe('handleUpdateCron — validation failures', () => {
@@ -358,6 +397,22 @@ describe('handleUpdateCron — validation failures', () => {
     const result = handleUpdateCron('boris', 'heartbeat', { prompt: '   ' });
     expect(result.ok).toBe(false);
     expect(result.field).toBe('prompt');
+  });
+
+  it('rejects empty protocol_file in patch', async () => {
+    writeCronsJson('boris', [makeCron()]);
+    const { handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleUpdateCron('boris', 'heartbeat', { protocol_file: '   ' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
+  });
+
+  it('rejects absolute protocol_file in patch', async () => {
+    writeCronsJson('boris', [makeCron()]);
+    const { handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleUpdateCron('boris', 'heartbeat', { protocol_file: '/tmp/HEARTBEAT.md' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
   });
 
   it('returns error when cron not found', async () => {

--- a/tests/unit/hooks/hook-crash-alert.test.ts
+++ b/tests/unit/hooks/hook-crash-alert.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { homedir, tmpdir } from 'os';
 
 const execFileMock = vi.fn();
 vi.mock('child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
 
-import { readMaxCrashesPerDay, notifyAgents } from '../../../src/hooks/hook-crash-alert';
+import { main, readMaxCrashesPerDay, notifyAgents } from '../../../src/hooks/hook-crash-alert';
 
 describe('readMaxCrashesPerDay', () => {
   let tmp: string;
@@ -143,5 +143,76 @@ describe('notifyAgents', () => {
     })).not.toThrow();
     // Second recipient still attempted
     expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('main fresh-session suppression', () => {
+  const originalEnv = { ...process.env };
+  let instanceId: string;
+  let ctxRoot: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    instanceId = `hook-test-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    ctxRoot = join(homedir(), '.cortextos', instanceId);
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    execFileMock.mockReset();
+    process.env = {
+      ...originalEnv,
+      CTX_INSTANCE_ID: instanceId,
+      CTX_AGENT_NAME: 'dev-g',
+      CTX_FRESH_SESSION_CRON: 'dev-g/heartbeat',
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.unstubAllGlobals();
+    rmSync(ctxRoot, { recursive: true, force: true });
+  });
+
+  it('returns before crashes.log, crash counter, Telegram, and agent notifications', async () => {
+    await main();
+
+    expect(existsSync(join(ctxRoot, 'logs', 'dev-g', 'crashes.log'))).toBe(false);
+    expect(existsSync(join(ctxRoot, 'state', 'dev-g', '.crash_count_today'))).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses side effects even when Telegram credentials are present', async () => {
+    process.env.BOT_TOKEN = 'token';
+    process.env.CHAT_ID = 'chat';
+
+    await main();
+
+    expect(existsSync(join(ctxRoot, 'logs', 'dev-g', 'crashes.log'))).toBe(false);
+    expect(existsSync(join(ctxRoot, 'state', 'dev-g', '.crash_count_today'))).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('does not consume marker files before returning', async () => {
+    const stateDir = join(ctxRoot, 'state', 'dev-g');
+    mkdirSync(stateDir, { recursive: true });
+    const markerPath = join(stateDir, '.restart-planned');
+    writeFileSync(markerPath, 'planned restart', 'utf-8');
+
+    await main();
+
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  it('normal crash still writes crashes.log when fresh-session marker is absent', async () => {
+    delete process.env.CTX_FRESH_SESSION_CRON;
+    delete process.env.BOT_TOKEN;
+    delete process.env.CHAT_ID;
+
+    await main();
+
+    const crashesLog = join(ctxRoot, 'logs', 'dev-g', 'crashes.log');
+    expect(readFileSync(crashesLog, 'utf-8')).toContain('type=crash');
+    expect(readFileSync(join(ctxRoot, 'state', 'dev-g', '.crash_count_today'), 'utf-8')).toContain(':1');
   });
 });

--- a/tests/unit/utils/agent-session.test.ts
+++ b/tests/unit/utils/agent-session.test.ts
@@ -1,0 +1,263 @@
+import { describe, it, expect } from 'vitest';
+import { join } from 'path';
+import { mkdirSync, writeFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import {
+  getAgentProjectDir,
+  redact,
+  redactWithCount,
+  parseJsonlTurns,
+  isSafePoint,
+} from '../../../src/utils/agent-session.js';
+
+describe('getAgentProjectDir', () => {
+  it('converts absolute path to slug', () => {
+    const dir = '/root/cortextos/orgs/1evo/agents/ops-g';
+    const result = getAgentProjectDir(dir);
+    expect(result).toContain('-root-cortextos-orgs-1evo-agents-ops-g');
+  });
+});
+
+describe('redact', () => {
+  it('strips telegram bot tokens', () => {
+    const text = 'token=1234567890:ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghi';
+    expect(redact(text)).not.toContain('1234567890:');
+  });
+
+  it('strips email addresses', () => {
+    const text = 'contact user@example.com about this';
+    expect(redact(text)).not.toContain('user@example.com');
+  });
+
+  it('counts substitutions', () => {
+    const text = 'user@example.com and admin@test.org';
+    const { count } = redactWithCount(text);
+    expect(count).toBe(2);
+  });
+
+  it('leaves ordinary text unchanged', () => {
+    const text = 'npm install && npm test';
+    expect(redact(text)).toBe(text);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// JSONL helpers
+// ---------------------------------------------------------------------------
+
+let _toolIdCounter = 0;
+function freshToolId() { return `tu-${++_toolIdCounter}`; }
+
+function makeTurn(role: 'user' | 'assistant', text: string, toolIds: string[] = []): string {
+  const contentBlocks: unknown[] = [{ type: 'text', text }];
+  for (const id of toolIds) {
+    contentBlocks.push({ type: 'tool_use', id, name: 'Bash', input: {} });
+  }
+  return JSON.stringify({
+    type: role,
+    uuid: `test-uuid-${Math.random()}`,
+    message: { role, content: contentBlocks },
+  });
+}
+
+function makeToolResults(ids: string[]): string {
+  return JSON.stringify({
+    type: 'user',
+    uuid: `test-uuid-${Math.random()}`,
+    message: {
+      role: 'user',
+      content: ids.map(id => ({ type: 'tool_result', tool_use_id: id, content: [{ type: 'text', text: 'ok' }] })),
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// parseJsonlTurns
+// ---------------------------------------------------------------------------
+
+describe('parseJsonlTurns', () => {
+  it('returns empty for non-existent file', () => {
+    expect(parseJsonlTurns('/tmp/nonexistent-xyzzy.jsonl')).toEqual([]);
+  });
+
+  it('parses user and assistant turns', () => {
+    const dir = join(tmpdir(), `agent-session-test-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'test.jsonl');
+    writeFileSync(path, [
+      makeTurn('user', 'Hello'),
+      makeTurn('assistant', 'World'),
+      '{}', // unknown record — should be skipped
+      'not json', // malformed — should be skipped
+    ].join('\n'));
+    const turns = parseJsonlTurns(path);
+    expect(turns).toHaveLength(2);
+    expect(turns[0].role).toBe('user');
+    expect(turns[1].role).toBe('assistant');
+    rmSync(dir, { recursive: true });
+  });
+
+  it('redacts secrets in parsed turns', () => {
+    const dir = join(tmpdir(), `agent-session-test-${Date.now()}`);
+    mkdirSync(dir, { recursive: true });
+    const path = join(dir, 'test.jsonl');
+    writeFileSync(path, makeTurn('user', 'email is secret@example.com'));
+    const turns = parseJsonlTurns(path);
+    expect(turns[0].contentText).not.toContain('secret@example.com');
+    rmSync(dir, { recursive: true });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isSafePoint — ID-based tool tracking
+// ---------------------------------------------------------------------------
+
+function makeJsonl(lines: string[]): string {
+  return lines.join('\n');
+}
+
+function writeTemp(lines: string[]): { path: string; cleanup: () => void } {
+  const dir = join(tmpdir(), `sp-test-${Date.now()}-${Math.random()}`);
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, 'test.jsonl');
+  writeFileSync(path, makeJsonl(lines));
+  return { path, cleanup: () => rmSync(dir, { recursive: true }) };
+}
+
+describe('isSafePoint', () => {
+  it('returns false for empty turns', () => {
+    expect(isSafePoint([])).toBe(false);
+  });
+
+  it('returns false when last turn is user', () => {
+    const { path, cleanup } = writeTemp([
+      makeTurn('user', 'hello'),
+      makeTurn('assistant', 'reply'),
+      makeTurn('user', 'follow up'),
+    ]);
+    expect(isSafePoint(parseJsonlTurns(path))).toBe(false);
+    cleanup();
+  });
+
+  it('returns true for clean assistant final turn (no tool use)', () => {
+    const { path, cleanup } = writeTemp([
+      makeTurn('user', 'hello'),
+      makeTurn('assistant', 'done'),
+    ]);
+    expect(isSafePoint(parseJsonlTurns(path))).toBe(true);
+    cleanup();
+  });
+
+  it('returns false when last assistant turn has pending tool_use', () => {
+    const id = freshToolId();
+    const { path, cleanup } = writeTemp([
+      makeTurn('user', 'run'),
+      makeTurn('assistant', 'calling', [id]),
+    ]);
+    expect(isSafePoint(parseJsonlTurns(path))).toBe(false);
+    cleanup();
+  });
+
+  it('returns true when tool_use + tool_result IDs match (single tool)', () => {
+    const id = freshToolId();
+    const { path, cleanup } = writeTemp([
+      makeTurn('user', 'run'),
+      makeTurn('assistant', 'calling', [id]),
+      makeToolResults([id]),
+      makeTurn('assistant', 'done'),
+    ]);
+    expect(isSafePoint(parseJsonlTurns(path))).toBe(true);
+    cleanup();
+  });
+
+  it('returns false when one of two parallel tool_use IDs has no result (codex-g multi-tool case)', () => {
+    const id1 = freshToolId();
+    const id2 = freshToolId();
+    const { path, cleanup } = writeTemp([
+      makeTurn('user', 'do two things'),
+      makeTurn('assistant', 'calling both', [id1, id2]),
+      makeToolResults([id1]), // only id1 returned
+      makeTurn('assistant', 'partial done'),
+    ]);
+    expect(isSafePoint(parseJsonlTurns(path))).toBe(false);
+    cleanup();
+  });
+
+  it('returns true when both parallel tool_use IDs have results', () => {
+    const id1 = freshToolId();
+    const id2 = freshToolId();
+    const { path, cleanup } = writeTemp([
+      makeTurn('user', 'do two things'),
+      makeTurn('assistant', 'calling both', [id1, id2]),
+      makeToolResults([id1, id2]),
+      makeTurn('assistant', 'all done'),
+    ]);
+    expect(isSafePoint(parseJsonlTurns(path))).toBe(true);
+    cleanup();
+  });
+
+  it('handles sequential tool calls all resolved', () => {
+    const id1 = freshToolId();
+    const id2 = freshToolId();
+    const { path, cleanup } = writeTemp([
+      makeTurn('user', 'step by step'),
+      makeTurn('assistant', 'first call', [id1]),
+      makeToolResults([id1]),
+      makeTurn('assistant', 'second call', [id2]),
+      makeToolResults([id2]),
+      makeTurn('assistant', 'all done'),
+    ]);
+    expect(isSafePoint(parseJsonlTurns(path))).toBe(true);
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Runtime normalization (getRuntime() is on AgentProcess — tested via behavior
+// in pauseForJsonlSnapshot which gates on 'claude-code' runtime only)
+// ---------------------------------------------------------------------------
+
+describe('runtime normalization contract', () => {
+  // These tests document the expected behavior of getRuntime() per the
+  // approved normalization rule: absent/legacy → 'claude-code'.
+  // The actual getRuntime() is on AgentProcess; these tests use the
+  // SnapshotAgentLike interface to verify the gate behavior.
+
+  const RUNTIMES_THAT_SKIP = ['codex-app-server', 'hermes', 'custom-runtime'];
+  const RUNTIMES_THAT_PROCEED = ['claude-code'];
+
+  for (const rt of RUNTIMES_THAT_SKIP) {
+    it(`pauseForJsonlSnapshot skips when runtime='${rt}'`, async () => {
+      const { pauseForJsonlSnapshot } = await import('../../../src/utils/agent-session.js');
+      const agent = { getRuntime: () => rt, getChildPid: () => null, getAgentDir: () => '/tmp' };
+      const result = await pauseForJsonlSnapshot(agent);
+      expect(result).toBeNull();
+    });
+  }
+
+  for (const rt of RUNTIMES_THAT_PROCEED) {
+    it(`pauseForJsonlSnapshot attempts snapshot when runtime='${rt}' (stops at no-PID)`, async () => {
+      const { pauseForJsonlSnapshot } = await import('../../../src/utils/agent-session.js');
+      // No PID → returns null after gate passes (not skipped by runtime check)
+      const logs: string[] = [];
+      const agent = { getRuntime: () => rt, getChildPid: () => null, getAgentDir: () => '/tmp' };
+      const result = await pauseForJsonlSnapshot(agent, (msg) => logs.push(msg));
+      expect(result).toBeNull();
+      // Should log 'no valid child PID', not 'not supported'
+      expect(logs.some(l => l.includes('no valid child PID') || l.includes('Cannot pause'))).toBe(true);
+      expect(logs.some(l => l.includes('not supported') && l.includes('runtime'))).toBe(false);
+    });
+  }
+
+  it('absent runtime (undefined) is treated as claude-code by getRuntime() default', () => {
+    // Verify the normalization rule in isolation: undefined → 'claude-code'
+    // This mirrors what AgentProcess.getRuntime() should return.
+    const normalizeRuntime = (rt: string | undefined) => rt ?? 'claude-code';
+    expect(normalizeRuntime(undefined)).toBe('claude-code');
+    expect(normalizeRuntime('')).toBe('');
+    expect(normalizeRuntime('claude-code')).toBe('claude-code');
+    expect(normalizeRuntime('claude')).toBe('claude');
+    expect(normalizeRuntime('codex-app-server')).toBe('codex-app-server');
+    expect(normalizeRuntime('hermes')).toBe('hermes');
+  });
+});

--- a/tests/unit/utils/sidecar-compactor.test.ts
+++ b/tests/unit/utils/sidecar-compactor.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  splitTurnsByTokenBudget,
+  flattenTurns,
+  validateAndPatchSummary,
+  buildLedgerDoc,
+  redactLedgerSummary,
+} from '../../../src/utils/sidecar-compactor.js';
+import type { ParsedTurn } from '../../../src/utils/agent-session.js';
+import type { CompactionSummary } from '../../../src/utils/sidecar-compactor.js';
+import type { CompactionLedger } from '../../../src/types/index.js';
+
+function makeTurn(role: 'user' | 'assistant', text: string, tokens = 100): ParsedTurn {
+  return { uuid: `u-${Math.random()}`, role, contentText: text, estimatedTokens: tokens, rawLine: '{}' };
+}
+
+describe('splitTurnsByTokenBudget', () => {
+  it('puts all turns in recent when total is under budget', () => {
+    const turns = [makeTurn('user', 'a', 100), makeTurn('assistant', 'b', 100)];
+    const { middle, recent } = splitTurnsByTokenBudget(turns, 1000);
+    expect(middle).toHaveLength(0);
+    expect(recent).toHaveLength(2);
+  });
+
+  it('splits turns when total exceeds budget', () => {
+    const turns = Array.from({ length: 10 }, (_, i) => makeTurn('user', `msg${i}`, 100));
+    const { middle, recent } = splitTurnsByTokenBudget(turns, 300);
+    expect(recent.length).toBeLessThanOrEqual(3);
+    expect(middle.length + recent.length).toBe(10);
+  });
+
+  it('always puts at least one turn in recent', () => {
+    const turns = [makeTurn('user', 'single', 5000)];
+    const { middle, recent } = splitTurnsByTokenBudget(turns, 100);
+    expect(recent).toHaveLength(1);
+    expect(middle).toHaveLength(0);
+  });
+});
+
+describe('flattenTurns', () => {
+  it('produces role-prefixed text blocks', () => {
+    const turns = [makeTurn('user', 'hello'), makeTurn('assistant', 'world')];
+    const result = flattenTurns(turns);
+    expect(result).toContain('user: hello');
+    expect(result).toContain('assistant: world');
+  });
+});
+
+describe('validateAndPatchSummary', () => {
+  it('returns null when next_action is empty', () => {
+    const s: CompactionSummary = {
+      resolved: [],
+      pending: ['something'],
+      key_facts: { current_state: 'state', next_action: '' },
+      redaction_count: 0,
+    };
+    expect(validateAndPatchSummary(s, false)).toBeNull();
+  });
+
+  it('patches empty pending when recent activity exists', () => {
+    const s: CompactionSummary = {
+      resolved: [],
+      pending: [],
+      key_facts: { current_state: 'state', next_action: 'do X' },
+      redaction_count: 0,
+    };
+    const result = validateAndPatchSummary(s, true);
+    expect(result).not.toBeNull();
+    expect(result!.pending).toHaveLength(1);
+    expect(result!.pending[0]).toContain('unknown');
+  });
+
+  it('passes valid summary unchanged', () => {
+    const s: CompactionSummary = {
+      resolved: ['task 1'],
+      pending: ['task 2'],
+      key_facts: { current_state: 'state', next_action: 'do Y' },
+      redaction_count: 0,
+    };
+    const result = validateAndPatchSummary(s, true);
+    expect(result).not.toBeNull();
+    expect(result!.pending).toEqual(['task 2']);
+    expect(result!.resolved).toEqual(['task 1']);
+  });
+});
+
+describe('redactLedgerSummary', () => {
+  it('redacts secrets in key_facts', () => {
+    const s: CompactionSummary = {
+      resolved: [],
+      pending: ['contact user@example.com'],
+      key_facts: { current_state: 'saw user@test.org', next_action: 'proceed' },
+      redaction_count: 0,
+    };
+    const result = redactLedgerSummary(s);
+    expect(JSON.stringify(result)).not.toContain('@example.com');
+    expect(result.redaction_count).toBeGreaterThan(0);
+  });
+
+  it('updates redaction_count cumulatively', () => {
+    const s: CompactionSummary = {
+      resolved: [],
+      pending: [],
+      key_facts: { current_state: 'clean', next_action: 'done' },
+      redaction_count: 5,
+    };
+    const result = redactLedgerSummary(s);
+    expect(result.redaction_count).toBe(5); // no new redactions in clean text
+  });
+});
+
+describe('buildLedgerDoc', () => {
+  it('produces markdown with all required sections', () => {
+    const ledger: CompactionLedger = {
+      schema_version: '1',
+      compacted_at: '2026-05-15T22:00:00.000Z',
+      session_id: 'abc-123',
+      context_pct_at_compact: 62,
+      variant: 'sonnet',
+      resolved: ['task A'],
+      pending: ['task B'],
+      key_facts: {
+        current_state: 'working on X',
+        next_action: 'deploy Y',
+        active_files: ['src/foo.ts'],
+        blockers: ['waiting for approval'],
+      },
+      recent_turns_summary: 'recent text here',
+      redaction_count: 3,
+    };
+    const doc = buildLedgerDoc('ops-g', ledger);
+    expect(doc).toContain('# Compaction Ledger');
+    expect(doc).toContain('## Resolved');
+    expect(doc).toContain('## Pending');
+    expect(doc).toContain('## Current State');
+    expect(doc).toContain('## Next Action');
+    expect(doc).toContain('## Active Files');
+    expect(doc).toContain('## Blockers');
+    expect(doc).toContain('task A');
+    expect(doc).toContain('task B');
+    expect(doc).toContain('src/foo.ts');
+  });
+
+  it('omits optional sections when empty', () => {
+    const ledger: CompactionLedger = {
+      schema_version: '1',
+      compacted_at: '2026-05-15T22:00:00.000Z',
+      session_id: 'abc-456',
+      context_pct_at_compact: 65,
+      variant: 'deterministic',
+      resolved: [],
+      pending: [],
+      key_facts: { current_state: 'idle', next_action: 'wait' },
+      recent_turns_summary: '',
+      redaction_count: 0,
+    };
+    const doc = buildLedgerDoc('ops-g', ledger);
+    expect(doc).not.toContain('## Active Files');
+    expect(doc).not.toContain('## Blockers');
+  });
+});

--- a/tools/skill-overlay-apply.sh
+++ b/tools/skill-overlay-apply.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# skill-overlay-apply.sh — enforce skill-overlay.json manifest on agent SKILL.md frontmatter
+#
+# Usage:
+#   ./tools/skill-overlay-apply.sh [--dry-run] [--revert] [--agent <name>]
+#
+# --dry-run   List changes without writing
+# --revert    Restore SKILL.md files from git (git checkout HEAD -- <file>)
+# --agent     Only process one agent (default: all)
+#
+# Idempotent: running twice produces no additional changes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ORGS_DIR="$REPO_ROOT/orgs"
+# Skills live in the filesystem (not git-tracked). Override with --live-repo-root
+# when running from a worktree where agent skill dirs are absent.
+LIVE_REPO_ROOT="$REPO_ROOT"
+
+DRY_RUN=false
+REVERT=false
+FILTER_AGENT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dry-run)        DRY_RUN=true ;;
+    --revert)         REVERT=true ;;
+    --agent)          FILTER_AGENT="$2"; shift ;;
+    --live-repo-root) LIVE_REPO_ROOT="$2"; shift ;;
+    *) echo "Unknown flag: $1" >&2; exit 1 ;;
+  esac
+  shift
+done
+
+LIVE_ORGS_DIR="$LIVE_REPO_ROOT/orgs"
+
+changes=0
+errors=0
+
+find "$ORGS_DIR" -name "skill-overlay.json" | sort | while read -r overlay_path; do
+  agent_dir="$(dirname "$overlay_path")"
+  agent_name="$(python3 -c "import json,sys; print(json.load(open('$overlay_path'))['agent'])" 2>/dev/null)"
+
+  if [[ -n "$FILTER_AGENT" && "$agent_name" != "$FILTER_AGENT" ]]; then
+    continue
+  fi
+
+  # Resolve skills against live repo (may differ from manifest/worktree root)
+  relative_agent="${agent_dir#$ORGS_DIR/}"
+  skills_dir="$LIVE_ORGS_DIR/$relative_agent/.claude/skills"
+  if [[ ! -d "$skills_dir" ]]; then
+    echo "[SKIP] $agent_name: no skills dir at $skills_dir"
+    continue
+  fi
+
+  if $REVERT; then
+    echo "[REVERT] $agent_name: restoring SKILL.md files from git (live: $skills_dir)"
+    git -C "$LIVE_REPO_ROOT" checkout HEAD -- "$skills_dir/" 2>/dev/null || \
+      echo "  [WARN] git revert failed for $agent_name — may not be tracked"
+    continue
+  fi
+
+  # Parse manual_only and auto_invoke arrays
+  manual_only="$(python3 -c "
+import json, sys
+data = json.load(open('$overlay_path'))
+print('\n'.join(data.get('manual_only', [])))
+")"
+  auto_invoke="$(python3 -c "
+import json, sys
+data = json.load(open('$overlay_path'))
+print('\n'.join(data.get('auto_invoke', [])))
+")"
+
+  # Process manual_only: ensure disable-model-invocation: true in frontmatter
+  while IFS= read -r skill; do
+    [[ -z "$skill" ]] && continue
+    skill_md="$skills_dir/$skill/SKILL.md"
+    if [[ ! -f "$skill_md" ]]; then
+      echo "[WARN] $agent_name/$skill: SKILL.md not found (dead reference in manifest)"
+      continue
+    fi
+    if grep -q "^disable-model-invocation:" "$skill_md" 2>/dev/null; then
+      # Already has the field — ensure it's true
+      current="$(grep "^disable-model-invocation:" "$skill_md" | head -1)"
+      if [[ "$current" == "disable-model-invocation: true" ]]; then
+        echo "[OK]   $agent_name/$skill: disable-model-invocation already true"
+      else
+        echo "[FIX]  $agent_name/$skill: setting disable-model-invocation: true (was: $current)"
+        if ! $DRY_RUN; then
+          sed -i "s/^disable-model-invocation:.*/disable-model-invocation: true/" "$skill_md"
+          ((changes++)) || true
+        fi
+      fi
+    else
+      # Insert after the opening ---
+      echo "[ADD]  $agent_name/$skill: adding disable-model-invocation: true"
+      if ! $DRY_RUN; then
+        sed -i '/^---/{n;s/^/disable-model-invocation: true\n/;:l;n;bl}' "$skill_md" 2>/dev/null || \
+          python3 -c "
+import re, sys
+content = open('$skill_md').read()
+# Insert after first --- block opener (second line after first ---)
+lines = content.split('\n')
+for i, line in enumerate(lines):
+    if i > 0 and line == '---':
+        lines.insert(i, 'disable-model-invocation: true')
+        break
+else:
+    # Insert after first line (the opening ---)
+    lines.insert(1, 'disable-model-invocation: true')
+open('$skill_md', 'w').write('\n'.join(lines))
+"
+        ((changes++)) || true
+      fi
+    fi
+  done <<< "$manual_only"
+
+  # Process auto_invoke: ensure disable-model-invocation is absent or false
+  while IFS= read -r skill; do
+    [[ -z "$skill" ]] && continue
+    skill_md="$skills_dir/$skill/SKILL.md"
+    if [[ ! -f "$skill_md" ]]; then
+      echo "[WARN] $agent_name/$skill: SKILL.md not found (dead reference in manifest)"
+      continue
+    fi
+    if grep -q "^disable-model-invocation: true" "$skill_md" 2>/dev/null; then
+      echo "[FIX]  $agent_name/$skill: removing disable-model-invocation: true (auto_invoke)"
+      if ! $DRY_RUN; then
+        sed -i "/^disable-model-invocation: true/d" "$skill_md"
+        ((changes++)) || true
+      fi
+    else
+      echo "[OK]   $agent_name/$skill: no disable-model-invocation (correct for auto_invoke)"
+    fi
+  done <<< "$auto_invoke"
+
+done
+
+if $DRY_RUN; then
+  echo ""
+  echo "[DRY-RUN] No files written. Remove --dry-run to apply."
+else
+  echo ""
+  echo "Done. $changes file(s) modified."
+fi

--- a/tools/skill-overlay-apply.sh
+++ b/tools/skill-overlay-apply.sh
@@ -122,9 +122,12 @@ revert_file() {
   local skill="$3"
   # Try git tracked version first
   if git -C "$LIVE_REPO_ROOT" ls-files --error-unmatch "$skill_md" &>/dev/null; then
-    git -C "$LIVE_REPO_ROOT" checkout HEAD -- "$skill_md" 2>/dev/null \
-      && echo "[REVERT] $agent/$skill: restored from git" \
-      || echo "  [WARN] $agent/$skill: git tracked but checkout failed"
+    if git -C "$LIVE_REPO_ROOT" checkout HEAD -- "$skill_md" 2>/dev/null; then
+      echo "[REVERT] $agent/$skill: restored from git"
+    else
+      echo "[ERROR] $agent/$skill: git-tracked but checkout failed — manual recovery needed" >&2
+      inc_errors
+    fi
   else
     # Fall back to most-recent .bak
     local latest_bak
@@ -133,7 +136,8 @@ revert_file() {
       cp "$latest_bak" "$skill_md"
       echo "[REVERT] $agent/$skill: restored from backup $latest_bak"
     else
-      echo "  [WARN] $agent/$skill: not git-tracked and no backup found — cannot revert"
+      echo "[ERROR] $agent/$skill: not git-tracked and no .bak found — cannot revert, manual recovery needed" >&2
+      inc_errors
     fi
   fi
 }

--- a/tools/skill-overlay-apply.sh
+++ b/tools/skill-overlay-apply.sh
@@ -3,10 +3,14 @@
 #
 # Usage:
 #   ./tools/skill-overlay-apply.sh [--dry-run] [--revert] [--agent <name>]
+#                                   [--live-repo-root <path>]
 #
-# --dry-run   List changes without writing
-# --revert    Restore SKILL.md files from git (git checkout HEAD -- <file>)
-# --agent     Only process one agent (default: all)
+# --dry-run          List changes without writing
+# --revert           Restore SKILL.md files: tries git checkout HEAD first,
+#                    falls back to .bak files created at last apply time
+# --agent            Only process one agent (default: all)
+# --live-repo-root   Path to live cortextos root (default: manifest root).
+#                    Use when running from a worktree where skill dirs are absent.
 #
 # Idempotent: running twice produces no additional changes.
 
@@ -15,8 +19,6 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 ORGS_DIR="$REPO_ROOT/orgs"
-# Skills live in the filesystem (not git-tracked). Override with --live-repo-root
-# when running from a worktree where agent skill dirs are absent.
 LIVE_REPO_ROOT="$REPO_ROOT"
 
 DRY_RUN=false
@@ -36,8 +38,91 @@ done
 
 LIVE_ORGS_DIR="$LIVE_REPO_ROOT/orgs"
 
-changes=0
-errors=0
+# Track changes via temp file (while-read runs in subshell, counters don't survive)
+CHANGES_FILE="$(mktemp)"
+echo 0 > "$CHANGES_FILE"
+trap 'rm -f "$CHANGES_FILE"' EXIT
+
+inc_changes() { echo $(( $(cat "$CHANGES_FILE") + 1 )) > "$CHANGES_FILE"; }
+
+# ── Frontmatter helpers (pure Python — handles missing frontmatter correctly) ──
+
+frontmatter_set_true() {
+  local skill_md="$1"
+  python3 - "$skill_md" <<'PYEOF'
+import sys, re
+
+path = sys.argv[1]
+content = open(path).read()
+
+if content.startswith('---'):
+    # Has frontmatter opener
+    rest = content[3:]
+    # Find the closing --- (must be at start of a line)
+    m = re.search(r'\n---(\n|$)', rest)
+    if m:
+        front = rest[:m.start()]
+        after = rest[m.end():]
+        if 'disable-model-invocation:' in front:
+            # Update existing field
+            front = re.sub(r'^disable-model-invocation:.*$', 'disable-model-invocation: true', front, flags=re.MULTILINE)
+        else:
+            front = 'disable-model-invocation: true\n' + front
+        new_content = '---\n' + front + '\n---\n' + after
+    else:
+        # Malformed frontmatter (no closing ---); insert after first line
+        new_content = '---\ndisable-model-invocation: true\n' + content[3:]
+else:
+    # No frontmatter — create minimal one
+    new_content = '---\ndisable-model-invocation: true\n---\n' + content
+
+open(path, 'w').write(new_content)
+PYEOF
+}
+
+frontmatter_remove() {
+  local skill_md="$1"
+  sed -i "/^disable-model-invocation: true/d" "$skill_md"
+}
+
+frontmatter_update_false() {
+  local skill_md="$1"
+  sed -i "s/^disable-model-invocation:.*/disable-model-invocation: false/" "$skill_md"
+}
+
+# ── Backup/revert helpers ─────────────────────────────────────────────────────
+
+BACKUP_SUFFIX=".bak.$(date +%Y%m%dT%H%M%S)"
+
+backup_file() {
+  local src="$1"
+  local bak="${src}${BACKUP_SUFFIX}"
+  cp "$src" "$bak"
+}
+
+revert_file() {
+  local skill_md="$1"
+  local agent="$2"
+  local skill="$3"
+  # Try git tracked version first
+  if git -C "$LIVE_REPO_ROOT" ls-files --error-unmatch "$skill_md" &>/dev/null; then
+    git -C "$LIVE_REPO_ROOT" checkout HEAD -- "$skill_md" 2>/dev/null \
+      && echo "[REVERT] $agent/$skill: restored from git" \
+      || echo "  [WARN] $agent/$skill: git tracked but checkout failed"
+  else
+    # Fall back to most-recent .bak
+    local latest_bak
+    latest_bak=$(ls -t "${skill_md}.bak."* 2>/dev/null | head -1)
+    if [[ -n "$latest_bak" ]]; then
+      cp "$latest_bak" "$skill_md"
+      echo "[REVERT] $agent/$skill: restored from backup $latest_bak"
+    else
+      echo "  [WARN] $agent/$skill: not git-tracked and no backup found — cannot revert"
+    fi
+  fi
+}
+
+# ── Main loop ─────────────────────────────────────────────────────────────────
 
 find "$ORGS_DIR" -name "skill-overlay.json" | sort | while read -r overlay_path; do
   agent_dir="$(dirname "$overlay_path")"
@@ -47,7 +132,6 @@ find "$ORGS_DIR" -name "skill-overlay.json" | sort | while read -r overlay_path;
     continue
   fi
 
-  # Resolve skills against live repo (may differ from manifest/worktree root)
   relative_agent="${agent_dir#$ORGS_DIR/}"
   skills_dir="$LIVE_ORGS_DIR/$relative_agent/.claude/skills"
   if [[ ! -d "$skills_dir" ]]; then
@@ -56,13 +140,17 @@ find "$ORGS_DIR" -name "skill-overlay.json" | sort | while read -r overlay_path;
   fi
 
   if $REVERT; then
-    echo "[REVERT] $agent_name: restoring SKILL.md files from git (live: $skills_dir)"
-    git -C "$LIVE_REPO_ROOT" checkout HEAD -- "$skills_dir/" 2>/dev/null || \
-      echo "  [WARN] git revert failed for $agent_name — may not be tracked"
+    manual_only="$(python3 -c "import json; d=json.load(open('$overlay_path')); print('\n'.join(d.get('manual_only',[])))")"
+    auto_invoke="$(python3 -c "import json; d=json.load(open('$overlay_path')); print('\n'.join(d.get('auto_invoke',[])))")"
+    for skill in $manual_only $auto_invoke; do
+      [[ -z "$skill" ]] && continue
+      skill_md="$skills_dir/$skill/SKILL.md"
+      [[ ! -f "$skill_md" ]] && continue
+      revert_file "$skill_md" "$agent_name" "$skill"
+    done
     continue
   fi
 
-  # Parse manual_only and auto_invoke arrays
   manual_only="$(python3 -c "
 import json, sys
 data = json.load(open('$overlay_path'))
@@ -74,7 +162,7 @@ data = json.load(open('$overlay_path'))
 print('\n'.join(data.get('auto_invoke', [])))
 ")"
 
-  # Process manual_only: ensure disable-model-invocation: true in frontmatter
+  # Process manual_only: ensure disable-model-invocation: true
   while IFS= read -r skill; do
     [[ -z "$skill" ]] && continue
     skill_md="$skills_dir/$skill/SKILL.md"
@@ -82,38 +170,22 @@ print('\n'.join(data.get('auto_invoke', [])))
       echo "[WARN] $agent_name/$skill: SKILL.md not found (dead reference in manifest)"
       continue
     fi
-    if grep -q "^disable-model-invocation:" "$skill_md" 2>/dev/null; then
-      # Already has the field — ensure it's true
+    if grep -q "^disable-model-invocation: true" "$skill_md" 2>/dev/null; then
+      echo "[OK]   $agent_name/$skill: disable-model-invocation already true"
+    elif grep -q "^disable-model-invocation:" "$skill_md" 2>/dev/null; then
       current="$(grep "^disable-model-invocation:" "$skill_md" | head -1)"
-      if [[ "$current" == "disable-model-invocation: true" ]]; then
-        echo "[OK]   $agent_name/$skill: disable-model-invocation already true"
-      else
-        echo "[FIX]  $agent_name/$skill: setting disable-model-invocation: true (was: $current)"
-        if ! $DRY_RUN; then
-          sed -i "s/^disable-model-invocation:.*/disable-model-invocation: true/" "$skill_md"
-          ((changes++)) || true
-        fi
+      echo "[FIX]  $agent_name/$skill: setting disable-model-invocation: true (was: $current)"
+      if ! $DRY_RUN; then
+        backup_file "$skill_md"
+        sed -i "s/^disable-model-invocation:.*/disable-model-invocation: true/" "$skill_md"
+        inc_changes
       fi
     else
-      # Insert after the opening ---
       echo "[ADD]  $agent_name/$skill: adding disable-model-invocation: true"
       if ! $DRY_RUN; then
-        sed -i '/^---/{n;s/^/disable-model-invocation: true\n/;:l;n;bl}' "$skill_md" 2>/dev/null || \
-          python3 -c "
-import re, sys
-content = open('$skill_md').read()
-# Insert after first --- block opener (second line after first ---)
-lines = content.split('\n')
-for i, line in enumerate(lines):
-    if i > 0 and line == '---':
-        lines.insert(i, 'disable-model-invocation: true')
-        break
-else:
-    # Insert after first line (the opening ---)
-    lines.insert(1, 'disable-model-invocation: true')
-open('$skill_md', 'w').write('\n'.join(lines))
-"
-        ((changes++)) || true
+        backup_file "$skill_md"
+        frontmatter_set_true "$skill_md"
+        inc_changes
       fi
     fi
   done <<< "$manual_only"
@@ -129,8 +201,9 @@ open('$skill_md', 'w').write('\n'.join(lines))
     if grep -q "^disable-model-invocation: true" "$skill_md" 2>/dev/null; then
       echo "[FIX]  $agent_name/$skill: removing disable-model-invocation: true (auto_invoke)"
       if ! $DRY_RUN; then
-        sed -i "/^disable-model-invocation: true/d" "$skill_md"
-        ((changes++)) || true
+        backup_file "$skill_md"
+        frontmatter_remove "$skill_md"
+        inc_changes
       fi
     else
       echo "[OK]   $agent_name/$skill: no disable-model-invocation (correct for auto_invoke)"
@@ -139,10 +212,11 @@ open('$skill_md', 'w').write('\n'.join(lines))
 
 done
 
+FINAL_CHANGES=$(cat "$CHANGES_FILE")
 if $DRY_RUN; then
   echo ""
   echo "[DRY-RUN] No files written. Remove --dry-run to apply."
 else
   echo ""
-  echo "Done. $changes file(s) modified."
+  echo "Done. ${FINAL_CHANGES} file(s) modified."
 fi

--- a/tools/skill-overlay-apply.sh
+++ b/tools/skill-overlay-apply.sh
@@ -13,8 +13,14 @@
 #                    Use when running from a worktree where skill dirs are absent.
 #
 # Idempotent: running twice produces no additional changes.
+# Partial-failure tolerant: per-skill errors are logged but do not abort the
+#   run. Re-running after a partial failure will pick up where it left off
+#   because every write checks current state before acting.
+# Backup-first: creates a timestamped .bak before every mutation. If the backup
+#   write fails, the mutation is skipped with an error (backup-first-abort).
 
-set -euo pipefail
+set -uo pipefail
+# Note: NOT using -e so per-skill errors are handled locally, not script-abort.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
@@ -38,12 +44,15 @@ done
 
 LIVE_ORGS_DIR="$LIVE_REPO_ROOT/orgs"
 
-# Track changes via temp file (while-read runs in subshell, counters don't survive)
+# Track changes and errors via temp files (while-read runs in subshell)
 CHANGES_FILE="$(mktemp)"
+ERRORS_FILE="$(mktemp)"
 echo 0 > "$CHANGES_FILE"
-trap 'rm -f "$CHANGES_FILE"' EXIT
+echo 0 > "$ERRORS_FILE"
+trap 'rm -f "$CHANGES_FILE" "$ERRORS_FILE"' EXIT
 
 inc_changes() { echo $(( $(cat "$CHANGES_FILE") + 1 )) > "$CHANGES_FILE"; }
+inc_errors()  { echo $(( $(cat "$ERRORS_FILE")  + 1 )) > "$ERRORS_FILE";  }
 
 # ── Frontmatter helpers (pure Python — handles missing frontmatter correctly) ──
 
@@ -94,10 +103,17 @@ frontmatter_update_false() {
 
 BACKUP_SUFFIX=".bak.$(date +%Y%m%dT%H%M%S)"
 
+# backup_file: creates a backup BEFORE mutation. Returns 1 (aborts caller) if
+# backup write fails — never mutate without a backup in place.
 backup_file() {
   local src="$1"
   local bak="${src}${BACKUP_SUFFIX}"
-  cp "$src" "$bak"
+  if ! cp "$src" "$bak" 2>/dev/null; then
+    echo "[ERROR] backup failed for $src — skipping mutation" >&2
+    inc_errors
+    return 1
+  fi
+  return 0
 }
 
 revert_file() {
@@ -176,16 +192,18 @@ print('\n'.join(data.get('auto_invoke', [])))
       current="$(grep "^disable-model-invocation:" "$skill_md" | head -1)"
       echo "[FIX]  $agent_name/$skill: setting disable-model-invocation: true (was: $current)"
       if ! $DRY_RUN; then
-        backup_file "$skill_md"
-        sed -i "s/^disable-model-invocation:.*/disable-model-invocation: true/" "$skill_md"
-        inc_changes
+        if backup_file "$skill_md"; then
+          sed -i "s/^disable-model-invocation:.*/disable-model-invocation: true/" "$skill_md"
+          inc_changes
+        fi
       fi
     else
       echo "[ADD]  $agent_name/$skill: adding disable-model-invocation: true"
       if ! $DRY_RUN; then
-        backup_file "$skill_md"
-        frontmatter_set_true "$skill_md"
-        inc_changes
+        if backup_file "$skill_md"; then
+          frontmatter_set_true "$skill_md"
+          inc_changes
+        fi
       fi
     fi
   done <<< "$manual_only"
@@ -201,9 +219,10 @@ print('\n'.join(data.get('auto_invoke', [])))
     if grep -q "^disable-model-invocation: true" "$skill_md" 2>/dev/null; then
       echo "[FIX]  $agent_name/$skill: removing disable-model-invocation: true (auto_invoke)"
       if ! $DRY_RUN; then
-        backup_file "$skill_md"
-        frontmatter_remove "$skill_md"
-        inc_changes
+        if backup_file "$skill_md"; then
+          frontmatter_remove "$skill_md"
+          inc_changes
+        fi
       fi
     else
       echo "[OK]   $agent_name/$skill: no disable-model-invocation (correct for auto_invoke)"
@@ -213,10 +232,16 @@ print('\n'.join(data.get('auto_invoke', [])))
 done
 
 FINAL_CHANGES=$(cat "$CHANGES_FILE")
+FINAL_ERRORS=$(cat "$ERRORS_FILE")
 if $DRY_RUN; then
   echo ""
   echo "[DRY-RUN] No files written. Remove --dry-run to apply."
 else
   echo ""
-  echo "Done. ${FINAL_CHANGES} file(s) modified."
+  if (( FINAL_ERRORS > 0 )); then
+    echo "Done. ${FINAL_CHANGES} file(s) modified, ${FINAL_ERRORS} error(s) — re-run to retry skipped files."
+    exit 1
+  else
+    echo "Done. ${FINAL_CHANGES} file(s) modified."
+  fi
 fi

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
     'hooks/hook-context-status': 'src/hooks/hook-context-status.ts',
+    // Pattern 1: variant-specific compactor loaded at runtime via dynamic import
+    'utils/sidecar-compactor-haiku': 'src/utils/sidecar-compactor-haiku.ts',
   },
   format: ['cjs'],
   target: 'node20',

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -12,8 +12,9 @@ export default defineConfig({
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
     'hooks/hook-context-status': 'src/hooks/hook-context-status.ts',
-    // Pattern 1: variant-specific compactor loaded at runtime via dynamic import
+    // Pattern 1: variant-specific compactors loaded at runtime via dynamic import
     'utils/sidecar-compactor-haiku': 'src/utils/sidecar-compactor-haiku.ts',
+    'utils/sidecar-compactor-sonnet': 'src/utils/sidecar-compactor-sonnet.ts',
   },
   format: ['cjs'],
   target: 'node20',


### PR DESCRIPTION
## Root Cause

`fresh_session` crons were wrapped in a guard:

```typescript
if (!cron.fresh_session) {
  updateCron(agentName, name, { last_fired_at, fire_count });
}
```

This meant `last_fired_at` and `fire_count` were **never written to crons.json** after a successful fire for `fresh_session: true` crons. On daemon restart, `computeNextFireAt` found `last_fired_at = null`, so `referenceMs = now` → `next_fire_at = now + interval`. Each restart pushed the schedule forward by the full interval.

## Evidence

- `design-g/heartbeat`: created `2026-05-15T10:43Z`, daemon restarted 9× within ~1h
- Each restart: `last_fired_at = null` → schedule reset to `now + 4h`
- First fire: `2026-05-16T00:01Z` — 13.3h after creation
- `fire_count: 1` in crons.json confirmed only one fire in that window

## Fix

Remove the `if (!cron.fresh_session)` guard. `updateCron()` now runs unconditionally after every successful fire, persisting `last_fired_at` and `fire_count` for both `fresh_session` and PTY crons.

## Test Plan

- [x] Updated unit test (`fresh_session success skips disk update` → `fresh_session success persists last_fired_at to disk`) — asserts `updateCron` is called with `last_fired_at` after fresh_session fire
- [x] `npm run build` — clean
- [x] `npm test` — cron-scheduler suite passes; remaining failures in phase3-docs + phase5-failure-modes are pre-existing and unrelated to this change
- [ ] Live verification: test-cron fire on `design-g/heartbeat` to confirm disk write and schedule stability post-restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)