### PR TITLE
fix(daemon): allow comma-separated ALLOWED_USER list

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -220,9 +220,9 @@ export class AgentManager {
         botToken = undefined;
       }
 
-      // ALLOWED_USER must be a numeric Telegram user ID, not a username
-      if (allowedUserId && !/^\d+$/.test(allowedUserId)) {
-        log(`SECURITY: ALLOWED_USER is not a numeric ID. Telegram user IDs are numbers (e.g. 123456789). Refusing to enable Telegram. Fix the .env file.`);
+      // ALLOWED_USER must be numeric Telegram user ID(s), comma-separated
+      if (allowedUserId && !/^\d+(,\d+)*$/.test(allowedUserId)) {
+        log(`SECURITY: ALLOWED_USER is not numeric ID(s). Use comma-separated Telegram user IDs (e.g. 123456789 or 123456789,987654321). Refusing to enable Telegram. Fix the .env file.`);
         allowedUserId = undefined;
       }
 
@@ -253,7 +253,7 @@ export class AgentManager {
       log,
       telegramApi,
       chatId,
-      allowedUserId: allowedUserId ? parseInt(allowedUserId, 10) : undefined,
+      allowedUserIds: allowedUserId ? new Set(allowedUserId.split(',').map(id => parseInt(id.trim(), 10))) : undefined,
     });
 
     // Send Telegram notification on crashes and session refreshes
@@ -318,10 +318,9 @@ export class AgentManager {
 
       poller.onMessage((msg) => {
         // ALLOWED_USER gate: if configured, ignore messages from other users.
-        // Use numeric comparison to avoid string coercion issues.
         if (allowedUserId) {
-          const allowedId = parseInt(allowedUserId, 10);
-          if (msg.from?.id !== allowedId) {
+          const allowedIds = new Set(allowedUserId.split(',').map(id => parseInt(id.trim(), 10)));
+          if (!msg.from?.id || !allowedIds.has(msg.from.id)) {
             log(`Ignoring message from unauthorized user (allowed_user gate)`);
             return;
           }
@@ -429,8 +428,8 @@ export class AgentManager {
         // ALLOWED_USER gate: same rule as message handler. If configured,
         // ignore reactions from other users.
         if (allowedUserId) {
-          const allowedId = parseInt(allowedUserId, 10);
-          if (reaction.user?.id !== allowedId) {
+          const allowedIds = new Set(allowedUserId.split(',').map(id => parseInt(id.trim(), 10)));
+          if (!reaction.user?.id || !allowedIds.has(reaction.user.id)) {
             log('Ignoring reaction from unauthorized user (allowed_user gate)');
             return;
           }


### PR DESCRIPTION
## Summary
- ALLOWED_USER in agent `.env` now accepts comma-separated Telegram user IDs (e.g. `123456789,987654321`)
- Regex validation updated from `^\d+$` to `^\d+(,\d+)*$`
- All three ALLOWED_USER gates (message handler, reaction handler, fast-checker config) parse the comma-separated list into a `Set<number>` for O(1) lookup

## Why
Agents need to accept messages from multiple authorized users (e.g. both Luke and Chase). Previously, setting `ALLOWED_USER=123,456` would fail validation and disable Telegram entirely.

## Test plan
- [ ] Single numeric ALLOWED_USER still works
- [ ] Comma-separated ALLOWED_USER (e.g. `8372578968,8864755248`) passes validation
- [ ] Messages from unlisted users are still rejected
- [ ] `npm run build` compiles cleanly
- [ ] `npm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)