### PR TITLE
feat(dashboard): agent fleet tile grid — readability fix (task_1779511432352)

### DIFF
--- a/dashboard/src/app/(dashboard)/page.tsx
+++ b/dashboard/src/app/(dashboard)/page.tsx
@@ -107,12 +107,12 @@ export default async function OverviewPage({
         />
       )}
 
-      {/* Agent Status Grid + Live Activity - two columns */}
+      {/* Agent Fleet Grid + Live Activity - two columns */}
       <div className="grid grid-cols-1 xl:grid-cols-3 gap-6">
-        <div className="xl:col-span-1">
+        <div className="xl:col-span-2">
           <AgentStatusGrid agents={agents} heartbeats={heartbeats} />
         </div>
-        <div className="xl:col-span-2">
+        <div className="xl:col-span-1">
           <LiveActivity initialEvents={recentEvents} />
         </div>
       </div>

--- a/dashboard/src/components/overview/agent-status-grid.tsx
+++ b/dashboard/src/components/overview/agent-status-grid.tsx
@@ -3,66 +3,103 @@
 import Link from 'next/link';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { HealthDot } from '@/components/shared/health-dot';
-import { IconRobot, IconChevronRight } from '@tabler/icons-react';
-import type { AgentSummary, Heartbeat } from '@/lib/types';
+import { IconRobot } from '@tabler/icons-react';
+import type { AgentSummary, Heartbeat, HealthStatus } from '@/lib/types';
 
 interface AgentStatusGridProps {
   agents: (AgentSummary & { emoji?: string; systemName?: string })[];
   heartbeats: Record<string, Heartbeat>;
 }
 
+function shortTimeAgo(iso?: string): string {
+  if (!iso) return '—';
+  const diffMs = Date.now() - new Date(iso).getTime();
+  if (diffMs < 90_000) return 'just now';
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 60) return `${diffMin}m ago`;
+  const diffHr = Math.floor(diffMin / 60);
+  if (diffHr < 24) return `${diffHr}h ago`;
+  return `${Math.floor(diffHr / 24)}d ago`;
+}
+
+const BORDER_CLASS: Record<HealthStatus, string> = {
+  healthy: 'border-l-emerald-500',
+  stale: 'border-l-amber-400',
+  down: 'border-l-rose-400',
+};
+
+const GROUP_ORDER: HealthStatus[] = ['healthy', 'stale', 'down'];
+const GROUP_LABEL: Record<HealthStatus, string> = {
+  healthy: 'Active',
+  stale: 'Stale',
+  down: 'Offline',
+};
+
 export function AgentStatusGrid({ agents, heartbeats }: AgentStatusGridProps) {
+  const grouped = GROUP_ORDER
+    .map((health) => ({
+      health,
+      label: GROUP_LABEL[health],
+      items: agents.filter((a) => a.health === health),
+    }))
+    .filter((g) => g.items.length > 0);
+
   return (
     <Card>
-      <CardHeader className="pb-3">
-        <CardTitle className="flex items-center gap-2 text-sm font-medium">
-          <IconRobot size={16} className="text-muted-foreground" />
-          Agent Fleet
+      <CardHeader className="pb-2">
+        <CardTitle className="flex flex-wrap items-center justify-between gap-2 text-sm font-medium">
+          <span className="flex items-center gap-2">
+            <IconRobot size={16} className="text-muted-foreground" />
+            Agent Fleet
+          </span>
+          {/* Legend */}
+          <span className="flex items-center gap-3 text-[11px] font-normal text-muted-foreground">
+            <span className="flex items-center gap-1"><HealthDot status="healthy" />Active</span>
+            <span className="flex items-center gap-1"><HealthDot status="stale" />Stale</span>
+            <span className="flex items-center gap-1"><HealthDot status="down" />Offline</span>
+          </span>
         </CardTitle>
       </CardHeader>
-      <CardContent className="space-y-1 pt-0">
+      <CardContent className="space-y-4 pt-0">
         {agents.length === 0 ? (
-          <p className="text-xs text-muted-foreground py-4 text-center">
-            No agents discovered
-          </p>
+          <p className="py-4 text-center text-xs text-muted-foreground">No agents discovered</p>
         ) : (
-          agents.map((agent) => {
-            const systemName = agent.systemName ?? agent.name;
-            const hb = heartbeats[systemName];
-            const currentTask = hb?.current_task || '';
-            const taskPreview = currentTask
-              .replace(/^WORKING ON:\s*/i, '')
-              .slice(0, 60);
+          grouped.map(({ health, label, items }) => (
+            <div key={health}>
+              <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                {label} · {items.length}
+              </p>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {items.map((agent) => {
+                  const systemName = agent.systemName ?? agent.name;
+                  const hb = heartbeats[systemName];
+                  const snippet = hb?.current_task
+                    ? hb.current_task.replace(/^WORKING ON:\s*/i, '').slice(0, 72)
+                    : null;
+                  const timeAgo = shortTimeAgo(hb?.last_heartbeat);
 
-            return (
-              <Link
-                key={systemName}
-                href={`/agents/${encodeURIComponent(systemName)}`}
-                className="group flex items-center gap-3 rounded-md px-2 py-2 hover:bg-muted/50 transition-colors"
-              >
-                <div className="flex h-8 w-8 items-center justify-center rounded-md bg-muted text-sm">
-                  {agent.emoji || agent.name.charAt(0).toUpperCase()}
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center gap-2">
-                    <span className="text-sm font-medium truncate">
-                      {agent.name}
-                    </span>
-                    <HealthDot status={agent.health} />
-                  </div>
-                  {taskPreview && (
-                    <p className="text-[11px] text-muted-foreground truncate">
-                      {taskPreview}
-                    </p>
-                  )}
-                </div>
-                <IconChevronRight
-                  size={14}
-                  className="shrink-0 text-muted-foreground/30 group-hover:text-muted-foreground transition-colors"
-                />
-              </Link>
-            );
-          })
+                  return (
+                    <Link
+                      key={systemName}
+                      href={`/agents/${encodeURIComponent(systemName)}`}
+                      className={`group flex flex-col gap-1 rounded-md border border-l-4 bg-card p-2 transition-colors hover:bg-muted/50 ${BORDER_CLASS[health]}`}
+                    >
+                      <div className="flex items-start gap-1.5">
+                        <HealthDot status={health} className="mt-0.5 shrink-0" />
+                        <span className="break-words text-[11px] font-medium leading-snug">
+                          {agent.name}
+                        </span>
+                      </div>
+                      <span className="text-[10px] tabular-nums text-muted-foreground">{timeAgo}</span>
+                      <p className="line-clamp-1 text-[10px] leading-snug text-muted-foreground">
+                        {snippet ?? <span className="italic opacity-60">Idle</span>}
+                      </p>
+                    </Link>
+                  );
+                })}
+              </div>
+            </div>
+          ))
         )}
       </CardContent>
     </Card>


### PR DESCRIPTION
## Summary

Fixes all 5 criteria from task_1779511432352_71663977 [FLEET-UI] (Agent-activity grid readability):

- **No truncation**: agent names use `break-words` instead of `truncate`
- **State grouping**: tiles grouped into Active / Stale / Offline sections with labeled headers + agent count
- **Legend**: HealthDot legend trio in card header (Active / Stale / Offline)
- **Consistent time grain**: custom `shortTimeAgo()` — "just now" / "Nm ago" / "Nh ago" / "Nd ago" (replaces verbose date-fns strings)
- **Consistent snippets**: every tile shows activity snippet or italic "Idle" — no more some-have-some-don't

Layout: fleet grid promoted to `xl:col-span-2` (was col-span-1) so 3-col tile grid fits; LiveActivity takes col-span-1.

## Files changed

- `dashboard/src/components/overview/agent-status-grid.tsx` — list → tile grid, grouping, legend, short time, snippet rule
- `dashboard/src/app/(dashboard)/page.tsx` — col-span swap: fleet=2, activity=1

Clean 1-commit diff on top of grandamenium/main.

## Test plan

- [ ] Home page loads, no build errors
- [ ] 3 sections render (Active / Stale / Offline) for non-empty groups only
- [ ] Long agent names wrap, no ellipsis
- [ ] Time shows "Nm ago" / "Nh ago" uniformly
- [ ] All tiles show snippet text or "Idle"

🤖 Generated with [Claude Code](https://claude.com/claude-code)