### PR TITLE
fix(daemon): gate shouldContinue JSONL check on Claude runtime only

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -459,7 +459,7 @@ export class AgentProcess {
       return hermesDbExists(hermesHome);
     }
 
-    // Check for force-fresh marker
+    // Check for force-fresh marker (all runtimes honor it).
     const forceFreshPath = join(this.env.ctxRoot, 'state', this.name, '.force-fresh');
     if (existsSync(forceFreshPath)) {
       try {
@@ -469,7 +469,24 @@ export class AgentProcess {
       return false;
     }
 
-    // Check for existing conversation
+    // codex-app-server: session continuity is tracked by the adapter's own
+    // codex-app-server-thread.json under ctxRoot/state/<agent>/. The Claude
+    // JSONL check below is meaningless for the codex runtime, and a stale
+    // Claude JSONL left over from a prior Claude-runtime tenure caused
+    // continue-mode → thread/resume timeout → exit_code=0 crash loop
+    // (testorg codex-agent crashed 3x with this signature on 2026-05-09,
+    // 05-14, and 05-16 before backoff drained the pending resume RPC).
+    if (this.config.runtime === 'codex-app-server') {
+      const threadStatePath = join(
+        this.env.ctxRoot,
+        'state',
+        this.name,
+        'codex-app-server-thread.json',
+      );
+      return existsSync(threadStatePath);
+    }
+
+    // Default (Claude runtime): existing conversation = JSONL files present.
     const launchDir = this.config.working_directory || this.env.agentDir;
     if (!launchDir) return false;
 

--- a/tests/unit/daemon/agent-process-codex-app-server.test.ts
+++ b/tests/unit/daemon/agent-process-codex-app-server.test.ts
@@ -145,5 +145,37 @@ describe('AgentProcess codex-app-server runtime', () => {
     await stopPromise;
     expect(mockCodexAppServerPty.kill).toHaveBeenCalled();
   }, 10000);
+
+  it('ignores stale Claude JSONL when picking continue vs fresh — uses codex thread state only', async () => {
+    // Regression: testorg codex-agent (runtime codex-app-server) had a leftover
+    // Claude JSONL from a prior Claude-runtime tenure. shouldContinue used to
+    // detect the JSONL and pick 'continue', which made startOrResumeThread
+    // attempt thread/resume against a stale Codex thread, time out, and
+    // exit_code=0 in a crash loop (2026-05-09, 05-14, 05-16). The runtime gate
+    // means: codex-app-server checks ITS OWN thread state file, never the
+    // Claude conversation dir.
+    const codexThreadPath = '/tmp/test-ctx/state/codex-app-agent/codex-app-server-thread.json';
+
+    // Stale Claude JSONL present but no codex-app-server thread state → fresh.
+    fsMocks.existsSync.mockImplementation((path: string) => {
+      if (path.endsWith('.force-fresh')) return false;
+      if (path === codexThreadPath) return false;
+      return false;
+    });
+    const apFresh = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    await apFresh.start();
+    expect(mockCodexAppServerPty.spawn).toHaveBeenLastCalledWith('fresh', expect.any(String));
+
+    // Codex thread state present → continue.
+    mockCodexAppServerPty.spawn.mockClear();
+    fsMocks.existsSync.mockImplementation((path: string) => {
+      if (path.endsWith('.force-fresh')) return false;
+      if (path === codexThreadPath) return true;
+      return false;
+    });
+    const apContinue = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    await apContinue.start();
+    expect(mockCodexAppServerPty.spawn).toHaveBeenLastCalledWith('continue', expect.any(String));
+  });
 });
 


### PR DESCRIPTION
## Summary

- `shouldContinue()` now uses a per-runtime check instead of falling through to the Claude JSONL probe for everything-not-hermes.
- For `runtime: codex-app-server`, session continuity is now decided by the adapter's own `codex-app-server-thread.json` state file under `ctxRoot/state/<agent>/`, never by `~/.claude/projects/...`.
- Hermes branch and `.force-fresh` marker unchanged. Claude runtime falls through to the existing JSONL probe.

## Why

testorg `codex-agent` (runtime `codex-app-server`) hit an `exit_code=0` crash loop on three separate days with the same signature: 3 clean exits with 5s/10s/20s backoff, then self-heal at start #4.

Root cause: the agent had a stale Claude JSONL from a prior Claude-runtime tenure under `~/.claude/projects/-Users-cortextos-cortextos-orgs-testorg-agents-codex-agent/`. `shouldContinue()` saw the JSONL → returned true → `start()` picked `continue` mode → `CodexAppServerPTY.startOrResumeThread()` issued `thread/resume` against a stale Codex thread → RPC timed out → process exited 0 → restart loop. The fourth start eventually succeeded once the pending resume RPC drained.

Logged crashes (from `~/.cortextos/default/logs/codex-agent/restarts.log`):

```
[2026-05-09T00:59:09Z] CRASH: exit_code=0 crash_count=1 backoff_s=5
[2026-05-09T02:54:02Z] CRASH: exit_code=0 crash_count=2 backoff_s=10
[2026-05-14T17:52:03Z] CRASH: exit_code=0 crash_count=1 backoff_s=5
[2026-05-14T17:53:08Z] CRASH: exit_code=0 crash_count=2 backoff_s=10
[2026-05-16T05:06:47Z] CRASH: exit_code=0 crash_count=1 backoff_s=5
[2026-05-16T05:07:53Z] CRASH: exit_code=0 crash_count=2 backoff_s=10
[2026-05-16T05:10:03Z] CRASH: exit_code=0 crash_count=3 backoff_s=20
```

## Test plan

- [x] New regression test: `tests/unit/daemon/agent-process-codex-app-server.test.ts` — stale Claude JSONL with no codex thread state must spawn `fresh`; thread state present must spawn `continue`.
- [x] Existing `agent-process.test.ts` and `agent-process-hermes.test.ts` still green (force-fresh + hermes paths unaffected).
- [x] `npm run build` clean.
- [ ] Once merged + rebuilt + daemon restarted, the stale JSONL at `~/.claude/projects/-Users-cortextos-cortextos-orgs-testorg-agents-codex-agent/325fab4f-5c8e-4b90-9e75-8264b86e8fe4.jsonl` should be irrelevant — codex-agent should boot fresh and stay up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)