### PR TITLE
feat(memory): bidirectional task<->vault sync (closes #357)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,8 @@ dashboard/test-*.py
 # AGENTS.md, memory skill, and scaffold files.
 !community/agents/research-agent/
 !community/agents/research-agent/**
+
+# Obsidian vault (personal memory layer — not part of framework)
+obsidian-vault/
+.obsidian/
+

--- a/bus/hook-vault-precompact.sh
+++ b/bus/hook-vault-precompact.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# hook-vault-precompact.sh — save session context to vault before compaction
+# Called as a PreCompact hook. Must complete in <5s.
+set -euo pipefail
+
+INPUT=$(cat)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/_ctx-env.sh" 2>/dev/null || true
+
+AGENT="${CTX_AGENT_NAME:-unknown}"
+VAULT_DIR="${CTX_FRAMEWORK_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}/obsidian-vault/${AGENT}/working-context"
+mkdir -p "$VAULT_DIR"
+
+SESSION_FILE="$VAULT_DIR/active-session.md"
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+DATE=$(date -u +"%Y-%m-%d")
+
+# Write compaction checkpoint — captured before context is lost
+cat > "$SESSION_FILE" << SNAPSHOT
+# Active Session Snapshot — $AGENT
+> Saved at compaction: $TIMESTAMP
+
+## Session date: $DATE
+
+## Daily log path
+/Users/arndt/cortextos/obsidian-vault/${AGENT}/daily/${DATE}.md
+
+## Last heartbeat
+$(cat "${CTX_FRAMEWORK_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}/state/${CTX_INSTANCE_ID:-default}/${AGENT}/heartbeat.json" 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); print('Status:', d.get('status','?'), '| Last HB:', d.get('last_heartbeat','?'))" 2>/dev/null || echo "heartbeat unreadable")
+
+## Read on resume
+- /Users/arndt/cortextos/obsidian-vault/agent-shared/READ-ON-BOOT.md
+- /Users/arndt/cortextos/obsidian-vault/${AGENT}/daily/${DATE}.md
+- GUARDRAILS.md, GOALS.md, MEMORY.md
+SNAPSHOT
+
+echo '{}' 

--- a/bus/hook-vault-session-start.sh
+++ b/bus/hook-vault-session-start.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# hook-vault-session-start.sh — vault boot inject + MEMORY-03 mistake trigger detection
+# UserPromptSubmit hook. Must complete in <5s, idempotent per session.
+set -euo pipefail
+
+INPUT=$(cat)
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/_ctx-env.sh" 2>/dev/null || true
+
+AGENT="${CTX_AGENT_NAME:-unknown}"
+VAULT_ROOT="${CTX_FRAMEWORK_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}/obsidian-vault"
+DATE=$(date -u +"%Y-%m-%d")
+TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+# --- MEMORY-03: Negative feedback trigger detection ---
+PROMPT_TEXT=$(echo "$INPUT" | python3 -c "
+import sys,json
+try:
+    d=json.load(sys.stdin)
+    # Try various field names for the user message
+    msg = d.get('message','') or d.get('prompt','') or d.get('text','') or str(d)
+    print(msg[:500].lower())
+except:
+    print('')
+" 2>/dev/null || echo "")
+
+NEGATIVE_TRIGGERS="kacke|scheiße|falsch|wrong|mist|f you|blödsinn|quatsch|nochmal falsch|wieder falsch|immer noch"
+if echo "$PROMPT_TEXT" | grep -qiE "$NEGATIVE_TRIGGERS" 2>/dev/null; then
+  MISTAKES_FILE="$VAULT_ROOT/${AGENT}/mistakes.md"
+  mkdir -p "$VAULT_ROOT/${AGENT}"
+  cat >> "$MISTAKES_FILE" << MISTAKE_EOF
+## $(date +"%Y-%m-%d %H:%M") — [AUTO-DETECTED] Negative user feedback
+**Was passiert:** User expressed dissatisfaction — trigger words detected in prompt.
+**Root cause:** To be filled in by agent after understanding the error.
+**Lesson:** Review what went wrong in this interaction and update GUARDRAILS if pattern is new.
+**Code-Ref:** Review last tool calls in session
+---
+MISTAKE_EOF
+fi
+
+# --- Boot context injection (first prompt per session only) ---
+SESSION_EPOCH="${CTX_SESSION_START_EPOCH:-0}"
+LOCK_FILE="/tmp/vault-boot-${AGENT}-${SESSION_EPOCH}.lock"
+if [[ ! -f "$LOCK_FILE" ]]; then
+  touch "$LOCK_FILE"
+  BOOT_FILE="$VAULT_ROOT/agent-shared/READ-ON-BOOT.md"
+  ACTIVE_SESSION="$VAULT_ROOT/${AGENT}/working-context.md"
+  
+  INJECT=""
+  [[ -f "$BOOT_FILE" ]] && INJECT=$(cat "$BOOT_FILE" 2>/dev/null | head -25 | sed 's/"/\\"/g' | tr '\n' ' ')
+  
+  if [[ -n "$INJECT" ]]; then
+    RESUME=""
+    [[ -f "$ACTIVE_SESSION" ]] && RESUME=" | Working context: $(head -5 "$ACTIVE_SESSION" 2>/dev/null | tail -3 | sed 's/"/\\"/g' | tr '\n' ' ')"
+    printf '{"hookSpecificOutput":{"additionalSystemPrompt":"[VAULT-BOOT] %s%s"}}' "$INJECT" "$RESUME"
+    exit 0
+  fi
+fi
+
+echo '{}'

--- a/bus/hook-vault-working-context-update.sh
+++ b/bus/hook-vault-working-context-update.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# MEMORY-04: Update working-context.md with current bus task state.
+# Called by: vault-working-context cron (every 30min)
+# Derives active projects from in-progress tasks and updates topic sections.
+
+set -euo pipefail
+
+VAULT="${CTX_FRAMEWORK_ROOT:-/Users/arndt/cortextos}/obsidian-vault"
+AGENT="${CTX_AGENT_NAME:-cortextos-improver}"
+WC_FILE="$VAULT/$AGENT/working-context.md"
+TODAY=$(date -u +%Y-%m-%d)
+NOW=$(date -u +%H:%M)
+
+# Get in-progress tasks for this agent from bus
+IN_PROGRESS=$(cortextos bus list-tasks --format json 2>/dev/null | \
+  python3 -c "
+import sys, json
+tasks = json.load(sys.stdin)
+agent = '${AGENT}'
+active = [t for t in tasks if t.get('status') == 'in_progress' and t.get('assigned_to') == agent]
+for t in active[:5]:
+    print(t['id'] + '|' + (t.get('title') or '')[:60])
+" 2>/dev/null || echo "")
+
+# Build active projects section
+PROJECTS_SECTION="## Active Projects (auto-updated by MEMORY-04 cron)
+"
+if [ -z "$IN_PROGRESS" ]; then
+  PROJECTS_SECTION+="*No in-progress tasks for $AGENT*
+"
+else
+  while IFS='|' read -r tid title; do
+    [ -z "$tid" ] && continue
+    PROJECTS_SECTION+="- **$tid**: $title
+"
+  done <<< "$IN_PROGRESS"
+fi
+
+# If working-context.md doesn't exist, create it
+if [ ! -f "$WC_FILE" ]; then
+  cat > "$WC_FILE" << TEMPLATE
+---
+type: working-context
+agent: $AGENT
+tags: [$AGENT, working-context, state, quality, guardrails, patterns]
+created: $TODAY
+modified: $TODAY
+---
+
+# $AGENT — Working Context
+**Current task:** (idle)
+**Last checkpoint:** $NOW UTC
+**Next action:** Check inbox + run crons
+TEMPLATE
+fi
+
+# Update modified date in frontmatter
+python3 << PYEOF
+from pathlib import Path
+import re
+
+wc = Path("$WC_FILE")
+content = wc.read_text()
+
+# Update modified date
+content = re.sub(r'^modified:.*$', f'modified: $TODAY', content, flags=re.M)
+
+# Remove stale "Active Projects" section if exists, re-add it
+content = re.sub(r'\n## Active Projects.*?(?=\n## |\Z)', '', content, flags=re.DOTALL)
+
+# Append updated section
+if not content.endswith('\n'):
+    content += '\n'
+content += '''\n${PROJECTS_SECTION}'''
+
+wc.write_text(content)
+print("working-context.md updated")
+PYEOF

--- a/bus/memory-08-feedback-sync.sh
+++ b/bus/memory-08-feedback-sync.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# MEMORY-08 Phase 1: Sync GitHub CI + Greptile reviews to Obsidian vault feedback/.
+# Runs every 15 minutes. Only processes new PRs since last-mined-pr.
+
+set -euo pipefail
+
+VAULT="/Users/arndt/cortextos/obsidian-vault/cortextos-improver"
+REPO="syntasticstudios/phytomedic-saas"
+LAST_MINED_FILE="/Users/arndt/phytomedic-saas/tests/quality/.last-mined-pr"
+TODAY=$(date -u +%Y-%m-%d)
+
+LAST=$(cat "$LAST_MINED_FILE" 2>/dev/null || echo 0)
+LATEST=$(gh pr list --repo "$REPO" --state all --limit 1 --json number --jq '.[0].number' 2>/dev/null || echo "$LAST")
+
+if [ "$LATEST" -le "$LAST" ]; then
+  echo "memory-08-feedback-sync: no new PRs (last=$LAST)"
+  exit 0
+fi
+
+mkdir -p "$VAULT/feedback/greptile" "$VAULT/feedback/ci"
+
+for pr in $(seq $((LAST+1)) $LATEST); do
+  PR_DATA=$(gh pr view "$pr" --repo "$REPO" \
+    --json number,title,mergedAt,statusCheckRollup,comments \
+    2>/dev/null) || continue
+
+  python3 - <<PYEOF
+import json, re
+from pathlib import Path
+from datetime import datetime, timezone
+
+pr_data = json.loads('''$PR_DATA'''.replace("'", "'\\''"))
+pr_num = pr_data.get('number', 0)
+today = '$TODAY'
+vault = Path('$VAULT')
+
+# Greptile sync
+reviews = [c for c in pr_data.get('comments', [])
+           if c.get('author', {}).get('login', '').startswith('greptile')]
+body = reviews[-1].get('body', '') if reviews else ''
+m = re.search(r'(\d)/5', body)
+score = int(m.group(1)) if m else None
+findings = list(set(re.findall(r'\b(?:P0|P1|P2)-\d+\b', body)))
+gate = 'ready' if score and score >= 4 else ('blocked' if score else 'unknown')
+
+greptile_md = f"""---
+type: feedback
+agent: cortextos-improver
+tags: [cortextos-improver, feedback, greptile]
+pr_number: {pr_num}
+greptile_score: {score if score is not None else 'null'}
+gate_status: {gate}
+state: {('merged' if pr_data.get('mergedAt') else 'open')}
+created: {today}
+modified: {today}
+---
+
+# Greptile — PR #{pr_num}
+
+**Score:** {f'{score}/5' if score else 'pending'}  
+**Gate:** {gate}  
+**Findings:** {', '.join(findings) if findings else 'none'}  
+
+## Review (excerpt)
+
+{body[:1500]}
+"""
+(vault / f'feedback/greptile/pr-{pr_num}.md').write_text(greptile_md)
+
+# CI sync
+checks = pr_data.get('statusCheckRollup') or []
+failed = sum(1 for c in checks if c.get('conclusion') in ('FAILURE', 'ERROR', 'TIMED_OUT'))
+ci_status = 'green' if checks and failed == 0 else ('red' if failed > 0 else 'unknown')
+
+ci_md = f"""---
+type: feedback
+agent: cortextos-improver
+tags: [cortextos-improver, feedback, ci]
+pr_number: {pr_num}
+ci_status: {ci_status}
+checks_total: {len(checks)}
+checks_failed: {failed}
+state: {('merged' if pr_data.get('mergedAt') else 'open')}
+merged_at: {(pr_data.get('mergedAt') or '')[:10]}
+created: {today}
+modified: {today}
+---
+
+# CI — PR #{pr_num}
+
+**Status:** {ci_status} {'✅' if ci_status == 'green' else '🔴' if ci_status == 'red' else '⏳'}  
+**Checks:** {len(checks) - failed}/{len(checks)} passed  
+
+## Checks
+
+{''.join(f"- **{c.get('name','?')}**: {c.get('conclusion') or c.get('status','?')}  \\n" for c in checks[:20])}
+"""
+(vault / f'feedback/ci/pr-{pr_num}.md').write_text(ci_md)
+print(f'synced PR {pr_num}: greptile={score}/5 ci={ci_status}')
+PYEOF
+
+done
+
+echo "memory-08-feedback-sync: synced PRs $((LAST+1))..$LATEST"

--- a/bus/vault-append-mistake.sh
+++ b/bus/vault-append-mistake.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# vault-append-mistake.sh — append a lesson-learned entry to agent mistakes.md
+# Usage: vault-append-mistake.sh "<title>" "<what-happened>" "<root-cause>" "<lesson>" [<code-ref>]
+# Non-interactive, idempotent, completes in <1s.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+source "${SCRIPT_DIR}/_ctx-env.sh" 2>/dev/null || true
+
+AGENT="${CTX_AGENT_NAME:-unknown}"
+VAULT_DIR="${CTX_FRAMEWORK_ROOT:-$(cd "$SCRIPT_DIR/.." && pwd)}/obsidian-vault/${AGENT}"
+MISTAKES_FILE="$VAULT_DIR/mistakes.md"
+TIMESTAMP=$(date +"%Y-%m-%d %H:%M")
+
+TITLE="${1:-unknown}"
+WHAT="${2:-}"
+CAUSE="${3:-}"
+LESSON="${4:-}"
+CODE_REF="${5:-}"
+
+mkdir -p "$VAULT_DIR"
+
+cat >> "$MISTAKES_FILE" << ENTRY_EOF
+## ${TIMESTAMP} — ${TITLE}
+**Was passiert:** ${WHAT}
+**Root cause:** ${CAUSE}
+**Lesson:** ${LESSON}
+$([ -n "${CODE_REF}" ] && echo "**Code-Ref:** ${CODE_REF}" || true)
+---
+ENTRY_EOF
+
+echo "Appended mistake to $MISTAKES_FILE"

--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -5,6 +5,7 @@ import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
 import { randomDigits } from '../utils/random.js';
 import { validatePriority } from '../utils/validate.js';
 import { logEvent } from './event.js';
+import { vaultWriteTask, vaultMoveTask, vaultArchiveTask } from './vault-sync.js';
 
 /**
  * Create a new task. Identical JSON format to bash create-task.sh.
@@ -91,6 +92,9 @@ export function createTask(
   for (const downId of blocks) addSymmetricEdge(paths, downId, 'blocked_by', taskId);
 
   appendTaskAudit(paths, taskId, { event: 'create', agent: agentName, to: 'pending', note: title });
+
+  // MEMORY-07: Sync new task to Obsidian vault (best-effort, never blocks).
+  vaultWriteTask(task);
 
   return taskId;
 }
@@ -282,6 +286,12 @@ export function updateTask(
     throw new Error(`Task ${taskId} update failed: ${err}`);
   }
   appendTaskAudit(paths, taskId, { event: 'update', agent: assignee || 'unknown', from: prevStatus, to: status });
+
+  // MEMORY-07: Move vault file to new status folder (best-effort).
+  if (prevStatus !== undefined) {
+    const updatedTask = JSON.parse(readFileSync(filePath, 'utf-8')) as Task;
+    vaultMoveTask(updatedTask, prevStatus);
+  }
 }
 
 /**
@@ -507,6 +517,12 @@ export function completeTask(
     } catch {
       // Never let observability break task completion.
     }
+  }
+
+  // MEMORY-07: Move vault file to completed folder (best-effort).
+  if (prevStatus !== undefined) {
+    const completedTask = JSON.parse(readFileSync(filePath, 'utf-8')) as Task;
+    vaultMoveTask(completedTask, prevStatus);
   }
 }
 
@@ -810,6 +826,8 @@ export function compactTasks(
       try {
         appendFileSync(archivePath, JSON.stringify(entry) + '\n', { encoding: 'utf-8', mode: 0o600 });
         unlinkSync(join(taskDir, `${task.id}.json`));
+        // MEMORY-07: Move vault file to archive subfolder (best-effort).
+        vaultArchiveTask(task.id, task.assigned_to ?? 'unassigned');
       } catch (err) {
         report.skipped.push({ id: task.id, reason: `archive write failed: ${err}` });
         continue;

--- a/src/bus/vault-sync.ts
+++ b/src/bus/vault-sync.ts
@@ -1,0 +1,174 @@
+import { existsSync, mkdirSync, renameSync, writeFileSync, unlinkSync } from 'fs';
+import { join } from 'path';
+import type { Task, TaskStatus } from '../types/index.js';
+
+/**
+ * MEMORY-07: Bidirectional vault sync for tasks.
+ *
+ * Writes/moves task markdown files into the Obsidian vault directory tree:
+ *   obsidian-vault/<agent>/tasks/{open,in-progress,completed}/<taskId>.md
+ *
+ * All operations are best-effort — a vault write failure never blocks
+ * the underlying task operation. The vault is a read-friendly mirror,
+ * not the source of truth.
+ *
+ * Vault root is derived from CTX_FRAMEWORK_ROOT env var. If not set,
+ * vault sync is silently skipped.
+ */
+
+function getVaultRoot(): string | null {
+  const frameworkRoot = process.env.CTX_FRAMEWORK_ROOT;
+  if (!frameworkRoot) return null;
+  const vaultRoot = join(frameworkRoot, 'obsidian-vault');
+  if (!existsSync(vaultRoot)) return null;
+  return vaultRoot;
+}
+
+function statusToFolder(status: TaskStatus): string {
+  switch (status) {
+    case 'pending': return 'open';
+    case 'in_progress': return 'in-progress';
+    case 'completed': return 'completed';
+    case 'cancelled': return 'completed';
+    default: return 'open';
+  }
+}
+
+function priorityEmoji(priority: string): string {
+  switch (priority) {
+    case 'urgent': return '🔴';
+    case 'high': return '🟠';
+    case 'normal': return '🟡';
+    case 'low': return '🟢';
+    default: return '⚪';
+  }
+}
+
+function buildTaskMarkdown(task: Task): string {
+  const now = new Date().toISOString().substring(0, 10);
+  const created = task.created_at?.substring(0, 10) ?? now;
+  const updated = task.updated_at?.substring(0, 10) ?? now;
+  const hasVerified = (task.result ?? '').match(/VERIFIED:/i) ? 'true' : 'false';
+  const agent = task.assigned_to ?? 'unassigned';
+
+  const frontmatter = [
+    '---',
+    `type: task`,
+    `agent: ${agent}`,
+    `task_id: ${task.id}`,
+    `status: ${task.status}`,
+    `priority: ${task.priority ?? 'normal'}`,
+    `assignee: ${agent}`,
+    `created_by: ${task.created_by ?? 'unknown'}`,
+    `org: ${task.org ?? ''}`,
+    task.project ? `project: ${task.project}` : null,
+    `created: ${created}`,
+    `modified: ${updated}`,
+    `has_verified: ${hasVerified}`,
+    `tags: [${agent}, task, ${statusToFolder(task.status)}, ${task.priority ?? 'normal'}]`,
+    '---',
+    '',
+  ].filter(line => line !== null).join('\n');
+
+  const body = [
+    `# ${priorityEmoji(task.priority ?? 'normal')} ${task.title}`,
+    '',
+    `**Status:** ${task.status}  `,
+    `**Priority:** ${task.priority ?? 'normal'}  `,
+    `**Assigned to:** ${agent}  `,
+    `**Created:** ${task.created_at}  `,
+    `**Updated:** ${task.updated_at}  `,
+    task.due_date ? `**Due:** ${task.due_date}  ` : null,
+    task.project ? `**Project:** ${task.project}  ` : null,
+    '',
+  ].filter(line => line !== null).join('\n');
+
+  const desc = task.description
+    ? `## Description\n\n${task.description}\n\n`
+    : '';
+
+  const result = task.result
+    ? `## Result\n\n${task.result}\n\n`
+    : '';
+
+  const busLink = `## Bus Link\n\n\`cortextos bus get-task ${task.id}\`\n`;
+
+  return frontmatter + body + desc + result + busLink;
+}
+
+/**
+ * Write (create or overwrite) a task's vault markdown file.
+ * Places it in the folder matching the task's current status.
+ */
+export function vaultWriteTask(task: Task): void {
+  try {
+    const vaultRoot = getVaultRoot();
+    if (!vaultRoot) return;
+
+    const agent = task.assigned_to ?? 'unassigned';
+    const folder = statusToFolder(task.status);
+    const agentTaskDir = join(vaultRoot, agent, 'tasks', folder);
+
+    mkdirSync(agentTaskDir, { recursive: true });
+    const filePath = join(agentTaskDir, `${task.id}.md`);
+    writeFileSync(filePath, buildTaskMarkdown(task), { encoding: 'utf-8', mode: 0o600 });
+  } catch {
+    // Best-effort — never block task operations on vault write failure.
+  }
+}
+
+/**
+ * Move a task's vault markdown file from oldStatus folder to newStatus folder.
+ * Falls back to a write if the source file doesn't exist (idempotent recovery).
+ */
+export function vaultMoveTask(task: Task, oldStatus: TaskStatus): void {
+  try {
+    const vaultRoot = getVaultRoot();
+    if (!vaultRoot) return;
+
+    const agent = task.assigned_to ?? 'unassigned';
+    const oldFolder = statusToFolder(oldStatus);
+    const newFolder = statusToFolder(task.status);
+
+    if (oldFolder === newFolder) {
+      // Same folder — just overwrite in place.
+      vaultWriteTask(task);
+      return;
+    }
+
+    const oldPath = join(vaultRoot, agent, 'tasks', oldFolder, `${task.id}.md`);
+    const newDir = join(vaultRoot, agent, 'tasks', newFolder);
+    mkdirSync(newDir, { recursive: true });
+    const newPath = join(newDir, `${task.id}.md`);
+
+    // Write the updated content first, then remove the old file.
+    // This avoids a window where the file doesn't exist in either place.
+    writeFileSync(newPath, buildTaskMarkdown(task), { encoding: 'utf-8', mode: 0o600 });
+    if (existsSync(oldPath)) {
+      try { unlinkSync(oldPath); } catch { /* best-effort */ }
+    }
+  } catch {
+    // Best-effort.
+  }
+}
+
+/**
+ * Archive a task's vault file (move completed → archive subfolder).
+ * Called when the bus compacts tasks older than 14 days.
+ */
+export function vaultArchiveTask(taskId: string, assignedTo: string): void {
+  try {
+    const vaultRoot = getVaultRoot();
+    if (!vaultRoot) return;
+
+    const agent = assignedTo ?? 'unassigned';
+    const completedPath = join(vaultRoot, agent, 'tasks', 'completed', `${taskId}.md`);
+    if (!existsSync(completedPath)) return;
+
+    const archiveDir = join(vaultRoot, agent, 'tasks', 'archive');
+    mkdirSync(archiveDir, { recursive: true });
+    renameSync(completedPath, join(archiveDir, `${taskId}.md`));
+  } catch {
+    // Best-effort.
+  }
+}

--- a/tests/unit/bus/vault-sync.test.ts
+++ b/tests/unit/bus/vault-sync.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { vaultWriteTask, vaultMoveTask, vaultArchiveTask } from '../../../src/bus/vault-sync';
+import type { Task } from '../../../src/types';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task_1234567890_abcde',
+    title: 'Sample task',
+    status: 'pending',
+    priority: 'normal',
+    assigned_to: 'alice',
+    created_by: 'bob',
+    created_at: '2026-05-18T12:00:00Z',
+    updated_at: '2026-05-18T12:00:00Z',
+    org: 'TestOrg',
+    description: 'A test task',
+    ...overrides,
+  } as Task;
+}
+
+describe('vault-sync', () => {
+  let frameworkRoot: string;
+  let vaultRoot: string;
+  const origEnv = process.env.CTX_FRAMEWORK_ROOT;
+
+  beforeEach(() => {
+    frameworkRoot = mkdtempSync(join(tmpdir(), 'cortextos-vault-test-'));
+    vaultRoot = join(frameworkRoot, 'obsidian-vault');
+    mkdirSync(vaultRoot, { recursive: true });
+    process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
+  });
+
+  afterEach(() => {
+    rmSync(frameworkRoot, { recursive: true, force: true });
+    if (origEnv === undefined) delete process.env.CTX_FRAMEWORK_ROOT;
+    else process.env.CTX_FRAMEWORK_ROOT = origEnv;
+  });
+
+  describe('vaultWriteTask', () => {
+    it('writes task markdown to obsidian-vault/<agent>/tasks/open/ for pending status', () => {
+      const task = makeTask({ status: 'pending' });
+      vaultWriteTask(task);
+      const expected = join(vaultRoot, 'alice', 'tasks', 'open', `${task.id}.md`);
+      expect(existsSync(expected)).toBe(true);
+      const content = readFileSync(expected, 'utf-8');
+      expect(content).toContain('type: task');
+      expect(content).toContain(`task_id: ${task.id}`);
+      expect(content).toContain('status: pending');
+      expect(content).toContain('Sample task');
+    });
+
+    it('places in-progress tasks in tasks/in-progress/', () => {
+      const task = makeTask({ status: 'in_progress' });
+      vaultWriteTask(task);
+      expect(existsSync(join(vaultRoot, 'alice', 'tasks', 'in-progress', `${task.id}.md`))).toBe(true);
+    });
+
+    it('places completed tasks in tasks/completed/', () => {
+      const task = makeTask({ status: 'completed' });
+      vaultWriteTask(task);
+      expect(existsSync(join(vaultRoot, 'alice', 'tasks', 'completed', `${task.id}.md`))).toBe(true);
+    });
+
+    it('uses "unassigned" agent directory when assigned_to is missing', () => {
+      const task = makeTask({ assigned_to: undefined });
+      vaultWriteTask(task);
+      expect(existsSync(join(vaultRoot, 'unassigned', 'tasks', 'open', `${task.id}.md`))).toBe(true);
+    });
+
+    it('silently skips when CTX_FRAMEWORK_ROOT is unset (best-effort)', () => {
+      delete process.env.CTX_FRAMEWORK_ROOT;
+      const task = makeTask();
+      expect(() => vaultWriteTask(task)).not.toThrow();
+      expect(existsSync(join(vaultRoot, 'alice'))).toBe(false);
+    });
+
+    it('silently skips when obsidian-vault dir does not exist (best-effort)', () => {
+      rmSync(vaultRoot, { recursive: true, force: true });
+      const task = makeTask();
+      expect(() => vaultWriteTask(task)).not.toThrow();
+    });
+
+    it('does not throw on write failure (best-effort)', () => {
+      const task = makeTask({ id: 'task_bad/path/segment' });
+      expect(() => vaultWriteTask(task)).not.toThrow();
+    });
+  });
+
+  describe('vaultMoveTask', () => {
+    it('moves file from open to in-progress folder on status transition', () => {
+      const task = makeTask({ status: 'pending' });
+      vaultWriteTask(task);
+      const oldPath = join(vaultRoot, 'alice', 'tasks', 'open', `${task.id}.md`);
+      expect(existsSync(oldPath)).toBe(true);
+
+      const updated = makeTask({ status: 'in_progress' });
+      vaultMoveTask(updated, 'pending');
+
+      const newPath = join(vaultRoot, 'alice', 'tasks', 'in-progress', `${task.id}.md`);
+      expect(existsSync(oldPath)).toBe(false);
+      expect(existsSync(newPath)).toBe(true);
+      expect(readFileSync(newPath, 'utf-8')).toContain('status: in_progress');
+    });
+
+    it('overwrites in place when oldStatus and newStatus map to same folder', () => {
+      // cancelled and completed both map to 'completed' folder
+      const task = makeTask({ status: 'completed' });
+      vaultWriteTask(task);
+      const path = join(vaultRoot, 'alice', 'tasks', 'completed', `${task.id}.md`);
+      const originalMtime = readFileSync(path, 'utf-8').length;
+
+      const updated = makeTask({ status: 'cancelled', result: 'VERIFIED: done' });
+      vaultMoveTask(updated, 'completed');
+
+      expect(existsSync(path)).toBe(true);
+      const newContent = readFileSync(path, 'utf-8');
+      expect(newContent.length).toBeGreaterThan(originalMtime);
+      expect(newContent).toContain('VERIFIED: done');
+    });
+
+    it('writes new file even if source missing (idempotent recovery)', () => {
+      const task = makeTask({ status: 'completed' });
+      vaultMoveTask(task, 'in_progress');
+      const newPath = join(vaultRoot, 'alice', 'tasks', 'completed', `${task.id}.md`);
+      expect(existsSync(newPath)).toBe(true);
+    });
+
+    it('silently skips when CTX_FRAMEWORK_ROOT unset', () => {
+      delete process.env.CTX_FRAMEWORK_ROOT;
+      const task = makeTask({ status: 'in_progress' });
+      expect(() => vaultMoveTask(task, 'pending')).not.toThrow();
+    });
+  });
+
+  describe('vaultArchiveTask', () => {
+    it('moves a completed task into the archive subfolder', () => {
+      const task = makeTask({ status: 'completed' });
+      vaultWriteTask(task);
+      const completedPath = join(vaultRoot, 'alice', 'tasks', 'completed', `${task.id}.md`);
+      expect(existsSync(completedPath)).toBe(true);
+
+      vaultArchiveTask(task.id, 'alice');
+
+      const archivePath = join(vaultRoot, 'alice', 'tasks', 'archive', `${task.id}.md`);
+      expect(existsSync(completedPath)).toBe(false);
+      expect(existsSync(archivePath)).toBe(true);
+    });
+
+    it('is a no-op if the completed file does not exist (best-effort)', () => {
+      expect(() => vaultArchiveTask('task_missing', 'alice')).not.toThrow();
+      expect(existsSync(join(vaultRoot, 'alice', 'tasks', 'archive'))).toBe(false);
+    });
+
+    it('silently skips when CTX_FRAMEWORK_ROOT unset', () => {
+      delete process.env.CTX_FRAMEWORK_ROOT;
+      expect(() => vaultArchiveTask('task_any', 'alice')).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Closes #357. Original work by @syntasticstudios; reconstructed from our clean soak rework + sandbox-validated, co-authored by cortext-designer. Bidirectional task<->Obsidian-vault sync (mirror on create, move on status change, archive on completion) + vault bus hooks + obsidian-mcp config. vault-sync 14/14, CI green.