### PR TITLE
feat(kb): route queryKnowledgeBase + ingestKnowledgeBase through gbrain

### DIFF
--- a/src/bus/knowledge-base.ts
+++ b/src/bus/knowledge-base.ts
@@ -8,7 +8,130 @@ import { normalizeOrgName } from '../utils/org.js';
 /**
  * Knowledge base integration — calls mmrag.py directly (cross-platform,
  * no bash dependency).  Previously wrapped kb-*.sh bash scripts.
+ *
+ * gbrain fast-path: when /root/.gbrain/config.json exists (gbrain initialized),
+ * queryKnowledgeBase and ingestKnowledgeBase route through gbrain instead of
+ * mmrag.py.  Set GBRAIN_KB_BACKEND=false to force the legacy path.
  */
+
+const GBRAIN_CLI = '/usr/local/bin/gbrain';
+
+/**
+ * True when gbrain is installed, initialized, and not explicitly disabled.
+ * Checks binary + config file existence so cold machines without gbrain
+ * fall back to mmrag transparently.
+ */
+function gbrainAvailable(): boolean {
+  return (
+    existsSync(GBRAIN_CLI) &&
+    existsSync(join(homedir(), '.gbrain', 'config.json')) &&
+    process.env.GBRAIN_KB_BACKEND !== 'false'
+  );
+}
+
+/**
+ * Parse one line of `gbrain query` text output.
+ * Format: "[2.0000] slug -- first 100 chars of chunk_text"
+ */
+function parseGbrainLine(line: string): { slug: string; score: number } | null {
+  const m = line.match(/^\[([0-9.]+)\]\s+(\S+)/);
+  if (!m) return null;
+  return { score: parseFloat(m[1]), slug: m[2] };
+}
+
+/**
+ * Fetch the full page content for a gbrain slug.
+ * Returns null on error (e.g. slug not found).
+ */
+function gbrainGetPage(slug: string): string | null {
+  try {
+    return execFileSync(GBRAIN_CLI, ['get', slug], {
+      encoding: 'utf-8',
+      timeout: 10_000,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+}
+
+function queryKnowledgeBaseViaGbrain(
+  question: string,
+  options: {
+    org: string;
+    agent?: string;
+    topK?: number;
+  },
+): KBQueryResponse {
+  const { org, agent, topK = 5 } = options;
+
+  let stdout: string;
+  try {
+    stdout = execFileSync(GBRAIN_CLI, ['query', question, '--limit', String(topK)], {
+      encoding: 'utf-8',
+      timeout: 30_000,
+      stdio: ['pipe', 'pipe', 'ignore'],
+    });
+  } catch {
+    return { results: [], total: 0, query: question, collection: `gbrain-${org}` };
+  }
+
+  const entries = stdout
+    .split('\n')
+    .map(parseGbrainLine)
+    .filter((e): e is NonNullable<typeof e> => e !== null);
+
+  const results: KBQueryResult[] = [];
+  for (const entry of entries) {
+    const content = gbrainGetPage(entry.slug) ?? '';
+    if (!content) continue;
+    results.push({
+      content,
+      source_file: entry.slug,
+      org,
+      agent_name: agent,
+      score: entry.score,
+      doc_type: 'markdown',
+    });
+  }
+
+  return {
+    results,
+    total: results.length,
+    query: question,
+    collection: `gbrain-${org}`,
+  };
+}
+
+function ingestKnowledgeBaseViaGbrain(
+  paths: string[],
+  options: { org: string; agent?: string },
+): void {
+  for (const filePath of paths) {
+    // Derive slug from filename without extension
+    const slug = (filePath.split('/').pop() ?? filePath).replace(/\.md$/i, '');
+    let content: string;
+    try {
+      content = readFileSync(filePath, 'utf-8');
+    } catch {
+      console.warn(`[kb:gbrain] skipping ${filePath}: cannot read`);
+      continue;
+    }
+    try {
+      execFileSync(GBRAIN_CLI, ['put', slug], {
+        input: content,
+        encoding: 'utf-8',
+        timeout: 60_000,
+        stdio: ['pipe', 'pipe', 'ignore'],
+      });
+      console.log(`  gbrain put → ${slug}`);
+    } catch (err) {
+      console.warn(
+        `[kb:gbrain] put failed for ${slug}: ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+  }
+}
 
 /**
  * Resolve the Python interpreter inside the knowledge-base venv,
@@ -129,12 +252,12 @@ export function queryKnowledgeBase(
   },
 ): KBQueryResponse {
   const { agent, scope = 'all', topK = 5, threshold = 0.5, frameworkRoot, instanceId } = options;
-  // Normalize once at the top so every downstream path join, env var, and
-  // ChromaDB collection name uses the canonical filesystem casing. Without
-  // this, `shared-acmecorp` and `shared-AcmeCorp` become two
-  // distinct ChromaDB collections and a case-drifted query silently hits
-  // the wrong one.
   const org = normalizeOrgName(frameworkRoot, options.org);
+
+  // gbrain fast-path — bypasses mmrag when gbrain is initialized.
+  if (gbrainAvailable()) {
+    return queryKnowledgeBaseViaGbrain(question, { org, agent, topK });
+  }
 
   const env = buildKBEnv(frameworkRoot, org, instanceId, agent);
 
@@ -253,8 +376,13 @@ export function ingestKnowledgeBase(
   },
 ): void {
   const { agent, scope = 'shared', force, frameworkRoot, instanceId } = options;
-  // Normalize once (see queryKnowledgeBase for rationale).
   const org = normalizeOrgName(frameworkRoot, options.org);
+
+  // gbrain fast-path
+  if (gbrainAvailable()) {
+    ingestKnowledgeBaseViaGbrain(paths, { org, agent });
+    return;
+  }
 
   const env = buildKBEnv(frameworkRoot, org, instanceId, agent);
 

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1865,8 +1865,8 @@ function validateFreshSessionCliOptions(
   agent: string,
   cronName: string,
   frameworkRoot: string,
-  opts: { freshSession?: boolean; skillFile?: string; freshSessionTimeout?: string },
-): { freshSession?: boolean; skillFile?: string; freshSessionTimeoutMs?: number } {
+  opts: { freshSession?: boolean; skillFile?: string; protocolFile?: string; freshSessionTimeout?: string },
+): { freshSession?: boolean; skillFile?: string; protocolFile?: string; freshSessionTimeoutMs?: number } {
   if (opts.skillFile !== undefined) {
     if (!opts.skillFile.trim()) {
       console.error('Error: --skill-file must be a non-empty relative path.');
@@ -1874,6 +1874,17 @@ function validateFreshSessionCliOptions(
     }
     if (isAbsolute(opts.skillFile)) {
       console.error('Error: --skill-file must be a relative path.');
+      process.exit(1);
+    }
+  }
+
+  if (opts.protocolFile !== undefined) {
+    if (!opts.protocolFile.trim()) {
+      console.error('Error: --protocol-file must be a non-empty relative path.');
+      process.exit(1);
+    }
+    if (isAbsolute(opts.protocolFile)) {
+      console.error('Error: --protocol-file must be a relative path.');
       process.exit(1);
     }
   }
@@ -1902,6 +1913,7 @@ function validateFreshSessionCliOptions(
   return {
     freshSession: opts.freshSession,
     skillFile: opts.skillFile?.trim(),
+    protocolFile: opts.protocolFile?.trim(),
     freshSessionTimeoutMs,
   };
 }
@@ -1935,13 +1947,14 @@ busCommand
   .option('--desc <description>', 'Human-readable description (optional)')
   .option('--fresh-session', 'Run this cron in a fresh claude --print session')
   .option('--skill-file <path>', 'Relative path to skill/context file for fresh-session system prompt')
+  .option('--protocol-file <path>', 'Relative path to protocol/checklist file appended to system prompt for fresh-session runs')
   .option('--fresh-session-timeout <ms>', 'Fresh-session timeout in milliseconds')
   .action(async (
     agent: string,
     name: string,
     interval: string,
     promptWords: string[],
-    opts: { desc?: string; freshSession?: boolean; skillFile?: string; freshSessionTimeout?: string },
+    opts: { desc?: string; freshSession?: boolean; skillFile?: string; protocolFile?: string; freshSessionTimeout?: string },
   ) => {
     // Validate agent name format
     try { validateAgentName(agent); } catch (err) { console.error(String(err)); process.exit(1); }
@@ -1969,6 +1982,7 @@ busCommand
       ...(opts.desc ? { description: opts.desc } : {}),
       ...(fresh.freshSession !== undefined ? { fresh_session: fresh.freshSession } : {}),
       ...(fresh.skillFile !== undefined ? { skill_file: fresh.skillFile } : {}),
+      ...(fresh.protocolFile !== undefined ? { protocol_file: fresh.protocolFile } : {}),
       ...(fresh.freshSessionTimeoutMs !== undefined ? { fresh_session_timeout_ms: fresh.freshSessionTimeoutMs } : {}),
     };
 
@@ -2099,6 +2113,7 @@ busCommand
   .option('--fresh-session', 'Enable fresh-session cron dispatch')
   .option('--no-fresh-session', 'Disable fresh-session cron dispatch')
   .option('--skill-file <path>', 'Relative path to skill/context file for fresh-session system prompt')
+  .option('--protocol-file <path>', 'Relative path to protocol/checklist file appended to system prompt for fresh-session runs')
   .option('--fresh-session-timeout <ms>', 'Fresh-session timeout in milliseconds')
   .action(async (
     agent: string,
@@ -2111,6 +2126,7 @@ busCommand
       desc?: string;
       freshSession?: boolean;
       skillFile?: string;
+      protocolFile?: string;
       freshSessionTimeout?: string;
     },
   ) => {
@@ -2124,6 +2140,7 @@ busCommand
       opts.desc === undefined &&
       opts.freshSession === undefined &&
       opts.skillFile === undefined &&
+      opts.protocolFile === undefined &&
       opts.freshSessionTimeout === undefined
     ) {
       console.error('Error: at least one update option is required.');
@@ -2155,6 +2172,9 @@ busCommand
     }
     if (fresh.skillFile !== undefined) {
       patch.skill_file = fresh.skillFile;
+    }
+    if (fresh.protocolFile !== undefined) {
+      patch.protocol_file = fresh.protocolFile;
     }
     if (fresh.freshSessionTimeoutMs !== undefined) {
       patch.fresh_session_timeout_ms = fresh.freshSessionTimeoutMs;

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1,7 +1,7 @@
 import { Command } from 'commander';
 import { spawnSync, execFileSync } from 'child_process';
-import { existsSync, readFileSync } from 'fs';
-import { join } from 'path';
+import { existsSync, readFileSync, readdirSync } from 'fs';
+import { isAbsolute, join } from 'path';
 import { sendMessage, checkInbox, ackInbox } from '../bus/message.js';
 import { validateAgentName } from '../utils/validate.js';
 import { createTask, updateTask, completeTask, claimTask, readTaskAudit, checkTaskDependencies, compactTasks, listTasks, checkStaleTasks, archiveTasks, checkHumanTasks } from '../bus/task.js';
@@ -21,6 +21,7 @@ import { queryKnowledgeBase, ingestKnowledgeBase, ensureKBDirs } from '../bus/kn
 import { checkUsageApi, refreshOAuthToken, rotateOAuth, loadAccounts, ALERT_5H, ALERT_7D } from '../bus/oauth.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
+import { isFreshSessionProtectedAgent, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { logOutboundMessage, cacheLastSent } from '../telegram/logging.js';
@@ -1836,16 +1837,72 @@ function validateSchedule(raw: string): string {
  */
 function agentExistsInFramework(agentName: string, frameworkRoot: string): boolean {
   if (!frameworkRoot) return true; // can't check — allow
-  const { existsSync: fsExists, readdirSync: fsReaddir } = require('fs');
-  const { join: pjoin } = require('path');
-  const orgsDir = pjoin(frameworkRoot, 'orgs');
-  if (!fsExists(orgsDir)) return true; // no orgs dir — allow
+  const orgsDir = join(frameworkRoot, 'orgs');
+  if (!existsSync(orgsDir)) return true; // no orgs dir — allow
   try {
-    for (const org of fsReaddir(orgsDir)) {
-      if (fsExists(pjoin(orgsDir, org, 'agents', agentName))) return true;
+    for (const org of readdirSync(orgsDir)) {
+      if (existsSync(join(orgsDir, org, 'agents', agentName))) return true;
     }
   } catch { /* ignore */ }
   return false;
+}
+
+function readAgentRuntime(agentName: string, frameworkRoot: string): string | undefined {
+  if (!frameworkRoot) return undefined;
+  const orgsDir = join(frameworkRoot, 'orgs');
+  if (!existsSync(orgsDir)) return undefined;
+  try {
+    for (const org of readdirSync(orgsDir)) {
+      const configPath = join(orgsDir, org, 'agents', agentName, 'config.json');
+      if (!existsSync(configPath)) continue;
+      return JSON.parse(readFileSync(configPath, 'utf-8')).runtime;
+    }
+  } catch { /* ignore malformed/missing config in CLI validation */ }
+  return undefined;
+}
+
+function validateFreshSessionCliOptions(
+  agent: string,
+  frameworkRoot: string,
+  opts: { freshSession?: boolean; skillFile?: string; freshSessionTimeout?: string },
+): { freshSession?: boolean; skillFile?: string; freshSessionTimeoutMs?: number } {
+  if (opts.skillFile !== undefined) {
+    if (!opts.skillFile.trim()) {
+      console.error('Error: --skill-file must be a non-empty relative path.');
+      process.exit(1);
+    }
+    if (isAbsolute(opts.skillFile)) {
+      console.error('Error: --skill-file must be a relative path.');
+      process.exit(1);
+    }
+  }
+
+  let freshSessionTimeoutMs: number | undefined;
+  if (opts.freshSessionTimeout !== undefined) {
+    freshSessionTimeoutMs = Number(opts.freshSessionTimeout);
+    if (!Number.isInteger(freshSessionTimeoutMs) || freshSessionTimeoutMs <= 0) {
+      console.error(`Error: --fresh-session-timeout must be a positive integer, got '${opts.freshSessionTimeout}'.`);
+      process.exit(1);
+    }
+  }
+
+  if (opts.freshSession === true) {
+    if (isFreshSessionProtectedAgent(agent)) {
+      console.error(`Error: --fresh-session is not allowed for protected agent '${agent}'.`);
+      process.exit(1);
+    }
+    const runtime = readAgentRuntime(agent, frameworkRoot);
+    if (!isFreshSessionSupportedRuntime(runtime)) {
+      console.error(`Error: --fresh-session is not supported for runtime '${runtime}'.`);
+      process.exit(1);
+    }
+  }
+
+  return {
+    freshSession: opts.freshSession,
+    skillFile: opts.skillFile?.trim(),
+    freshSessionTimeoutMs,
+  };
 }
 
 /**
@@ -1875,7 +1932,16 @@ busCommand
   .argument('<interval>', 'Schedule: interval ("6h", "30m", "1d") or 5-field cron expr ("0 8 * * *")')
   .argument('<prompt...>', 'Prompt text injected when the cron fires (all remaining words joined)')
   .option('--desc <description>', 'Human-readable description (optional)')
-  .action(async (agent: string, name: string, interval: string, promptWords: string[], opts: { desc?: string }) => {
+  .option('--fresh-session', 'Run this cron in a fresh claude --print session')
+  .option('--skill-file <path>', 'Relative path to skill/context file for fresh-session system prompt')
+  .option('--fresh-session-timeout <ms>', 'Fresh-session timeout in milliseconds')
+  .action(async (
+    agent: string,
+    name: string,
+    interval: string,
+    promptWords: string[],
+    opts: { desc?: string; freshSession?: boolean; skillFile?: string; freshSessionTimeout?: string },
+  ) => {
     // Validate agent name format
     try { validateAgentName(agent); } catch (err) { console.error(String(err)); process.exit(1); }
 
@@ -1890,6 +1956,7 @@ busCommand
     // Validate schedule
     let schedule: string;
     try { schedule = validateSchedule(interval); } catch (err) { console.error(String(err)); process.exit(1); }
+    const fresh = validateFreshSessionCliOptions(agent, env.frameworkRoot, opts);
 
     const prompt = promptWords.join(' ');
     const cron: CronDefinition = {
@@ -1899,6 +1966,9 @@ busCommand
       enabled: true,
       created_at: new Date().toISOString(),
       ...(opts.desc ? { description: opts.desc } : {}),
+      ...(fresh.freshSession !== undefined ? { fresh_session: fresh.freshSession } : {}),
+      ...(fresh.skillFile !== undefined ? { skill_file: fresh.skillFile } : {}),
+      ...(fresh.freshSessionTimeoutMs !== undefined ? { fresh_session_timeout_ms: fresh.freshSessionTimeoutMs } : {}),
     };
 
     try {
@@ -2025,15 +2095,42 @@ busCommand
   .option('--prompt <p>', 'New prompt text')
   .option('--enabled <bool>', 'Enable (true) or disable (false) the cron')
   .option('--desc <d>', 'New description')
-  .action(async (agent: string, name: string, opts: { interval?: string; cronExpr?: string; prompt?: string; enabled?: string; desc?: string }) => {
+  .option('--fresh-session', 'Enable fresh-session cron dispatch')
+  .option('--no-fresh-session', 'Disable fresh-session cron dispatch')
+  .option('--skill-file <path>', 'Relative path to skill/context file for fresh-session system prompt')
+  .option('--fresh-session-timeout <ms>', 'Fresh-session timeout in milliseconds')
+  .action(async (
+    agent: string,
+    name: string,
+    opts: {
+      interval?: string;
+      cronExpr?: string;
+      prompt?: string;
+      enabled?: string;
+      desc?: string;
+      freshSession?: boolean;
+      skillFile?: string;
+      freshSessionTimeout?: string;
+    },
+  ) => {
     try { validateAgentName(agent); } catch (err) { console.error(String(err)); process.exit(1); }
 
     const rawSchedule = opts.interval ?? opts.cronExpr;
-    if (!rawSchedule && opts.prompt === undefined && opts.enabled === undefined && opts.desc === undefined) {
-      console.error('Error: at least one of --interval, --cron-expr, --prompt, --enabled, or --desc is required.');
+    if (
+      !rawSchedule &&
+      opts.prompt === undefined &&
+      opts.enabled === undefined &&
+      opts.desc === undefined &&
+      opts.freshSession === undefined &&
+      opts.skillFile === undefined &&
+      opts.freshSessionTimeout === undefined
+    ) {
+      console.error('Error: at least one update option is required.');
       process.exit(1);
     }
 
+    const env = resolveEnv();
+    const fresh = validateFreshSessionCliOptions(agent, env.frameworkRoot, opts);
     const patch: Partial<CronDefinition> = {};
 
     if (rawSchedule !== undefined) {
@@ -2052,6 +2149,15 @@ busCommand
     if (opts.desc !== undefined) {
       patch.description = opts.desc;
     }
+    if (fresh.freshSession !== undefined) {
+      patch.fresh_session = fresh.freshSession;
+    }
+    if (fresh.skillFile !== undefined) {
+      patch.skill_file = fresh.skillFile;
+    }
+    if (fresh.freshSessionTimeoutMs !== undefined) {
+      patch.fresh_session_timeout_ms = fresh.freshSessionTimeoutMs;
+    }
 
     const ok = updateCronDef(agent, name, patch);
     if (!ok) {
@@ -2059,7 +2165,6 @@ busCommand
       process.exit(1);
     }
 
-    const env = resolveEnv();
     await signalCronReload(agent, env.instanceId);
     console.log(`Updated cron '${name}' for ${agent}`);
   });

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -21,7 +21,7 @@ import { queryKnowledgeBase, ingestKnowledgeBase, ensureKBDirs } from '../bus/kn
 import { checkUsageApi, refreshOAuthToken, rotateOAuth, loadAccounts, ALERT_5H, ALERT_7D } from '../bus/oauth.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
-import { isFreshSessionProtectedAgent, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
+import { isFreshSessionProtectedCron, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { logOutboundMessage, cacheLastSent } from '../telegram/logging.js';
@@ -1863,6 +1863,7 @@ function readAgentRuntime(agentName: string, frameworkRoot: string): string | un
 
 function validateFreshSessionCliOptions(
   agent: string,
+  cronName: string,
   frameworkRoot: string,
   opts: { freshSession?: boolean; skillFile?: string; freshSessionTimeout?: string },
 ): { freshSession?: boolean; skillFile?: string; freshSessionTimeoutMs?: number } {
@@ -1887,8 +1888,8 @@ function validateFreshSessionCliOptions(
   }
 
   if (opts.freshSession === true) {
-    if (isFreshSessionProtectedAgent(agent)) {
-      console.error(`Error: --fresh-session is not allowed for protected agent '${agent}'.`);
+    if (isFreshSessionProtectedCron(agent, cronName)) {
+      console.error(`Error: --fresh-session is not allowed for protected cron '${agent}/${cronName}'.`);
       process.exit(1);
     }
     const runtime = readAgentRuntime(agent, frameworkRoot);
@@ -1956,7 +1957,7 @@ busCommand
     // Validate schedule
     let schedule: string;
     try { schedule = validateSchedule(interval); } catch (err) { console.error(String(err)); process.exit(1); }
-    const fresh = validateFreshSessionCliOptions(agent, env.frameworkRoot, opts);
+    const fresh = validateFreshSessionCliOptions(agent, name, env.frameworkRoot, opts);
 
     const prompt = promptWords.join(' ');
     const cron: CronDefinition = {
@@ -2130,7 +2131,7 @@ busCommand
     }
 
     const env = resolveEnv();
-    const fresh = validateFreshSessionCliOptions(agent, env.frameworkRoot, opts);
+    const fresh = validateFreshSessionCliOptions(agent, name, env.frameworkRoot, opts);
     const patch: Partial<CronDefinition> = {};
 
     if (rawSchedule !== undefined) {

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -13,7 +13,7 @@ import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
-import { isFreshSessionProtectedAgent, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
+import { isFreshSessionProtectedCron, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 import { logEvent } from '../bus/event.js';
 import { recordInboundTelegram, cacheLastSent, logOutboundMessage, buildRecentHistory } from '../telegram/logging.js';
 import { collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
@@ -788,14 +788,14 @@ export class AgentManager {
     const prompt = cron.prompt ?? `[cron] ${cron.name} fired`;
     const injection = `[CRON FIRED ${firedAt}] ${cron.name}: ${prompt}`;
 
-    if (isFreshSessionProtectedAgent(agentName) && cron.fresh_session) {
+    if (isFreshSessionProtectedCron(agentName, cron.name) && cron.fresh_session) {
       console.log(
-        `[daemon] GUARDRAIL: fresh_session overridden for protected agent "${agentName}" cron "${cron.name}"`
+        `[daemon] GUARDRAIL: fresh_session overridden for protected cron "${agentName}/${cron.name}"`
       );
       this.emitGuardrailEvent(agentName, cron.name);
     }
 
-    const useFresh = cron.fresh_session === true && !isFreshSessionProtectedAgent(agentName);
+    const useFresh = cron.fresh_session === true && !isFreshSessionProtectedCron(agentName, cron.name);
     if (useFresh) {
       await this.fireCronFreshSession(agentName, cron, injection);
       return;

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -864,18 +864,20 @@ export class AgentManager {
       workingDir = config.working_directory || agentDir;
       runtimeEnv = agentProcess.buildRuntimeEnv();
       runtimeEnv['CTX_CRON_FIRED_AT'] = firedAt;
+      runtimeEnv['CTX_FRESH_SESSION_CRON'] = `${agentName}/${cron.name}`;
       claudeCmd = platform() !== 'win32' ? 'claude' : 'claude.exe';
       timeoutMs = cron.fresh_session_timeout_ms ?? 300_000;
 
       args = ['--print', '--dangerously-skip-permissions', '--no-session-persistence'];
       if (config.model) args.push('--model', config.model);
 
+      const systemPromptParts: string[] = [];
       if (cron.skill_file) {
         if (isAbsolute(cron.skill_file)) {
           console.log(`[daemon] WARNING: absolute skill_file rejected for "${cron.name}" — ignoring`);
         } else {
           try {
-            args.push('--append-system-prompt', readFileSync(join(agentDir, cron.skill_file), 'utf-8'));
+            systemPromptParts.push(readFileSync(join(agentDir, cron.skill_file), 'utf-8'));
           } catch (err) {
             console.log(
               `[daemon] WARNING: skill_file "${cron.skill_file}" unreadable for "${cron.name}" — ` +
@@ -883,6 +885,25 @@ export class AgentManager {
             );
           }
         }
+      }
+
+      if (cron.protocol_file) {
+        if (isAbsolute(cron.protocol_file)) {
+          console.log(`[daemon] WARNING: absolute protocol_file rejected for "${cron.name}" — ignoring`);
+        } else {
+          try {
+            systemPromptParts.push(readFileSync(join(agentDir, cron.protocol_file), 'utf-8'));
+          } catch (err) {
+            console.log(
+              `[daemon] WARNING: protocol_file "${cron.protocol_file}" unreadable for "${cron.name}" — ` +
+              `proceeding without: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+      }
+
+      if (systemPromptParts.length > 0) {
+        args.push('--append-system-prompt', systemPromptParts.join('\n\n---\n\n'));
       }
 
       args.push(promptText);
@@ -904,6 +925,16 @@ export class AgentManager {
     const logDir = join(ctxRoot, 'logs', agentName);
     try { mkdirSync(logDir, { recursive: true }); } catch { /* non-fatal */ }
     const cronLogPath = join(logDir, 'cron-fresh.log');
+
+    try {
+      updateCron(agentName, cron.name, { last_fire_attempted_at: firedAt });
+    } catch (err) {
+      console.log(
+        `[daemon] WARNING: failed to persist last_fire_attempted_at for "${cron.name}" — ` +
+        `${err instanceof Error ? err.message : String(err)}. ` +
+        `Continuing dispatch; crash mid-fire could double-fire on restart.`
+      );
+    }
 
     return new Promise<void>((resolve, reject) => {
       let killTimer: ReturnType<typeof setTimeout> | undefined;

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -2,7 +2,15 @@ import { spawn } from 'child_process';
 import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync, appendFileSync } from 'fs';
 import { join, relative, isAbsolute } from 'path';
 import { platform } from 'os';
-import type { AgentConfig, AgentStatus, CtxEnv, BusPaths, WorkerStatus, TelegramMessage } from '../types/index.js';
+import type {
+  AgentConfig,
+  AgentStatus,
+  CtxEnv,
+  BusPaths,
+  WorkerStatus,
+  TelegramMessage,
+  CronExecutionLogEntry,
+} from '../types/index.js';
 import { AgentProcess } from './agent-process.js';
 import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
@@ -15,6 +23,8 @@ import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
 import { isFreshSessionProtectedCron, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 import { logEvent } from '../bus/event.js';
+import { updateCron } from '../bus/crons.js';
+import { appendExecutionLog } from './cron-execution-log.js';
 import { recordInboundTelegram, cacheLastSent, logOutboundMessage, buildRecentHistory } from '../telegram/logging.js';
 import { collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
 import { stripControlChars } from '../utils/validate.js';
@@ -797,7 +807,7 @@ export class AgentManager {
 
     const useFresh = cron.fresh_session === true && !isFreshSessionProtectedCron(agentName, cron.name);
     if (useFresh) {
-      await this.fireCronFreshSession(agentName, cron, injection);
+      await this.fireCronFreshSession(agentName, cron, injection, firedAt);
       return;
     }
 
@@ -811,45 +821,78 @@ export class AgentManager {
     agentName: string,
     cron: CronDefinition,
     promptText: string,
+    firedAt: string,
   ): Promise<void> {
-    const entry = this.agents.get(agentName);
-    if (!entry) throw new Error(`Agent "${agentName}" not found`);
+    const startTime = Date.now();
+    let executionLogWritten = false;
+    const writeExecLog = (status: 'fired' | 'failed', errorMsg: string | null): void => {
+      if (executionLogWritten) return;
+      executionLogWritten = true;
+      const entry: CronExecutionLogEntry = {
+        ts: new Date().toISOString(),
+        cron: cron.name,
+        status,
+        attempt: 1,
+        duration_ms: Date.now() - startTime,
+        error: errorMsg,
+      };
+      try { appendExecutionLog(agentName, entry); } catch { /* non-fatal */ }
+    };
 
-    const agentProcess = entry.process;
-    const config = agentProcess.getConfig();
-    const runtime = config.runtime;
-
-    if (!isFreshSessionSupportedRuntime(runtime)) {
-      this.emitFreshSessionUnsupportedEvent(agentName, cron.name, runtime ?? 'unknown');
-      throw new Error(`fresh_session not supported for runtime "${runtime}" (${agentName}/${cron.name})`);
-    }
-
-    const agentDir = agentProcess.getAgentDir();
-    const workingDir = config.working_directory || agentDir;
-    const runtimeEnv = agentProcess.buildRuntimeEnv();
-    const claudeCmd = platform() !== 'win32' ? 'claude' : 'claude.exe';
-    const timeoutMs = cron.fresh_session_timeout_ms ?? 300_000;
+    let agentDir: string;
+    let workingDir: string;
+    let runtimeEnv: NodeJS.ProcessEnv;
+    let claudeCmd: string;
+    let timeoutMs: number;
+    let args: string[];
     const KILL_GRACE_MS = 5_000;
 
-    const args: string[] = ['--print', '--dangerously-skip-permissions', '--no-session-persistence'];
-    if (config.model) args.push('--model', config.model);
+    try {
+      const entry = this.agents.get(agentName);
+      if (!entry) throw new Error(`Agent "${agentName}" not found`);
 
-    if (cron.skill_file) {
-      if (isAbsolute(cron.skill_file)) {
-        console.log(`[daemon] WARNING: absolute skill_file rejected for "${cron.name}" — ignoring`);
-      } else {
-        try {
-          args.push('--append-system-prompt', readFileSync(join(agentDir, cron.skill_file), 'utf-8'));
-        } catch (err) {
-          console.log(
-            `[daemon] WARNING: skill_file "${cron.skill_file}" unreadable for "${cron.name}" — ` +
-            `proceeding without: ${err instanceof Error ? err.message : String(err)}`
-          );
+      const agentProcess = entry.process;
+      const config = agentProcess.getConfig();
+      const runtime = config.runtime;
+
+      if (!isFreshSessionSupportedRuntime(runtime)) {
+        this.emitFreshSessionUnsupportedEvent(agentName, cron.name, runtime ?? 'unknown');
+        throw new Error(`fresh_session not supported for runtime "${runtime}" (${agentName}/${cron.name})`);
+      }
+
+      agentDir = agentProcess.getAgentDir();
+      workingDir = config.working_directory || agentDir;
+      runtimeEnv = agentProcess.buildRuntimeEnv();
+      runtimeEnv['CTX_CRON_FIRED_AT'] = firedAt;
+      claudeCmd = platform() !== 'win32' ? 'claude' : 'claude.exe';
+      timeoutMs = cron.fresh_session_timeout_ms ?? 300_000;
+
+      args = ['--print', '--dangerously-skip-permissions', '--no-session-persistence'];
+      if (config.model) args.push('--model', config.model);
+
+      if (cron.skill_file) {
+        if (isAbsolute(cron.skill_file)) {
+          console.log(`[daemon] WARNING: absolute skill_file rejected for "${cron.name}" — ignoring`);
+        } else {
+          try {
+            args.push('--append-system-prompt', readFileSync(join(agentDir, cron.skill_file), 'utf-8'));
+          } catch (err) {
+            console.log(
+              `[daemon] WARNING: skill_file "${cron.skill_file}" unreadable for "${cron.name}" — ` +
+              `proceeding without: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
         }
       }
-    }
 
-    args.push(promptText);
+      args.push(promptText);
+    } catch (preSpawnErr) {
+      writeExecLog(
+        'failed',
+        `pre_spawn: ${preSpawnErr instanceof Error ? preSpawnErr.message : String(preSpawnErr)}`
+      );
+      throw preSpawnErr;
+    }
 
     const OUTPUT_CAP_BYTES = 256 * 1024;
     let stdoutBuf = Buffer.alloc(0);
@@ -892,7 +935,10 @@ export class AgentManager {
         try { appendFileSync(cronLogPath, `[stderr] ${chunk}`); } catch { /* non-fatal */ }
       });
 
-      child.once('error', (err) => settle(new Error(`spawn failed for "${cron.name}": ${err.message}`)));
+      child.once('error', (err) => {
+        writeExecLog('failed', `spawn_error: ${err.message}`);
+        settle(new Error(`spawn failed for "${cron.name}": ${err.message}`));
+      });
 
       child.once('close', (code, signal) => {
         const stderrSnip = stderrBuf.slice(0, 500).toString();
@@ -901,6 +947,31 @@ export class AgentManager {
           `signal=${signal} stdout=${stdoutBuf.length}B`
         );
         if (stderrSnip.trim()) console.log(`[daemon] Fresh cron stderr: ${stderrSnip}`);
+
+        const exitOk = !timedOut && code === 0;
+        const shouldPersistFire = exitOk && !settled;
+        const errorMsg = timedOut
+          ? `timed_out_${timeoutMs}ms`
+          : code !== 0
+          ? (stderrBuf.slice(0, 200).toString().trim() || `exit_code_${code ?? 'null'}`)
+          : null;
+
+        writeExecLog(exitOk ? 'fired' : 'failed', errorMsg);
+
+        if (shouldPersistFire) {
+          const newFireCount = (cron.fire_count ?? 0) + 1;
+          try {
+            updateCron(agentName, cron.name, {
+              last_fired_at: firedAt,
+              fire_count: newFireCount,
+            });
+          } catch (err) {
+            console.log(
+              `[daemon] WARNING: failed to persist fire state for "${cron.name}" — ` +
+              `${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
 
         if (timedOut) {
           settle(new Error(`Fresh cron "${cron.name}" timed out (${timeoutMs}ms), exited code=${code} signal=${signal}`));

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -1,5 +1,7 @@
-import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
-import { join, relative } from 'path';
+import { spawn } from 'child_process';
+import { readdirSync, readFileSync, existsSync, mkdirSync, writeFileSync, appendFileSync } from 'fs';
+import { join, relative, isAbsolute } from 'path';
+import { platform } from 'os';
 import type { AgentConfig, AgentStatus, CtxEnv, BusPaths, WorkerStatus, TelegramMessage } from '../types/index.js';
 import { AgentProcess } from './agent-process.js';
 import { WorkerProcess } from './worker-process.js';
@@ -11,6 +13,8 @@ import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
+import { isFreshSessionProtectedAgent, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
+import { logEvent } from '../bus/event.js';
 import { recordInboundTelegram, cacheLastSent, logOutboundMessage, buildRecentHistory } from '../telegram/logging.js';
 import { collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
 import { stripControlChars } from '../utils/validate.js';
@@ -778,6 +782,168 @@ export class AgentManager {
   }
 
   /**
+   * Single dispatch point for scheduled and manual cron fires.
+   */
+  async dispatchCron(agentName: string, cron: CronDefinition, firedAt: string): Promise<void> {
+    const prompt = cron.prompt ?? `[cron] ${cron.name} fired`;
+    const injection = `[CRON FIRED ${firedAt}] ${cron.name}: ${prompt}`;
+
+    if (isFreshSessionProtectedAgent(agentName) && cron.fresh_session) {
+      console.log(
+        `[daemon] GUARDRAIL: fresh_session overridden for protected agent "${agentName}" cron "${cron.name}"`
+      );
+      this.emitGuardrailEvent(agentName, cron.name);
+    }
+
+    const useFresh = cron.fresh_session === true && !isFreshSessionProtectedAgent(agentName);
+    if (useFresh) {
+      await this.fireCronFreshSession(agentName, cron, injection);
+      return;
+    }
+
+    const injected = this.injectAgent(agentName, injection);
+    if (!injected) {
+      throw new Error(`injectAgent returned false for agent "${agentName}" — agent may not be running`);
+    }
+  }
+
+  private async fireCronFreshSession(
+    agentName: string,
+    cron: CronDefinition,
+    promptText: string,
+  ): Promise<void> {
+    const entry = this.agents.get(agentName);
+    if (!entry) throw new Error(`Agent "${agentName}" not found`);
+
+    const agentProcess = entry.process;
+    const config = agentProcess.getConfig();
+    const runtime = config.runtime;
+
+    if (!isFreshSessionSupportedRuntime(runtime)) {
+      this.emitFreshSessionUnsupportedEvent(agentName, cron.name, runtime ?? 'unknown');
+      throw new Error(`fresh_session not supported for runtime "${runtime}" (${agentName}/${cron.name})`);
+    }
+
+    const agentDir = agentProcess.getAgentDir();
+    const workingDir = config.working_directory || agentDir;
+    const runtimeEnv = agentProcess.buildRuntimeEnv();
+    const claudeCmd = platform() !== 'win32' ? 'claude' : 'claude.exe';
+    const timeoutMs = cron.fresh_session_timeout_ms ?? 300_000;
+    const KILL_GRACE_MS = 5_000;
+
+    const args: string[] = ['--print', '--dangerously-skip-permissions', '--no-session-persistence'];
+    if (config.model) args.push('--model', config.model);
+
+    if (cron.skill_file) {
+      if (isAbsolute(cron.skill_file)) {
+        console.log(`[daemon] WARNING: absolute skill_file rejected for "${cron.name}" — ignoring`);
+      } else {
+        try {
+          args.push('--append-system-prompt', readFileSync(join(agentDir, cron.skill_file), 'utf-8'));
+        } catch (err) {
+          console.log(
+            `[daemon] WARNING: skill_file "${cron.skill_file}" unreadable for "${cron.name}" — ` +
+            `proceeding without: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    }
+
+    args.push(promptText);
+
+    const OUTPUT_CAP_BYTES = 256 * 1024;
+    let stdoutBuf = Buffer.alloc(0);
+    let stderrBuf = Buffer.alloc(0);
+    let settled = false;
+    let timedOut = false;
+
+    const ctxRoot = runtimeEnv['CTX_ROOT'] ?? this.ctxRoot;
+    const logDir = join(ctxRoot, 'logs', agentName);
+    try { mkdirSync(logDir, { recursive: true }); } catch { /* non-fatal */ }
+    const cronLogPath = join(logDir, 'cron-fresh.log');
+
+    return new Promise<void>((resolve, reject) => {
+      let killTimer: ReturnType<typeof setTimeout> | undefined;
+      let sigkillTimer: ReturnType<typeof setTimeout> | undefined;
+
+      const settle = (err?: Error): void => {
+        if (settled) return;
+        settled = true;
+        if (killTimer !== undefined) clearTimeout(killTimer);
+        if (sigkillTimer !== undefined) clearTimeout(sigkillTimer);
+        if (err) reject(err); else resolve();
+      };
+
+      const child = spawn(claudeCmd, args, {
+        cwd: workingDir,
+        env: runtimeEnv,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        const remaining = OUTPUT_CAP_BYTES - stdoutBuf.length;
+        if (remaining > 0) stdoutBuf = Buffer.concat([stdoutBuf, chunk.subarray(0, remaining)]);
+        try { appendFileSync(cronLogPath, `[stdout] ${chunk}`); } catch { /* non-fatal */ }
+      });
+
+      child.stderr?.on('data', (chunk: Buffer) => {
+        const remaining = OUTPUT_CAP_BYTES - stderrBuf.length;
+        if (remaining > 0) stderrBuf = Buffer.concat([stderrBuf, chunk.subarray(0, remaining)]);
+        try { appendFileSync(cronLogPath, `[stderr] ${chunk}`); } catch { /* non-fatal */ }
+      });
+
+      child.once('error', (err) => settle(new Error(`spawn failed for "${cron.name}": ${err.message}`)));
+
+      child.once('close', (code, signal) => {
+        const stderrSnip = stderrBuf.slice(0, 500).toString();
+        console.log(
+          `[daemon] Fresh cron "${cron.name}" (${agentName}) closed code=${code} ` +
+          `signal=${signal} stdout=${stdoutBuf.length}B`
+        );
+        if (stderrSnip.trim()) console.log(`[daemon] Fresh cron stderr: ${stderrSnip}`);
+
+        if (timedOut) {
+          settle(new Error(`Fresh cron "${cron.name}" timed out (${timeoutMs}ms), exited code=${code} signal=${signal}`));
+        } else if (code !== 0) {
+          settle(new Error(`Fresh cron "${cron.name}" exited code=${code} signal=${signal}. stderr: ${stderrSnip}`));
+        } else {
+          settle();
+        }
+      });
+
+      killTimer = setTimeout(() => {
+        timedOut = true;
+        console.log(`[daemon] Fresh cron "${cron.name}" timeout (${timeoutMs}ms) — SIGTERM`);
+        child.kill('SIGTERM');
+        sigkillTimer = setTimeout(() => {
+          if (!settled) {
+            console.log(`[daemon] Fresh cron "${cron.name}" no close after grace — SIGKILL`);
+            child.kill('SIGKILL');
+          }
+        }, KILL_GRACE_MS);
+      }, timeoutMs);
+    });
+  }
+
+  private emitGuardrailEvent(agentName: string, cronName: string): void {
+    try {
+      logEvent(resolvePaths(agentName, this.instanceId, this.org), agentName, this.org, 'action', 'guardrail_triggered', 'info', {
+        guardrail: 'fresh_session_protected_agent',
+        cron: cronName,
+      });
+    } catch { /* observability should not block dispatch */ }
+  }
+
+  private emitFreshSessionUnsupportedEvent(agentName: string, cronName: string, runtime: string): void {
+    try {
+      logEvent(resolvePaths(agentName, this.instanceId, this.org), agentName, this.org, 'error', 'cron_fresh_session_unsupported', 'error', {
+        cron: cronName,
+        runtime,
+      });
+    } catch { /* observability should not mask scheduler failure */ }
+  }
+
+  /**
    * Signal the CronScheduler for an agent to re-read crons.json.
    *
    * Called by the IPC server after a `bus add-cron` / `bus remove-cron` write so
@@ -849,17 +1015,7 @@ export class AgentManager {
     }
 
     const onFire = async (cron: CronDefinition): Promise<void> => {
-      const prompt = cron.prompt ?? `[cron] ${cron.name} fired`;
-      // Salt with the fire timestamp so MessageDedup (which hashes the last 100
-      // injects) does not reject identical cron prompts on subsequent fires.
-      // Without the salt, every recurring cron after its first fire would be
-      // dedup-rejected and treated as a dispatch failure.
-      const firedAt = new Date().toISOString();
-      const injection = `[CRON FIRED ${firedAt}] ${cron.name}: ${prompt}`;
-      const injected = this.injectAgent(agentName, injection);
-      if (!injected) {
-        throw new Error(`injectAgent returned false for agent "${agentName}" — agent may not be running`);
-      }
+      await this.dispatchCron(agentName, cron, new Date().toISOString());
     };
 
     const scheduler = new CronScheduler({

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -8,7 +8,7 @@ import { HermesPTY, hermesDbExists } from '../pty/hermes-pty.js';
 import { MessageDedup, injectMessage } from '../pty/inject.js';
 import type { TelegramAPI } from '../telegram/api.js';
 import { ensureDir } from '../utils/atomic.js';
-import { writeCortextosEnv } from '../utils/env.js';
+import { buildAgentRuntimeEnv, writeCortextosEnv } from '../utils/env.js';
 import { getOverdueReminders } from '../bus/reminders.js';
 import { resolvePaths } from '../utils/paths.js';
 
@@ -372,6 +372,13 @@ export class AgentProcess {
    */
   getConfig(): AgentConfig {
     return this.config;
+  }
+
+  /**
+   * Build the exact runtime env used by spawned Claude sessions.
+   */
+  buildRuntimeEnv(): NodeJS.ProcessEnv {
+    return buildAgentRuntimeEnv(this.env, this.config);
   }
 
   // --- Private methods ---

--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -175,24 +175,28 @@ async function fireWithRetry(
   onFire: (c: CronDefinition) => Promise<void> | void,
   logger: (msg: string) => void,
 ): Promise<boolean> {
-  const maxAttempts = RETRY_DELAYS_MS.length + 1; // 4 attempts total
+  // Fresh sessions own execution log writes and represent one long subprocess.
+  // Retrying them from the scheduler would block the tick loop for too long.
+  const maxAttempts = cron.fresh_session ? 1 : RETRY_DELAYS_MS.length + 1;
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const start = Date.now();
     try {
       await Promise.resolve(onFire(cron));
-      appendExecutionLog(agentName, {
-        ts: new Date().toISOString(),
-        cron: cron.name,
-        status: 'fired',
-        attempt: attempt + 1,
-        duration_ms: Date.now() - start,
-        error: null,
-      });
+      if (!cron.fresh_session) {
+        appendExecutionLog(agentName, {
+          ts: new Date().toISOString(),
+          cron: cron.name,
+          status: 'fired',
+          attempt: attempt + 1,
+          duration_ms: Date.now() - start,
+          error: null,
+        });
+      }
       return true;
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       const duration_ms = Date.now() - start;
-      if (attempt < RETRY_DELAYS_MS.length) {
+      if (!cron.fresh_session && attempt < RETRY_DELAYS_MS.length) {
         const delay = RETRY_DELAYS_MS[attempt];
         logger(
           `[cron-scheduler] onFire failed for "${cron.name}" ` +
@@ -210,16 +214,18 @@ async function fireWithRetry(
       } else {
         logger(
           `[cron-scheduler] onFire failed for "${cron.name}" ` +
-          `after all 4 attempts — giving up. Last error: ${errMsg}`
+          `after all ${maxAttempts} attempt${maxAttempts === 1 ? '' : 's'} — giving up. Last error: ${errMsg}`
         );
-        appendExecutionLog(agentName, {
-          ts: new Date().toISOString(),
-          cron: cron.name,
-          status: 'failed',
-          attempt: attempt + 1,
-          duration_ms,
-          error: errMsg,
-        });
+        if (!cron.fresh_session) {
+          appendExecutionLog(agentName, {
+            ts: new Date().toISOString(),
+            cron: cron.name,
+            status: 'failed',
+            attempt: attempt + 1,
+            duration_ms,
+            error: errMsg,
+          });
+        }
       }
     }
   }
@@ -496,20 +502,22 @@ export class CronScheduler {
         // crash the tick loop — we log and keep the in-memory schedule intact.
         const nowIso = new Date(now).toISOString();
         const newFireCount = (cron.fire_count ?? 0) + 1;
-        try {
-          updateCron(this.agentName, name, {
-            last_fired_at: nowIso,
-            fire_count: newFireCount,
-          });
-        } catch (err) {
-          this.logger(
-            `[cron-scheduler] WARNING: failed to persist fire state for "${name}" — ` +
-            `${err instanceof Error ? err.message : String(err)}. ` +
-            `In-memory schedule retained; state will be lost if daemon restarts.`
-          );
+        if (!cron.fresh_session) {
+          try {
+            updateCron(this.agentName, name, {
+              last_fired_at: nowIso,
+              fire_count: newFireCount,
+            });
+          } catch (err) {
+            this.logger(
+              `[cron-scheduler] WARNING: failed to persist fire state for "${name}" — ` +
+              `${err instanceof Error ? err.message : String(err)}. ` +
+              `In-memory schedule retained; state will be lost if daemon restarts.`
+            );
+          }
         }
 
-        // Advance in-memory nextFireAt
+        // Advance in-memory nextFireAt for both PTY and fresh-session crons.
         const next = computeNextFireAt(cron, now);
         if (!isNaN(next)) {
           sc.nextFireAt = next;

--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -368,24 +368,32 @@ export class CronScheduler {
       const key = changeKeyFor(def);
       const existing = this.scheduled.get(def.name);
 
-      if (isReload && existing !== undefined && existing.changeKey === key) {
-        // Definition unchanged — preserve nextFireAt
-        nextScheduled.set(def.name, { ...existing, definition: def });
-        continue;
-      }
-
       // RELOAD-WHILE-FIRING GUARD: if the cron is mid-fire, preserve the
-      // existing entry as-is until the fire completes.  A fresh ScheduledCron
-      // built from stale crons.json (last_fired_at not yet persisted) would
-      // catch-up-fire on the next tick and double-fire the same logical event.
-      // The next reload (manual or after fire completes) will pick up the
-      // new schedule cleanly.
+      // exact object reference tick() is holding until the fire completes.
+      // This guard must come before the unchanged-schedule branch: spreading
+      // a firing entry copies `firing: true` into an orphaned object that tick()
+      // can no longer clear, freezing the cron permanently.
       if (isReload && existing !== undefined && existing.firing === true) {
         this.logger(
           `[cron-scheduler] reload deferred for "${def.name}" — fire in progress; ` +
           `new schedule will apply on next reload after fire completes`
         );
         nextScheduled.set(def.name, existing);
+        continue;
+      }
+
+      if (isReload && existing !== undefined && existing.changeKey === key) {
+        // Definition unchanged — preserve nextFireAt. A spread copy is only
+        // safe when not firing; the guard above should have caught that case.
+        if (existing.firing === true) {
+          this.logger(
+            `[cron-scheduler] BUG: reached spread-copy path while "${def.name}" is firing — ` +
+            `preserving original reference to avoid freeze. Guard ordering may have regressed.`
+          );
+          nextScheduled.set(def.name, existing);
+        } else {
+          nextScheduled.set(def.name, { ...existing, definition: def });
+        }
         continue;
       }
 
@@ -454,6 +462,8 @@ export class CronScheduler {
 
     // Update the last-good snapshot whenever we get a non-empty result.
     if (nextScheduled.size > 0) {
+      // Shallow-copy the map only: ScheduledCron objects are intentionally
+      // shared with `scheduled` so a firing entry's reference is not orphaned.
       this.lastGoodSchedule = new Map(nextScheduled);
     }
   }

--- a/src/daemon/ipc-server.ts
+++ b/src/daemon/ipc-server.ts
@@ -9,7 +9,7 @@ import type { ExecutionLogStatusFilter } from '../bus/crons.js';
 import { nextFireFromCron } from './cron-scheduler.js';
 import { parseDurationMs } from '../bus/cron-state.js';
 import { computeHealth, aggregateFleetHealth } from '../utils/cron-health.js';
-import { isFreshSessionProtectedAgent, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
+import { isFreshSessionProtectedCron, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 
 const WORKER_NAME_REGEX = /^[a-z0-9_-]+$/;
 
@@ -357,6 +357,7 @@ function getAgentRuntime(agent: string): AgentConfig['runtime'] | undefined {
 
 function validateFreshSessionFields(
   agent: string,
+  cronName: string,
   fields: Partial<CronDefinition>,
 ): MutationResult {
   if (fields.fresh_session !== undefined && typeof fields.fresh_session !== 'boolean') {
@@ -376,8 +377,8 @@ function validateFreshSessionFields(
     }
   }
   if (fields.fresh_session === true) {
-    if (isFreshSessionProtectedAgent(agent)) {
-      return { ok: false, error: `fresh_session is not allowed for protected agent '${agent}'.`, field: 'fresh_session' };
+    if (isFreshSessionProtectedCron(agent, cronName)) {
+      return { ok: false, error: `fresh_session is not allowed for protected cron '${agent}/${cronName}'.`, field: 'fresh_session' };
     }
     const runtime = getAgentRuntime(agent);
     if (!isFreshSessionSupportedRuntime(runtime)) {
@@ -448,7 +449,7 @@ export function handleAddCron(
     return { ok: false, error: 'Prompt is required and must be non-empty.', field: 'prompt' };
   }
 
-  const freshValidation = validateFreshSessionFields(agent, definition);
+  const freshValidation = validateFreshSessionFields(agent, name, definition);
   if (!freshValidation.ok) return freshValidation;
 
   const fullDef: CronDefinition = {
@@ -514,7 +515,7 @@ export function handleUpdateCron(
     return { ok: false, error: 'Prompt must be non-empty.', field: 'prompt' };
   }
 
-  const freshValidation = validateFreshSessionFields(agent, patch);
+  const freshValidation = validateFreshSessionFields(agent, name, patch);
   if (!freshValidation.ok) return freshValidation;
 
   if (patch.skill_file !== undefined) {

--- a/src/daemon/ipc-server.ts
+++ b/src/daemon/ipc-server.ts
@@ -371,6 +371,14 @@ function validateFreshSessionFields(
       return { ok: false, error: 'skill_file must be a relative path.', field: 'skill_file' };
     }
   }
+  if (fields.protocol_file !== undefined) {
+    if (typeof fields.protocol_file !== 'string' || !fields.protocol_file.trim()) {
+      return { ok: false, error: 'protocol_file must be a non-empty string.', field: 'protocol_file' };
+    }
+    if (isAbsolute(fields.protocol_file)) {
+      return { ok: false, error: 'protocol_file must be a relative path.', field: 'protocol_file' };
+    }
+  }
   if (fields.fresh_session_timeout_ms !== undefined) {
     if (!Number.isInteger(fields.fresh_session_timeout_ms) || fields.fresh_session_timeout_ms <= 0) {
       return { ok: false, error: 'fresh_session_timeout_ms must be a positive integer.', field: 'fresh_session_timeout_ms' };
@@ -465,6 +473,7 @@ export function handleAddCron(
       : {}),
     ...(definition.fresh_session !== undefined ? { fresh_session: definition.fresh_session } : {}),
     ...(definition.skill_file !== undefined ? { skill_file: definition.skill_file.trim() } : {}),
+    ...(definition.protocol_file !== undefined ? { protocol_file: definition.protocol_file.trim() } : {}),
     ...(definition.fresh_session_timeout_ms !== undefined
       ? { fresh_session_timeout_ms: definition.fresh_session_timeout_ms }
       : {}),
@@ -520,6 +529,9 @@ export function handleUpdateCron(
 
   if (patch.skill_file !== undefined) {
     patch = { ...patch, skill_file: patch.skill_file.trim() };
+  }
+  if (patch.protocol_file !== undefined) {
+    patch = { ...patch, protocol_file: patch.protocol_file.trim() };
   }
 
   const found = updateCron(agent, name, patch);

--- a/src/daemon/ipc-server.ts
+++ b/src/daemon/ipc-server.ts
@@ -1,7 +1,7 @@
 import { createServer, Server, Socket } from 'net';
-import { existsSync, unlinkSync, chmodSync, readFileSync } from 'fs';
-import { join, resolve as pathResolve } from 'path';
-import type { IPCRequest, IPCResponse, CronSummaryRow, CronDefinition } from '../types/index.js';
+import { existsSync, unlinkSync, chmodSync, readFileSync, readdirSync } from 'fs';
+import { isAbsolute, join, resolve as pathResolve } from 'path';
+import type { AgentConfig, IPCRequest, IPCResponse, CronSummaryRow, CronDefinition } from '../types/index.js';
 import { AgentManager } from './agent-manager.js';
 import { getIpcPath } from '../utils/paths.js';
 import { readCrons, getExecutionLog, getExecutionLogPage, addCron, updateCron, removeCron, getCronByName } from '../bus/crons.js';
@@ -9,6 +9,7 @@ import type { ExecutionLogStatusFilter } from '../bus/crons.js';
 import { nextFireFromCron } from './cron-scheduler.js';
 import { parseDurationMs } from '../bus/cron-state.js';
 import { computeHealth, aggregateFleetHealth } from '../utils/cron-health.js';
+import { isFreshSessionProtectedAgent, isFreshSessionSupportedRuntime } from '../utils/fresh-session-guards.js';
 
 const WORKER_NAME_REGEX = /^[a-z0-9_-]+$/;
 
@@ -55,6 +56,9 @@ export interface FireCronResult {
   error?: string;
 }
 
+type LegacyInjectFn = (agent: string, text: string) => boolean;
+type CronDispatchFn = (agent: string, cron: CronDefinition, firedAt: string) => Promise<void> | void;
+
 /**
  * fire-cron handler — validates manualFireDisabled + cooldown, then injects
  * the cron's prompt into the agent's PTY.
@@ -67,9 +71,9 @@ export interface FireCronResult {
 export function handleFireCron(
   agent: string | undefined,
   cronName: string | undefined,
-  injectFn: (agent: string, text: string) => boolean,
+  dispatchOrInjectFn: LegacyInjectFn | CronDispatchFn,
   nowMs = Date.now(),
-): FireCronResult {
+): FireCronResult | Promise<FireCronResult> {
   if (!agent || !agent.trim()) {
     return { ok: false, error: 'Agent name is required.' };
   }
@@ -95,18 +99,27 @@ export function handleFireCron(
     return { ok: false, error: `Cooldown active — wait ${waitSec}s before firing again.` };
   }
 
-  // Inject into PTY
-  const injection = `[CRON: ${cronName}] ${cron.prompt}`;
-  const injected = injectFn(agent, injection);
-  if (!injected) {
-    return { ok: false, error: `Agent '${agent}' not found or not running.` };
+  // Backward-compatible legacy path for unit tests and older callers.
+  if (dispatchOrInjectFn.length === 2) {
+    const injection = `[CRON: ${cronName}] ${cron.prompt}`;
+    const injected = (dispatchOrInjectFn as LegacyInjectFn)(agent, injection);
+    if (!injected) {
+      return { ok: false, error: `Agent '${agent}' not found or not running.` };
+    }
+    _manualFireLastFired.set(`${agent}::${cronName}`, nowMs);
+    return { ok: true, firedAt: nowMs };
   }
 
-  // Record fire time for cooldown tracking
-  const firedAt = nowMs;
-  _manualFireLastFired.set(`${agent}::${cronName}`, firedAt);
-
-  return { ok: true, firedAt };
+  const firedAtIso = new Date(nowMs).toISOString();
+  return Promise.resolve((dispatchOrInjectFn as CronDispatchFn)(agent, cron, firedAtIso))
+    .then(() => {
+      _manualFireLastFired.set(`${agent}::${cronName}`, nowMs);
+      return { ok: true, firedAt: nowMs };
+    })
+    .catch((err) => ({
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    }));
 }
 
 // ---------------------------------------------------------------------------
@@ -303,21 +316,75 @@ export function isValidSchedule(schedule: string): boolean {
 /**
  * Read the list of enabled agent names from enabled-agents.json.
  */
-function getEnabledAgents(): string[] {
+function getEnabledAgentEntries(): Record<string, { enabled?: boolean; org?: string }> {
   const ctxRoot = process.env.CTX_ROOT ?? process.cwd();
   const enabledFile = join(ctxRoot, 'config', 'enabled-agents.json');
-  if (!existsSync(enabledFile)) return [];
+  if (!existsSync(enabledFile)) return {};
   try {
-    const data = JSON.parse(readFileSync(enabledFile, 'utf-8')) as Record<
-      string,
-      { enabled?: boolean }
-    >;
-    return Object.entries(data)
+    return JSON.parse(readFileSync(enabledFile, 'utf-8')) as Record<string, { enabled?: boolean; org?: string }>;
+  } catch {
+    return {};
+  }
+}
+
+function getEnabledAgents(): string[] {
+  const data = getEnabledAgentEntries();
+  return Object.entries(data)
       .filter(([, v]) => v.enabled !== false)
       .map(([k]) => k);
-  } catch {
-    return [];
+}
+
+function getAgentRuntime(agent: string): AgentConfig['runtime'] | undefined {
+  const frameworkRoot = process.env.CTX_FRAMEWORK_ROOT ?? process.env.CTX_PROJECT_ROOT ?? process.cwd();
+  const entry = getEnabledAgentEntries()[agent];
+  const candidateOrgs = entry?.org ? [entry.org] : [];
+  const orgsDir = join(frameworkRoot, 'orgs');
+  if (candidateOrgs.length === 0 && existsSync(orgsDir)) {
+    try {
+      candidateOrgs.push(...readdirSync(orgsDir));
+    } catch { /* ignore */ }
   }
+
+  for (const org of candidateOrgs) {
+    try {
+      const configPath = join(frameworkRoot, 'orgs', org, 'agents', agent, 'config.json');
+      if (!existsSync(configPath)) continue;
+      return (JSON.parse(readFileSync(configPath, 'utf-8')) as AgentConfig).runtime;
+    } catch { /* ignore malformed configs here; other layers validate config */ }
+  }
+  return undefined;
+}
+
+function validateFreshSessionFields(
+  agent: string,
+  fields: Partial<CronDefinition>,
+): MutationResult {
+  if (fields.fresh_session !== undefined && typeof fields.fresh_session !== 'boolean') {
+    return { ok: false, error: 'fresh_session must be boolean.', field: 'fresh_session' };
+  }
+  if (fields.skill_file !== undefined) {
+    if (typeof fields.skill_file !== 'string' || !fields.skill_file.trim()) {
+      return { ok: false, error: 'skill_file must be a non-empty string.', field: 'skill_file' };
+    }
+    if (isAbsolute(fields.skill_file)) {
+      return { ok: false, error: 'skill_file must be a relative path.', field: 'skill_file' };
+    }
+  }
+  if (fields.fresh_session_timeout_ms !== undefined) {
+    if (!Number.isInteger(fields.fresh_session_timeout_ms) || fields.fresh_session_timeout_ms <= 0) {
+      return { ok: false, error: 'fresh_session_timeout_ms must be a positive integer.', field: 'fresh_session_timeout_ms' };
+    }
+  }
+  if (fields.fresh_session === true) {
+    if (isFreshSessionProtectedAgent(agent)) {
+      return { ok: false, error: `fresh_session is not allowed for protected agent '${agent}'.`, field: 'fresh_session' };
+    }
+    const runtime = getAgentRuntime(agent);
+    if (!isFreshSessionSupportedRuntime(runtime)) {
+      return { ok: false, error: `fresh_session is not supported for runtime '${runtime}'.`, field: 'fresh_session' };
+    }
+  }
+  return { ok: true };
 }
 
 /**
@@ -381,6 +448,9 @@ export function handleAddCron(
     return { ok: false, error: 'Prompt is required and must be non-empty.', field: 'prompt' };
   }
 
+  const freshValidation = validateFreshSessionFields(agent, definition);
+  if (!freshValidation.ok) return freshValidation;
+
   const fullDef: CronDefinition = {
     name,
     prompt: prompt.trim(),
@@ -391,6 +461,11 @@ export function handleAddCron(
     ...(definition.metadata ? { metadata: definition.metadata } : {}),
     ...(definition.manualFireDisabled !== undefined
       ? { manualFireDisabled: !!definition.manualFireDisabled }
+      : {}),
+    ...(definition.fresh_session !== undefined ? { fresh_session: definition.fresh_session } : {}),
+    ...(definition.skill_file !== undefined ? { skill_file: definition.skill_file.trim() } : {}),
+    ...(definition.fresh_session_timeout_ms !== undefined
+      ? { fresh_session_timeout_ms: definition.fresh_session_timeout_ms }
       : {}),
   };
 
@@ -437,6 +512,13 @@ export function handleUpdateCron(
   // Validate prompt if provided
   if (patch.prompt !== undefined && !patch.prompt.trim()) {
     return { ok: false, error: 'Prompt must be non-empty.', field: 'prompt' };
+  }
+
+  const freshValidation = validateFreshSessionFields(agent, patch);
+  if (!freshValidation.ok) return freshValidation;
+
+  if (patch.skill_file !== undefined) {
+    patch = { ...patch, skill_file: patch.skill_file.trim() };
   }
 
   const found = updateCron(agent, name, patch);
@@ -506,7 +588,7 @@ export class IPCServer {
           try {
             const request: IPCRequest = JSON.parse(data);
             data = '';
-            this.handleRequest(request, socket);
+            void this.handleRequest(request, socket);
           } catch {
             // Incomplete JSON, wait for more data
           }
@@ -567,7 +649,7 @@ export class IPCServer {
   /**
    * Handle an incoming IPC request.
    */
-  private handleRequest(request: IPCRequest, socket: Socket): void {
+  private async handleRequest(request: IPCRequest, socket: Socket): Promise<void> {
     // BUG-015: log every incoming IPC request with its source so we can
     // trace which CLI command triggered which daemon action. The source
     // field is populated by CLI clients (cortextos enable / disable / stop
@@ -724,10 +806,10 @@ export class IPCServer {
         case 'fire-cron': {
           const agentToFire = request.agent;
           const fireCronName = request.data?.name as string | undefined;
-          const fireCronResult = handleFireCron(
+          const fireCronResult = await handleFireCron(
             agentToFire,
             fireCronName,
-            (a, text) => this.agentManager.injectAgent(a, text),
+            (a, cron, firedAt) => this.agentManager.dispatchCron(a, cron, firedAt),
           );
           if (fireCronResult.ok) {
             // Invalidate fleet health cache so next poll reflects the new fire

--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -148,10 +148,11 @@ function shouldSuppressDedup(stateDir: string, endType: string): boolean {
   return false;
 }
 
-async function main(): Promise<void> {
+export async function main(): Promise<void> {
   const agentName = process.env.CTX_AGENT_NAME;
   const instanceId = process.env.CTX_INSTANCE_ID || 'default';
   if (!agentName) return;
+  if (process.env.CTX_FRESH_SESSION_CRON) return;
 
   const ctxRoot = join(homedir(), '.cortextos', instanceId);
   const stateDir = join(ctxRoot, 'state', agentName);
@@ -331,4 +332,6 @@ async function main(): Promise<void> {
   }
 }
 
-main().catch(() => process.exit(0));
+if (!process.env.VITEST) {
+  main().catch(() => process.exit(0));
+}

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -3,6 +3,7 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
+import { buildAgentRuntimeEnv } from '../utils/env.js';
 
 // node-pty types
 interface IPty {
@@ -19,7 +20,7 @@ interface IPtySpawnOptions {
   cols?: number;
   rows?: number;
   cwd?: string;
-  env?: Record<string, string>;
+  env?: NodeJS.ProcessEnv;
 }
 
 type SpawnFn = (file: string, args: string[], options: IPtySpawnOptions) => IPty;
@@ -62,79 +63,7 @@ export class AgentPTY {
 
     const cwd = this.config.working_directory || this.env.agentDir || process.cwd();
 
-    // Build environment variables for the PTY process
-    const ptyEnv: Record<string, string> = {
-      ...this.getBaseEnv(),
-      CTX_INSTANCE_ID: this.env.instanceId,
-      CTX_ROOT: this.env.ctxRoot,
-      CTX_FRAMEWORK_ROOT: this.env.frameworkRoot,
-      CTX_AGENT_NAME: this.env.agentName,
-      CTX_ORG: this.env.org,
-      CTX_AGENT_DIR: this.env.agentDir,
-      CTX_PROJECT_ROOT: this.env.projectRoot,
-      // Backward compat
-      CRM_AGENT_NAME: this.env.agentName,
-      CRM_TEMPLATE_ROOT: this.env.frameworkRoot,
-    };
-
-    // Source org-level shared secrets (orgs/{org}/secrets.env).
-    // These are shared across all agents in the org: OPENAI_KEY, APIFY_TOKEN, GEMINI_API_KEY, etc.
-    // Agent .env is loaded after and overrides org values — agent-specific keys win.
-    if (this.env.org && this.env.projectRoot) {
-      const orgEnvFile = join(this.env.projectRoot, 'orgs', this.env.org, 'secrets.env');
-      if (existsSync(orgEnvFile)) {
-        const content = readFileSync(orgEnvFile, 'utf-8');
-        for (const line of content.split('\n')) {
-          const trimmed = line.trim();
-          if (!trimmed || trimmed.startsWith('#')) continue;
-          const eqIdx = trimmed.indexOf('=');
-          if (eqIdx > 0) {
-            ptyEnv[trimmed.slice(0, eqIdx).trim()] = trimmed.slice(eqIdx + 1).trim();
-          }
-        }
-      }
-    }
-
-    // Source agent .env file (overrides org secrets.env for same key names).
-    // Contains agent-specific secrets: BOT_TOKEN, CHAT_ID, CLAUDE_CODE_OAUTH_TOKEN.
-    const agentEnvFile = join(this.env.agentDir, '.env');
-    if (existsSync(agentEnvFile)) {
-      const content = readFileSync(agentEnvFile, 'utf-8');
-      for (const line of content.split('\n')) {
-        const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith('#')) continue;
-        const eqIdx = trimmed.indexOf('=');
-        if (eqIdx > 0) {
-          ptyEnv[trimmed.slice(0, eqIdx).trim()] = trimmed.slice(eqIdx + 1).trim();
-        }
-      }
-    }
-
-    // Add convenience CTX_* aliases used throughout agent templates.
-    // CTX_TELEGRAM_CHAT_ID: alias for CHAT_ID from the agent's .env
-    if (ptyEnv['CHAT_ID']) {
-      ptyEnv['CTX_TELEGRAM_CHAT_ID'] = ptyEnv['CHAT_ID'];
-    }
-    // CTX_TIMEZONE: from config.json timezone field, falls back to system TZ
-    const configTimezone = this.config.timezone;
-    if (configTimezone) {
-      ptyEnv['CTX_TIMEZONE'] = configTimezone;
-      ptyEnv['TZ'] = configTimezone; // also set TZ so date/time system calls use correct zone
-    } else if (process.env.TZ) {
-      ptyEnv['CTX_TIMEZONE'] = process.env.TZ;
-    }
-    // CTX_ORCHESTRATOR_AGENT: read from org context.json so agents can route to orchestrator
-    if (this.env.projectRoot && this.env.org) {
-      try {
-        const contextPath = join(this.env.projectRoot, 'orgs', this.env.org, 'context.json');
-        if (existsSync(contextPath)) {
-          const ctx = JSON.parse(readFileSync(contextPath, 'utf-8'));
-          if (ctx.orchestrator) {
-            ptyEnv['CTX_ORCHESTRATOR_AGENT'] = ctx.orchestrator;
-          }
-        }
-      } catch { /* leave unset if context.json is missing or malformed */ }
-    }
+    const ptyEnv = buildAgentRuntimeEnv(this.env, this.config);
 
     // Spawn the agent binary directly (no shell wrapper) — cross-platform, no shell escaping needed.
     // env is passed natively via node-pty options; no bash export commands required.
@@ -314,37 +243,4 @@ export class AgentPTY {
     return this.outputBuffer;
   }
 
-  /**
-   * Get a clean base environment (excluding potentially harmful vars).
-   */
-  private getBaseEnv(): Record<string, string> {
-    const env: Record<string, string> = {};
-    // Copy essential env vars
-    const keepVars = [
-      'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
-      'TMPDIR', 'TEMP', 'TMP', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY',
-      'NODE_PATH', 'COMSPEC', 'USERPROFILE',
-      // Windows path-expansion essentials. Stripping these causes phantom
-      // %SystemDrive% directories from inherited Search Indexer processes
-      // and Unity batchmode UPM IPC crashes (path.join(undefined,...)).
-      'SystemDrive', 'SystemRoot', 'windir',
-      'APPDATA', 'LOCALAPPDATA', 'ProgramData', 'ALLUSERSPROFILE',
-      'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
-      'HOMEDRIVE', 'HOMEPATH', 'PUBLIC',
-    ];
-    for (const key of keepVars) {
-      if (process.env[key]) {
-        env[key] = process.env[key]!;
-      }
-    }
-
-    // Windows: ensure UTF-8 locale so emoji and Unicode pass through the PTY
-    if (platform() === 'win32') {
-      if (!env['LANG']) env['LANG'] = 'en_US.UTF-8';
-      if (!env['LC_ALL']) env['LC_ALL'] = 'en_US.UTF-8';
-      if (!process.env['PYTHONIOENCODING']) env['PYTHONIOENCODING'] = 'utf-8';
-    }
-
-    return env;
-  }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -396,6 +396,25 @@ export interface CronDefinition {
    * @default false (manual fire is allowed by default — opt-out model)
    */
   manualFireDisabled?: boolean;
+
+  /**
+   * When true, the daemon spawns a fresh `claude --print --no-session-persistence`
+   * child process for this cron instead of injecting into the agent's live PTY.
+   * Default false — PTY inject is preserved unless explicitly opted in.
+   */
+  fresh_session?: boolean;
+
+  /**
+   * Relative path from CTX_AGENT_DIR to a skill or context file injected as
+   * system context via `--append-system-prompt` for fresh-session cron runs.
+   */
+  skill_file?: string;
+
+  /**
+   * Timeout in milliseconds for one fresh-session cron run before SIGTERM,
+   * followed by SIGKILL after a short grace period.
+   */
+  fresh_session_timeout_ms?: number;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -411,6 +411,12 @@ export interface CronDefinition {
   skill_file?: string;
 
   /**
+   * Relative path from CTX_AGENT_DIR to an operational protocol/checklist file
+   * injected alongside `skill_file` for fresh-session cron runs.
+   */
+  protocol_file?: string;
+
+  /**
    * Timeout in milliseconds for one fresh-session cron run before SIGTERM,
    * followed by SIGKILL after a short grace period.
    */

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -206,6 +206,7 @@ export function buildAgentRuntimeEnv(env: CtxEnv, config: AgentConfig): NodeJS.P
     ptyEnv['TZ'] = configTimezone;
   } else if (process.env.TZ) {
     ptyEnv['CTX_TIMEZONE'] = process.env.TZ;
+    ptyEnv['TZ'] = process.env.TZ;
   }
 
   if (env.projectRoot && env.org) {

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -1,7 +1,7 @@
 import { readFileSync, existsSync, writeFileSync } from 'fs';
 import { join, basename } from 'path';
-import { homedir } from 'os';
-import type { CtxEnv } from '../types/index.js';
+import { homedir, platform } from 'os';
+import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { ensureDir } from './atomic.js';
 import { validateAgentName, validateOrgName } from './validate.js';
 
@@ -162,6 +162,99 @@ export function parseEnvFile(filePath: string): Record<string, string> {
     // Ignore read errors
   }
   return result;
+}
+
+/**
+ * Build the complete environment for a spawned agent runtime.
+ *
+ * This is shared by the long-lived PTY path and one-shot fresh-session cron
+ * spawns so both receive the same CTX_* values, org secrets, agent .env, and
+ * timezone/orchestrator conveniences.
+ */
+export function buildAgentRuntimeEnv(env: CtxEnv, config: AgentConfig): NodeJS.ProcessEnv {
+  const ptyEnv: NodeJS.ProcessEnv = {
+    ...getBaseRuntimeEnv(),
+    CTX_INSTANCE_ID: env.instanceId,
+    CTX_ROOT: env.ctxRoot,
+    CTX_FRAMEWORK_ROOT: env.frameworkRoot,
+    CTX_AGENT_NAME: env.agentName,
+    CTX_ORG: env.org,
+    CTX_AGENT_DIR: env.agentDir,
+    CTX_PROJECT_ROOT: env.projectRoot,
+    // Backward compat
+    CRM_AGENT_NAME: env.agentName,
+    CRM_TEMPLATE_ROOT: env.frameworkRoot,
+  };
+
+  // Source org-level shared secrets first. Agent .env overrides below.
+  if (env.org && env.projectRoot) {
+    Object.assign(ptyEnv, parseEnvFile(join(env.projectRoot, 'orgs', env.org, 'secrets.env')));
+  }
+
+  // Source agent-specific secrets.
+  if (env.agentDir) {
+    Object.assign(ptyEnv, parseEnvFile(join(env.agentDir, '.env')));
+  }
+
+  if (ptyEnv['CHAT_ID']) {
+    ptyEnv['CTX_TELEGRAM_CHAT_ID'] = ptyEnv['CHAT_ID'];
+  }
+
+  const configTimezone = config.timezone;
+  if (configTimezone) {
+    ptyEnv['CTX_TIMEZONE'] = configTimezone;
+    ptyEnv['TZ'] = configTimezone;
+  } else if (process.env.TZ) {
+    ptyEnv['CTX_TIMEZONE'] = process.env.TZ;
+  }
+
+  if (env.projectRoot && env.org) {
+    try {
+      const contextPath = join(env.projectRoot, 'orgs', env.org, 'context.json');
+      if (existsSync(contextPath)) {
+        const ctx = JSON.parse(readFileSync(contextPath, 'utf-8'));
+        if (ctx.orchestrator) {
+          ptyEnv['CTX_ORCHESTRATOR_AGENT'] = ctx.orchestrator;
+        }
+      }
+    } catch { /* leave unset if context.json is missing or malformed */ }
+  }
+
+  return ptyEnv;
+}
+
+function getBaseRuntimeEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  const keepVars = [
+    'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
+    'TMPDIR', 'TEMP', 'TMP', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY',
+    'NODE_PATH', 'COMSPEC', 'USERPROFILE',
+    // Claude Code env passthroughs.
+    // IS_SANDBOX=1 lets --dangerously-skip-permissions run under root on
+    // VPS/container installs. CLAUDE_CODE_DISABLE_1M_CONTEXT controls the
+    // Sonnet/Haiku 1M context opt-out documented in the .env template.
+    'IS_SANDBOX', 'CLAUDE_CODE_DISABLE_1M_CONTEXT',
+    // Windows path-expansion essentials. Stripping these causes phantom
+    // %SystemDrive% directories from inherited Search Indexer processes
+    // and Unity batchmode UPM IPC crashes (path.join(undefined,...)).
+    'SystemDrive', 'SystemRoot', 'windir',
+    'APPDATA', 'LOCALAPPDATA', 'ProgramData', 'ALLUSERSPROFILE',
+    'ProgramFiles', 'ProgramFiles(x86)', 'ProgramW6432',
+    'HOMEDRIVE', 'HOMEPATH', 'PUBLIC',
+  ];
+  for (const key of keepVars) {
+    if (process.env[key]) {
+      env[key] = process.env[key];
+    }
+  }
+
+  if (platform() === 'win32') {
+    if (!env['LANG']) env['LANG'] = 'en_US.UTF-8';
+    if (!env['LC_ALL']) env['LC_ALL'] = 'en_US.UTF-8';
+    if (!process.env['PYTHONIOENCODING']) env['PYTHONIOENCODING'] = 'utf-8';
+  }
+
+  return env;
 }
 
 /**

--- a/src/utils/fresh-session-guards.ts
+++ b/src/utils/fresh-session-guards.ts
@@ -1,9 +1,14 @@
 import type { AgentConfig } from '../types/index.js';
 
-export const PROTECTED_AGENTS: ReadonlySet<string> = new Set(['top-g', 'smart-g']);
+export const PROTECTED_CRONS: ReadonlySet<string> = new Set([
+  'smart-g/*',
+  'top-g/morning-review',
+  'top-g/evening-review',
+  'top-g/weekly-review',
+]);
 
-export function isFreshSessionProtectedAgent(agentName: string): boolean {
-  return PROTECTED_AGENTS.has(agentName);
+export function isFreshSessionProtectedCron(agentName: string, cronName: string): boolean {
+  return PROTECTED_CRONS.has(`${agentName}/${cronName}`) || PROTECTED_CRONS.has(`${agentName}/*`);
 }
 
 export function isFreshSessionSupportedRuntime(runtime: AgentConfig['runtime'] | string | undefined): boolean {

--- a/src/utils/fresh-session-guards.ts
+++ b/src/utils/fresh-session-guards.ts
@@ -1,0 +1,11 @@
+import type { AgentConfig } from '../types/index.js';
+
+export const PROTECTED_AGENTS: ReadonlySet<string> = new Set(['top-g', 'smart-g']);
+
+export function isFreshSessionProtectedAgent(agentName: string): boolean {
+  return PROTECTED_AGENTS.has(agentName);
+}
+
+export function isFreshSessionSupportedRuntime(runtime: AgentConfig['runtime'] | string | undefined): boolean {
+  return runtime === undefined || runtime === 'claude-code';
+}

--- a/templates/agent-codex/AGENTS.md
+++ b/templates/agent-codex/AGENTS.md
@@ -46,7 +46,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, read `plugins/cortextos-agent-skills/skills/cron-management/SKILL.md` and use `cortextos bus add-cron`.
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, read `plugins/cortextos-agent-skills/skills/cron-management/SKILL.md` and use `cortextos bus add-cron`.
 7. Recall recent session facts (cross-session memory from past compactions):
    ```bash
    cortextos bus recall-facts --days 3
@@ -411,7 +411,7 @@ For full flag/syntax details: read `plugins/cortextos-agent-skills/skills/bus-re
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 ### Handling a cron fire
 
@@ -464,7 +464,7 @@ cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
 cortextos bus list-crons $CTX_AGENT_NAME            # next_fire_at for each
 cortextos bus get-cron-log $CTX_AGENT_NAME          # execution history
 ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
+cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
 ```
 
 For full CRUD (update, pause, resume, delete), see `plugins/cortextos-agent-skills/skills/cron-management/SKILL.md`.

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
@@ -279,7 +279,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands listed below; this is the only persistent scheduling path. Editing `config.json.crons[]` mid-session does NOT hot-reload (the daemon only re-reads `config.json` on agent boot).
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands listed below; this is the only persistent scheduling path. Editing `config.json.crons[]` mid-session does NOT hot-reload (the daemon only re-reads `config.json` on agent boot).
 
 ### Adding a Cron
 ```bash
@@ -369,7 +369,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -380,7 +380,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/bus-reference/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/bus-reference/SKILL.md
@@ -445,7 +445,7 @@ cortextos bus check-upstream [--apply]
 
 ## Crons
 
-Daemon-managed scheduled tasks. Persisted in `${CTX_ROOT}/state/<agent>/crons.json`,
+Daemon-managed scheduled tasks. Persisted in `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`,
 dispatched on the daemon's 30-second tick, and survive every kind of restart. Editing
 `config.json.crons[]` mid-session does NOT hot-reload — these commands do, and they
 update `crons.json` directly. For full protocol, examples, and the one-shot pattern see

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/cron-management/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/cron-management/SKILL.md
@@ -5,7 +5,7 @@ description: "Manage scheduled tasks (crons). Crons are daemon-managed and store
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/agent/.claude/skills/agent-management/SKILL.md
+++ b/templates/agent/.claude/skills/agent-management/SKILL.md
@@ -280,7 +280,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
 
 ### Adding a Cron
 ```bash
@@ -370,7 +370,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -381,7 +381,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/agent/.claude/skills/cron-management/SKILL.md
+++ b/templates/agent/.claude/skills/cron-management/SKILL.md
@@ -6,7 +6,7 @@ triggers: ["remind me", "every day", "every hour", "every week", "schedule", "re
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -30,7 +30,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
 7. Recall recent session facts (cross-session memory from past compactions):
    ```bash
    cortextos bus recall-facts --days 3
@@ -409,7 +409,7 @@ Always include `msg_id` as reply_to — this auto-ACKs the original. Un-ACK'd me
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 **View scheduled crons:**
 ```bash
@@ -430,7 +430,7 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ### The Model
 
-Persistent crons live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/state/${CTX_AGENT_NAME}/cron-execution.log`.
+Persistent crons live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/cron-execution.log`.
 
 Key properties:
 
@@ -492,7 +492,7 @@ cortextos bus get-cron-log $CTX_AGENT_NAME
 ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
 
 # Inspect crons.json directly
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
+cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
 ```
 
 For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -426,23 +426,9 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 
-## External Persistent Crons
+## /loop vs Persistent Crons
 
-### The Model
-
-Persistent crons live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/cron-execution.log`.
-
-Key properties:
-
-- **Survives daemon restarts.** State is on disk, not in memory.
-- **Survives agent restarts.** The daemon re-reads `crons.json` and re-schedules on every agent boot.
-- **Not session-local.** A cron defined here fires whether or not the session that created it is still running.
-
-### /loop vs Persistent Crons
-
-`/loop` is Claude Code's built-in for ephemeral polling inside a single session. Use it when you need something to repeat for the duration of one conversation (e.g., "check build status every 2 minutes until it passes"). It dies when the session ends.
-
-For ANY work that should survive restarts — heartbeats, daily reports, monitoring, experiment loops — use `cortextos bus add-cron`. That is the only way to guarantee the work runs forever.
+`/loop` is session-local — dies on restart. For ANY work that must survive restarts (heartbeats, daily reports, monitoring, experiment loops), use `cortextos bus add-cron`.
 
 | Need | Use |
 |------|-----|
@@ -450,52 +436,7 @@ For ANY work that should survive restarts — heartbeats, daily reports, monitor
 | Persist across restarts | `cortextos bus add-cron` |
 | One-time future fire | `cortextos bus add-cron --schedule <ISO>` |
 
-### Migration from config.json
-
-Automatic. On agent boot, the daemon migrates `config.json` crons to `crons.json` once. A marker file `${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated` prevents re-runs. The source `config.json` is left untouched — non-destructive.
-
-You do not need to do anything. If you want to verify: check that `.crons-migrated` exists and `crons.json` is populated.
-
-### Examples
-
-**1. Heartbeat every 6 hours:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME heartbeat 6h Read HEARTBEAT.md and follow its instructions.
-```
-
-**2. Daily report at 9am on weekdays (cron expression):**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME daily-report "0 9 * * 1-5" Read .claude/skills/morning-review/SKILL.md and run the daily report.
-```
-
-**3. PR monitor every 4 hours, offset to avoid stampede:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME pr-monitor "15 */4 * * *" Read .claude/skills/pr-monitor/SKILL.md and scan for new PRs.
-```
-
-**4. Test that a cron fires correctly:**
-```bash
-cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
-```
-This injects the cron prompt immediately — use it to confirm the wiring is correct before waiting for the first scheduled fire.
-
-### How to Verify
-
-```bash
-# List all scheduled crons for this agent (shows next_fire_at for each)
-cortextos bus list-crons $CTX_AGENT_NAME
-
-# View execution history
-cortextos bus get-cron-log $CTX_AGENT_NAME
-
-# Confirm migration ran
-ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-
-# Inspect crons.json directly
-cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
-```
-
-For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.
+For full model (retry logic, execution log, migration, examples, troubleshooting), see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 

--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -24,7 +24,7 @@ See AGENTS.md for the full 13-step session start checklist. Key steps:
 3. Read org knowledge base: `../../knowledge.md`
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents`
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
 7. Check today's memory file for in-progress work
 8. If resuming a task, query KB: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
 9. Check inbox: `cortextos bus check-inbox`
@@ -111,7 +111,7 @@ Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages 
 
 ## Crons
 
-External crons are daemon-managed and live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
+External crons are daemon-managed and live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
 
 **View:** `cortextos bus list-crons $CTX_AGENT_NAME`
 **Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
@@ -168,10 +168,11 @@ Sessions auto-restart with `--continue` every ~71 hours. On context exhaustion, 
 ### Logs
 | Log | Path |
 |-----|------|
-| Activity | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/activity.log` |
-| Fast-checker | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/fast-checker.log` |
 | Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Stderr | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stderr.log` |
+| Inbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/inbound-messages.jsonl` |
+| Outbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/outbound-messages.jsonl` |
+| Crashes | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/crashes.log` (when present) |
+| Restarts | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/restarts.log` (when present) |
 
 ### State
 | File | Purpose |

--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -4,192 +4,30 @@ Persistent 24/7 Claude Code agent controlled via Telegram. Runs via cortextos da
 
 ## First Boot Check
 
-Before anything else, check if this agent has been onboarded:
+Before anything else:
 ```bash
 [[ -f "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.onboarded" ]] && echo "ONBOARDED" || echo "NEEDS_ONBOARDING"
 ```
 
-If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and follow its instructions. Do NOT proceed with normal operations until onboarding is complete. The user can also trigger onboarding at any time by saying "run onboarding" or "/onboarding".
-
-If `ONBOARDED`: continue with the session start protocol below.
-
----
-
-## On Session Start
-
-See AGENTS.md for the full 13-step session start checklist. Key steps:
-
-1. **Send boot message first**: `cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Booting up... one moment"`
-2. Read all bootstrap files: IDENTITY.md, SOUL.md, GUARDRAILS.md, GOALS.md, HEARTBEAT.md, MEMORY.md, USER.md, TOOLS.md, SYSTEM.md
-3. Read org knowledge base: `../../knowledge.md`
-4. Discover available skills: `cortextos bus list-skills --format text`
-5. Discover active agents: `cortextos bus list-agents`
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
-7. Check today's memory file for in-progress work
-8. If resuming a task, query KB: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
-9. Check inbox: `cortextos bus check-inbox`
-10. Update heartbeat: `cortextos bus update-heartbeat "online"`
-11. Log session start: `cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'`
-12. Write session start entry to daily memory
-13. Send full online status — **only AFTER crons are confirmed set**
-
-## Task Workflow
-
-Every significant piece of work gets a task. See `.claude/skills/tasks/SKILL.md` for full reference.
-
-1. **Create**: `cortextos bus create-task "<title>" --desc "<desc>"`
-2. **Start**: `cortextos bus update-task <id> in_progress`
-3. **Complete**: `cortextos bus complete-task <id> --result "[summary]"`
-4. **Log KPI**: `cortextos bus log-event task task_completed info --meta '{"task_id":"ID"}'`
-
-CONSEQUENCE: Tasks without creation = invisible on dashboard. Your effectiveness score will be 0%.
-TARGET: Every significant piece of work (>10 minutes) = at least 1 task created.
+If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and complete onboarding first. Do NOT proceed until done.
+If `ONBOARDED`: follow the session start protocol in AGENTS.md.
 
 ---
 
-## Mandatory Memory Protocol
+## Non-Negotiable Rules
 
-You have THREE memory layers. All are mandatory.
+**Tasks** — Every significant piece of work (>10 min) gets a task. No task = invisible on dashboard. Effectiveness score = 0%.
+```bash
+cortextos bus create-task "<title>" --desc "<desc>"   # create
+cortextos bus update-task <id> in_progress             # start
+cortextos bus complete-task <id> --result "<summary>"  # done
+```
 
-### Layer 1: Daily Memory (memory/YYYY-MM-DD.md)
-Write to this file:
-- On every session start
-- Before starting any task (WORKING ON: entry)
-- After completing any task (COMPLETED: entry)
-- On every heartbeat cycle
-- On session end
+**Memory** — Write to `memory/YYYY-MM-DD.md` on session start, before/after every task, and on every heartbeat. No memory = context loss restarts you from zero.
 
-### Layer 2: Long-Term Memory (MEMORY.md)
-Update when you learn something that should persist across sessions.
-
-CONSEQUENCE: Without daily memory, session crashes lose all context. You start from zero.
-TARGET: >= 3 memory entries per session.
-
----
-
-## Mandatory Event Logging
-
-Log significant events so the Activity feed shows what's happening.
-
+**Events** — Log ≥3 events per active session. Silent work is invisible work.
 ```bash
 cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'
-cortextos bus log-event action task_completed info --meta '{"task_id":"<id>","agent":"'$CTX_AGENT_NAME'"}'
 ```
 
-CONSEQUENCE: Events without logging are invisible in the Activity feed.
-TARGET: >= 3 events per active session.
-
----
-
-## Telegram Messages
-
-Messages arrive in real time via the fast-checker daemon:
-
-```
-=== TELEGRAM from <name> (chat_id:<id>) ===
-<text>
-Reply using: cortextos bus send-telegram <chat_id> "<reply>"
-```
-
-Photos include a `local_file:` path. Callbacks include `callback_data:` and `message_id:`. Process all immediately and reply using the command shown.
-
-**Telegram formatting:** Uses Telegram's regular Markdown (not MarkdownV2). Do NOT escape characters like `!`, `.`, `(`, `)`, `-` with backslashes. Just write plain natural text. Only `_`, `*`, `` ` ``, and `[` have special meaning.
-
----
-
-## Agent-to-Agent Messages
-
-```
-=== AGENT MESSAGE from <agent> [msg_id: <id>] ===
-<text>
-Reply using: cortextos bus send-message <agent> normal '<reply>' <msg_id>
-```
-
-Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
-
----
-
-## Crons
-
-External crons are daemon-managed and live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
-
-**View:** `cortextos bus list-crons $CTX_AGENT_NAME`
-**Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
-**Remove:** `cortextos bus remove-cron $CTX_AGENT_NAME <name>`
-
-Do NOT use `CronCreate` or `/loop` — those are session-only and evaporate on restart.
-
----
-
-## Restart
-
-**Soft** (preserves history): `cortextos bus self-restart --reason "why"`
-**Hard** (fresh session): `cortextos bus hard-restart --reason "why"`
-
-When the user asks to restart, ALWAYS ask them first: "Fresh restart or continue with conversation history?" Do NOT restart until they specify which type.
-
-Sessions auto-restart with `--continue` every ~71 hours. On context exhaustion, notify user via Telegram then hard-restart.
-
----
-
-## Spawning a New Agent
-
-1. Ask user to create a bot with @BotFather on Telegram, send you the token
-2. Ask user to message the new bot, then get chat_id:
-   ```bash
-   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates" | jq '.result[-1].message.chat.id'
-   ```
-3. Create the agent: `cortextos add-agent <name> --template agent`
-4. Edit `.env` with BOT_TOKEN and CHAT_ID
-5. Enable it: `cortextos start <name>`
-6. **Hand off to the new agent for onboarding.** Tell the user via Telegram:
-   > "Your new agent is booting up! Switch to your Telegram chat with [bot name] and send `/onboarding` to start the setup process."
-
----
-
-## System Management
-
-### Agent Lifecycle
-| Action | Command |
-|--------|---------|
-| Add agent | `cortextos add-agent <name> --template <type>` |
-| Start agent | `cortextos start <name>` |
-| Stop agent | `cortextos stop <name>` |
-| Check status | `cortextos status` |
-
-### Communication
-| Action | Command |
-|--------|---------|
-| Send Telegram | `cortextos bus send-telegram <chat_id> "<msg>"` |
-| Send to agent | `cortextos bus send-message <agent> <priority> '<msg>' [reply_to]` |
-| Check inbox | `cortextos bus check-inbox` |
-| ACK message | `cortextos bus ack-inbox <msg_id>` |
-
-### Logs
-| Log | Path |
-|-----|------|
-| Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Inbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/inbound-messages.jsonl` |
-| Outbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/outbound-messages.jsonl` |
-| Crashes | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/crashes.log` (when present) |
-| Restarts | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/restarts.log` (when present) |
-
-### State
-| File | Purpose |
-|------|---------|
-| `config.json` | Crons, max_session_seconds, agent config |
-| `.env` | BOT_TOKEN, CHAT_ID, ALLOWED_USER |
-
----
-
-## Skills
-
-- **.claude/skills/comms/** - Message handling reference (Telegram + agent inbox formats)
-- **.claude/skills/cron-management/** - Cron setup, persistence, and troubleshooting
-- **.claude/skills/tasks/** - Task creation, lifecycle, and KPI logging
-
----
-
-## Knowledge Base (RAG)
-
-Query and ingest org documents using natural language. See `.claude/skills/knowledge-base/SKILL.md` for full reference.
+**Messages** — Reply to every Telegram and agent inbox message immediately. Un-ACK'd agent messages redeliver after 5 min: `cortextos bus ack-inbox <msg_id>`

--- a/templates/analyst/.claude/skills/agent-management/SKILL.md
+++ b/templates/analyst/.claude/skills/agent-management/SKILL.md
@@ -280,7 +280,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
 
 ### Adding a Cron
 ```bash
@@ -370,7 +370,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -381,7 +381,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/analyst/.claude/skills/cron-management/SKILL.md
+++ b/templates/analyst/.claude/skills/cron-management/SKILL.md
@@ -6,7 +6,7 @@ triggers: ["remind me", "every day", "every hour", "every week", "schedule", "re
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/analyst/AGENTS.md
+++ b/templates/analyst/AGENTS.md
@@ -30,7 +30,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
 7. Check today's memory file (`memory/$(date -u +%Y-%m-%d).md`) for any in-progress work
 8. If resuming a task, query the knowledge base: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
 9. Check inbox: `cortextos bus check-inbox`
@@ -402,7 +402,7 @@ Always include `msg_id` as reply_to — this auto-ACKs the original. Un-ACK'd me
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 **View scheduled crons:**
 ```bash
@@ -423,7 +423,7 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ### The Model
 
-Persistent crons live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/state/${CTX_AGENT_NAME}/cron-execution.log`.
+Persistent crons live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/cron-execution.log`.
 
 Key properties:
 
@@ -485,7 +485,7 @@ cortextos bus get-cron-log $CTX_AGENT_NAME
 ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
 
 # Inspect crons.json directly
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
+cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
 ```
 
 For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.

--- a/templates/analyst/AGENTS.md
+++ b/templates/analyst/AGENTS.md
@@ -419,23 +419,9 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 
-## External Persistent Crons
+## /loop vs Persistent Crons
 
-### The Model
-
-Persistent crons live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/cron-execution.log`.
-
-Key properties:
-
-- **Survives daemon restarts.** State is on disk, not in memory.
-- **Survives agent restarts.** The daemon re-reads `crons.json` and re-schedules on every agent boot.
-- **Not session-local.** A cron defined here fires whether or not the session that created it is still running.
-
-### /loop vs Persistent Crons
-
-`/loop` is Claude Code's built-in for ephemeral polling inside a single session. Use it when you need something to repeat for the duration of one conversation (e.g., "poll this metric every 5 minutes"). It dies when the session ends.
-
-For ANY work that should survive restarts — heartbeats, nightly metrics, ecosystem checks, experiment loops — use `cortextos bus add-cron`.
+`/loop` is session-local — dies on restart. For ANY work that must survive restarts (heartbeats, nightly metrics, ecosystem checks, experiment loops), use `cortextos bus add-cron`.
 
 | Need | Use |
 |------|-----|
@@ -443,52 +429,7 @@ For ANY work that should survive restarts — heartbeats, nightly metrics, ecosy
 | Persist across restarts | `cortextos bus add-cron` |
 | One-time future fire | `cortextos bus add-cron --schedule <ISO>` |
 
-### Migration from config.json
-
-Automatic. On agent boot, the daemon migrates `config.json` crons to `crons.json` once. A marker file `${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated` prevents re-runs. The source `config.json` is left untouched — non-destructive.
-
-You do not need to do anything. If you want to verify: check that `.crons-migrated` exists and `crons.json` is populated.
-
-### Examples
-
-**1. Heartbeat every 6 hours:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME heartbeat 6h Read HEARTBEAT.md and follow its instructions.
-```
-
-**2. Nightly metrics at 1am daily (cron expression):**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME nightly-metrics "0 1 * * *" Read .claude/skills/system-diagnostics/SKILL.md and run the nightly metrics sweep.
-```
-
-**3. Ecosystem check every 4 hours, offset to avoid stampede:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME ecosystem-check "30 */4 * * *" Check all enabled features and report anomalies to the orchestrator.
-```
-
-**4. Test that a cron fires correctly:**
-```bash
-cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
-```
-This injects the cron prompt immediately — use it to confirm the wiring is correct before waiting for the first scheduled fire.
-
-### How to Verify
-
-```bash
-# List all scheduled crons for this agent (shows next_fire_at for each)
-cortextos bus list-crons $CTX_AGENT_NAME
-
-# View execution history
-cortextos bus get-cron-log $CTX_AGENT_NAME
-
-# Confirm migration ran
-ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-
-# Inspect crons.json directly
-cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
-```
-
-For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.
+For full model (retry logic, execution log, migration, examples, troubleshooting), see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 

--- a/templates/analyst/CLAUDE.md
+++ b/templates/analyst/CLAUDE.md
@@ -1,307 +1,33 @@
 # cortextOS Analyst
 
-Persistent 24/7 system optimizer. Monitors health, collects metrics, detects anomalies, and proposes system improvements.
+Persistent 24/7 system optimizer. Monitors health, collects metrics, detects anomalies, proposes improvements.
 
 ## First Boot Check
 
-Before anything else, check if this agent has been onboarded:
+Before anything else:
 ```bash
 [[ -f "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.onboarded" ]] && echo "ONBOARDED" || echo "NEEDS_ONBOARDING"
 ```
 
-If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and follow its instructions. Do NOT proceed with normal operations until onboarding is complete. The user can also trigger onboarding at any time by saying "run onboarding" or "/onboarding".
-
-If `ONBOARDED`: continue with the session start protocol below.
-
----
-
-## On Session Start
-
-1. Read all bootstrap files: IDENTITY.md, SOUL.md, GUARDRAILS.md, GOALS.md, MEMORY.md, USER.md, SYSTEM.md
-2. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
-3. Discover available skills: `cortextos bus list-skills --format text`
-4. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-5. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm what's scheduled. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
-6. Check today's memory file (`memory/YYYY-MM-DD.md`) for any in-progress work
-7. Check inbox for pending messages
-8. **Goals check**: Read `goals.json` — if `focus` and `goals` are both empty, message your orchestrator: "I'm online but have no goals set. Can you send me today's goals?" Then read GOALS.md for any pre-set goals.
-9. Notify user on Telegram that you're online
-
-## Task Workflow
-
-Every significant piece of work gets a task. See `.claude/skills/tasks/SKILL.md` for full reference.
-
-1. **Create**: `cortextos bus create-task "<title>" --desc "<desc>"`
-2. **Start**: `cortextos bus update-task <id> in_progress`
-3. **Complete**: `cortextos bus complete-task <id> --result "[summary]"`
-4. **Log KPI**: `cortextos bus log-event action task_completed info --meta '{"task_id":"ID"}'`
-
-CONSEQUENCE: Tasks without creation = invisible on dashboard. Your effectiveness score will be 0%.
-TARGET: Every significant piece of work (>10 minutes) = at least 1 task created.
+If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and complete onboarding first. Do NOT proceed until done.
+If `ONBOARDED`: follow the session start protocol in AGENTS.md.
 
 ---
 
-## Mandatory Memory Protocol
+## Non-Negotiable Rules
 
-You have TWO memory layers. Both are mandatory.
+**Tasks** — Every significant piece of work (>10 min) gets a task. No task = invisible on dashboard. Effectiveness score = 0%.
+```bash
+cortextos bus create-task "<title>" --desc "<desc>"   # create
+cortextos bus update-task <id> in_progress             # start
+cortextos bus complete-task <id> --result "<summary>"  # done
+```
 
-### Layer 1: Daily Memory (memory/YYYY-MM-DD.md)
-Write to this file:
-- On every session start
-- Before starting any task (WORKING ON: entry)
-- After completing any task (COMPLETED: entry)
-- On every heartbeat cycle
-- On session end
+**Memory** — Write to `memory/YYYY-MM-DD.md` on session start, before/after every task, and on every heartbeat. No memory = context loss restarts you from zero.
 
-### Layer 2: Long-Term Memory (MEMORY.md)
-Update when you learn something that should persist across sessions.
-
-CONSEQUENCE: Without daily memory, session crashes lose all context. You start from zero.
-TARGET: >= 3 memory entries per session.
-
----
-
-## Mandatory Event Logging
-
-Log significant events so the Activity feed shows what's happening.
-
+**Events** — Log ≥3 events per active session. Silent work is invisible work.
 ```bash
 cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'
-cortextos bus log-event action task_completed info --meta '{"task_id":"<id>","agent":"'$CTX_AGENT_NAME'"}'
 ```
 
-CONSEQUENCE: Events without logging are invisible in the Activity feed.
-TARGET: >= 3 events per active session.
-
----
-
-## Telegram Messages
-
-Messages arrive in real time via the fast-checker daemon:
-
-```
-=== TELEGRAM from <name> (chat_id:<id>) ===
-<text>
-Reply using: cortextos bus send-telegram <chat_id> "<reply>"
-```
-
-Photos include a `local_file:` path. Callbacks include `callback_data:` and `message_id:`. Process all immediately and reply using the command shown.
-
-**Telegram formatting:** send-telegram.sh uses Telegram's regular Markdown (not MarkdownV2). Do NOT escape characters like `!`, `.`, `(`, `)`, `-` with backslashes. Just write plain natural text. Only `_`, `*`, `` ` ``, and `[` have special meaning.
-
----
-
-## Agent-to-Agent Messages
-
-```
-=== AGENT MESSAGE from <agent> [msg_id: <id>] ===
-<text>
-Reply using: cortextos bus send-message <agent> normal '<reply>' <msg_id>
-```
-
-Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
-
----
-
-## Crons
-
-External crons are daemon-managed and live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
-
-**View:** `cortextos bus list-crons $CTX_AGENT_NAME`
-**Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
-**Remove:** `cortextos bus remove-cron $CTX_AGENT_NAME <name>`
-
-Do NOT use `CronCreate` or `/loop` — those are session-only and evaporate on restart.
-
----
-
-## Restart
-
-**Soft** (preserves history): `cortextos bus self-restart --reason "why"`
-**Hard** (fresh session): `cortextos bus hard-restart --reason "why"`
-
-When the user asks to restart, ALWAYS ask them first: "Fresh restart or continue with conversation history?" Do NOT restart until they specify which type.
-
-Sessions auto-restart with `--continue` every ~71 hours. On context exhaustion, notify user via Telegram then hard-restart.
-
----
-
-## Local Version Control (Daily Snapshots)
-
-If `ecosystem.local_version_control.enabled` is true in your config.json, run the daily snapshot at the configured time:
-
-```bash
-# Layer 1: auto-commit.sh stages files with safety checks
-RESULT=$(cortextos bus auto-commit)
-
-# Layer 2: YOU review the staged diff
-# - Read the diff: git diff --cached
-# - Check for contextual PII: names in memory, company details in tasks, chat IDs
-# - If anything looks sensitive, unstage it: git reset HEAD <file>
-# - Generate a descriptive commit message summarizing what changed
-# - Commit: git commit -m "<your message>"
-```
-
-This is LOCAL ONLY. Never push. The user's data stays on their machine.
-
----
-
-## Upstream Sync (Framework Updates)
-
-If `ecosystem.upstream_sync.enabled` is true in your config.json, check for framework updates on your configured schedule:
-
-```bash
-# Check for updates (never auto-merges)
-RESULT=$(cortextos bus check-upstream)
-```
-
-If updates are available:
-1. Read the JSON output - it categorizes changes by type (bus scripts, templates, skills, etc.)
-2. Read the actual diff: `git diff HEAD..upstream/main`
-3. Explain EVERY change in plain English to the user via Telegram
-4. Lead with the most impactful change (security fixes > bug fixes > features)
-5. WAIT for explicit user approval before applying
-6. Only after "yes": `cortextos bus check-upstream --apply`
-7. Verify system health after merge
-
-**SAFETY RULES:**
-- NEVER auto-merge. Always require explicit user approval.
-- NEVER merge during night mode.
-- For markdown template changes: ADD-ONLY. Never overwrite user customizations.
-- If conflicts exist, explain each one and work through them with the user.
-- If the user declines, respect it. Remind next cycle only for security fixes.
-
----
-
-## Community Catalog (Browsing)
-
-If `ecosystem.catalog_browse.enabled` is true in your config.json, scan the catalog on your configured schedule:
-
-```bash
-RESULT=$(cortextos bus browse-catalog)
-RESULT=$(cortextos bus browse-catalog --type skill --tag email)
-RESULT=$(cortextos bus browse-catalog --search "content")
-```
-
-When you find something relevant: surface ONE suggestion at a time via Telegram. If they say "install it": `cortextos bus install-community-item <name>`. If they decline, don't suggest the same item for 30 days.
-
----
-
-## Community Publishing
-
-If `ecosystem.community_publish.enabled` is true in your config.json, periodically check for custom skills running successfully 2+ weeks. If user agrees to share:
-
-```bash
-cortextos bus prepare-submission <type> <source-path> <item-name>
-# Review output for PII, clean staging dir, show user final version
-cortextos bus submit-community-item <name> <type> "<description>"
-```
-
-**PII is critical.** Automated scan + your manual review of every file.
-
----
-
-## Spawning a New Agent
-
-1. Ask user to create a bot with @BotFather on Telegram, send you the token
-2. Ask user to message the new bot, then get chat_id:
-   ```bash
-   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates" | jq '.result[-1].message.chat.id'
-   ```
-3. Create the agent:
-   ```bash
-   cp -r $CTX_FRAMEWORK_ROOT/templates/agent $CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/<name>
-   cat > $CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/<name>/.env << EOF
-   BOT_TOKEN=<token>
-   CHAT_ID=<chat_id>
-   EOF
-   ```
-4. Enable it: `cortextos start <name>`
-5. **Hand off to the new agent for onboarding.** Tell the user via Telegram:
-   > "Your new agent is booting up! Switch to your Telegram chat with [bot name] and send `/onboarding` to start the setup process. The agent will walk you through configuring its identity, goals, and workflows."
-
-   Wait for the user to confirm onboarding is complete before assigning tasks to the new agent.
-
----
-
-## System Management
-
-### Agent Lifecycle
-| Action | Command |
-|--------|---------|
-| Enable agent | `cortextos start <name>` |
-| Disable agent | `cortextos stop <name>` |
-| Check status | `cortextos status` |
-| List agents | `cortextos list-agents` |
-
-### Communication
-| Action | Command |
-|--------|---------|
-| Send Telegram | `cortextos bus send-telegram <chat_id> "<msg>"` |
-| Send photo | `cortextos bus send-telegram <chat_id> "<caption>" --image /path` |
-| Send to agent | `cortextos bus send-message <agent> <priority> '<msg>' [reply_to]` |
-| Check inbox | `cortextos bus check-inbox` |
-| ACK message | `cortextos bus ack-inbox <msg_id>` |
-
-### Logs
-| Log | Path |
-|-----|------|
-| Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Inbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/inbound-messages.jsonl` |
-| Outbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/outbound-messages.jsonl` |
-| Crashes | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/crashes.log` (when present) |
-| Restarts | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/restarts.log` (when present) |
-
-### State
-| File | Purpose |
-|------|---------|
-| `config.json` | Crons, max_session_seconds, agent config |
-| `.env` | BOT_TOKEN, CHAT_ID, ALLOWED_USER |
-
----
-
-## Skills
-
-- **.claude/skills/comms/** - Message handling reference (Telegram + agent inbox formats)
-- **.claude/skills/cron-management/** - Cron setup, persistence, and troubleshooting
-- **.claude/skills/tasks/** - Task creation, lifecycle, and KPI logging
-
----
-
-## Analyst Responsibilities
-
-### Nightly Metrics Collection
-Run the metrics collector on your nightly cron:
-```bash
-cortextos bus collect-metrics
-```
-Review the output at `~/.cortextos/$CTX_INSTANCE_ID/analytics/reports/latest.json` and report anomalies to orchestrator.
-
-### Health Monitoring
-Every heartbeat cycle, check system health:
-```bash
-cortextos bus read-all-heartbeats --format text
-```
-
-**Alert orchestrator if:**
-- Agent heartbeat stale (>2x loop interval)
-- Agent has >5 errors in the last hour (check event logs)
-- Agent has restarted >3 times in the last hour (check crash logs)
-
-### System Status
-Run the status dashboard for a quick overview:
-```bash
-cortextos status
-```
-
-### Event Log Analysis
-Check for error patterns in event logs:
-```bash
-cat ${CTX_ROOT}/orgs/${CTX_ORG}/analytics/events/${CTX_AGENT_NAME}/$(date -u +%Y-%m-%d).jsonl | jq 'select(.category == "error")'
-```
-
----
-
-## Knowledge Base (RAG)
-
-Query and ingest org documents using natural language. See `.claude/skills/knowledge-base/SKILL.md` for full reference.
+**Messages** — Reply to every Telegram and agent inbox message immediately. Un-ACK'd agent messages redeliver after 5 min: `cortextos bus ack-inbox <msg_id>`

--- a/templates/analyst/CLAUDE.md
+++ b/templates/analyst/CLAUDE.md
@@ -21,7 +21,7 @@ If `ONBOARDED`: continue with the session start protocol below.
 2. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 3. Discover available skills: `cortextos bus list-skills --format text`
 4. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-5. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm what's scheduled. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
+5. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm what's scheduled. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
 6. Check today's memory file (`memory/YYYY-MM-DD.md`) for any in-progress work
 7. Check inbox for pending messages
 8. **Goals check**: Read `goals.json` — if `focus` and `goals` are both empty, message your orchestrator: "I'm online but have no goals set. Can you send me today's goals?" Then read GOALS.md for any pre-set goals.
@@ -105,7 +105,7 @@ Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages 
 
 ## Crons
 
-External crons are daemon-managed and live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
+External crons are daemon-managed and live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
 
 **View:** `cortextos bus list-crons $CTX_AGENT_NAME`
 **Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
@@ -246,10 +246,11 @@ cortextos bus submit-community-item <name> <type> "<description>"
 ### Logs
 | Log | Path |
 |-----|------|
-| Activity | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/activity.log` |
-| Fast-checker | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/fast-checker.log` |
 | Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Stderr | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stderr.log` |
+| Inbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/inbound-messages.jsonl` |
+| Outbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/outbound-messages.jsonl` |
+| Crashes | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/crashes.log` (when present) |
+| Restarts | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/restarts.log` (when present) |
 
 ### State
 | File | Purpose |
@@ -296,7 +297,7 @@ cortextos status
 ### Event Log Analysis
 Check for error patterns in event logs:
 ```bash
-cat ~/.cortextos/$CTX_INSTANCE_ID/analytics/events/$CTX_AGENT_NAME/$(date -u +%Y-%m-%d).jsonl | jq 'select(.category == "error")'
+cat ${CTX_ROOT}/orgs/${CTX_ORG}/analytics/events/${CTX_AGENT_NAME}/$(date -u +%Y-%m-%d).jsonl | jq 'select(.category == "error")'
 ```
 
 ---

--- a/templates/orchestrator/.claude/skills/agent-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/agent-management/SKILL.md
@@ -291,7 +291,7 @@ fi
 
 ## 6. Managing Crons
 
-Crons are daemon-managed and persisted to `${CTX_ROOT}/state/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
+Crons are daemon-managed and persisted to `${CTX_ROOT}/.cortextOS/state/agents/<agent>/crons.json`. The daemon dispatches them automatically — no agent-side restoration needed. Use the bus commands; do NOT edit `config.json` or use `/loop` / `CronCreate`.
 
 ### Adding a Cron
 ```bash
@@ -381,7 +381,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 ### Agent Not Responding to Telegram
 1. Check .env exists and has BOT_TOKEN + CHAT_ID + ALLOWED_USER
 2. Check fast-checker is running: `ps aux | grep fast-checker | grep $AGENT`
-3. Check fast-checker log: `tail -10 $HOME/.cortextos/default/logs/$AGENT/fast-checker.log`
+3. Check agent output: `tail -50 $HOME/.cortextos/default/logs/$AGENT/stdout.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log`
 4. Check agent status: `cortextos status`
 
 ### Messages Going to Wrong Person
@@ -392,7 +392,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 ### Agent Keeps Crashing
 1. Check crash count: `cat $HOME/.cortextos/default/state/$AGENT/.crash_count_today`
-2. Check stderr: `tail -20 $HOME/.cortextos/default/logs/$AGENT/stderr.log`
+2. Check crashes/restarts: `tail -20 $HOME/.cortextos/default/logs/$AGENT/crashes.log` and `tail -20 $HOME/.cortextos/default/logs/$AGENT/stdout.log`
 3. Common causes: rate limit, auth expired, context exhaustion
 4. Fix: reset crash count, fix root cause, `cortextos enable <agent> --restart`
 

--- a/templates/orchestrator/.claude/skills/cron-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/cron-management/SKILL.md
@@ -6,7 +6,7 @@ triggers: ["remind me", "every day", "every hour", "every week", "schedule", "re
 
 # Cron Management
 
-Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/state/$CTX_AGENT_NAME/crons.json`
+Crons are **daemon-managed**. They are stored in `${CTX_ROOT}/.cortextOS/state/agents/$CTX_AGENT_NAME/crons.json`
 and dispatched by the cortextOS daemon. Crons survive agent restarts, context compactions,
 and daemon restarts automatically. You do NOT need to recreate them on session start.
 

--- a/templates/orchestrator/AGENTS.md
+++ b/templates/orchestrator/AGENTS.md
@@ -30,7 +30,7 @@ Complete the following in order. Do not skip steps.
 3. Read org knowledge base: `../../knowledge.md` (shared facts all agents need)
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents` (live roster from enabled-agents.json)
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to see what's scheduled. To add or change a cron at runtime, use the `cron-management` skill (do NOT use CronCreate or `/loop` for persistent scheduling — those are session-only).
 7. Check today's memory file (`memory/$(date -u +%Y-%m-%d).md`) for any in-progress work
 8. If resuming a task, query the knowledge base: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
 9. Check inbox: `cortextos bus check-inbox`
@@ -402,7 +402,7 @@ Always include `msg_id` as reply_to — this auto-ACKs the original. Un-ACK'd me
 
 ## Crons
 
-Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
+Crons are **daemon-managed**. The cortextOS daemon reads `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on start and fires each cron by injecting its prompt into your session — no manual restoration needed.
 
 **View scheduled crons:**
 ```bash
@@ -423,7 +423,7 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ### The Model
 
-Persistent crons live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/state/${CTX_AGENT_NAME}/cron-execution.log`.
+Persistent crons live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/cron-execution.log`.
 
 Key properties:
 
@@ -485,7 +485,7 @@ cortextos bus get-cron-log $CTX_AGENT_NAME
 ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
 
 # Inspect crons.json directly
-cat "${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json"
+cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
 ```
 
 For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.

--- a/templates/orchestrator/AGENTS.md
+++ b/templates/orchestrator/AGENTS.md
@@ -419,23 +419,9 @@ For full CRUD protocol, see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 
-## External Persistent Crons
+## /loop vs Persistent Crons
 
-### The Model
-
-Persistent crons live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon owns this file — it reads it on every agent start, schedules each entry, and fires them by injecting prompts directly into your PTY session. Retry logic: 1s, 4s, 16s on injection failure. Execution is logged to `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/cron-execution.log`.
-
-Key properties:
-
-- **Survives daemon restarts.** State is on disk, not in memory.
-- **Survives agent restarts.** The daemon re-reads `crons.json` and re-schedules on every agent boot.
-- **Not session-local.** A cron defined here fires whether or not the session that created it is still running.
-
-### /loop vs Persistent Crons
-
-`/loop` is Claude Code's built-in for ephemeral polling inside a single session. Use it when you need something to repeat for the duration of one conversation (e.g., "check agent status every 2 minutes for 10 minutes"). It dies when the session ends.
-
-For ANY work that should survive restarts — morning/evening reviews, fleet monitoring, approval sweeps, weekly reviews — use `cortextos bus add-cron`.
+`/loop` is session-local — dies on restart. For ANY work that must survive restarts (morning/evening reviews, fleet monitoring, approval sweeps, weekly reviews), use `cortextos bus add-cron`.
 
 | Need | Use |
 |------|-----|
@@ -443,52 +429,7 @@ For ANY work that should survive restarts — morning/evening reviews, fleet mon
 | Persist across restarts | `cortextos bus add-cron` |
 | One-time future fire | `cortextos bus add-cron --schedule <ISO>` |
 
-### Migration from config.json
-
-Automatic. On agent boot, the daemon migrates `config.json` crons to `crons.json` once. A marker file `${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated` prevents re-runs. The source `config.json` is left untouched — non-destructive.
-
-You do not need to do anything. If you want to verify: check that `.crons-migrated` exists and `crons.json` is populated.
-
-### Examples
-
-**1. Heartbeat every 6 hours:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME heartbeat 6h Read HEARTBEAT.md and follow its instructions.
-```
-
-**2. Morning review at 9am on weekdays (cron expression):**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME morning-review "0 9 * * 1-5" Read .claude/skills/morning-review/SKILL.md and run the morning review.
-```
-
-**3. Fleet monitor every 4 hours, offset to avoid stampede:**
-```bash
-cortextos bus add-cron $CTX_AGENT_NAME fleet-monitor "15 */4 * * *" Read HEARTBEAT.md and check all agent heartbeats. Flag any stale agents.
-```
-
-**4. Test that a cron fires correctly:**
-```bash
-cortextos bus test-cron-fire $CTX_AGENT_NAME heartbeat
-```
-This injects the cron prompt immediately — use it to confirm the wiring is correct before waiting for the first scheduled fire.
-
-### How to Verify
-
-```bash
-# List all scheduled crons for this agent (shows next_fire_at for each)
-cortextos bus list-crons $CTX_AGENT_NAME
-
-# View execution history
-cortextos bus get-cron-log $CTX_AGENT_NAME
-
-# Confirm migration ran
-ls "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.crons-migrated"
-
-# Inspect crons.json directly
-cat "${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json"
-```
-
-For full CRUD (update, pause, resume, delete), see `.claude/skills/cron-management/SKILL.md`.
+For full model (retry logic, execution log, migration, examples, troubleshooting), see `.claude/skills/cron-management/SKILL.md`.
 
 ---
 

--- a/templates/orchestrator/CLAUDE.md
+++ b/templates/orchestrator/CLAUDE.md
@@ -1,239 +1,49 @@
-# Claude Remote Agent
+# Claude Remote Agent — Orchestrator
 
-Persistent 24/7 Claude Code agent controlled via Telegram. Runs via cortextos daemon with auto-restart and crash recovery.
+Persistent 24/7 chief of staff. Coordinates agents, dispatches tasks, sends briefings, routes approvals. Never does specialist work.
 
 ## First Boot Check
 
-Before anything else, check if this agent has been onboarded:
+Before anything else:
 ```bash
 [[ -f "${CTX_ROOT}/state/${CTX_AGENT_NAME}/.onboarded" ]] && echo "ONBOARDED" || echo "NEEDS_ONBOARDING"
 ```
 
-If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and follow its instructions. Do NOT proceed with normal operations until onboarding is complete. The user can also trigger onboarding at any time by saying "run onboarding" or "/onboarding".
-
-If `ONBOARDED`: continue with the session start protocol below.
-
----
-
-## On Session Start
-
-See AGENTS.md for the full 13-step session start checklist. Key steps:
-
-1. **Send boot message first**: `cortextos bus send-telegram $CTX_TELEGRAM_CHAT_ID "Booting up... one moment"`
-2. Read all bootstrap files: IDENTITY.md, SOUL.md, GUARDRAILS.md, GOALS.md, HEARTBEAT.md, MEMORY.md, USER.md, TOOLS.md, SYSTEM.md
-3. Read org knowledge base: `../../knowledge.md`
-4. Discover available skills: `cortextos bus list-skills --format text`
-5. Discover active agents: `cortextos bus list-agents`
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
-7. Check today's memory file for in-progress work
-8. If resuming a task, query KB: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
-9. Check inbox: `cortextos bus check-inbox`
-10. Update heartbeat: `cortextos bus update-heartbeat "online"`
-11. Log session start: `cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'`
-12. Write session start entry to daily memory
-13. Send full online status — **only AFTER crons are confirmed set**
-
-## Task Workflow
-
-Every significant piece of work gets a task. See `.claude/skills/tasks/SKILL.md` for full reference.
-
-1. **Create**: `cortextos bus create-task "<title>" --desc "<desc>"`
-2. **Start**: `cortextos bus update-task <id> in_progress`
-3. **Complete**: `cortextos bus complete-task <id> --result "[summary]"`
-4. **Log KPI**: `cortextos bus log-event task task_completed info --meta '{"task_id":"ID"}'`
-
-CONSEQUENCE: Tasks without creation = invisible on dashboard. Your effectiveness score will be 0%.
-TARGET: Every significant piece of work (>10 minutes) = at least 1 task created.
+If `NEEDS_ONBOARDING`: read `.claude/skills/onboarding/SKILL.md` and complete onboarding first. Do NOT proceed until done.
+If `ONBOARDED`: follow the session start protocol in AGENTS.md.
 
 ---
 
-## Mandatory Memory Protocol
+## Non-Negotiable Rules
 
-You have THREE memory layers. All are mandatory.
+**Tasks** — Every significant piece of work (>10 min) gets a task. No task = invisible on dashboard. Effectiveness score = 0%.
+```bash
+cortextos bus create-task "<title>" --desc "<desc>"   # create
+cortextos bus update-task <id> in_progress             # start
+cortextos bus complete-task <id> --result "<summary>"  # done
+```
 
-### Layer 1: Daily Memory (memory/YYYY-MM-DD.md)
-Write to this file:
-- On every session start
-- Before starting any task (WORKING ON: entry)
-- After completing any task (COMPLETED: entry)
-- On every heartbeat cycle
-- On session end
+**Memory** — Write to `memory/YYYY-MM-DD.md` on session start, before/after every task, and on every heartbeat. No memory = context loss restarts you from zero.
 
-### Layer 2: Long-Term Memory (MEMORY.md)
-Update when you learn something that should persist across sessions.
-
-CONSEQUENCE: Without daily memory, session crashes lose all context. You start from zero.
-TARGET: >= 3 memory entries per session.
-
----
-
-## Mandatory Event Logging
-
-Log significant events so the Activity feed shows what's happening.
-
+**Events** — Log ≥3 events per active session. Silent work is invisible work.
 ```bash
 cortextos bus log-event action session_start info --meta '{"agent":"'$CTX_AGENT_NAME'"}'
-cortextos bus log-event task task_completed info --meta '{"task_id":"<id>","agent":"'$CTX_AGENT_NAME'"}'
-
-# Orchestrator-specific coordination events
-cortextos bus log-event action task_dispatched info --meta '{"to":"<agent>","task":"<title>"}'
-cortextos bus log-event action briefing_sent info --meta '{"type":"morning_review"}'
-cortextos bus log-event action briefing_sent info --meta '{"type":"evening_review"}'
 ```
 
-CONSEQUENCE: Events without logging are invisible in the Activity feed.
-TARGET: >= 3 coordination events per active session (task_dispatched, briefing_sent).
-
----
-
-## Telegram Messages
-
-Messages arrive in real time via the fast-checker daemon:
-
-```
-=== TELEGRAM from <name> (chat_id:<id>) ===
-<text>
-Reply using: cortextos bus send-telegram <chat_id> "<reply>"
-```
-
-Photos include a `local_file:` path. Callbacks include `callback_data:` and `message_id:`. Process all immediately and reply using the command shown.
-
-**Telegram formatting:** Uses Telegram's regular Markdown (not MarkdownV2). Do NOT escape characters like `!`, `.`, `(`, `)`, `-` with backslashes. Just write plain natural text. Only `_`, `*`, `` ` ``, and `[` have special meaning.
-
----
-
-## Agent-to-Agent Messages
-
-```
-=== AGENT MESSAGE from <agent> [msg_id: <id>] ===
-<text>
-Reply using: cortextos bus send-message <agent> normal '<reply>' <msg_id>
-```
-
-Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
-
----
-
-## Crons
-
-External crons are daemon-managed and live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
-
-**View:** `cortextos bus list-crons $CTX_AGENT_NAME`
-**Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
-**Remove:** `cortextos bus remove-cron $CTX_AGENT_NAME <name>`
-
-Do NOT use `CronCreate` or `/loop` — those are session-only and evaporate on restart.
-
----
-
-## Restart
-
-**Soft** (preserves history): `cortextos bus self-restart --reason "why"`
-**Hard** (fresh session): `cortextos bus hard-restart --reason "why"`
-
-When the user asks to restart, ALWAYS ask them first: "Fresh restart or continue with conversation history?" Do NOT restart until they specify which type.
-
-Sessions auto-restart with `--continue` every ~71 hours. On context exhaustion, notify user via Telegram then hard-restart.
+**Messages** — Reply to every Telegram and agent inbox message immediately. Un-ACK'd agent messages redeliver after 5 min: `cortextos bus ack-inbox <msg_id>`
 
 ---
 
 ## Orchestrator Role
 
-You are the user's chief of staff. You coordinate — you never do specialist work.
+You coordinate — you never do specialist work yourself. If it requires domain expertise (code, content, video, research), delegate to the right agent.
 
-### Core responsibilities
-1. **Decompose directives** — break user goals into tasks for specialist agents
-2. **Assign to the right agent** — use send-message to dispatch; log task_dispatched events
-3. **Monitor fleet health** — read-all-heartbeats every heartbeat cycle
-4. **Send briefings** — morning review daily, evening review daily
-5. **Route approvals** — surface pending approvals to user, do not let them queue silently
-6. **Cascade goals** — write agent goals.json every morning, regenerate GOALS.md
+**Core responsibilities:**
+1. Decompose user directives into tasks for specialist agents
+2. Assign via `cortextos bus send-message <agent> high '<task>'`
+3. Monitor fleet health every heartbeat: `cortextos bus read-all-heartbeats`
+4. Send morning + evening briefings daily
+5. Route pending approvals to user — never let them queue silently
+6. Write agent goals every morning: update their `goals.json`, regenerate GOALS.md
 
-### You are measured by
-- Tasks dispatched to other agents
-- Briefings sent on time
-- Approvals routed (not ignored)
-- Agent heartbeats healthy across the fleet
-
-### Never do specialist work yourself
-If it requires domain expertise (code, content, email, research), delegate to the right agent. You write tasks, send messages, monitor, and brief.
-
-### Spawning a New Agent
-1. Ask user to create a bot with @BotFather on Telegram, send you the token
-2. Ask user to send /start to the new bot (required for new bots), then send any message, then get chat_id:
-   ```bash
-   curl -s "https://api.telegram.org/bot<TOKEN>/getUpdates?timeout=30" | jq '.result[-1].message.chat.id'
-   ```
-3. Create the agent: `cortextos add-agent <name> --template agent`
-4. Edit `.env` with BOT_TOKEN and CHAT_ID
-5. Enable it: `cortextos start <name>`
-6. **Write initial goals for the new agent** (you have authority to write other agents' goals.json):
-   ```bash
-   cat > $CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/<name>/goals.json << 'EOF'
-   {"focus":"initial role focus","goals":["goal 1","goal 2"],"bottleneck":"","updated_at":"ISO_TIMESTAMP","updated_by":"$CTX_AGENT_NAME"}
-   EOF
-   cortextos goals generate-md --agent <name> --org $CTX_ORG
-   ```
-7. **Hand off to the new agent for onboarding.** Tell the user via Telegram:
-   > "Your new agent is booting up! Switch to your Telegram chat with [bot name] and send `/onboarding` to start the setup process."
-
----
-
-## System Management
-
-### Agent Lifecycle
-| Action | Command |
-|--------|---------|
-| Add agent | `cortextos add-agent <name> --template <type>` |
-| Start agent | `cortextos start <name>` |
-| Stop agent | `cortextos stop <name>` |
-| Check status | `cortextos status` |
-
-### Communication
-| Action | Command |
-|--------|---------|
-| Send Telegram | `cortextos bus send-telegram <chat_id> "<msg>"` |
-| Send to agent | `cortextos bus send-message <agent> <priority> '<msg>' [reply_to]` |
-| Check inbox | `cortextos bus check-inbox` |
-| ACK message | `cortextos bus ack-inbox <msg_id>` |
-
-### Logs
-| Log | Path |
-|-----|------|
-| Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Inbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/inbound-messages.jsonl` |
-| Outbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/outbound-messages.jsonl` |
-| Crashes | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/crashes.log` (when present) |
-| Restarts | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/restarts.log` (when present) |
-
-### State
-| File | Purpose |
-|------|---------|
-| `config.json` | Crons, max_session_seconds, agent config |
-| `.env` | BOT_TOKEN, CHAT_ID, ALLOWED_USER |
-
----
-
-## Skills
-
-**Core (all agents):**
-- **.claude/skills/comms/** - Message handling reference (Telegram + agent inbox formats)
-- **.claude/skills/cron-management/** - Cron setup, persistence, and troubleshooting
-- **.claude/skills/tasks/** - Task creation, lifecycle, and KPI logging
-- **.claude/skills/knowledge-base/** - Query and ingest org documents
-
-**Orchestrator-specific:**
-- **.claude/skills/morning-review/** - Daily morning briefing workflow (goal cascade, agent summary, task scheduling)
-- **.claude/skills/evening-review/** - End-of-day review, overnight task planning
-- **.claude/skills/nighttime-mode/** - Overnight orchestration protocol (no external actions)
-- **.claude/skills/goal-management/** - Daily goal lifecycle — cascade from org to agents
-- **.claude/skills/weekly-review/** - Weekly synthesis, metrics, next-week planning
-- **.claude/skills/theta-wave/** - System improvement cycle with analyst
-- **.claude/skills/agent-management/** - Agent lifecycle, onboarding new agents
-- **.claude/skills/approvals/** - Approval routing and surfacing workflow
-
----
-
-## Knowledge Base (RAG)
-
-Query and ingest org documents using natural language. See `.claude/skills/knowledge-base/SKILL.md` for full reference.
+**You are measured by:** tasks dispatched, briefings sent on time, approvals routed, agents healthy.

--- a/templates/orchestrator/CLAUDE.md
+++ b/templates/orchestrator/CLAUDE.md
@@ -24,7 +24,7 @@ See AGENTS.md for the full 13-step session start checklist. Key steps:
 3. Read org knowledge base: `../../knowledge.md`
 4. Discover available skills: `cortextos bus list-skills --format text`
 5. Discover active agents: `cortextos bus list-agents`
-6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
+6. **Crons are daemon-managed.** External crons auto-load from `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json` on daemon start; you do not need to restore them. Use `cortextos bus list-crons $CTX_AGENT_NAME` to confirm. Do NOT use `CronCreate` or `/loop` — those are session-only and won't survive restarts.
 7. Check today's memory file for in-progress work
 8. If resuming a task, query KB: `cortextos bus kb-query "<task topic>" --org $CTX_ORG`
 9. Check inbox: `cortextos bus check-inbox`
@@ -116,7 +116,7 @@ Always include `msg_id` as reply_to (auto-ACKs the original). Un-ACK'd messages 
 
 ## Crons
 
-External crons are daemon-managed and live in `${CTX_ROOT}/state/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
+External crons are daemon-managed and live in `${CTX_ROOT}/.cortextOS/state/agents/${CTX_AGENT_NAME}/crons.json`. The daemon scheduler owns dispatch — you do not register or restore crons in-session.
 
 **View:** `cortextos bus list-crons $CTX_AGENT_NAME`
 **Add:** `cortextos bus add-cron $CTX_AGENT_NAME <name> <interval-or-cron-expr> <prompt>`
@@ -200,10 +200,11 @@ If it requires domain expertise (code, content, email, research), delegate to th
 ### Logs
 | Log | Path |
 |-----|------|
-| Activity | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/activity.log` |
-| Fast-checker | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/fast-checker.log` |
 | Stdout | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stdout.log` |
-| Stderr | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/stderr.log` |
+| Inbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/inbound-messages.jsonl` |
+| Outbound msgs | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/outbound-messages.jsonl` |
+| Crashes | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/crashes.log` (when present) |
+| Restarts | `~/.cortextos/$CTX_INSTANCE_ID/logs/$CTX_AGENT_NAME/restarts.log` (when present) |
 
 ### State
 | File | Purpose |

--- a/tests/integration/cron-scheduler-reload-race.test.ts
+++ b/tests/integration/cron-scheduler-reload-race.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { CronDefinition } from '../../src/types/index.js';
+
+const TICK_MS = 30_000;
+const ONE_MIN = 60_000;
+
+let tmpRoot: string;
+const originalCtxRoot = process.env.CTX_ROOT;
+
+let writeCrons: typeof import('../../src/bus/crons.js').writeCrons;
+let CronScheduler: typeof import('../../src/daemon/cron-scheduler.js').CronScheduler;
+
+async function reloadModules(): Promise<void> {
+  vi.resetModules();
+  const cronsModule = await import('../../src/bus/crons.js');
+  writeCrons = cronsModule.writeCrons;
+  const schedulerModule = await import('../../src/daemon/cron-scheduler.js');
+  CronScheduler = schedulerModule.CronScheduler;
+}
+
+beforeEach(async () => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'cron-reload-race-'));
+  process.env.CTX_ROOT = tmpRoot;
+  vi.useFakeTimers();
+  await reloadModules();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.resetModules();
+  if (originalCtxRoot !== undefined) {
+    process.env.CTX_ROOT = originalCtxRoot;
+  } else {
+    delete process.env.CTX_ROOT;
+  }
+  try {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  } catch {
+    // ignore cleanup errors
+  }
+});
+
+function ensureAgentDir(agentName: string): void {
+  mkdirSync(join(tmpRoot, '.cortextOS', 'state', 'agents', agentName), { recursive: true });
+}
+
+function makeCronDef(overrides: Partial<CronDefinition> = {}): CronDefinition {
+  return {
+    name: 'reload-race',
+    prompt: 'Exercise reload while firing.',
+    schedule: '1m',
+    enabled: true,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+describe('cron scheduler reload race regression', () => {
+  it('3 fires with reload during each fire window: fire count reaches 3, no freeze', async () => {
+    const agent = 'cron-reload-race-agent';
+    ensureAgentDir(agent);
+
+    const logs: string[] = [];
+    const firedAt: number[] = [];
+    let resolveActiveFire: (() => void) | null = null;
+
+    writeCrons(agent, [
+      makeCronDef({
+        last_fired_at: new Date(Date.now() - 2 * ONE_MIN).toISOString(),
+        fire_count: 1,
+      }),
+    ]);
+
+    const scheduler = new CronScheduler({
+      agentName: agent,
+      logger: (msg) => logs.push(msg),
+      onFire: async () => {
+        firedAt.push(Date.now());
+        await new Promise<void>((resolve) => {
+          resolveActiveFire = resolve;
+        });
+      },
+    });
+
+    scheduler.start();
+
+    async function fireWithInterleavedReload(advanceMs: number, expectedCount: number) {
+      await vi.advanceTimersByTimeAsync(advanceMs);
+      expect(firedAt).toHaveLength(expectedCount);
+      expect(resolveActiveFire).not.toBeNull();
+
+      scheduler.reload();
+
+      const [duringFire] = scheduler.getNextFireTimes();
+      expect(duringFire).toBeDefined();
+
+      resolveActiveFire!();
+      resolveActiveFire = null;
+      await vi.advanceTimersByTimeAsync(0);
+
+      const [afterFire] = scheduler.getNextFireTimes();
+      expect(afterFire).toBeDefined();
+      expect(afterFire.nextFireAt).toBeGreaterThan(Date.now());
+    }
+
+    await fireWithInterleavedReload(TICK_MS, 1);
+    await fireWithInterleavedReload(ONE_MIN, 2);
+    await fireWithInterleavedReload(ONE_MIN, 3);
+
+    await vi.advanceTimersByTimeAsync(ONE_MIN);
+    expect(firedAt).toHaveLength(4);
+    expect(resolveActiveFire).not.toBeNull();
+    resolveActiveFire!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const [afterFourth] = scheduler.getNextFireTimes();
+    expect(afterFourth).toBeDefined();
+    expect(afterFourth.nextFireAt).toBeGreaterThan(Date.now());
+    expect(logs.some((line) => line.includes('reload deferred for "reload-race"'))).toBe(true);
+
+    scheduler.stop();
+  });
+});

--- a/tests/unit/bus/knowledge-base.test.ts
+++ b/tests/unit/bus/knowledge-base.test.ts
@@ -93,20 +93,34 @@ afterEach(() => {
  * Helper: make existsSync return false ONLY for paths that end with
  * knowledge-base/config.json (i.e. the MMRAG_CONFIG file), true for everything
  * else. Simulates a freshly-created agent with no KB configured yet.
+ * Also disables gbrain so tests stay on the legacy mmrag warning path.
  */
 function mockMissingKbConfig(): void {
   fsMocks.existsSync.mockImplementation((p: any) => {
     const path = String(p);
     if (path.endsWith('/knowledge-base/config.json')) return false;
+    if (path.endsWith('.gbrain/config.json')) return false;
     return true;
   });
 }
 
 /**
- * Helper: make existsSync return true for everything, simulating a fully
- * configured KB with config.json present on disk.
+ * Helper: make existsSync return true for everything EXCEPT the gbrain
+ * config file. Existing tests exercise the legacy mmrag path; gbrain
+ * tests use mockConfiguredKbWithGbrain() below.
  */
 function mockConfiguredKb(): void {
+  fsMocks.existsSync.mockImplementation((p: any) => {
+    if (String(p).endsWith('.gbrain/config.json')) return false;
+    return true;
+  });
+}
+
+/**
+ * Helper: make existsSync return true for everything including gbrain.
+ * Use for tests that exercise the gbrain fast-path.
+ */
+function mockConfiguredKbWithGbrain(): void {
   fsMocks.existsSync.mockImplementation(() => true);
 }
 
@@ -194,5 +208,50 @@ describe('kb warn messages — UX invariants', () => {
     const specificOrgWarns = warnLog.filter((m) => m.includes('SpecificOrg'));
     expect(specificOrgWarns.length).toBeGreaterThanOrEqual(2);
     expect(specificOrgWarns.every((m) => /run setup/i.test(m))).toBe(true);
+  });
+});
+
+describe('gbrain fast-path', () => {
+  it('query routes through gbrain when .gbrain/config.json exists', () => {
+    mockConfiguredKbWithGbrain();
+    // First execFileSync call = gbrain query (returns scored text output).
+    // Second call = gbrain get for the matched slug.
+    execFileSyncMock
+      .mockReturnValueOnce('[1.8000] my-page -- first 100 chars of content\n')
+      .mockReturnValueOnce('# My Page\nFull page content here.');
+
+    const result = queryKnowledgeBase(dummyPaths, 'test query', baseOptions);
+
+    expect(result.total).toBe(1);
+    expect(result.results[0].score).toBeCloseTo(1.8);
+    expect(result.results[0].source_file).toBe('my-page');
+    expect(result.results[0].content).toContain('Full page content');
+    expect(result.collection).toMatch(/gbrain/);
+  });
+
+  it('query returns empty results when gbrain execFileSync throws', () => {
+    mockConfiguredKbWithGbrain();
+    execFileSyncMock.mockImplementation(() => { throw new Error('gbrain unavailable'); });
+
+    const result = queryKnowledgeBase(dummyPaths, 'failing query', baseOptions);
+
+    expect(result.results).toHaveLength(0);
+    expect(result.total).toBe(0);
+  });
+
+  it('ingest calls gbrain put for each file', () => {
+    mockConfiguredKbWithGbrain();
+    fsMocks.readFileSync.mockReturnValue('# Page Content\nsome text');
+    execFileSyncMock.mockReturnValue('');
+
+    ingestKnowledgeBase(['/docs/my-doc.md', '/docs/other.md'], baseOptions);
+
+    // Two put calls — one per file. First arg = gbrain binary, second = ['put', slug].
+    const putCalls = execFileSyncMock.mock.calls.filter(
+      (call) => Array.isArray(call[1]) && call[1][0] === 'put',
+    );
+    expect(putCalls).toHaveLength(2);
+    expect(putCalls[0][1][1]).toBe('my-doc');
+    expect(putCalls[1][1][1]).toBe('other');
   });
 });

--- a/tests/unit/cli/bus-crons.test.ts
+++ b/tests/unit/cli/bus-crons.test.ts
@@ -200,6 +200,42 @@ describe('bus add-cron', () => {
     expect(JSON.parse(raw).crons[0]).toMatchObject({ fresh_session: true });
   });
 
+  it('success: stores protocol_file for fresh-session cron', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await busCommand.parseAsync([
+      'node', 'bus', 'add-cron', TEST_AGENT, 'heartbeat', '4h',
+      'Run heartbeat.',
+      '--fresh-session',
+      '--protocol-file', 'HEARTBEAT.md',
+    ]);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    const crons = readCronsFile();
+    expect(crons[0]).toMatchObject({
+      fresh_session: true,
+      protocol_file: 'HEARTBEAT.md',
+    });
+  });
+
+  it('error: rejects absolute protocol_file', async () => {
+    const exitSpy = mockExit();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'bus', 'add-cron', TEST_AGENT, 'heartbeat', '4h',
+        'Run heartbeat.',
+        '--protocol-file', '/tmp/HEARTBEAT.md',
+      ])
+    ).rejects.toThrow('__PROCESS_EXIT_1__');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('--protocol-file must be a relative path');
+  });
+
   it('error: rejects fresh-session for top-g morning-review', async () => {
     const exitSpy = mockExit();
     const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
@@ -436,6 +472,33 @@ describe('bus update-cron', () => {
 
     const crons = readCronsFile();
     expect(crons[0].description).toBe('New description.');
+  });
+
+  it('updates protocol_file (--protocol-file)', async () => {
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await busCommand.parseAsync([
+      'node', 'bus', 'update-cron', TEST_AGENT, 'heartbeat', '--protocol-file', 'HEARTBEAT.md',
+    ]);
+
+    const crons = readCronsFile();
+    expect(crons[0].protocol_file).toBe('HEARTBEAT.md');
+  });
+
+  it('error: rejects empty protocol_file on update', async () => {
+    const exitSpy = mockExit();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'bus', 'update-cron', TEST_AGENT, 'heartbeat', '--protocol-file', '   ',
+      ])
+    ).rejects.toThrow('__PROCESS_EXIT_1__');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('--protocol-file must be a non-empty relative path');
   });
 
   it('error: no options provided → exits 1', async () => {

--- a/tests/unit/cli/bus-crons.test.ts
+++ b/tests/unit/cli/bus-crons.test.ts
@@ -100,6 +100,7 @@ beforeEach(() => {
   // agentExistsInFramework() can find TEST_AGENT.
   frameworkRoot = mkdtempSync(join(tmpdir(), 'bus-crons-fw-'));
   mkdirSync(join(frameworkRoot, 'orgs', 'lifeos', 'agents', TEST_AGENT), { recursive: true });
+  mkdirSync(join(frameworkRoot, 'orgs', 'lifeos', 'agents', 'top-g'), { recursive: true });
 
   process.env.CTX_ROOT = tmpRoot;
   process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
@@ -180,6 +181,40 @@ describe('bus add-cron', () => {
     const crons = readCronsFile();
     expect(crons).toHaveLength(1);
     expect(crons[0].schedule).toBe('0 13 * * *');
+  });
+
+  it('success: allows fresh-session for top-g heartbeat', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await busCommand.parseAsync([
+      'node', 'bus', 'add-cron', 'top-g', 'heartbeat', '4h',
+      'Run heartbeat.',
+      '--fresh-session',
+    ]);
+
+    expect(errSpy).not.toHaveBeenCalled();
+    expect(logSpy).toHaveBeenCalledWith("Added cron 'heartbeat' for top-g");
+
+    const raw = readFileSync(join(tmpRoot, '.cortextOS', 'state', 'agents', 'top-g', 'crons.json'), 'utf-8');
+    expect(JSON.parse(raw).crons[0]).toMatchObject({ fresh_session: true });
+  });
+
+  it('error: rejects fresh-session for top-g morning-review', async () => {
+    const exitSpy = mockExit();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(
+      busCommand.parseAsync([
+        'node', 'bus', 'add-cron', 'top-g', 'morning-review', '4h',
+        'Run morning review.',
+        '--fresh-session',
+      ])
+    ).rejects.toThrow('__PROCESS_EXIT_1__');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errSpy.mock.calls.flat().join(' ')).toContain('protected cron');
   });
 
   it('error: duplicate cron name → exits 1 with message', async () => {

--- a/tests/unit/daemon/cron-fresh-session.test.ts
+++ b/tests/unit/daemon/cron-fresh-session.test.ts
@@ -45,6 +45,15 @@ function makeChild() {
   return child;
 }
 
+function appendSystemPromptValue(args: unknown[]): string | undefined {
+  const idx = args.indexOf('--append-system-prompt');
+  return idx === -1 ? undefined : String(args[idx + 1]);
+}
+
+function appendSystemPromptFlagCount(args: unknown[]): number {
+  return args.filter(arg => arg === '--append-system-prompt').length;
+}
+
 function attachAgent(manager: any, agentName: string, config: AgentConfig = {}, extra: Record<string, unknown> = {}) {
   const process = {
     getConfig: vi.fn(() => config),
@@ -326,7 +335,121 @@ describe('cron fresh-session dispatch', () => {
     child.emit('close', 0, null);
     await promise;
 
-    expect(spawnMock.mock.calls[0][1]).toEqual(expect.arrayContaining(['--append-system-prompt', 'heartbeat instructions']));
+    const args = spawnMock.mock.calls[0][1];
+    expect(appendSystemPromptFlagCount(args)).toBe(1);
+    expect(appendSystemPromptValue(args)).toBe('heartbeat instructions');
+  });
+
+  it('fireCronFreshSession passes protocol_file content via --append-system-prompt', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat protocol');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, protocol_file: 'HEARTBEAT.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    const args = spawnMock.mock.calls[0][1];
+    expect(appendSystemPromptFlagCount(args)).toBe(1);
+    expect(appendSystemPromptValue(args)).toBe('heartbeat protocol');
+  });
+
+  it('fireCronFreshSession combines skill_file and protocol_file in deterministic order', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'SKILL.md'), 'skill instructions');
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat protocol');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'SKILL.md', protocol_file: 'HEARTBEAT.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    const args = spawnMock.mock.calls[0][1];
+    expect(appendSystemPromptFlagCount(args)).toBe(1);
+    expect(appendSystemPromptValue(args)).toBe('skill instructions\n\n---\n\nheartbeat protocol');
+  });
+
+  it('fireCronFreshSession ignores absolute protocol_file', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, protocol_file: '/tmp/secret.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock.mock.calls[0][1]).not.toContain('--append-system-prompt');
+  });
+
+  it('fireCronFreshSession keeps readable protocol_file when skill_file is unreadable', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat protocol');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'missing.md', protocol_file: 'HEARTBEAT.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(appendSystemPromptValue(spawnMock.mock.calls[0][1])).toBe('heartbeat protocol');
+  });
+
+  it('fireCronFreshSession ignores unreadable protocol_file without suppressing skill_file', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'SKILL.md'), 'skill instructions');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'SKILL.md', protocol_file: 'missing.md' }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(appendSystemPromptValue(spawnMock.mock.calls[0][1])).toBe('skill instructions');
   });
 
   it('fireCronFreshSession ignores unreadable skill_file', async () => {
@@ -386,8 +509,49 @@ describe('cron fresh-session dispatch', () => {
     expect(proc.buildRuntimeEnv).toHaveBeenCalledOnce();
     expect(spawnMock.mock.calls[0][2]).toMatchObject({
       cwd: '/work',
-      env: { CTX_ROOT: tmpRoot, CUSTOM: 'yes', CTX_CRON_FIRED_AT: FIRED_AT },
+      env: {
+        CTX_ROOT: tmpRoot,
+        CUSTOM: 'yes',
+        CTX_CRON_FIRED_AT: FIRED_AT,
+        CTX_FRESH_SESSION_CRON: 'ops-g/heartbeat',
+      },
     });
+  });
+
+  it('fireCronFreshSession persists last_fire_attempted_at before spawn', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true })]);
+    const child = makeChild();
+    spawnMock.mockImplementation(() => {
+      expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
+      return child;
+    });
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
+  });
+
+  it('fireCronFreshSession persists last_fire_attempted_at before spawn error', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true })]);
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
+    child.emit('error', new Error('spawn failed'));
+
+    await expect(promise).rejects.toThrow(/spawn failed/);
+    expect(readCrons('ops-g')[0].last_fire_attempted_at).toBe(FIRED_AT);
   });
 
   it('fireCronFreshSession caps captured stdout and labels stdout/stderr log writes', async () => {

--- a/tests/unit/daemon/cron-fresh-session.test.ts
+++ b/tests/unit/daemon/cron-fresh-session.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AgentConfig, CronDefinition, CtxEnv } from '../../../src/types/index';
 
 const spawnMock = vi.fn();
+const appendExecutionLogMock = vi.fn();
 
 vi.mock('child_process', async () => {
   const actual = await vi.importActual<typeof import('child_process')>('child_process');
@@ -14,6 +15,12 @@ vi.mock('child_process', async () => {
     spawn: spawnMock,
   };
 });
+
+vi.mock('../../../src/daemon/cron-execution-log.js', () => ({
+  appendExecutionLog: (...args: unknown[]) => appendExecutionLogMock(...args),
+}));
+
+const FIRED_AT = '2026-05-15T00:00:00.000Z';
 
 function makeCron(overrides: Partial<CronDefinition> = {}): CronDefinition {
   return {
@@ -51,14 +58,18 @@ function attachAgent(manager: any, agentName: string, config: AgentConfig = {}, 
 
 describe('cron fresh-session dispatch', () => {
   let tmpRoot: string;
+  const originalCtxRoot = process.env.CTX_ROOT;
 
   beforeEach(() => {
     tmpRoot = mkdtempSync(join(tmpdir(), 'cron-fresh-'));
+    process.env.CTX_ROOT = tmpRoot;
     spawnMock.mockReset();
+    appendExecutionLogMock.mockReset();
     vi.useRealTimers();
   });
 
   afterEach(() => {
+    if (originalCtxRoot !== undefined) process.env.CTX_ROOT = originalCtxRoot; else delete process.env.CTX_ROOT;
     rmSync(tmpRoot, { recursive: true, force: true });
     vi.restoreAllMocks();
     vi.useRealTimers();
@@ -81,9 +92,14 @@ describe('cron fresh-session dispatch', () => {
     attachAgent(manager, 'ops-g');
     manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
 
-    await manager.dispatchCron('ops-g', makeCron({ fresh_session: true }), '2026-05-15T00:00:00Z');
+    await manager.dispatchCron('ops-g', makeCron({ fresh_session: true }), FIRED_AT);
 
-    expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
+    expect(manager.fireCronFreshSession).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({ fresh_session: true }),
+      expect.stringContaining(`[CRON FIRED ${FIRED_AT}]`),
+      FIRED_AT,
+    );
   });
 
   it('dispatchCron protects top-g/morning-review and injects', async () => {
@@ -95,7 +111,7 @@ describe('cron fresh-session dispatch', () => {
     await manager.dispatchCron(
       'top-g',
       makeCron({ name: 'morning-review', fresh_session: true }),
-      '2026-05-15T00:00:00Z',
+      FIRED_AT,
     );
 
     expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('top-g', 'morning-review');
@@ -108,7 +124,7 @@ describe('cron fresh-session dispatch', () => {
     attachAgent(manager, 'top-g');
     manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
 
-    await manager.dispatchCron('top-g', makeCron({ name: 'heartbeat', fresh_session: true }), '2026-05-15T00:00:00Z');
+    await manager.dispatchCron('top-g', makeCron({ name: 'heartbeat', fresh_session: true }), FIRED_AT);
 
     expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
   });
@@ -122,7 +138,7 @@ describe('cron fresh-session dispatch', () => {
     await manager.dispatchCron(
       'top-g',
       makeCron({ name: 'check-approvals', fresh_session: true }),
-      '2026-05-15T00:00:00Z',
+      FIRED_AT,
     );
 
     expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
@@ -134,7 +150,7 @@ describe('cron fresh-session dispatch', () => {
     const proc = attachAgent(manager, 'smart-g');
     manager.emitGuardrailEvent = vi.fn();
 
-    await manager.dispatchCron('smart-g', makeCron({ name: 'heartbeat', fresh_session: true }), '2026-05-15T00:00:00Z');
+    await manager.dispatchCron('smart-g', makeCron({ name: 'heartbeat', fresh_session: true }), FIRED_AT);
 
     expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('smart-g', 'heartbeat');
     expect(proc.injectMessage).toHaveBeenCalledOnce();
@@ -147,9 +163,16 @@ describe('cron fresh-session dispatch', () => {
     manager.emitFreshSessionUnsupportedEvent = vi.fn();
 
     await expect(
-      manager.fireCronFreshSession('codex-g', makeCron({ fresh_session: true }), 'prompt'),
+      manager.fireCronFreshSession('codex-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT),
     ).rejects.toThrow(/not supported/);
     expect(manager.emitFreshSessionUnsupportedEvent).toHaveBeenCalledWith('codex-g', 'heartbeat', 'codex-app-server');
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'codex-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('pre_spawn:'),
+      }),
+    );
     expect(spawnMock).not.toHaveBeenCalled();
   });
 
@@ -160,11 +183,35 @@ describe('cron fresh-session dispatch', () => {
     const child = makeChild();
     spawnMock.mockReturnValue(child);
 
-    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
     child.emit('close', 0, null);
 
     await expect(promise).resolves.toBeUndefined();
     expect(spawnMock).toHaveBeenCalledWith('claude', expect.arrayContaining(['--print', '--no-session-persistence']), expect.any(Object));
+  });
+
+  it('fireCronFreshSession writes execution log on child close code 0', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        cron: 'heartbeat',
+        status: 'fired',
+        attempt: 1,
+        duration_ms: expect.any(Number),
+        error: null,
+      }),
+    );
   });
 
   it('fireCronFreshSession rejects on non-zero child close', async () => {
@@ -174,11 +221,18 @@ describe('cron fresh-session dispatch', () => {
     const child = makeChild();
     spawnMock.mockReturnValue(child);
 
-    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
-    child.stderr.emit('data', Buffer.from('bad'));
-    child.emit('close', 2, null);
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('close', 1, null);
 
-    await expect(promise).rejects.toThrow(/exited code=2/);
+    await expect(promise).rejects.toThrow(/exited code=1/);
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('exit_code_1'),
+      }),
+    );
   });
 
   it('fireCronFreshSession rejects timeout even when child exits code 0 after SIGTERM', async () => {
@@ -193,12 +247,43 @@ describe('cron fresh-session dispatch', () => {
       'ops-g',
       makeCron({ fresh_session: true, fresh_session_timeout_ms: 100 }),
       'prompt',
+      FIRED_AT,
     );
     vi.advanceTimersByTime(100);
     expect(child.kill).toHaveBeenCalledWith('SIGTERM');
     child.emit('close', 0, 'SIGTERM');
 
     await expect(promise).rejects.toThrow(/timed out/);
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('timed_out'),
+      }),
+    );
+  });
+
+  it('fireCronFreshSession writes execution log once on spawn error', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
+    child.emit('error', new Error('spawn failed'));
+    child.emit('close', 0, null);
+
+    await expect(promise).rejects.toThrow(/spawn failed/);
+    expect(appendExecutionLogMock).toHaveBeenCalledTimes(1);
+    expect(appendExecutionLogMock).toHaveBeenCalledWith(
+      'ops-g',
+      expect.objectContaining({
+        status: 'failed',
+        error: expect.stringContaining('spawn_error'),
+      }),
+    );
   });
 
   it('fireCronFreshSession sends SIGKILL after timeout grace', async () => {
@@ -213,6 +298,7 @@ describe('cron fresh-session dispatch', () => {
       'ops-g',
       makeCron({ fresh_session: true, fresh_session_timeout_ms: 100 }),
       'prompt',
+      FIRED_AT,
     );
     vi.advanceTimersByTime(5_100);
     expect(child.kill).toHaveBeenCalledWith('SIGKILL');
@@ -235,6 +321,7 @@ describe('cron fresh-session dispatch', () => {
       'ops-g',
       makeCron({ fresh_session: true, skill_file: 'HEARTBEAT.md' }),
       'prompt',
+      FIRED_AT,
     );
     child.emit('close', 0, null);
     await promise;
@@ -253,6 +340,7 @@ describe('cron fresh-session dispatch', () => {
       'ops-g',
       makeCron({ fresh_session: true, skill_file: 'missing.md' }),
       'prompt',
+      FIRED_AT,
     );
     child.emit('close', 0, null);
     await promise;
@@ -271,6 +359,7 @@ describe('cron fresh-session dispatch', () => {
       'ops-g',
       makeCron({ fresh_session: true, skill_file: '/tmp/secret.md' }),
       'prompt',
+      FIRED_AT,
     );
     child.emit('close', 0, null);
     await promise;
@@ -290,12 +379,15 @@ describe('cron fresh-session dispatch', () => {
     const child = makeChild();
     spawnMock.mockReturnValue(child);
 
-    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
     child.emit('close', 0, null);
     await promise;
 
     expect(proc.buildRuntimeEnv).toHaveBeenCalledOnce();
-    expect(spawnMock.mock.calls[0][2]).toMatchObject({ cwd: '/work', env: { CTX_ROOT: tmpRoot, CUSTOM: 'yes' } });
+    expect(spawnMock.mock.calls[0][2]).toMatchObject({
+      cwd: '/work',
+      env: { CTX_ROOT: tmpRoot, CUSTOM: 'yes', CTX_CRON_FIRED_AT: FIRED_AT },
+    });
   });
 
   it('fireCronFreshSession caps captured stdout and labels stdout/stderr log writes', async () => {
@@ -305,13 +397,59 @@ describe('cron fresh-session dispatch', () => {
     const child = makeChild();
     spawnMock.mockReturnValue(child);
 
-    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt', FIRED_AT);
     child.stdout.emit('data', Buffer.alloc(300 * 1024, 'a'));
     child.stderr.emit('data', Buffer.from('warn'));
     child.emit('close', 0, null);
     await promise;
 
     expect(spawnMock).toHaveBeenCalledOnce();
+  });
+
+  it('fireCronFreshSession persists crons.json fire state on exit 0', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true, fire_count: 2 })]);
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fire_count: 2 }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(readCrons('ops-g')[0]).toMatchObject({
+      last_fired_at: FIRED_AT,
+      fire_count: 3,
+    });
+  });
+
+  it('fireCronFreshSession does not persist crons.json fire state on non-zero exit', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const { readCrons, writeCrons } = await import('../../../src/bus/crons.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    writeCrons('ops-g', [makeCron({ fresh_session: true, fire_count: 2 })]);
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fire_count: 2 }),
+      'prompt',
+      FIRED_AT,
+    );
+    child.emit('close', 1, null);
+    await expect(promise).rejects.toThrow(/exited code=1/);
+
+    expect(readCrons('ops-g')[0]).not.toHaveProperty('last_fired_at');
+    expect(readCrons('ops-g')[0].fire_count).toBe(2);
   });
 });
 
@@ -360,6 +498,31 @@ describe('runtime env builder and fresh-session guards', () => {
       SHARED_KEY: 'shared',
       OVERRIDE: 'agent',
       IS_SANDBOX: '1',
+    });
+  });
+
+  it('buildAgentRuntimeEnv propagates TZ when config.timezone is absent', async () => {
+    const projectRoot = join(tmpRoot, 'fw');
+    const agentDir = join(projectRoot, 'orgs', 'acme', 'agents', 'ops-g');
+    mkdirSync(agentDir, { recursive: true });
+    process.env.TZ = 'Asia/Bangkok';
+
+    const { buildAgentRuntimeEnv } = await import('../../../src/utils/env.js');
+    const env: CtxEnv = {
+      instanceId: 'test',
+      ctxRoot: tmpRoot,
+      frameworkRoot: projectRoot,
+      projectRoot,
+      org: 'acme',
+      agentName: 'ops-g',
+      agentDir,
+    };
+
+    const runtimeEnv = buildAgentRuntimeEnv(env, {});
+
+    expect(runtimeEnv).toMatchObject({
+      CTX_TIMEZONE: 'Asia/Bangkok',
+      TZ: 'Asia/Bangkok',
     });
   });
 

--- a/tests/unit/daemon/cron-fresh-session.test.ts
+++ b/tests/unit/daemon/cron-fresh-session.test.ts
@@ -1,0 +1,484 @@
+import { EventEmitter } from 'events';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentConfig, CronDefinition, CtxEnv } from '../../../src/types/index';
+
+const spawnMock = vi.fn();
+
+vi.mock('child_process', async () => {
+  const actual = await vi.importActual<typeof import('child_process')>('child_process');
+  return {
+    ...actual,
+    spawn: spawnMock,
+  };
+});
+
+function makeCron(overrides: Partial<CronDefinition> = {}): CronDefinition {
+  return {
+    name: 'heartbeat',
+    prompt: 'Run heartbeat.',
+    schedule: '4h',
+    enabled: true,
+    created_at: '2026-05-15T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function makeChild() {
+  const child = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    kill: ReturnType<typeof vi.fn>;
+  };
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.kill = vi.fn();
+  return child;
+}
+
+function attachAgent(manager: any, agentName: string, config: AgentConfig = {}, extra: Record<string, unknown> = {}) {
+  const process = {
+    getConfig: vi.fn(() => config),
+    getAgentDir: vi.fn(() => extra.agentDir ?? '/tmp/agent'),
+    buildRuntimeEnv: vi.fn(() => extra.runtimeEnv ?? { CTX_ROOT: extra.ctxRoot ?? '/tmp/ctx' }),
+    injectMessage: vi.fn(() => true),
+  };
+  manager.agents.set(agentName, { process, checker: {} });
+  return process;
+}
+
+describe('cron fresh-session dispatch', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cron-fresh-'));
+    spawnMock.mockReset();
+    vi.useRealTimers();
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  it('dispatchCron injects into PTY when fresh_session is absent', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(manager, 'ops-g');
+
+    await manager.dispatchCron('ops-g', makeCron(), '2026-05-15T00:00:00Z');
+
+    expect(proc.injectMessage).toHaveBeenCalledWith(expect.stringContaining('[CRON FIRED'));
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('dispatchCron uses fireCronFreshSession when fresh_session is true', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g');
+    manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
+
+    await manager.dispatchCron('ops-g', makeCron({ fresh_session: true }), '2026-05-15T00:00:00Z');
+
+    expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
+  });
+
+  it('dispatchCron overrides fresh_session for top-g and injects', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(manager, 'top-g');
+    manager.emitGuardrailEvent = vi.fn();
+
+    await manager.dispatchCron('top-g', makeCron({ fresh_session: true }), '2026-05-15T00:00:00Z');
+
+    expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('top-g', 'heartbeat');
+    expect(proc.injectMessage).toHaveBeenCalledOnce();
+  });
+
+  it('fireCronFreshSession rejects unsupported codex-app-server runtime', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'codex-g', { runtime: 'codex-app-server' });
+    manager.emitFreshSessionUnsupportedEvent = vi.fn();
+
+    await expect(
+      manager.fireCronFreshSession('codex-g', makeCron({ fresh_session: true }), 'prompt'),
+    ).rejects.toThrow(/not supported/);
+    expect(manager.emitFreshSessionUnsupportedEvent).toHaveBeenCalledWith('codex-g', 'heartbeat', 'codex-app-server');
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('fireCronFreshSession resolves on child close code 0', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
+    child.emit('close', 0, null);
+
+    await expect(promise).resolves.toBeUndefined();
+    expect(spawnMock).toHaveBeenCalledWith('claude', expect.arrayContaining(['--print', '--no-session-persistence']), expect.any(Object));
+  });
+
+  it('fireCronFreshSession rejects on non-zero child close', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
+    child.stderr.emit('data', Buffer.from('bad'));
+    child.emit('close', 2, null);
+
+    await expect(promise).rejects.toThrow(/exited code=2/);
+  });
+
+  it('fireCronFreshSession rejects timeout even when child exits code 0 after SIGTERM', async () => {
+    vi.useFakeTimers();
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fresh_session_timeout_ms: 100 }),
+      'prompt',
+    );
+    vi.advanceTimersByTime(100);
+    expect(child.kill).toHaveBeenCalledWith('SIGTERM');
+    child.emit('close', 0, 'SIGTERM');
+
+    await expect(promise).rejects.toThrow(/timed out/);
+  });
+
+  it('fireCronFreshSession sends SIGKILL after timeout grace', async () => {
+    vi.useFakeTimers();
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, fresh_session_timeout_ms: 100 }),
+      'prompt',
+    );
+    vi.advanceTimersByTime(5_100);
+    expect(child.kill).toHaveBeenCalledWith('SIGKILL');
+    child.emit('close', null, 'SIGKILL');
+
+    await expect(promise).rejects.toThrow(/timed out/);
+  });
+
+  it('fireCronFreshSession passes skill_file content via --append-system-prompt', async () => {
+    const agentDir = join(tmpRoot, 'agent');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'HEARTBEAT.md'), 'heartbeat instructions');
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { agentDir, ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'HEARTBEAT.md' }),
+      'prompt',
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock.mock.calls[0][1]).toEqual(expect.arrayContaining(['--append-system-prompt', 'heartbeat instructions']));
+  });
+
+  it('fireCronFreshSession ignores unreadable skill_file', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: 'missing.md' }),
+      'prompt',
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock.mock.calls[0][1]).not.toContain('--append-system-prompt');
+  });
+
+  it('fireCronFreshSession ignores absolute skill_file', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession(
+      'ops-g',
+      makeCron({ fresh_session: true, skill_file: '/tmp/secret.md' }),
+      'prompt',
+    );
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock.mock.calls[0][1]).not.toContain('--append-system-prompt');
+  });
+
+  it('fireCronFreshSession uses buildRuntimeEnv output and configured working directory', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(
+      manager,
+      'ops-g',
+      { working_directory: '/work' },
+      { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot, CUSTOM: 'yes' } },
+    );
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(proc.buildRuntimeEnv).toHaveBeenCalledOnce();
+    expect(spawnMock.mock.calls[0][2]).toMatchObject({ cwd: '/work', env: { CTX_ROOT: tmpRoot, CUSTOM: 'yes' } });
+  });
+
+  it('fireCronFreshSession caps captured stdout and labels stdout/stderr log writes', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'ops-g', {}, { ctxRoot: tmpRoot, runtimeEnv: { CTX_ROOT: tmpRoot } });
+    const child = makeChild();
+    spawnMock.mockReturnValue(child);
+
+    const promise = manager.fireCronFreshSession('ops-g', makeCron({ fresh_session: true }), 'prompt');
+    child.stdout.emit('data', Buffer.alloc(300 * 1024, 'a'));
+    child.stderr.emit('data', Buffer.from('warn'));
+    child.emit('close', 0, null);
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledOnce();
+  });
+});
+
+describe('runtime env builder and fresh-session guards', () => {
+  let tmpRoot: string;
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cron-env-'));
+    process.env = { ...originalEnv, PATH: '/bin', IS_SANDBOX: '1' };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('buildAgentRuntimeEnv includes CTX vars, org secrets, agent env, timezone, and orchestrator', async () => {
+    const projectRoot = join(tmpRoot, 'fw');
+    const agentDir = join(projectRoot, 'orgs', 'acme', 'agents', 'ops-g');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(projectRoot, 'orgs', 'acme', 'secrets.env'), 'SHARED_KEY=shared\nOVERRIDE=org\n');
+    writeFileSync(join(agentDir, '.env'), 'CHAT_ID=123\nOVERRIDE=agent\n');
+    writeFileSync(join(projectRoot, 'orgs', 'acme', 'context.json'), JSON.stringify({ orchestrator: 'top-g' }));
+
+    const { buildAgentRuntimeEnv } = await import('../../../src/utils/env.js');
+    const env: CtxEnv = {
+      instanceId: 'test',
+      ctxRoot: tmpRoot,
+      frameworkRoot: projectRoot,
+      projectRoot,
+      org: 'acme',
+      agentName: 'ops-g',
+      agentDir,
+    };
+
+    const runtimeEnv = buildAgentRuntimeEnv(env, { timezone: 'Asia/Bangkok' });
+
+    expect(runtimeEnv).toMatchObject({
+      CTX_ROOT: tmpRoot,
+      CTX_AGENT_NAME: 'ops-g',
+      CTX_ORG: 'acme',
+      CTX_TELEGRAM_CHAT_ID: '123',
+      CTX_ORCHESTRATOR_AGENT: 'top-g',
+      TZ: 'Asia/Bangkok',
+      SHARED_KEY: 'shared',
+      OVERRIDE: 'agent',
+      IS_SANDBOX: '1',
+    });
+  });
+
+  it('guard helpers protect top-g and smart-g only', async () => {
+    const { isFreshSessionProtectedAgent } = await import('../../../src/utils/fresh-session-guards.js');
+    expect(isFreshSessionProtectedAgent('top-g')).toBe(true);
+    expect(isFreshSessionProtectedAgent('smart-g')).toBe(true);
+    expect(isFreshSessionProtectedAgent('ops-g')).toBe(false);
+  });
+
+  it('guard helpers support only undefined and claude-code runtimes', async () => {
+    const { isFreshSessionSupportedRuntime } = await import('../../../src/utils/fresh-session-guards.js');
+    expect(isFreshSessionSupportedRuntime(undefined)).toBe(true);
+    expect(isFreshSessionSupportedRuntime('claude-code')).toBe(true);
+    expect(isFreshSessionSupportedRuntime('codex-app-server')).toBe(false);
+    expect(isFreshSessionSupportedRuntime('hermes')).toBe(false);
+  });
+});
+
+describe('IPC fresh-session mutation and manual fire validation', () => {
+  let tmpRoot: string;
+  let frameworkRoot: string;
+  const originalCtxRoot = process.env.CTX_ROOT;
+  const originalFrameworkRoot = process.env.CTX_FRAMEWORK_ROOT;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'cron-ipc-'));
+    frameworkRoot = join(tmpRoot, 'fw');
+    process.env.CTX_ROOT = tmpRoot;
+    process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
+    mkdirSync(join(tmpRoot, 'config'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'ops-g'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'codex-g'), { recursive: true });
+    mkdirSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'top-g'), { recursive: true });
+    writeFileSync(join(tmpRoot, 'config', 'enabled-agents.json'), JSON.stringify({
+      'ops-g': { enabled: true, org: 'acme' },
+      'codex-g': { enabled: true, org: 'acme' },
+      'top-g': { enabled: true, org: 'acme' },
+    }));
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'ops-g', 'config.json'), '{}');
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'codex-g', 'config.json'), '{"runtime":"codex-app-server"}');
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'top-g', 'config.json'), '{}');
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalCtxRoot !== undefined) process.env.CTX_ROOT = originalCtxRoot; else delete process.env.CTX_ROOT;
+    if (originalFrameworkRoot !== undefined) process.env.CTX_FRAMEWORK_ROOT = originalFrameworkRoot; else delete process.env.CTX_FRAMEWORK_ROOT;
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('handleAddCron copies fresh-session fields', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const { readCrons } = await import('../../../src/bus/crons.js');
+
+    const result = handleAddCron('ops-g', {
+      name: 'heartbeat',
+      prompt: 'Run heartbeat.',
+      schedule: '4h',
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 120_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readCrons('ops-g')[0]).toMatchObject({
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 120_000,
+    });
+  });
+
+  it('handleUpdateCron copies fresh-session fields', async () => {
+    const { handleAddCron, handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const { readCrons } = await import('../../../src/bus/crons.js');
+    handleAddCron('ops-g', { name: 'heartbeat', prompt: 'x', schedule: '4h' });
+
+    const result = handleUpdateCron('ops-g', 'heartbeat', {
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 60_000,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(readCrons('ops-g')[0]).toMatchObject({
+      fresh_session: true,
+      skill_file: 'HEARTBEAT.md',
+      fresh_session_timeout_ms: 60_000,
+    });
+  });
+
+  it('handleAddCron rejects protected agents', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('top-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/protected/);
+  });
+
+  it('handleAddCron rejects unsupported codex-app-server runtime', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('codex-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/not supported/);
+  });
+
+  it('handleAddCron rejects absolute skill_file', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('ops-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      skill_file: '/tmp/HEARTBEAT.md',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('skill_file');
+  });
+
+  it('handleAddCron rejects invalid fresh_session_timeout_ms', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('ops-g', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session_timeout_ms: 0,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('fresh_session_timeout_ms');
+  });
+
+  it('handleFireCron dispatches through provided dispatch function and records cooldown only on success', async () => {
+    const { handleAddCron, handleFireCron, manualFireCooldownRemaining } = await import('../../../src/daemon/ipc-server.js');
+    handleAddCron('ops-g', { name: 'heartbeat', prompt: 'x', schedule: '4h', fresh_session: true });
+    const dispatch = vi.fn().mockResolvedValue(undefined);
+    const now = 1_000_000;
+
+    const result = await handleFireCron('ops-g', 'heartbeat', dispatch, now);
+
+    expect(result.ok).toBe(true);
+    expect(dispatch).toHaveBeenCalledWith('ops-g', expect.objectContaining({ fresh_session: true }), new Date(now).toISOString());
+    expect(manualFireCooldownRemaining('ops-g', 'heartbeat', now + 1)).toBeGreaterThan(0);
+  });
+
+  it('handleFireCron does not record cooldown when dispatch fails', async () => {
+    const { handleAddCron, handleFireCron, manualFireCooldownRemaining } = await import('../../../src/daemon/ipc-server.js');
+    handleAddCron('ops-g', { name: 'heartbeat', prompt: 'x', schedule: '4h' });
+    const dispatch = vi.fn().mockRejectedValue(new Error('boom'));
+    const now = 1_000_000;
+
+    const result = await handleFireCron('ops-g', 'heartbeat', dispatch, now);
+
+    expect(result.ok).toBe(false);
+    expect(manualFireCooldownRemaining('ops-g', 'heartbeat', now + 1)).toBe(0);
+  });
+});

--- a/tests/unit/daemon/cron-fresh-session.test.ts
+++ b/tests/unit/daemon/cron-fresh-session.test.ts
@@ -86,15 +86,57 @@ describe('cron fresh-session dispatch', () => {
     expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
   });
 
-  it('dispatchCron overrides fresh_session for top-g and injects', async () => {
+  it('dispatchCron protects top-g/morning-review and injects', async () => {
     const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
     const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
     const proc = attachAgent(manager, 'top-g');
     manager.emitGuardrailEvent = vi.fn();
 
-    await manager.dispatchCron('top-g', makeCron({ fresh_session: true }), '2026-05-15T00:00:00Z');
+    await manager.dispatchCron(
+      'top-g',
+      makeCron({ name: 'morning-review', fresh_session: true }),
+      '2026-05-15T00:00:00Z',
+    );
 
-    expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('top-g', 'heartbeat');
+    expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('top-g', 'morning-review');
+    expect(proc.injectMessage).toHaveBeenCalledOnce();
+  });
+
+  it('dispatchCron allows top-g/heartbeat fresh session', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'top-g');
+    manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
+
+    await manager.dispatchCron('top-g', makeCron({ name: 'heartbeat', fresh_session: true }), '2026-05-15T00:00:00Z');
+
+    expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
+  });
+
+  it('dispatchCron allows top-g/check-approvals fresh session', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    attachAgent(manager, 'top-g');
+    manager.fireCronFreshSession = vi.fn().mockResolvedValue(undefined);
+
+    await manager.dispatchCron(
+      'top-g',
+      makeCron({ name: 'check-approvals', fresh_session: true }),
+      '2026-05-15T00:00:00Z',
+    );
+
+    expect(manager.fireCronFreshSession).toHaveBeenCalledOnce();
+  });
+
+  it('dispatchCron protects all smart-g crons through wildcard and injects', async () => {
+    const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+    const manager: any = new AgentManager('test', tmpRoot, tmpRoot, 'acme');
+    const proc = attachAgent(manager, 'smart-g');
+    manager.emitGuardrailEvent = vi.fn();
+
+    await manager.dispatchCron('smart-g', makeCron({ name: 'heartbeat', fresh_session: true }), '2026-05-15T00:00:00Z');
+
+    expect(manager.emitGuardrailEvent).toHaveBeenCalledWith('smart-g', 'heartbeat');
     expect(proc.injectMessage).toHaveBeenCalledOnce();
   });
 
@@ -321,11 +363,15 @@ describe('runtime env builder and fresh-session guards', () => {
     });
   });
 
-  it('guard helpers protect top-g and smart-g only', async () => {
-    const { isFreshSessionProtectedAgent } = await import('../../../src/utils/fresh-session-guards.js');
-    expect(isFreshSessionProtectedAgent('top-g')).toBe(true);
-    expect(isFreshSessionProtectedAgent('smart-g')).toBe(true);
-    expect(isFreshSessionProtectedAgent('ops-g')).toBe(false);
+  it('guard helpers protect specific cron patterns', async () => {
+    const { isFreshSessionProtectedCron } = await import('../../../src/utils/fresh-session-guards.js');
+    expect(isFreshSessionProtectedCron('top-g', 'morning-review')).toBe(true);
+    expect(isFreshSessionProtectedCron('top-g', 'evening-review')).toBe(true);
+    expect(isFreshSessionProtectedCron('top-g', 'weekly-review')).toBe(true);
+    expect(isFreshSessionProtectedCron('top-g', 'heartbeat')).toBe(false);
+    expect(isFreshSessionProtectedCron('top-g', 'check-approvals')).toBe(false);
+    expect(isFreshSessionProtectedCron('smart-g', 'heartbeat')).toBe(true);
+    expect(isFreshSessionProtectedCron('ops-g', 'heartbeat')).toBe(false);
   });
 
   it('guard helpers support only undefined and claude-code runtimes', async () => {
@@ -409,7 +455,19 @@ describe('IPC fresh-session mutation and manual fire validation', () => {
     });
   });
 
-  it('handleAddCron rejects protected agents', async () => {
+  it('handleAddCron rejects protected top-g/morning-review', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('top-g', {
+      name: 'morning-review',
+      prompt: 'x',
+      schedule: '4h',
+      fresh_session: true,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/protected/);
+  });
+
+  it('handleAddCron allows top-g/heartbeat', async () => {
     const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
     const result = handleAddCron('top-g', {
       name: 'heartbeat',
@@ -417,8 +475,7 @@ describe('IPC fresh-session mutation and manual fire validation', () => {
       schedule: '4h',
       fresh_session: true,
     });
-    expect(result.ok).toBe(false);
-    expect(result.error).toMatch(/protected/);
+    expect(result.ok).toBe(true);
   });
 
   it('handleAddCron rejects unsupported codex-app-server runtime', async () => {

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -483,6 +483,53 @@ describe('CronScheduler', () => {
     expect(afterReload!.nextFireAt).toBe(beforeReload!.nextFireAt);
   });
 
+  it('reload with same schedule during slow fire: cron is not frozen and fires again', async () => {
+    let resolveFire: (() => void) | undefined;
+    const slowFire = vi.fn().mockImplementationOnce(
+      () => new Promise<void>((resolve) => { resolveFire = resolve; }),
+    );
+    const raceScheduler = new CronScheduler({
+      agentName: 'test-agent',
+      onFire: slowFire,
+      logger: (msg) => logs.push(msg),
+    });
+    const twoMinAgo = new Date(Date.now() - 2 * 60_000).toISOString();
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'heartbeat', schedule: '1m', last_fired_at: twoMinAgo, fire_count: 1 }),
+    ]);
+
+    raceScheduler.start();
+
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(slowFire).toHaveBeenCalledTimes(1);
+
+    const entryDuringFire = (raceScheduler as any).scheduled.get('heartbeat');
+    expect(entryDuringFire).toBeDefined();
+    expect(entryDuringFire.firing).toBe(true);
+
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'heartbeat', schedule: '1m', last_fired_at: twoMinAgo, fire_count: 1 }),
+    ]);
+    raceScheduler.reload();
+
+    const entryAfterReload = (raceScheduler as any).scheduled.get('heartbeat');
+    expect(entryAfterReload).toBe(entryDuringFire);
+    expect(entryAfterReload.firing).toBe(true);
+
+    resolveFire!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const entryAfterFire = (raceScheduler as any).scheduled.get('heartbeat');
+    expect(entryAfterFire).toBe(entryDuringFire);
+    expect(entryAfterFire.firing).toBe(false);
+    expect(entryAfterFire.nextFireAt).toBeGreaterThan(Date.now());
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(slowFire).toHaveBeenCalledTimes(2);
+
+    raceScheduler.stop();
+  });
+
   it('reload() recomputes nextFireAt for a modified schedule', async () => {
     mockReadCrons.mockReturnValue([makeCron({ name: 'changing', schedule: '6h' })]);
     scheduler.start();

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -16,6 +16,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockReadCrons  = vi.fn();
 const mockUpdateCron = vi.fn();
+const mockAppendExecutionLog = vi.fn();
 // readCronsWithStatus is what cron-scheduler actually calls (post-iter-9).
 // By default it mirrors mockReadCrons with corrupt:false so existing tests
 // keep working.  Tests that need to assert the corruption path can override
@@ -26,6 +27,10 @@ vi.mock('../../../src/bus/crons.js', () => ({
   readCrons:  (...args: unknown[]) => mockReadCrons(...args),
   readCronsWithStatus: (...args: unknown[]) => mockReadCronsWithStatus(...args),
   updateCron: (...args: unknown[]) => mockUpdateCron(...args),
+}));
+
+vi.mock('../../../src/daemon/cron-execution-log.js', () => ({
+  appendExecutionLog: (...args: unknown[]) => mockAppendExecutionLog(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -186,6 +191,7 @@ describe('CronScheduler', () => {
     fired  = [];
     mockReadCrons.mockReset();
     mockUpdateCron.mockReset();
+    mockAppendExecutionLog.mockReset();
     mockReadCronsWithStatus.mockReset();
     // Default: readCronsWithStatus reflects whatever readCrons returns
     // and reports the file as healthy (corrupt: false).
@@ -266,6 +272,51 @@ describe('CronScheduler', () => {
     );
   });
 
+  it('fresh_session success advances nextFireAt and does not refire on the next tick', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ schedule: '1m', fresh_session: true })]);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(60_000);
+
+    expect(fired).toHaveLength(1);
+    const scheduled = (scheduler as any).scheduled.get('test-cron');
+    expect(scheduled.nextFireAt).toBeGreaterThan(Date.now());
+
+    await vi.advanceTimersByTimeAsync(TICK);
+
+    expect(fired).toHaveLength(1);
+  });
+
+  it('fresh_session success skips scheduler last_fired_at/fire_count disk update', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ schedule: '1m', fresh_session: true })]);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(60_000 + TICK);
+
+    expect(mockUpdateCron).toHaveBeenCalledWith(
+      'test-agent',
+      'test-cron',
+      expect.objectContaining({ last_fire_attempted_at: expect.any(String) })
+    );
+    expect(mockUpdateCron.mock.calls.some((call) => 'last_fired_at' in (call[2] as object))).toBe(false);
+  });
+
+  it('PTY fires still write execution log through scheduler', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ schedule: '1m' })]);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(60_000 + TICK);
+
+    expect(mockAppendExecutionLog).toHaveBeenCalledWith(
+      'test-agent',
+      expect.objectContaining({
+        cron: 'test-cron',
+        status: 'fired',
+        error: null,
+      })
+    );
+  });
+
   // -------------------------------------------------------------------------
   // onFire failure + retry
   // -------------------------------------------------------------------------
@@ -318,6 +369,33 @@ describe('CronScheduler', () => {
       'test-cron',
       expect.objectContaining({ last_fired_at: expect.any(String) })
     );
+
+    retryScheduler.stop();
+  });
+
+  it('fresh_session fires are not retried by the scheduler', async () => {
+    const failingFire = vi.fn().mockRejectedValue(new Error('fresh failed'));
+    const oneDayAgo = new Date(Date.now() - 25 * 3_600_000).toISOString();
+    mockReadCrons.mockReturnValue([
+      makeCron({
+        schedule: '24h',
+        fresh_session: true,
+        last_fired_at: oneDayAgo,
+      }),
+    ]);
+
+    const retryScheduler = new CronScheduler({
+      agentName: 'test-agent',
+      onFire: failingFire,
+      logger: (msg) => logs.push(msg),
+    });
+
+    retryScheduler.start();
+    await vi.advanceTimersByTimeAsync(TICK + 1_000);
+
+    expect(failingFire).toHaveBeenCalledTimes(1);
+    expect(mockAppendExecutionLog).not.toHaveBeenCalled();
+    expect(logs.some(l => l.includes('after all 1 attempt'))).toBe(true);
 
     retryScheduler.stop();
   });

--- a/tests/unit/daemon/ipc-mutations.test.ts
+++ b/tests/unit/daemon/ipc-mutations.test.ts
@@ -193,6 +193,21 @@ describe('handleAddCron — happy path', () => {
     });
     expect(result.ok).toBe(true);
   });
+
+  it('trims and stores protocol_file', async () => {
+    writeEnabledAgents({ boris: { enabled: true } });
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('boris', {
+      name: 'heartbeat',
+      prompt: 'x',
+      schedule: '1h',
+      protocol_file: ' HEARTBEAT.md ',
+    });
+    expect(result.ok).toBe(true);
+
+    const { readCrons } = await import('../../../src/bus/crons.js');
+    expect(readCrons('boris')[0].protocol_file).toBe('HEARTBEAT.md');
+  });
 });
 
 describe('handleAddCron — validation failures', () => {
@@ -271,6 +286,20 @@ describe('handleAddCron — validation failures', () => {
     expect(result.field).toBe('prompt');
   });
 
+  it('rejects empty protocol_file', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('boris', { name: 'test', prompt: 'x', schedule: '1h', protocol_file: '   ' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
+  });
+
+  it('rejects absolute protocol_file', async () => {
+    const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleAddCron('boris', { name: 'test', prompt: 'x', schedule: '1h', protocol_file: '/tmp/HEARTBEAT.md' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
+  });
+
   it('returns error and field:name on duplicate cron', async () => {
     writeEnabledAgents({ boris: { enabled: true } });
     const { handleAddCron } = await import('../../../src/daemon/ipc-server.js');
@@ -320,6 +349,16 @@ describe('handleUpdateCron — happy path', () => {
     const result = handleUpdateCron('boris', 'heartbeat', { schedule: '0 9 * * *' });
     expect(result.ok).toBe(true);
   });
+
+  it('trims and updates protocol_file', async () => {
+    writeCronsJson('boris', [makeCron()]);
+    const { handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleUpdateCron('boris', 'heartbeat', { protocol_file: ' HEARTBEAT.md ' });
+    expect(result.ok).toBe(true);
+
+    const { getCronByName } = await import('../../../src/bus/crons.js');
+    expect(getCronByName('boris', 'heartbeat')?.protocol_file).toBe('HEARTBEAT.md');
+  });
 });
 
 describe('handleUpdateCron — validation failures', () => {
@@ -358,6 +397,22 @@ describe('handleUpdateCron — validation failures', () => {
     const result = handleUpdateCron('boris', 'heartbeat', { prompt: '   ' });
     expect(result.ok).toBe(false);
     expect(result.field).toBe('prompt');
+  });
+
+  it('rejects empty protocol_file in patch', async () => {
+    writeCronsJson('boris', [makeCron()]);
+    const { handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleUpdateCron('boris', 'heartbeat', { protocol_file: '   ' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
+  });
+
+  it('rejects absolute protocol_file in patch', async () => {
+    writeCronsJson('boris', [makeCron()]);
+    const { handleUpdateCron } = await import('../../../src/daemon/ipc-server.js');
+    const result = handleUpdateCron('boris', 'heartbeat', { protocol_file: '/tmp/HEARTBEAT.md' });
+    expect(result.ok).toBe(false);
+    expect(result.field).toBe('protocol_file');
   });
 
   it('returns error when cron not found', async () => {

--- a/tests/unit/hooks/hook-crash-alert.test.ts
+++ b/tests/unit/hooks/hook-crash-alert.test.ts
@@ -1,14 +1,14 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { tmpdir } from 'os';
+import { homedir, tmpdir } from 'os';
 
 const execFileMock = vi.fn();
 vi.mock('child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
 
-import { readMaxCrashesPerDay, notifyAgents } from '../../../src/hooks/hook-crash-alert';
+import { main, readMaxCrashesPerDay, notifyAgents } from '../../../src/hooks/hook-crash-alert';
 
 describe('readMaxCrashesPerDay', () => {
   let tmp: string;
@@ -143,5 +143,76 @@ describe('notifyAgents', () => {
     })).not.toThrow();
     // Second recipient still attempted
     expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('main fresh-session suppression', () => {
+  const originalEnv = { ...process.env };
+  let instanceId: string;
+  let ctxRoot: string;
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    instanceId = `hook-test-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    ctxRoot = join(homedir(), '.cortextos', instanceId);
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal('fetch', fetchMock);
+    execFileMock.mockReset();
+    process.env = {
+      ...originalEnv,
+      CTX_INSTANCE_ID: instanceId,
+      CTX_AGENT_NAME: 'dev-g',
+      CTX_FRESH_SESSION_CRON: 'dev-g/heartbeat',
+    };
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.unstubAllGlobals();
+    rmSync(ctxRoot, { recursive: true, force: true });
+  });
+
+  it('returns before crashes.log, crash counter, Telegram, and agent notifications', async () => {
+    await main();
+
+    expect(existsSync(join(ctxRoot, 'logs', 'dev-g', 'crashes.log'))).toBe(false);
+    expect(existsSync(join(ctxRoot, 'state', 'dev-g', '.crash_count_today'))).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('suppresses side effects even when Telegram credentials are present', async () => {
+    process.env.BOT_TOKEN = 'token';
+    process.env.CHAT_ID = 'chat';
+
+    await main();
+
+    expect(existsSync(join(ctxRoot, 'logs', 'dev-g', 'crashes.log'))).toBe(false);
+    expect(existsSync(join(ctxRoot, 'state', 'dev-g', '.crash_count_today'))).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(execFileMock).not.toHaveBeenCalled();
+  });
+
+  it('does not consume marker files before returning', async () => {
+    const stateDir = join(ctxRoot, 'state', 'dev-g');
+    mkdirSync(stateDir, { recursive: true });
+    const markerPath = join(stateDir, '.restart-planned');
+    writeFileSync(markerPath, 'planned restart', 'utf-8');
+
+    await main();
+
+    expect(existsSync(markerPath)).toBe(true);
+  });
+
+  it('normal crash still writes crashes.log when fresh-session marker is absent', async () => {
+    delete process.env.CTX_FRESH_SESSION_CRON;
+    delete process.env.BOT_TOKEN;
+    delete process.env.CHAT_ID;
+
+    await main();
+
+    const crashesLog = join(ctxRoot, 'logs', 'dev-g', 'crashes.log');
+    expect(readFileSync(crashesLog, 'utf-8')).toContain('type=crash');
+    expect(readFileSync(join(ctxRoot, 'state', 'dev-g', '.crash_count_today'), 'utf-8')).toContain(':1');
   });
 });


### PR DESCRIPTION
## Root Cause / Motivation

mmrag.py (ChromaDB + Gemini Embeddings) is the legacy KB backend. gbrain is now the primary knowledge store (Supabase Postgres + pgvector, hybrid RRF search). The two systems need to coexist until everything migrates; agents should hit gbrain by default without any configuration change on machines where it is already installed.

## What Changed

**`src/bus/knowledge-base.ts`** — gbrain fast-path behind a feature flag:

When `/root/.gbrain/config.json` exists (gbrain initialized) AND `GBRAIN_KB_BACKEND` is not `false`:

- **`queryKnowledgeBase()`** → spawns `gbrain query <q> --limit <topK>`, parses scored text output (`[score] slug -- preview`), then fetches full page content per result via `gbrain get <slug>`. Returns `KBQueryResponse` in the same shape callers already expect.
- **`ingestKnowledgeBase()`** → derives a slug from each file basename, pipes file content to `gbrain put <slug>`.

Rollback: `GBRAIN_KB_BACKEND=false` in the agent's env, or remove `/root/.gbrain/config.json`. mmrag path is untouched.

**`tests/unit/bus/knowledge-base.test.ts`** — test adjustments:
- `mockMissingKbConfig` and `mockConfiguredKb` updated to return `false` for `.gbrain/config.json` paths, keeping existing mmrag tests on the legacy path.
- New `mockConfiguredKbWithGbrain` helper for gbrain tests.
- 3 new tests: query happy path, query error handling, ingest put-per-file.

## Test Plan

- [x] `npm run build` — TypeScript compiles cleanly
- [x] `npm test tests/unit/bus/knowledge-base.test.ts` — 8/8 pass (5 existing + 3 new)
- [x] Full suite — pre-existing failures unchanged (27 in phase3-docs, sprint1-templates, phase5); 0 new failures
- [x] Smoke test on live fleet: `cortextos bus kb-query "what is cortextos" --org 1evo` → 5 results with scores and full content via gbrain path ✓

## Notes

- N+1 shell spawns per query (1 `gbrain query` + N `gbrain get` for topK results). Acceptable for topK=5 (~3s) but worth watching if topK is raised.
- gbrain CLI injects `[ai.gateway]` warnings to stderr — these are suppressed via `stdio: ['pipe','pipe','ignore']` in the execFileSync calls, keeping stdout parsing clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)