### PR TITLE
fix(cron-migration): accept type:"cron" + schedule alias on auto-load

### DIFF
--- a/src/daemon/cron-migration.ts
+++ b/src/daemon/cron-migration.ts
@@ -161,17 +161,25 @@ function convertEntry(
   entry: CronEntry,
   agentName: string,
 ): { cron: CronDefinition } | { skip: string } {
-  const { name, type, interval, cron: cronExpr, fire_at, prompt } = entry;
+  const { name, type, interval, cron: cronExpr, schedule: scheduleAlias, fire_at, prompt } = entry;
 
-  // Treat absent `type` as "recurring" (spec requirement)
+  // Treat absent `type` as "recurring" (spec requirement).
+  // `cron` is a synonym for `recurring` — both auto-load as a recurring
+  // CronDefinition. The distinct type lets config authors self-document a
+  // crontab-scheduled entry; CronScheduler interprets interval vs crontab from
+  // the `schedule` shape downstream, so the two paths converge here.
   const effectiveType = type ?? 'recurring';
+
+  // `schedule` on the config entry is an authoring alias for `cron`. If both
+  // are present the explicit `cron` field wins (no silent conflict).
+  const cronOrSchedule = cronExpr ?? scheduleAlias;
 
   // Disabled crons: migrate as disabled (preserve operator intent)
   if (effectiveType === 'disabled') {
     // Disabled entries still need a schedule — use interval or cron expression if present
-    const schedule = cronExpr ?? interval;
+    const schedule = cronOrSchedule ?? interval;
     if (!schedule) {
-      return { skip: `cron "${name}" is disabled and has no interval/cron — skipping` };
+      return { skip: `cron "${name}" is disabled and has no interval/cron/schedule — skipping` };
     }
     const def: CronDefinition = {
       name,
@@ -211,12 +219,12 @@ function convertEntry(
     };
   }
 
-  // Recurring cron — requires a schedule
-  // Use cron expression if present (takes precedence), else interval shorthand
-  const schedule = cronExpr ?? interval;
+  // Recurring cron (including type:"cron") — requires a schedule.
+  // Use crontab expression if present (takes precedence), else interval shorthand.
+  const schedule = cronOrSchedule ?? interval;
   if (!schedule) {
     return {
-      skip: `cron "${name}" has no interval or cron expression — skipping`,
+      skip: `cron "${name}" has no interval/cron/schedule — skipping`,
     };
   }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -209,12 +209,19 @@ export interface CronEntry {
   interval?: string;
   /** For time-anchored crons: a cron expression (e.g. "0 8 * * *"). Takes precedence over interval. */
   cron?: string;
+  /** Alias for `cron` — config-author shorthand. If both `cron` and `schedule`
+   *  are present, `cron` wins. Accepted so author-written configs that use the
+   *  more natural "schedule" key auto-load without a daemon-side rename. */
+  schedule?: string;
   /** For one-shot crons: ISO 8601 datetime when the cron should fire. */
   fire_at?: string;
   prompt: string;
   /** "recurring" (default) restores on every session start.
-   *  "once" restores only if fire_at is still in the future; deleted after firing. */
-  type?: 'recurring' | 'once' | 'disabled';
+   *  "cron" is a synonym for recurring with a crontab expression — auto-loads
+   *    identically to recurring; explicit type kept so configs can self-document.
+   *  "once" restores only if fire_at is still in the future; deleted after firing.
+   *  "disabled" preserves operator intent (entry migrated as enabled:false). */
+  type?: 'recurring' | 'cron' | 'once' | 'disabled';
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/crons-migration.test.ts
+++ b/tests/integration/crons-migration.test.ts
@@ -415,6 +415,96 @@ describe('migrateCronsForAgent', () => {
     // cron field takes precedence (mirrors convertEntry logic)
     expect(crons[0].schedule).toBe('0 8 * * *');
   });
+
+  // ---------------------------------------------------------------------------
+  // Test: type:"cron" recognised as a recurring synonym (config-author shorthand)
+  // Regression: previously type:"cron" with a `schedule` field fell through to
+  // the recurring path but the `schedule` key wasn't read, so the migration
+  // skipped the entry with "no interval or cron expression".
+  // ---------------------------------------------------------------------------
+
+  it('migrates type:"cron" with cron field as recurring', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'cron-typed-cron');
+    writeConfigJson(agentDir, [
+      { name: 'daily-summary', type: 'cron', cron: '0 18 * * *', prompt: 'Daily summary.' },
+    ]);
+
+    const result = migrateCronsForAgent('cron-typed-cron', join(agentDir, 'config.json'), tmpCtxRoot);
+
+    expect(result.status).toBe('migrated');
+    expect(result.cronsMigrated).toBe(1);
+    expect(result.cronsSkipped).toHaveLength(0);
+
+    const crons = readCrons('cron-typed-cron');
+    expect(crons).toHaveLength(1);
+    expect(crons[0].schedule).toBe('0 18 * * *');
+    expect(crons[0].enabled).toBe(true);
+    expect(crons[0].metadata?.original_type).toBe('cron');
+  });
+
+  it('migrates type:"cron" with schedule alias field (author-friendly shorthand)', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'cron-schedule-alias');
+    writeConfigJson(agentDir, [
+      // Mudxero-style author convention: type:"cron" + schedule:"0 18 * * *"
+      { name: 'daily-summary', type: 'cron', schedule: '0 18 * * *', prompt: 'Daily summary.' },
+    ]);
+
+    const result = migrateCronsForAgent('cron-schedule-alias', join(agentDir, 'config.json'), tmpCtxRoot);
+
+    expect(result.status).toBe('migrated');
+    expect(result.cronsMigrated).toBe(1);
+    expect(result.cronsSkipped).toHaveLength(0);
+
+    const crons = readCrons('cron-schedule-alias');
+    expect(crons).toHaveLength(1);
+    expect(crons[0].schedule).toBe('0 18 * * *');
+    expect(crons[0].enabled).toBe(true);
+  });
+
+  it('accepts schedule alias on type:"recurring" entries too', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'rec-schedule-alias');
+    writeConfigJson(agentDir, [
+      { name: 'morning', type: 'recurring', schedule: '0 8 * * *', prompt: 'Morning.' },
+    ]);
+
+    migrateCronsForAgent('rec-schedule-alias', join(agentDir, 'config.json'), tmpCtxRoot);
+
+    const crons = readCrons('rec-schedule-alias');
+    expect(crons).toHaveLength(1);
+    expect(crons[0].schedule).toBe('0 8 * * *');
+  });
+
+  it('cron field wins when both cron and schedule are present on a type:"cron" entry', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'cron-both-fields');
+    writeConfigJson(agentDir, [
+      { name: 'conflict', type: 'cron', cron: '0 8 * * *', schedule: '0 18 * * *', prompt: 'Cron wins.' },
+    ]);
+
+    migrateCronsForAgent('cron-both-fields', join(agentDir, 'config.json'), tmpCtxRoot);
+
+    const crons = readCrons('cron-both-fields');
+    expect(crons).toHaveLength(1);
+    expect(crons[0].schedule).toBe('0 8 * * *');
+  });
+
+  it('skips type:"cron" entries with no cron, schedule, or interval', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'cron-no-schedule');
+    writeConfigJson(agentDir, [
+      { name: 'nope', type: 'cron', prompt: 'No schedule field anywhere.' },
+    ]);
+
+    const logs: string[] = [];
+    const result = migrateCronsForAgent('cron-no-schedule', join(agentDir, 'config.json'), tmpCtxRoot, {
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.status).toBe('migrated');
+    expect(result.cronsMigrated).toBe(0);
+    expect(result.cronsSkipped).toContain('nope');
+
+    const skipLog = logs.find((l) => l.includes('nope') && l.includes('interval/cron/schedule'));
+    expect(skipLog).toBeTruthy();
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`CronEntry.type` previously only accepted `'recurring' | 'once' | 'disabled'`. Authors who wrote `type:"cron"` plus `schedule:"0 18 * * *"` in their agent `config.json` (a natural convention given the type name) watched the daemon silently skip the entry on boot — neither field name was recognised by `convertEntry`, which only read `cron` and `interval`.

`bus add-cron` already writes a `CronDefinition` directly so the registration path worked. Only the `config.json -> crons.json` migration ran on agent boot dropped these entries.

## Changes

- `src/types/index.ts`: extend `CronEntry.type` with `'cron'` as a recurring synonym so config files can self-document a crontab-scheduled entry. Add optional `schedule?: string` as an author-facing alias for the `cron` field.
- `src/daemon/cron-migration.ts`: `convertEntry` now reads `cron ?? schedule ?? interval` (cron wins when both crontab fields are present). Skip-log text upgraded to name all three possible fields.
- `tests/integration/crons-migration.test.ts`: 5 new cases — `type:"cron"` with `cron` field, `type:"cron"` with `schedule` alias, `schedule` alias on `type:"recurring"`, precedence when both are present, no-schedule skip path.

## Test plan

- [x] `npm run build` — clean
- [x] `npx vitest run tests/integration/crons-migration.test.ts` — 23/23 pass (18 existing + 5 new)
- [x] Full `npm test` — 11 test files fail on this branch but the same 11 fail on clean `upstream/main` (pre-existing, all dashboard/Next.js missing-package or phase4/5 simulation env, none touch cron-migration paths)
- [x] No regression on `tests/unit/cli/bus-crons.test.ts` or `tests/integration/upgrade-cron-teaching-cli.test.ts` (both pass in isolation)