### PR TITLE
fix(cli): validate org name in init + add-agent (closes #408)

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, copyFi
 import { join, resolve } from 'path';
 import { homedir } from 'os';
 import { OrgContext } from '../types';
-import { validateAgentName } from '../utils/validate';
+import { validateAgentName, validateOrgName } from '../utils/validate';
 
 const VALID_RUNTIMES = ['claude-code', 'hermes', 'codex-app-server'] as const;
 type RuntimeKind = typeof VALID_RUNTIMES[number];
@@ -71,6 +71,20 @@ export const addAgentCommand = new Command('add-agent')
 
     if (!org) {
       console.error('No organization found. Run "cortextos init <org>" first.');
+      process.exit(1);
+    }
+
+    // Mirror the BUG-041 fix above for the resolved org name.
+    // Mixed-case orgs pass through add-agent today (whether supplied via --org or
+    // auto-detected from the orgs/ directory), get committed to disk, and then
+    // break every `cortextos bus *` invocation at runtime because env.ts strictly
+    // validates CTX_ORG. The dashboard API also rejects them with HTTP 400.
+    // Canonical rule: src/utils/validate.ts:validateOrgName (/^[a-z0-9_-]+$/).
+    try {
+      validateOrgName(org);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      console.error(`Org names must match /^[a-z0-9_-]+$/ (lowercase letters, numbers, underscores, hyphens).`);
       process.exit(1);
     }
 

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync, readd
 import { join } from 'path';
 import { homedir } from 'os';
 import { ensureDir } from '../utils/atomic.js';
+import { validateOrgName } from '../utils/validate.js';
 import type { OrgContext } from '../types/index.js';
 
 export const initCommand = new Command('init')
@@ -10,6 +11,21 @@ export const initCommand = new Command('init')
   .option('--instance <id>', 'Instance ID', 'default')
   .description('Create a new cortextOS organization')
   .action(async (orgName: string, options: { instance: string }) => {
+    // Validate the org name BEFORE creating anything on disk.
+    // Without this, mixed-case names like 'teamStupid' pass through `init`,
+    // get written to disk, and then fail every dashboard add-agent and every
+    // `cortextos bus *` invocation at runtime because `src/utils/env.ts` and
+    // the dashboard API both call `validateOrgName()` strictly. Mirrors the
+    // BUG-041 fix for `validateAgentName()` in src/cli/add-agent.ts.
+    try {
+      validateOrgName(orgName);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      console.error(`Org names must match /^[a-z0-9_-]+$/ (lowercase letters, numbers, underscores, hyphens).`);
+      console.error(`Examples of valid names: acme, myco, demo, team-1, team_alpha`);
+      process.exit(1);
+    }
+
     const instanceId = options.instance;
     const ctxRoot = join(homedir(), '.cortextos', instanceId);
     const projectRoot = process.cwd();

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -15,6 +15,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { spawnSync } from 'child_process';
 import { TelegramAPI, formatValidateError } from '../telegram/api.js';
+import { validateAgentName, validateOrgName } from '../utils/validate.js';
 
 function rl(): Interface {
   return createInterface({ input: process.stdin, output: process.stdout });
@@ -165,14 +166,6 @@ async function validateTelegramCredsInteractive(
   return null;
 }
 
-function validateAgentName(name: string): boolean {
-  return /^[a-z0-9_-]+$/.test(name);
-}
-
-function validateOrgName(name: string): boolean {
-  return /^[a-z0-9_-]+$/.test(name);
-}
-
 function findProjectRoot(): string {
   // Prefer CTX_FRAMEWORK_ROOT if set (running inside cortextOS session)
   if (process.env.CTX_FRAMEWORK_ROOT && existsSync(join(process.env.CTX_FRAMEWORK_ROOT, 'dist', 'cli.js'))) {
@@ -237,7 +230,9 @@ export const setupCommand = new Command('setup')
     let orgName = '';
     while (true) {
       orgName = await askRequired(iface, '  Organization name: ', 'Organization name cannot be empty.');
-      if (!validateOrgName(orgName)) {
+      try {
+        validateOrgName(orgName);
+      } catch {
         console.log('  Invalid name. Use lowercase letters, numbers, hyphens, and underscores only.');
         continue;
       }
@@ -265,7 +260,9 @@ export const setupCommand = new Command('setup')
     let orchName = '';
     while (true) {
       orchName = await askDefault(iface, '  Orchestrator agent name', 'boss');
-      if (!validateAgentName(orchName)) {
+      try {
+        validateAgentName(orchName);
+      } catch {
         console.log('  Invalid name. Use lowercase letters, numbers, hyphens, and underscores only.');
         continue;
       }
@@ -350,7 +347,9 @@ export const setupCommand = new Command('setup')
       let agentName = '';
       while (true) {
         agentName = await askRequired(iface, '  Agent name: ', 'Agent name is required.');
-        if (!validateAgentName(agentName)) {
+        try {
+          validateAgentName(agentName);
+        } catch {
           console.log('  Invalid name. Use lowercase letters, numbers, hyphens, and underscores only.');
           continue;
         }

--- a/tests/unit/cli/add-agent-validation.test.ts
+++ b/tests/unit/cli/add-agent-validation.test.ts
@@ -93,3 +93,66 @@ describe('BUG-041: add-agent agent name validation', () => {
     expect(exitSpy).toHaveBeenCalledWith(1);
   });
 });
+
+/**
+ * Issue #407 regression test: `cortextos add-agent` must reject invalid
+ * --org values for the same reasons it rejects invalid agent names —
+ * mixed-case orgs pass scaffolding but then break every `cortextos bus *`
+ * invocation at runtime (env.ts strictly validates CTX_ORG) and every
+ * dashboard add-agent attempt (POST /api/agents returns HTTP 400).
+ */
+describe('issue #407: add-agent --org name validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects --org teamStupid (camelCase) before any filesystem write', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'validagent', '--template', 'agent', '--org', 'teamStupid']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join(' ');
+    expect(errorOutput).toContain("Invalid org name 'teamStupid'");
+    expect(errorOutput).toContain('/^[a-z0-9_-]+$/');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects --org with spaces', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'validagent', '--template', 'agent', '--org', 'my org']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects --org path-traversal attempts', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      addAgentCommand.parseAsync(
+        ['node', 'cli', 'validagent', '--template', 'agent', '--org', '../escape']
+      )
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/tests/unit/cli/init-validation.test.ts
+++ b/tests/unit/cli/init-validation.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Issue #407 regression test: `cortextos init` must reject invalid org
+ * names (mixed-case, spaces, path traversal, etc.) BEFORE creating any
+ * filesystem artifacts.
+ *
+ * Before the fix, `cortextos init teamStupid` succeeded at the CLI level,
+ * wrote `orgs/teamStupid/` to disk, registered the org context, and THEN
+ * failed every dashboard `POST /api/agents` call (HTTP 400) and every
+ * `cortextos bus *` invocation at runtime because `src/utils/env.ts` and
+ * the dashboard API both call `validateOrgName()` strictly. Affected orgs
+ * were unusable from any UI surface.
+ *
+ * The fix calls `validateOrgName()` at the entry of the init action, so
+ * bad names are rejected upfront and the caller gets a clear error before
+ * any filesystem state is touched.
+ *
+ * Mirrors the BUG-041 pattern in `add-agent-validation.test.ts`.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { initCommand } from '../../../src/cli/init';
+
+describe('issue #407: init org name validation', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('rejects teamStupid (camelCase) before any filesystem write', async () => {
+    // Commander calls process.exit(1) on validation failure. We intercept it
+    // by throwing, which we catch via expect().rejects. This avoids the test
+    // runner itself exiting on process.exit().
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', 'teamStupid'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const errorOutput = consoleErrorSpy.mock.calls.flat().join(' ');
+    expect(errorOutput).toContain("Invalid org name 'teamStupid'");
+    expect(errorOutput).toContain('/^[a-z0-9_-]+$/');
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects a single-uppercase-letter name (Acme)', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', 'Acme'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects names with spaces', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', 'my org'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+
+  it('rejects path traversal attempts', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(((code?: number) => {
+      throw new Error(`__TEST_PROCESS_EXIT_${code}__`);
+    }) as never);
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      initCommand.parseAsync(['node', 'cli', '../evil'])
+    ).rejects.toThrow(/__TEST_PROCESS_EXIT_1__/);
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+  });
+});


### PR DESCRIPTION
Closes #408. Original work by @thehoff; rebased onto current main and sandbox-validated, co-authored by cortext-designer.

Wires canonical validateOrgName() (/^[a-z0-9_-]+$/) into init <org> and add-agent --org — the two paths that bypassed it (mixed-case names previously broke later dashboard/bus calls with 400).

Validation: CI green 3/3. Live CLI edge cases: accepts myorg/team_1/my-org; rejects MYORG/'my org'/../etc/org! before touching filesystem.