### PR TITLE
fix(daemon): cron --continue race + heartbeat watchdog env

### DIFF
--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -167,7 +167,14 @@ function computeNextFireAt(cron: CronDefinition, referenceMs: number): number {
 // Retry helper
 // ---------------------------------------------------------------------------
 
-const RETRY_DELAYS_MS = [1_000, 4_000, 16_000];
+// Exponential back-off across 8 attempts (initial + 7 retries) for a cumulative
+// wait of ~127 s before giving up. The previous 4-attempt window (1 + 4 + 16 s
+// = 21 s) was reliably exhausted when a cron fired during a Claude Code
+// `--continue` restart: status flips to 'running' on PTY spawn but the session
+// is still rehydrating its transcript, so `injectMessage()` returns false until
+// bootstrap completes. Heavy transcripts (multi-MB) can take well over 21 s,
+// causing the prompt to be lost. 127 s covers observed worst-case rehydration.
+const RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000];
 
 async function fireWithRetry(
   cron: CronDefinition,
@@ -175,7 +182,7 @@ async function fireWithRetry(
   onFire: (c: CronDefinition) => Promise<void> | void,
   logger: (msg: string) => void,
 ): Promise<boolean> {
-  const maxAttempts = RETRY_DELAYS_MS.length + 1; // 4 attempts total
+  const maxAttempts = RETRY_DELAYS_MS.length + 1; // 8 attempts total
   for (let attempt = 0; attempt < maxAttempts; attempt++) {
     const start = Date.now();
     try {
@@ -196,7 +203,7 @@ async function fireWithRetry(
         const delay = RETRY_DELAYS_MS[attempt];
         logger(
           `[cron-scheduler] onFire failed for "${cron.name}" ` +
-          `(attempt ${attempt + 1}/4, retrying in ${delay}ms): ${errMsg}`
+          `(attempt ${attempt + 1}/${maxAttempts}, retrying in ${delay}ms): ${errMsg}`
         );
         appendExecutionLog(agentName, {
           ts: new Date().toISOString(),
@@ -210,7 +217,7 @@ async function fireWithRetry(
       } else {
         logger(
           `[cron-scheduler] onFire failed for "${cron.name}" ` +
-          `after all 4 attempts — giving up. Last error: ${errMsg}`
+          `after all ${maxAttempts} attempts — giving up. Last error: ${errMsg}`
         );
         appendExecutionLog(agentName, {
           ts: new Date().toISOString(),

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -111,9 +111,18 @@ export class FastChecker {
     const agentName = this.agent.name;
     this.heartbeatTimer = setInterval(() => {
       const ts = new Date().toISOString();
-      execFile('cortextos', ['bus', 'update-heartbeat', `[watchdog] ${agentName} alive — idle session ${ts}`], (err) => {
-        if (err) this.log(`Heartbeat watchdog error: ${err.message}`);
-      });
+      // Pass CTX_AGENT_NAME explicitly: the daemon (parent) has no per-agent
+      // value in its own env, and resolveEnv() falls back to basename(cwd)
+      // which yields the repo dir name (e.g. "MudBot") and trips
+      // validateAgentName() because of the capital letter.
+      execFile(
+        'cortextos',
+        ['bus', 'update-heartbeat', `[watchdog] ${agentName} alive — idle session ${ts}`],
+        { env: { ...process.env, CTX_AGENT_NAME: agentName } },
+        (err) => {
+          if (err) this.log(`Heartbeat watchdog error: ${err.message}`);
+        },
+      );
     }, HEARTBEAT_INTERVAL_MS);
 
     while (this.running) {

--- a/tests/integration/phase1-backtesting.test.ts
+++ b/tests/integration/phase1-backtesting.test.ts
@@ -475,7 +475,7 @@ describe('Scenario 4: PTY injection failure / retries', () => {
     expect(fired[0].error).toBeNull();
   });
 
-  it('exhausts all 4 attempts and logs status=failed after all retries fail', async () => {
+  it('exhausts all 8 attempts and logs status=failed after all retries fail', async () => {
     const agent = 'exhaust-agent';
     ensureAgentDir(agent);
 
@@ -494,44 +494,48 @@ describe('Scenario 4: PTY injection failure / retries', () => {
     });
     s.start();
 
-    // Drive through all 4 attempts: tick + 1s + 4s + 16s + buffer
+    // Drive through all 8 attempts: tick + 1+2+4+8+16+32+64s + buffer
     await vi.advanceTimersByTimeAsync(TICK_MS);
     await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(2_000);
     await vi.advanceTimersByTimeAsync(4_000);
+    await vi.advanceTimersByTimeAsync(8_000);
     await vi.advanceTimersByTimeAsync(16_000);
+    await vi.advanceTimersByTimeAsync(32_000);
+    await vi.advanceTimersByTimeAsync(64_000);
     await vi.advanceTimersByTimeAsync(1_000);
 
     s.stop();
 
-    // 4 attempts total
-    expect(alwaysFail).toHaveBeenCalledTimes(4);
+    // 8 attempts total
+    expect(alwaysFail).toHaveBeenCalledTimes(8);
 
     const logEntries = readLog(agent).filter(e => e.cron === 'failing-cron');
     const retried = logEntries.filter(e => e.status === 'retried');
     const failed = logEntries.filter(e => e.status === 'failed');
 
-    // 3 retried + 1 failed
-    expect(retried).toHaveLength(3);
+    // 7 retried + 1 failed
+    expect(retried).toHaveLength(7);
     expect(failed).toHaveLength(1);
 
-    expect(failed[0].attempt).toBe(4);
+    expect(failed[0].attempt).toBe(8);
     expect(failed[0].error).toContain('total PTY failure');
 
     // Scheduler must NOT crash
     expect(logs.some(l => l.includes('giving up'))).toBe(true);
   });
 
-  it('retry timing matches 1s/4s/16s schedule', async () => {
+  it('retry timing matches exponential 1/2/4/8/16/32/64s schedule', async () => {
     const agent = 'timing-agent';
     ensureAgentDir(agent);
 
     const callTimes: number[] = [];
     let callCount = 0;
 
-    const failFirst3 = vi.fn().mockImplementation(async () => {
+    const failFirst7 = vi.fn().mockImplementation(async () => {
       callTimes.push(Date.now());
       callCount++;
-      if (callCount < 4) throw new Error('retry me');
+      if (callCount < 8) throw new Error('retry me');
     });
 
     addCron(agent, makeCronDef('timed-cron', '24h', {
@@ -540,31 +544,37 @@ describe('Scenario 4: PTY injection failure / retries', () => {
 
     const s = new CronScheduler({
       agentName: agent,
-      onFire: failFirst3,
+      onFire: failFirst7,
       logger: () => {},
     });
     s.start();
 
-    // Drive all retries
+    // Drive all retries (1+2+4+8+16+32+64 = 127s cumulative)
     await vi.advanceTimersByTimeAsync(TICK_MS);
-    await vi.advanceTimersByTimeAsync(1_000 + 4_000 + 16_000 + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000 + 2_000 + 4_000 + 8_000 + 16_000 + 32_000 + 64_000 + 1_000);
 
     s.stop();
 
-    expect(callTimes).toHaveLength(4);
+    expect(callTimes).toHaveLength(8);
 
     // Gaps between successive calls should approximate the backoff delays
-    const gap1 = callTimes[1] - callTimes[0]; // ~1s
-    const gap2 = callTimes[2] - callTimes[1]; // ~4s
-    const gap3 = callTimes[3] - callTimes[2]; // ~16s
+    const gaps = [
+      callTimes[1] - callTimes[0],   // ~1s
+      callTimes[2] - callTimes[1],   // ~2s
+      callTimes[3] - callTimes[2],   // ~4s
+      callTimes[4] - callTimes[3],   // ~8s
+      callTimes[5] - callTimes[4],   // ~16s
+      callTimes[6] - callTimes[5],   // ~32s
+      callTimes[7] - callTimes[6],   // ~64s
+    ];
+    const expectedDelays = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000];
 
-    // With fake timers the gaps should match the sleep durations closely
-    expect(gap1).toBeGreaterThanOrEqual(1_000);
-    expect(gap1).toBeLessThanOrEqual(2_000);
-    expect(gap2).toBeGreaterThanOrEqual(4_000);
-    expect(gap2).toBeLessThanOrEqual(6_000);
-    expect(gap3).toBeGreaterThanOrEqual(16_000);
-    expect(gap3).toBeLessThanOrEqual(20_000);
+    for (let i = 0; i < gaps.length; i++) {
+      const min = expectedDelays[i];
+      const max = expectedDelays[i] + Math.max(1_000, expectedDelays[i] * 0.25);
+      expect(gaps[i]).toBeGreaterThanOrEqual(min);
+      expect(gaps[i]).toBeLessThanOrEqual(max);
+    }
   });
 });
 

--- a/tests/integration/phase5-e2e-simulation.test.ts
+++ b/tests/integration/phase5-e2e-simulation.test.ts
@@ -802,8 +802,10 @@ describe('Scenario 5: PTY degradation — slow injection, intermittent failure, 
    * thin synchronous boolean wrapper around AgentProcess.injectMessage(). Retries at
    * the scheduler layer cover all injectAgent failure modes — PTY slow, PTY absent, etc.
    *
-   * The scheduler retries 3 times with 1s/4s/16s backoff (4 attempts total).
-   * "Eventual delivery" window: max 21s after initial attempt.
+   * The scheduler retries 7 times with 1/2/4/8/16/32/64 s backoff (8 attempts total).
+   * "Eventual delivery" window: max ~127 s after initial attempt. The window was
+   * widened from the original 4-attempt / 21 s budget so a cron firing during a
+   * Claude Code `--continue` restart is not dropped while the session rehydrates.
    *
    * Documented as finding, not a gap — the design is intentional.
    */
@@ -904,7 +906,7 @@ describe('Scenario 5: PTY degradation — slow injection, intermittent failure, 
     expect(succeeded[0].ts).toBeDefined();
   });
 
-  it('5c: persistent failure — exhausts 4 attempts, logs final failure with attempt counts', async () => {
+  it('5c: persistent failure — exhausts 8 attempts, logs final failure with attempt counts', async () => {
     const agent = 'dead-pty-agent';
     ensureAgentDir(agent);
 
@@ -923,31 +925,35 @@ describe('Scenario 5: PTY degradation — slow injection, intermittent failure, 
     const s = buildScheduler(agent, alwaysFail, logs);
     s.start();
 
-    // Drive all 4 attempts: tick + 1s + 4s + 16s + buffer
+    // Drive all 8 attempts: tick + 1+2+4+8+16+32+64s + buffer
     await vi.advanceTimersByTimeAsync(TICK_MS);
     await vi.advanceTimersByTimeAsync(1_000);
+    await vi.advanceTimersByTimeAsync(2_000);
     await vi.advanceTimersByTimeAsync(4_000);
+    await vi.advanceTimersByTimeAsync(8_000);
     await vi.advanceTimersByTimeAsync(16_000);
+    await vi.advanceTimersByTimeAsync(32_000);
+    await vi.advanceTimersByTimeAsync(64_000);
     await vi.advanceTimersByTimeAsync(1_000);
 
     s.stop();
 
-    // 4 total attempts
-    expect(alwaysFail).toHaveBeenCalledTimes(4);
+    // 8 total attempts
+    expect(alwaysFail).toHaveBeenCalledTimes(8);
 
     const logEntries = readLog(agent).filter(e => e.cron === 'dead-cron');
     const retriedEntries = logEntries.filter(e => e.status === 'retried');
     const failedEntries = logEntries.filter(e => e.status === 'failed');
 
-    // 3 retried + 1 final failed
-    expect(retriedEntries).toHaveLength(3);
+    // 7 retried + 1 final failed
+    expect(retriedEntries).toHaveLength(7);
     expect(failedEntries).toHaveLength(1);
 
-    // Attempt numbers logged correctly (1, 2, 3 for retried; 4 for failed)
-    expect(retriedEntries[0].attempt).toBe(1);
-    expect(retriedEntries[1].attempt).toBe(2);
-    expect(retriedEntries[2].attempt).toBe(3);
-    expect(failedEntries[0].attempt).toBe(4);
+    // Attempt numbers logged correctly (1..7 for retried; 8 for failed)
+    for (let i = 0; i < 7; i++) {
+      expect(retriedEntries[i].attempt).toBe(i + 1);
+    }
+    expect(failedEntries[0].attempt).toBe(8);
 
     // "giving up" log message present
     expect(logs.some(l => l.includes('giving up'))).toBe(true);
@@ -956,43 +962,50 @@ describe('Scenario 5: PTY degradation — slow injection, intermittent failure, 
     // (tested by successful stop() call above without throw)
   });
 
-  it('5d: retry timing matches 1s/4s/16s exponential backoff schedule', async () => {
+  it('5d: retry timing matches 1/2/4/8/16/32/64s exponential backoff schedule', async () => {
     const agent = 'timing-pty-agent';
     ensureAgentDir(agent);
 
     const callTimes: number[] = [];
     let count = 0;
 
-    const failFirst3 = vi.fn().mockImplementation(async () => {
+    const failFirst7 = vi.fn().mockImplementation(async () => {
       callTimes.push(Date.now());
       count++;
-      if (count < 4) throw new Error('retry me');
+      if (count < 8) throw new Error('retry me');
     });
 
     addCron(agent, makeCronDef('timed', '24h', {
       last_fired_at: new Date(Date.now() - 25 * ONE_HOUR).toISOString(),
     }));
 
-    const s = buildScheduler(agent, failFirst3);
+    const s = buildScheduler(agent, failFirst7);
     s.start();
 
     await vi.advanceTimersByTimeAsync(TICK_MS);
-    await vi.advanceTimersByTimeAsync(1_000 + 4_000 + 16_000 + 1_000);
+    await vi.advanceTimersByTimeAsync(1_000 + 2_000 + 4_000 + 8_000 + 16_000 + 32_000 + 64_000 + 1_000);
 
     s.stop();
 
-    expect(callTimes).toHaveLength(4);
+    expect(callTimes).toHaveLength(8);
 
-    const gap1 = callTimes[1] - callTimes[0]; // ~1s
-    const gap2 = callTimes[2] - callTimes[1]; // ~4s
-    const gap3 = callTimes[3] - callTimes[2]; // ~16s
+    const gaps = [
+      callTimes[1] - callTimes[0],
+      callTimes[2] - callTimes[1],
+      callTimes[3] - callTimes[2],
+      callTimes[4] - callTimes[3],
+      callTimes[5] - callTimes[4],
+      callTimes[6] - callTimes[5],
+      callTimes[7] - callTimes[6],
+    ];
+    const expected = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000];
 
-    expect(gap1).toBeGreaterThanOrEqual(1_000);
-    expect(gap1).toBeLessThanOrEqual(2_000);
-    expect(gap2).toBeGreaterThanOrEqual(4_000);
-    expect(gap2).toBeLessThanOrEqual(6_000);
-    expect(gap3).toBeGreaterThanOrEqual(16_000);
-    expect(gap3).toBeLessThanOrEqual(20_000);
+    for (let i = 0; i < gaps.length; i++) {
+      const min = expected[i];
+      const max = expected[i] + Math.max(1_000, expected[i] * 0.25);
+      expect(gaps[i]).toBeGreaterThanOrEqual(min);
+      expect(gaps[i]).toBeLessThanOrEqual(max);
+    }
   });
 });
 

--- a/tests/integration/phase5-failure-modes.test.ts
+++ b/tests/integration/phase5-failure-modes.test.ts
@@ -1259,7 +1259,7 @@ describe('AF-2: Sequential fire under slow PTY — drift quantification', () => 
 // ---------------------------------------------------------------------------
 
 describe('FM-6: PTY blocked — retries until accepting, recovery within spec', () => {
-  it('PTY blocks for first 3 attempts then succeeds on attempt 4; log shows all 4 attempts', async () => {
+  it('PTY blocks for first 4 attempts then succeeds on attempt 5; log shows all 5 attempts', async () => {
     const agent = 'fm-pty-blocked';
     ensureAgentDir(agent);
 
@@ -1271,31 +1271,31 @@ describe('FM-6: PTY blocked — retries until accepting, recovery within spec', 
 
     const scheduler = buildScheduler(agent, async (c) => {
       callCount++;
-      if (callCount < 4) {
+      if (callCount < 5) {
         throw new Error(`PTY blocked (attempt ${callCount})`);
       }
       fired.push(c.name);
     }, logs);
     scheduler.start();
 
-    // Advance to trigger + enough time for 3 retries (1s + 4s + 16s = 21s)
-    await vi.advanceTimersByTimeAsync(ONE_HOUR + TICK_MS + 25_000);
+    // Advance to trigger + enough time for 4 retries (1s + 2s + 4s + 8s = 15s)
+    await vi.advanceTimersByTimeAsync(ONE_HOUR + TICK_MS + 20_000);
 
     expect(fired.length).toBe(1);
-    expect(callCount).toBe(4); // exactly 4 attempts
+    expect(callCount).toBe(5); // exactly 5 attempts
 
-    // Log shows retried (×3) + fired (×1)
+    // Log shows retried (×4) + fired (×1)
     const log = readLog(agent);
     const retriedEntries = log.filter(e => e.status === 'retried');
     const firedEntries = log.filter(e => e.status === 'fired');
-    expect(retriedEntries.length).toBe(3);
+    expect(retriedEntries.length).toBe(4);
     expect(firedEntries.length).toBe(1);
-    expect(firedEntries[0].attempt).toBe(4);
+    expect(firedEntries[0].attempt).toBe(5);
 
     scheduler.stop();
   });
 
-  it('PTY permanently blocked — all 4 attempts exhausted; scheduler continues, healthy cron unaffected', async () => {
+  it('PTY permanently blocked — all 8 attempts exhausted; scheduler continues, healthy cron unaffected', async () => {
     const agent = 'fm-pty-dead';
     ensureAgentDir(agent);
 
@@ -1318,11 +1318,12 @@ describe('FM-6: PTY blocked — retries until accepting, recovery within spec', 
     }, logs);
     scheduler.start();
 
-    // One tick fires both; dead-cron goes through 4 attempts in ~21s
-    await vi.advanceTimersByTimeAsync(TICK_MS + 25_000);
+    // One tick fires both; dead-cron goes through 8 attempts over ~127s
+    // (1+2+4+8+16+32+64s back-offs). Extra buffer for fake-timer slop.
+    await vi.advanceTimersByTimeAsync(TICK_MS + 135_000);
 
-    // dead-cron: 4 attempts, all failed
-    expect(deadCallCount).toBe(4);
+    // dead-cron: 8 attempts, all failed
+    expect(deadCallCount).toBe(8);
 
     // healthy-cron: fired successfully despite neighbor failing
     expect(healthyCallCount).toBeGreaterThan(0);
@@ -1331,7 +1332,7 @@ describe('FM-6: PTY blocked — retries until accepting, recovery within spec', 
     expect(scheduler.getNextFireTimes().length).toBeGreaterThan(0);
 
     // giving-up log message present
-    const givingUpMsg = logs.find(l => l.includes('giving up') || l.includes('all 4 attempts'));
+    const givingUpMsg = logs.find(l => l.includes('giving up') || l.includes('all 8 attempts'));
     expect(givingUpMsg).toBeDefined();
 
     scheduler.stop();

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -270,7 +270,7 @@ describe('CronScheduler', () => {
   // onFire failure + retry
   // -------------------------------------------------------------------------
 
-  it('retries onFire 3 times on failure then gives up without crashing', async () => {
+  it('retries onFire 7 times on failure then gives up without crashing', async () => {
     const failingFire = vi.fn().mockRejectedValue(new Error('PTY unavailable'));
 
     // Use a very long schedule so the cron never becomes due a SECOND time
@@ -294,11 +294,16 @@ describe('CronScheduler', () => {
 
     retryScheduler.start();
 
-    // Advance through one tick (fires catch-up) plus all retry back-offs (1s+4s+16s)
-    await vi.advanceTimersByTimeAsync(TICK + 1_000 + 4_000 + 16_000 + 1_000);
+    // Advance through one tick (fires catch-up) plus all retry back-offs
+    // (1s+2s+4s+8s+16s+32s+64s = 127s). Window widened from 4 -> 8 attempts
+    // so a cron firing during a slow Claude Code `--continue` rehydration
+    // (PTY status='running' but transcript still loading) is not dropped.
+    await vi.advanceTimersByTimeAsync(
+      TICK + 1_000 + 2_000 + 4_000 + 8_000 + 16_000 + 32_000 + 64_000 + 1_000,
+    );
 
-    // 4 total calls: 1 initial + 3 retries
-    expect(failingFire).toHaveBeenCalledTimes(4);
+    // 8 total calls: 1 initial + 7 retries
+    expect(failingFire).toHaveBeenCalledTimes(8);
 
     // Scheduler must NOT crash — the log should contain a give-up message
     expect(retryLogs.some(l => l.includes('giving up'))).toBe(true);

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -798,8 +798,38 @@ describe('FastChecker', () => {
       expect(execFile).toHaveBeenCalledWith(
         'cortextos',
         expect.arrayContaining(['bus', 'update-heartbeat', expect.stringContaining('[watchdog] my-agent alive — idle session')]),
+        expect.objectContaining({ env: expect.any(Object) }),
         expect.any(Function),
       );
+      checker.stop();
+      checker.wake();
+    });
+
+    it('passes CTX_AGENT_NAME explicitly so the child does not fall back to basename(cwd)', async () => {
+      const { execFile } = await import('child_process');
+      const execMock = execFile as ReturnType<typeof vi.fn>;
+      const agent = createMockAgent('my-agent');
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      checker.start();
+      await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
+
+      // Find the watchdog call (filter by '[watchdog]' marker in args)
+      const watchdogCall = execMock.mock.calls.find((args: unknown[]) => {
+        const argv = args[1] as string[] | undefined;
+        return Array.isArray(argv) && argv.some(a => typeof a === 'string' && a.includes('[watchdog]'));
+      });
+      expect(watchdogCall).toBeDefined();
+
+      const options = watchdogCall![2] as { env: Record<string, string> };
+      expect(options).toBeDefined();
+      expect(options.env).toBeDefined();
+      // The fix: CTX_AGENT_NAME is forwarded explicitly so the spawned
+      // `cortextos bus update-heartbeat` does NOT fall back to
+      // basename(process.cwd()) — which would yield the repo dir name
+      // (e.g. 'MudBot') and fail validateAgentName() because of the
+      // uppercase letter.
+      expect(options.env.CTX_AGENT_NAME).toBe('my-agent');
+
       checker.stop();
       checker.wake();
     });
@@ -821,16 +851,17 @@ describe('FastChecker', () => {
 
     it('does not fire before bootstrap completes', async () => {
       const { execFile } = await import('child_process');
+      const execMock = execFile as ReturnType<typeof vi.fn>;
       const agent = createMockAgent('my-agent');
       agent.isBootstrapped.mockReturnValue(false);
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(20 * 1000);
-      expect(execFile).not.toHaveBeenCalledWith(
-        'cortextos',
-        expect.arrayContaining([expect.stringContaining('[watchdog]')]),
-        expect.any(Function),
-      );
+      const fired = execMock.mock.calls.some((args: unknown[]) => {
+        const argv = args[1] as string[] | undefined;
+        return Array.isArray(argv) && argv.some(a => typeof a === 'string' && a.includes('[watchdog]'));
+      });
+      expect(fired).toBe(false);
       checker.stop();
       checker.wake();
     });


### PR DESCRIPTION
## Summary

Two related production bugs that surface together during a Claude Code `--continue` restart of an agent process:

### Bug 1 — Cron prompt-injection race

`CronScheduler.fireWithRetry` exhausts after 4 attempts inside a ~21s window (`RETRY_DELAYS_MS = [1_000, 4_000, 16_000]`). During a `--continue` rehydration the child `AgentProcess` flips `status === 'running'` the instant the PTY spawns, but `AgentProcess.injectMessage` still no-ops:

```ts
// src/daemon/agent-process.ts
injectMessage(content: string): boolean {
  if (!this.pty || this.status !== 'running') {
    return false;
  }
  // …
}
```

The PTY is alive, but stdin is still streaming a multi-MB transcript replay before the agent is ready to read injected input. With ~21s of total retry budget, a slow rehydration silently drops the cron — the execution log records `failed` and no operator alert fires.

**Fix:** extend the retry shape to `1+2+4+8+16+32+64s` (8 attempts, ~127s window). Same exponential-backoff shape, longer ceiling. This is a stop-gap; the real fix is to drain queued cron firings against an explicit bootstrap-completion event from `AgentProcess`, which I'd suggest tracking as a follow-up.

### Bug 2 — Heartbeat watchdog rejects daemon agent name

`FastChecker` spawns a `cortextos bus update-heartbeat` every 15s via `execFile`. With no explicit `env` option the child inherits `process.env`, and the daemon process does **not** always have `CTX_AGENT_NAME` set — it can derive identity from `CTX_AGENT_DIR`. When `resolveEnv()` runs in the child:

```ts
// src/utils/env.ts
const agentName =
  overrides?.agentName ||
  process.env.CTX_AGENT_NAME ||
  envFile.CTX_AGENT_NAME ||
  basename(process.cwd());  // ← falls back to "MudBot" (capital M)
```

It falls through to `basename(daemon-cwd)` and produces a name like `MudBot` that `validateAgentName` (`/^[a-z0-9_-]+$/`) rejects. Result: `Invalid agent name 'MudBot'` spammed in the watchdog log every 15s, no heartbeat ever recorded.

There's no agent-side workaround — `update-heartbeat` has no `--agent` flag, and the daemon spawn ignores per-agent `.env` files. The fix has to live in the daemon.

**Fix:** explicitly pass `CTX_AGENT_NAME: agentName` in the `execFile` env override. One-line change at the call site; `FastChecker` already holds the canonical agent name.

## Evidence

Real-world impact captured against a fork running an agent in a parent dir named `MudBot`:

- `daily-pnl-summary` cron fired at `07:33 BNE` (after a `--continue` restart) but never delivered; execution log shows `failed` after 4 retries inside the 21s window.
- Daemon log shows `Heartbeat watchdog error: Invalid agent name 'MudBot'` repeating every 15s on the same agent. Agent reports `[CRON FIRED …]` but the heartbeat in the dashboard hasn't moved since the restart.

## Changes

**Code (2 files):**

- `src/daemon/cron-scheduler.ts` — `RETRY_DELAYS_MS = [1_000, 2_000, 4_000, 8_000, 16_000, 32_000, 64_000]`; rationale comment block; max-attempts comment and log-message templates updated from hardcoded `4` to `\${maxAttempts}`.
- `src/daemon/fast-checker.ts` — heartbeat-watchdog `execFile` call now passes `{ env: { ...process.env, CTX_AGENT_NAME: agentName } }`.

**Tests (5 files):**

- `tests/unit/daemon/cron-scheduler.test.ts` — retry count `3 → 7`, `failingFire` calls `4 → 8`, advance-time totals updated.
- `tests/unit/daemon/fast-checker.test.ts` — existing test updated for 4-arg `execFile` signature; new regression test asserts `options.env.CTX_AGENT_NAME === 'my-agent'` via a watchdog-call filter (so bootstrap-check tests stay independent).
- `tests/integration/phase5-failure-modes.test.ts` — \"first 3 then succeeds on 4\" → \"first 4 then attempt 5\" with `retried×4 + fired×1`; \"all 4 attempts\" → \"all 8\" with `deadCallCount=8`, advance `135s`.
- `tests/integration/phase1-backtesting.test.ts` — \"exhausts 4 attempts\" → \"exhausts 8 attempts\" (`retried.length=7`, `failed.attempt=8`); retry-timing test rewritten from `[1s,4s,16s]` to `[1,2,4,8,16,32,64]s` with array-based gap assertions.
- `tests/integration/phase5-e2e-simulation.test.ts` — comment block at scenario 5 updated for the new budget; tests 5c/5d updated for 8 attempts and the new spacing.

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 1545 passed / 1 failed; the failure is `dashboard/.../next/server` pre-existing on `upstream/main` (verified by running the same test on a clean checkout of `upstream/main` — same failure). 11 dashboard files fail to import `next/server` on both `main` and this branch.
- [x] Targeted unit tests: `cron-scheduler` + `fast-checker` 74/74 pass.
- [x] Targeted integration tests: phase1-backtesting, phase5-failure-modes, phase5-e2e-simulation retry/heartbeat assertions all pass.

## Follow-up (not in this PR)

Bug 1's real fix is event-driven, not time-window-driven: have `AgentProcess` emit a `bootstrap-complete` event after the rehydration stream finishes, and have `CronScheduler` queue firings against that event for newly-spawned agents instead of racing the PTY. Happy to open a follow-up issue if useful.