### PR TITLE
fix(daemon): kill false-positive crash detection on --continue rollovers (closes #445)

### DIFF
--- a/src/bus/heartbeat.ts
+++ b/src/bus/heartbeat.ts
@@ -1,7 +1,62 @@
-import { readdirSync, readFileSync } from 'fs';
+import { readdirSync, readFileSync, existsSync, unlinkSync, statSync } from 'fs';
 import { join } from 'path';
 import type { Heartbeat, BusPaths } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+
+/**
+ * SessionEnd-hook end-type markers (see src/hooks/hook-crash-alert.ts). A
+ * restart writes one of these; the crash-alert hook reads it WITHOUT consuming
+ * it, because one restart fires the hook twice and both firings must classify
+ * from the same marker. clearEndMarkers is the marker's primary cleanup: an
+ * agent updating its heartbeat is genuinely alive in its post-restart session,
+ * so a pending end-marker is stale and is removed here — but only once it is
+ * past the grace window below. The hook's TTL is the backstop for a start that
+ * fails before ever heartbeating.
+ */
+const END_TYPE_MARKERS = [
+  '.restart-planned',
+  '.session-refresh',
+  '.user-restart',
+  '.user-disable',
+  '.user-stop',
+  '.daemon-crashed',
+  '.daemon-stop',
+];
+
+/**
+ * A marker younger than this is left alone by clearEndMarkers — it may belong
+ * to a restart still in flight. The hazard: the post-restart session can reach
+ * its first heartbeat before the dying restart's SECOND SessionEnd firing
+ * lands (firing#2 is typically 13-22s after firing#1, but not hard-bounded).
+ * Without a grace window, that heartbeat would wipe the marker and firing#2
+ * would classify `crash` — the exact false positive this whole change exists
+ * to kill, reintroduced under a narrower window.
+ *
+ * The grace makes that race negligible, not mathematically zero: a firing#2
+ * delayed past 120s under heavy load could still miss the marker. That is the
+ * same bounded residual as the hook's TTL and is accepted. The window is sized
+ * generously on the TTL's cost asymmetry — too tight reopens the FP; too loose
+ * only delays cleanup harmlessly (the heartbeat clears it on a later pass, and
+ * the 300s hook TTL backstops). 120s clears any plausible firing#2 delay while
+ * staying well under the TTL.
+ */
+const MARKER_CLEAR_GRACE_MS = 120_000; // 2 minutes
+
+/**
+ * Remove SessionEnd-hook end-type markers from an agent's state dir, skipping
+ * any marker younger than MARKER_CLEAR_GRACE_MS (an in-flight restart whose
+ * second hook firing may not have landed yet). `nowMs` is injectable for tests.
+ */
+export function clearEndMarkers(stateDir: string, nowMs: number = Date.now()): void {
+  for (const file of END_TYPE_MARKERS) {
+    const p = join(stateDir, file);
+    if (!existsSync(p)) continue;
+    try {
+      if (nowMs - statSync(p).mtimeMs < MARKER_CLEAR_GRACE_MS) continue; // in-flight — leave it
+      unlinkSync(p);
+    } catch { /* ignore — best-effort cleanup */ }
+  }
+}
 
 /**
  * Update heartbeat for the current agent.
@@ -34,6 +89,14 @@ export function updateHeartbeat(
     join(paths.stateDir, 'heartbeat.json'),
     JSON.stringify(heartbeat),
   );
+
+  // The agent is alive in its (post-restart) session — clear stale SessionEnd
+  // markers so the crash-alert hook cannot misclassify a later genuine crash
+  // as a planned restart. Markers inside the grace window are left in place
+  // (an in-flight restart's second hook firing may not have landed); they are
+  // cleared on a later heartbeat. This is the primary marker cleanup; the
+  // hook's TTL is the failed-start backstop.
+  clearEndMarkers(paths.stateDir);
 }
 
 /**

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -299,6 +299,23 @@ export class AgentProcess {
    */
   async sessionRefresh(): Promise<void> {
     this.log('Session refresh (--continue restart)');
+    // Write .session-refresh marker so the SessionEnd crash-alert hook
+    // (src/hooks/hook-crash-alert.ts) classifies the imminent PTY exit as a
+    // session refresh rather than a crash. The hook's marker handler +
+    // quiet-suppression set + message switch were all wired for this type,
+    // but no writer existed — every --continue rollover at the session-time
+    // cap surfaced as a false-positive 'crash' on chief/analyst + the
+    // crashes.log file.
+    try {
+      const paths = resolvePaths(this.name, this.env.instanceId, this.env.org);
+      writeFileSync(
+        join(paths.stateDir, '.session-refresh'),
+        'session-time-cap rollover\n',
+        'utf-8',
+      );
+    } catch (err) {
+      this.log(`Failed to write .session-refresh marker: ${err}`);
+    }
     await this.stop();
     await this.start();
     this.log('Session refreshed');

--- a/src/hooks/hook-crash-alert.ts
+++ b/src/hooks/hook-crash-alert.ts
@@ -148,6 +148,101 @@ function shouldSuppressDedup(stateDir: string, endType: string): boolean {
   return false;
 }
 
+/**
+ * A restart marker is valid for the hook only while younger than this. The TTL
+ * budget runs from when the marker is WRITTEN — which is inside sessionRefresh
+ * BEFORE `await stop()` — to the LAST hook firing it must still classify, i.e.
+ * firing#2. So the budget must cover: stop()'s PTY-exit wait + the inter-firing
+ * gap. The inter-firing gap is ~13-22s typical; stop() is normally fast but is
+ * NOT bounded — BUG-011 exists precisely because PTY exit can hang. 300s is
+ * sized to absorb a slow stop() on top of the firing gap, not just the gap.
+ *
+ * The daemon's post-restart heartbeat is the primary clear (see updateHeartbeat
+ * in src/bus/heartbeat.ts). This TTL is the BACKSTOP for a failed start that
+ * never heartbeats: a marker older than the TTL is treated as stale, ignored,
+ * and lazy-unlinked, so it cannot misclassify a genuine crash arbitrarily far
+ * in the future.
+ *
+ * Sized on a deliberate cost asymmetry: a TTL too tight re-exposes the exact
+ * false-positive bug (it would ignore the marker at a slow firing#2); a TTL too
+ * generous only widens the bounded failed-start false-negative window — which
+ * the heartbeat-staleness monitor catches as a secondary path anyway.
+ */
+const MARKER_TTL_MS = 300_000; // 5 minutes
+
+/**
+ * Read the hook's stdin JSON payload. Claude Code pipes a JSON object to
+ * SessionEnd hooks containing `session_id` (the ending session's id) plus
+ * other event fields. Mirrors the stdin-read in hook-context-status.ts.
+ * Returns {} on any failure. The session_id is recorded in crashes.log for
+ * audit; it is not used for classification.
+ */
+async function readHookInput(): Promise<{ session_id?: string }> {
+  const chunks: Buffer[] = [];
+  await new Promise<void>((resolve) => {
+    // Fallback so a stdin that never ends can't hang the hook. unref()'d and
+    // cleared on a clean end/error so the timer never keeps the process alive
+    // past its work — without this the hook lingers up to 1.5s after it is done.
+    const timer = setTimeout(resolve, 1500);
+    timer.unref?.();
+    const finish = () => { clearTimeout(timer); resolve(); };
+    process.stdin.on('data', (chunk: Buffer) => chunks.push(chunk));
+    process.stdin.on('end', finish);
+    process.stdin.on('error', finish);
+  });
+  try {
+    return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Classify a SessionEnd from the state markers, returning the marker-derived
+ * end type + reason — WITHOUT consuming the marker.
+ *
+ * Why no-consume: a single restart fires the SessionEnd hook TWICE for one
+ * logical session-end (~13-22s apart) — once from the dying PTY, once from
+ * the next PTY's fresh-launch cleanup. Every restart path writes exactly ONE
+ * hook-recognized marker. The previous code unlinked the marker on the first
+ * firing, so the second firing found nothing and was logged as a false
+ * `type=crash reason=none` — the FP pairs in crashes.log. Leaving the marker
+ * in place lets BOTH firings classify correctly. The marker is cleared by the
+ * daemon's first-post-restart heartbeat (the successor session is genuinely
+ * up by then), with the TTL above as the failed-start backstop.
+ *
+ * A marker older than MARKER_TTL_MS is treated as stale: ignored (so it
+ * cannot misclassify a later genuine crash) and lazy-unlinked here.
+ *
+ * Returns { endType: 'crash' } when no fresh marker is present.
+ */
+export function classifyFromMarkers(
+  stateDir: string,
+  markers: { file: string; type: string }[],
+  nowMs: number = Date.now(),
+): { endType: string; reason: string } {
+  for (const marker of markers) {
+    const markerPath = join(stateDir, marker.file);
+    if (!existsSync(markerPath)) continue;
+    let ageMs = 0;
+    try {
+      ageMs = nowMs - statSync(markerPath).mtimeMs;
+    } catch { /* unreadable mtime — treat as fresh, fall through to classify */ }
+    if (ageMs > MARKER_TTL_MS) {
+      // Stale: the first-heartbeat clear evidently never fired (failed
+      // start). Do not classify from it — lazy-unlink and keep looking.
+      try { unlinkSync(markerPath); } catch { /* ignore */ }
+      continue;
+    }
+    let reason = '';
+    try {
+      reason = readFileSync(markerPath, 'utf-8').trim();
+    } catch { /* ignore */ }
+    return { endType: marker.type, reason };
+  }
+  return { endType: 'crash', reason: '' };
+}
+
 async function main(): Promise<void> {
   const agentName = process.env.CTX_AGENT_NAME;
   const instanceId = process.env.CTX_INSTANCE_ID || 'default';
@@ -160,11 +255,16 @@ async function main(): Promise<void> {
   mkdirSync(stateDir, { recursive: true });
   mkdirSync(logDir, { recursive: true });
 
-  // Determine end type from state markers (written by other parts of the system
-  // before the Claude Code session exits).
-  let endType = 'crash';
-  let reason = '';
+  // session_id is recorded in crashes.log for audit only — not used to
+  // classify. (An earlier iteration deduped firings by session_id; that was
+  // wrong — the two firings of one restart carry DIFFERENT session_ids, one
+  // real session + one ephemeral. The fix is marker-handling, not id-dedup.)
+  const hookInput = await readHookInput();
+  const sessionId = typeof hookInput.session_id === 'string' ? hookInput.session_id : '';
 
+  // Determine end type from state markers (written by other parts of the
+  // system before the Claude Code session exits). Markers are NOT consumed
+  // here — see classifyFromMarkers for why (restart fires this hook twice).
   const markers = [
     { file: '.restart-planned', type: 'planned-restart' },
     { file: '.session-refresh', type: 'session-refresh' },
@@ -178,17 +278,9 @@ async function main(): Promise<void> {
     { file: '.daemon-stop', type: 'daemon-stop' },
   ];
 
-  for (const marker of markers) {
-    const markerPath = join(stateDir, marker.file);
-    if (existsSync(markerPath)) {
-      endType = marker.type;
-      try {
-        reason = readFileSync(markerPath, 'utf-8').trim();
-        unlinkSync(markerPath);
-      } catch { /* ignore */ }
-      break;
-    }
-  }
+  const classified = classifyFromMarkers(stateDir, markers);
+  let endType = classified.endType;
+  let reason = classified.reason;
 
   // If no marker matched but the stdout tail shows a rate-limit signature,
   // reclassify as rate-limited. Prevents the 30-minute 🚨 CRASH buzz storm
@@ -235,8 +327,12 @@ async function main(): Promise<void> {
   } catch { /* ignore */ }
 
   // Always log to crashes.log — we want visibility even when alerts are muted.
+  // session_id is recorded purely for audit (there is no session_id dedup —
+  // an earlier iteration tried that and it was removed). If a duplicate-firing
+  // FP ever slips through, two crashes.log lines sharing a session value make
+  // it provable after the fact.
   const timestamp = new Date().toISOString();
-  const logLine = `${timestamp} type=${endType} reason=${reason || 'none'} last_task=${lastTask}\n`;
+  const logLine = `${timestamp} type=${endType} reason=${reason || 'none'} session=${sessionId || 'unknown'} last_task=${lastTask}\n`;
   try {
     appendFileSync(join(logDir, 'crashes.log'), logLine);
   } catch { /* ignore */ }

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../../src/bus/reminders.js', () => ({
 }));
 
 vi.mock('../../../src/utils/paths.js', () => ({
-  resolvePaths: vi.fn().mockReturnValue({}),
+  resolvePaths: vi.fn().mockReturnValue({ stateDir: '/tmp/test-ctx/state/alice' }),
 }));
 
 const fsMocks = {
@@ -247,6 +247,27 @@ describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
     const stopOrder = stopSpy.mock.invocationCallOrder[0];
     const startOrder = startSpy.mock.invocationCallOrder[0];
     expect(stopOrder).toBeLessThan(startOrder);
+  });
+
+  it('sessionRefresh() writes .session-refresh marker before stop (false-crash FP fix)', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    const stopSpy = vi.spyOn(ap, 'stop').mockResolvedValue();
+    vi.spyOn(ap, 'start').mockResolvedValue();
+    fsMocks.writeFileSync.mockReset();
+
+    await ap.sessionRefresh();
+
+    const writeIdx = fsMocks.writeFileSync.mock.calls.findIndex(
+      (call) => String(call[0]).endsWith('.session-refresh'),
+    );
+    expect(writeIdx).toBeGreaterThanOrEqual(0);
+    expect(String(fsMocks.writeFileSync.mock.calls[writeIdx][0])).toBe('/tmp/test-ctx/state/alice/.session-refresh');
+    // The marker must be written BEFORE stop() — a SessionEnd hook firing as
+    // the PTY dies must already see the marker, or it classifies a false crash.
+    const markerWriteOrder = fsMocks.writeFileSync.mock.invocationCallOrder[writeIdx];
+    expect(markerWriteOrder).toBeLessThan(stopSpy.mock.invocationCallOrder[0]);
   });
 });
 

--- a/tests/unit/hooks/hook-crash-alert.test.ts
+++ b/tests/unit/hooks/hook-crash-alert.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -8,7 +8,8 @@ vi.mock('child_process', () => ({
   execFile: (...args: unknown[]) => execFileMock(...args),
 }));
 
-import { readMaxCrashesPerDay, notifyAgents } from '../../../src/hooks/hook-crash-alert';
+import { readMaxCrashesPerDay, notifyAgents, classifyFromMarkers } from '../../../src/hooks/hook-crash-alert';
+import { clearEndMarkers } from '../../../src/bus/heartbeat';
 
 describe('readMaxCrashesPerDay', () => {
   let tmp: string;
@@ -143,5 +144,132 @@ describe('notifyAgents', () => {
     })).not.toThrow();
     // Second recipient still attempted
     expect(execFileMock).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('classifyFromMarkers', () => {
+  let tmp: string;
+  const MARKERS = [
+    { file: '.restart-planned', type: 'planned-restart' },
+    { file: '.session-refresh', type: 'session-refresh' },
+    { file: '.user-restart', type: 'user-restart' },
+    { file: '.user-stop', type: 'user-stop' },
+  ];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-markers-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('no marker present → endType crash', () => {
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('crash');
+  });
+
+  it('fresh marker → classified by type, with its reason', () => {
+    writeFileSync(join(tmp, '.restart-planned'), 'planned reboot', 'utf-8');
+    const r = classifyFromMarkers(tmp, MARKERS);
+    expect(r.endType).toBe('planned-restart');
+    expect(r.reason).toBe('planned reboot');
+  });
+
+  it('does NOT consume the marker — both firings of a restart see it', () => {
+    writeFileSync(join(tmp, '.session-refresh'), 'rollover', 'utf-8');
+    // Firing #1 — the dying PTY's SessionEnd.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh');
+    // Firing #2 — the next PTY's fresh-launch cleanup. Marker must still be
+    // there: this is the FP that the old unlink-on-read code produced.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh');
+    expect(existsSync(join(tmp, '.session-refresh'))).toBe(true);
+  });
+
+  it('marker older than the TTL → treated as stale: ignored AND lazy-unlinked', () => {
+    const markerPath = join(tmp, '.restart-planned');
+    writeFileSync(markerPath, 'stale planned restart', 'utf-8');
+    // Simulate a marker whose first-heartbeat clear never fired (failed
+    // start): classify with a "now" well past the 5-minute TTL.
+    const farFuture = Date.now() + 10 * 60 * 1000;
+    const r = classifyFromMarkers(tmp, MARKERS, farFuture);
+    expect(r.endType).toBe('crash'); // stale marker must NOT mask a real crash
+    expect(existsSync(markerPath)).toBe(false); // lazy-unlinked
+  });
+
+  it('first matching marker wins (precedence order preserved)', () => {
+    writeFileSync(join(tmp, '.restart-planned'), 'planned', 'utf-8');
+    writeFileSync(join(tmp, '.user-stop'), 'stopped', 'utf-8');
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('planned-restart');
+  });
+});
+
+describe('clearEndMarkers (via heartbeat)', () => {
+  let tmp: string;
+  const ALL = ['.restart-planned', '.session-refresh', '.user-restart', '.user-stop', '.daemon-stop'];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-clear-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('a post-grace heartbeat removes every pending end-type marker', () => {
+    for (const f of ALL) writeFileSync(join(tmp, f), 'x', 'utf-8');
+    // nowMs well past the grace window — the markers are no longer in-flight.
+    clearEndMarkers(tmp, Date.now() + 10 * 60 * 1000);
+    for (const f of ALL) expect(existsSync(join(tmp, f))).toBe(false);
+  });
+
+  it('leaves a fresh (within-grace) marker in place — an in-flight restart', () => {
+    for (const f of ALL) writeFileSync(join(tmp, f), 'x', 'utf-8');
+    // nowMs ≈ marker mtime → every marker is within the grace window.
+    clearEndMarkers(tmp);
+    for (const f of ALL) expect(existsSync(join(tmp, f))).toBe(true);
+  });
+
+  it('is a no-op when no markers are present', () => {
+    expect(() => clearEndMarkers(tmp)).not.toThrow();
+  });
+});
+
+describe('marker lifecycle (classify → clearEndMarkers → classify)', () => {
+  let tmp: string;
+  const MARKERS = [
+    { file: '.restart-planned', type: 'planned-restart' },
+    { file: '.session-refresh', type: 'session-refresh' },
+    { file: '.user-restart', type: 'user-restart' },
+    { file: '.user-stop', type: 'user-stop' },
+  ];
+
+  beforeEach(() => {
+    tmp = mkdtempSync(join(tmpdir(), 'crashalert-lifecycle-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('both restart firings classify, a post-grace heartbeat clears, then a real crash classifies as crash', () => {
+    writeFileSync(join(tmp, '.restart-planned'), 'planned reboot', 'utf-8');
+    // Firing #1 and #2 of the dying restart — both must see the marker.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('planned-restart');
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('planned-restart');
+    // Post-restart session heartbeats past the grace window → marker cleared.
+    clearEndMarkers(tmp, Date.now() + 10 * 60 * 1000);
+    expect(existsSync(join(tmp, '.restart-planned'))).toBe(false);
+    // A genuine crash AFTER the clear must classify as crash — not be masked.
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('crash');
+  });
+
+  it('a heartbeat DURING the in-flight restart (within grace) does NOT wipe the marker — firing#2 still classifies', () => {
+    // This is the Finding-1 race: a fast-booting successor heartbeats before
+    // the dying restart's second SessionEnd firing lands.
+    writeFileSync(join(tmp, '.session-refresh'), 'rollover', 'utf-8');
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh'); // firing #1
+    clearEndMarkers(tmp); // successor's first heartbeat — marker still within grace
+    expect(existsSync(join(tmp, '.session-refresh'))).toBe(true);
+    expect(classifyFromMarkers(tmp, MARKERS).endType).toBe('session-refresh'); // firing #2 — no false crash
   });
 });


### PR DESCRIPTION
Closes #445. Original work by @asachs01; rebased onto current main and sandbox-validated, co-authored by cortext-designer.

Writes a .session-refresh marker so the SessionEnd hook stops classifying --continue rollovers as crashes; no-unlink handling so a double-fire restart still classifies right; replaces broken session_id dedup.

Validation: CI green 3/3. Live on built crash-alert hook: marker present->session-refresh (not crash), no marker->crash, double-fire->both correct, zero real Telegram sends.