### PR TITLE
fix(cron-scheduler): use created_at as referenceMs floor for pre-first-fire schedule drift

### DIFF
--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -386,15 +386,25 @@ export class CronScheduler {
       // New or modified cron — compute fresh nextFireAt.
       // Base: take the most recent of crons.json.last_fired_at,
       // crons.json.last_fire_attempted_at (set pre-onFire to detect crash
-      // mid-fire — iter 11), and cron-state.json.last_fire (either may be
-      // more current depending on which write path recorded the fire).
-      // Fall back to now.
+      // mid-fire — iter 11), cron-state.json.last_fire (either may be
+      // more current depending on which write path recorded the fire),
+      // and crons.json.created_at (floor: prevents schedule drift on
+      // repeated daemon restarts before the first fire — without it,
+      // all-null timestamps fall back to now and push next_fire_at forward
+      // by the full interval on every restart).
+      // Fall back to now only for crons missing created_at (legacy entries).
       const stateFire = stateLastFireByName.get(def.name);
       const candidates: number[] = [];
       if (def.last_fired_at) candidates.push(new Date(def.last_fired_at).getTime());
       if (def.last_fire_attempted_at) candidates.push(new Date(def.last_fire_attempted_at).getTime());
       if (stateFire) candidates.push(new Date(stateFire).getTime());
-      const referenceMs = candidates.length > 0 ? Math.max(...candidates) : now;
+      // created_at is a floor used ONLY when no fire history exists: prevents
+      // schedule drift on repeated daemon restarts before the first fire.
+      // It must NOT enter the max() pool — doing so would suppress catch-up
+      // for crons with old last_fired_at but recent created_at.
+      const referenceMs = candidates.length > 0
+        ? Math.max(...candidates)
+        : (def.created_at ? new Date(def.created_at).getTime() : now);
 
       let nextFireAt = computeNextFireAt(def, referenceMs);
 

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -266,6 +266,26 @@ describe('CronScheduler', () => {
     );
   });
 
+  it('created_at used as referenceMs floor when no fire history — prevents pre-first-fire schedule drift', () => {
+    // A cron created 2h ago with no last_fired_at / last_fire_attempted_at.
+    // Without created_at in candidates, each daemon restart would set
+    // referenceMs=now and push next_fire_at forward by the full interval.
+    // With created_at, referenceMs=created_at and next_fire_at is stable.
+    const createdAt = new Date(Date.now() - 2 * 60 * 60_000).toISOString(); // 2h ago
+    mockReadCrons.mockReturnValue([
+      makeCron({ schedule: '4h', created_at: createdAt }),
+    ]);
+    scheduler.start();
+
+    // After start, the cron should be scheduled ~2h from now (4h - 2h elapsed).
+    // If created_at was NOT used, nextFireAt would be now+4h (4h from now).
+    const scheduled = (scheduler as any).scheduled.get('test-cron');
+    const twoHoursMs = 2 * 60 * 60_000;
+    // nextFireAt should be closer to now+2h than now+4h
+    expect(scheduled.nextFireAt).toBeLessThan(Date.now() + twoHoursMs + 60_000);
+    expect(scheduled.nextFireAt).toBeGreaterThan(Date.now() + twoHoursMs - 60_000);
+  });
+
   // -------------------------------------------------------------------------
   // onFire failure + retry
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Root Cause

A cron that has never fired has all-null timestamps (`last_fired_at`, `last_fire_attempted_at`, `cron-state.json.last_fire`). The scheduler's `referenceMs` computation fell back to `now`, so `next_fire_at = now + interval` on every daemon restart — the cron drifted forward indefinitely and could never reach its first fire slot.

## Repro

- Cron created at T=0, interval=4h
- Daemon restarts at T=2h (no fire yet): `referenceMs = now` → `next_fire_at = now+4h = T+6h`
- Daemon restarts again at T=5h: `referenceMs = now` → `next_fire_at = now+4h = T+9h`
- Cron never fires

## Fix

Use `created_at` as the fallback `referenceMs` **only** when the candidates pool (fire history) is empty:

```typescript
const referenceMs = candidates.length > 0
  ? Math.max(...candidates)
  : (def.created_at ? new Date(def.created_at).getTime() : now);
```

`created_at` must **not** enter the `max()` pool — doing so would suppress catch-up for crons with old `last_fired_at` but recent `created_at`. The pool contains actual fire evidence; `created_at` is a reference floor only when that evidence is absent.

## Test Plan

- [x] `npm run build` — clean
- [x] `npm test tests/unit/daemon/cron-scheduler.test.ts` — 29/29 pass
- [x] Added one regression test: cron created 2h ago, 4h schedule → `next_fire_at ≈ now+2h` (verifies fix; without it would be `now+4h`)
- [x] All existing catch-up, reload, and retry tests still pass (no regression from `created_at` placement)

## Related

- Supersedes PR #455 (bundled with unrelated work — closing in favor of this clean scope per James's feedback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)