### PR TITLE
feat(usage-monitor): unified Claude Max + Codex usage tracking

### DIFF
--- a/bus/check-usage-api.sh
+++ b/bus/check-usage-api.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
-# Check Claude Max API usage via the OAuth usage endpoint.
-# Reads the OAuth token from macOS Keychain, calls the undocumented
-# api.anthropic.com/api/oauth/usage endpoint, and returns utilization data.
+# Check Claude Max and Codex plan usage.
+# Claude Max: reads OAuth token from macOS Keychain, calls the undocumented
+# api.anthropic.com/api/oauth/usage endpoint.
+# Codex: reads ~/.codex/auth.json, refreshes OAuth token if needed, then calls
+# chatgpt.com/backend-api/wham/usage to get real used_percent for 5h and 7d windows.
 #
 # Usage:
 #   cortextos bus check-usage-api [--warn-7day N] [--warn-5h N] [--chat-id ID]
@@ -12,10 +14,11 @@
 #   --chat-id ID    Telegram chat ID to send alerts to (uses CTX_TELEGRAM_CHAT_ID if omitted)
 #   --force         Bypass the 3-minute result cache
 #
-# Output: JSON with utilization fields, or exits 1 on error.
+# Output: JSON with utilization fields + codex plan info, or exits 1 on error.
 #
-# Cache: results are cached for 3 minutes at $CTX_ROOT/state/usage/api-cache.json
+# Cache: Claude Max results are cached for 3 minutes at $CTX_ROOT/state/usage/api-cache.json
 # to avoid hitting the hard rate limit (~5 requests per token before 429).
+# Codex wham/usage is cached for 5 minutes at $CTX_ROOT/state/usage/codex-wham-cache.json.
 
 set -euo pipefail
 
@@ -44,6 +47,170 @@ if [[ -z "${CHAT_ID}" ]]; then
   CHAT_ID="${CTX_TELEGRAM_CHAT_ID:-}"
 fi
 
+# ── Codex wham/usage API: returns live used_percent for 5h and 7d windows ────
+_codex_wham_usage() {
+  local auth_file="$HOME/.codex/auth.json"
+  local cache_file="${CTX_ROOT}/state/usage/codex-wham-cache.json"
+  local cache_ttl=300  # 5 minutes
+
+  [[ -f "$auth_file" ]] || return 1
+
+  # Return cached result if fresh
+  if [[ "$FORCE" == "false" && -f "$cache_file" ]]; then
+    local age=$(( $(date +%s) - $(date -r "$cache_file" +%s 2>/dev/null || echo 0) ))
+    if [[ $age -lt $cache_ttl ]]; then
+      cat "$cache_file"
+      return 0
+    fi
+  fi
+
+  # Get a valid access token (use existing if not expired, refresh otherwise)
+  local access_token
+  access_token=$(python3 -c "
+import json, base64, time
+try:
+    auth = json.load(open('$auth_file'))
+    token = auth.get('tokens', {}).get('access_token', '')
+    seg = token.split('.')[1]
+    seg += '=' * (4 - len(seg) % 4)
+    payload = json.loads(base64.b64decode(seg))
+    if payload.get('exp', 0) - time.time() > 300:
+        print(token)
+    else:
+        print('')
+except:
+    print('')
+" 2>/dev/null)
+
+  if [[ -z "$access_token" ]]; then
+    local refresh_token
+    refresh_token=$(python3 -c "
+import json
+try:
+    auth = json.load(open('$auth_file'))
+    print(auth.get('tokens', {}).get('refresh_token', ''))
+except:
+    print('')
+" 2>/dev/null)
+    [[ -z "$refresh_token" ]] && return 1
+    access_token=$(curl -sf "https://auth.openai.com/oauth/token" \
+      -X POST -H "Content-Type: application/json" \
+      -d "{\"grant_type\":\"refresh_token\",\"refresh_token\":\"$refresh_token\",\"client_id\":\"app_EMoamEEZ73f0CkXaXp7hrann\"}" \
+      --max-time 10 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin).get('access_token',''))" 2>/dev/null)
+    [[ -z "$access_token" ]] && return 1
+  fi
+
+  local result
+  result=$(curl -sf "https://chatgpt.com/backend-api/wham/usage" \
+    -H "Authorization: Bearer $access_token" \
+    -H "Accept: application/json" \
+    -H "User-Agent: OpenAI-Codex/1.0" \
+    --max-time 10 2>/dev/null) || return 1
+
+  echo "$result" > "$cache_file"
+  echo "$result"
+}
+
+# ── Codex plan helper (JWT decode + wham/usage live % + SQLite token counts) ──
+_codex_json() {
+  local auth_file="$HOME/.codex/auth.json"
+  local db_file="$HOME/.codex/logs_2.sqlite"
+  [[ -f "$auth_file" ]] || { echo '{"error":"~/.codex/auth.json not found"}'; return; }
+
+  local wham_json=""
+  wham_json=$(_codex_wham_usage 2>/dev/null) || true
+
+  CODEX_AUTH="$auth_file" CODEX_DB="$db_file" WHAM_JSON="$wham_json" python3 -c "
+import json, base64, time, os, re, sqlite3
+from datetime import datetime, timezone
+
+result = {}
+
+# JWT decode: plan type + token expiry
+try:
+    auth = json.load(open(os.environ['CODEX_AUTH']))
+    token = auth.get('tokens', {}).get('access_token', '')
+    seg = token.split('.')[1]
+    seg += '=' * (4 - len(seg) % 4)
+    payload = json.loads(base64.b64decode(seg))
+    claims = payload.get('https://api.openai.com/auth', {})
+    result['plan_type'] = claims.get('chatgpt_plan_type', 'unknown')
+    result['token_expires_in_hours'] = round((payload.get('exp', 0) - time.time()) / 3600, 1)
+except Exception as e:
+    result['plan_type'] = 'unknown'
+    result['token_expires_in_hours'] = None
+    result['jwt_error'] = str(e)
+
+# Live usage % from wham/usage API
+wham_raw = os.environ.get('WHAM_JSON', '')
+if wham_raw:
+    try:
+        wham = json.loads(wham_raw)
+        rl = wham.get('rate_limit', {})
+        pw = rl.get('primary_window', {})
+        sw = rl.get('secondary_window', {})
+        result['utilization_5h']  = pw.get('used_percent')
+        result['utilization_7d']  = sw.get('used_percent')
+        result['reset_5h_seconds'] = pw.get('reset_after_seconds')
+        result['reset_7d_seconds'] = sw.get('reset_after_seconds')
+        result['limit_reached']   = rl.get('limit_reached', False)
+        result['allowed']         = rl.get('allowed', True)
+    except Exception:
+        pass
+
+# SQLite usage: aggregate token counts from recent turns
+db_path = os.environ.get('CODEX_DB', '')
+if db_path and os.path.exists(db_path):
+    try:
+        conn = sqlite3.connect(db_path)
+        now = int(time.time())
+        cutoff_5h  = now - 18000
+        cutoff_24h = now - 86400
+
+        rows = conn.execute(
+            'SELECT ts, feedback_log_body FROM logs WHERE feedback_log_body LIKE ? AND ts > ? ORDER BY ts DESC LIMIT 500',
+            ('%codex.turn.token_usage.total_tokens%', cutoff_24h)
+        ).fetchall()
+
+        tokens_5h = 0
+        tokens_24h = 0
+        models_5h = {}
+
+        for ts, body in rows:
+            m_total = re.search(r'token_usage\.total_tokens=(\d+)', body)
+            m_model = re.search(r'model=([^\s\}]+)', body)
+            if not m_total:
+                continue
+            total = int(m_total.group(1))
+            model = m_model.group(1) if m_model else 'unknown'
+            tokens_24h += total
+            if ts > cutoff_5h:
+                tokens_5h += total
+                models_5h[model] = models_5h.get(model, 0) + total
+
+        result['tokens_5h']  = tokens_5h
+        result['tokens_24h'] = tokens_24h
+        result['models_5h']  = models_5h
+        conn.close()
+    except Exception as e:
+        result['usage_error'] = str(e)
+
+print(json.dumps(result))
+" 2>/dev/null || echo '{"error":"codex data fetch failed"}'
+}
+
+_merge_codex() {
+  local resp="$1"
+  local codex
+  codex=$(_codex_json)
+  RESP_JSON="$resp" CODEX_JSON="$codex" python3 -c "
+import json, os
+d = json.loads(os.environ['RESP_JSON'])
+d['codex'] = json.loads(os.environ['CODEX_JSON'])
+print(json.dumps(d))
+" 2>/dev/null || echo "$resp"
+}
+
 # ── Cache check ─────────────────────────────────────────────────────────────
 CACHE_DIR="${CTX_ROOT}/state/usage"
 CACHE_FILE="${CACHE_DIR}/api-cache.json"
@@ -54,7 +221,7 @@ mkdir -p "$CACHE_DIR"
 if [[ "$FORCE" == "false" && -f "$CACHE_FILE" ]]; then
   cache_age=$(( $(date +%s) - $(date -r "$CACHE_FILE" +%s 2>/dev/null || echo 0) ))
   if [[ $cache_age -lt $CACHE_TTL ]]; then
-    cat "$CACHE_FILE"
+    _merge_codex "$(cat "$CACHE_FILE")"
     exit 0
   fi
 fi
@@ -134,7 +301,45 @@ if [[ -n "$CHAT_ID" ]]; then
     fi
     echo "$SEND_MSG" >&2
   fi
+
+  # Codex token expiry warning (< 24h)
+  CODEX_EXPIRES=$(CODEX_AUTH="$HOME/.codex/auth.json" python3 -c "
+import json, base64, time, os
+try:
+    auth = json.load(open(os.environ['CODEX_AUTH']))
+    token = auth.get('tokens', {}).get('access_token', '')
+    seg = token.split('.')[1] + '=='
+    payload = json.loads(base64.b64decode(seg))
+    print(round((payload.get('exp', 0) - time.time()) / 3600, 1))
+except: print(9999)
+" 2>/dev/null || echo 9999)
+  if python3 -c "import sys; sys.exit(0 if float('${CODEX_EXPIRES}') < 24 else 1)" 2>/dev/null; then
+    SEND_MSG="Warning: Codex OAuth token expires in ${CODEX_EXPIRES}h. Run Codex and re-authenticate."
+    if [[ -f "$SCRIPT_DIR/send-telegram.sh" ]]; then
+      bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
+    fi
+    echo "$SEND_MSG" >&2
+  fi
+
+  # Codex usage threshold checks (from wham/usage)
+  CODEX_WHAM=$(_codex_wham_usage 2>/dev/null || echo "")
+  if [[ -n "$CODEX_WHAM" ]]; then
+    CODEX_5H=$(echo "$CODEX_WHAM" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('rate_limit',{}).get('primary_window',{}).get('used_percent',-1))" 2>/dev/null || echo -1)
+    CODEX_7D=$(echo "$CODEX_WHAM" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('rate_limit',{}).get('secondary_window',{}).get('used_percent',-1))" 2>/dev/null || echo -1)
+    CODEX_LIMIT=$(echo "$CODEX_WHAM" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('rate_limit',{}).get('limit_reached',False))" 2>/dev/null || echo "False")
+
+    if [[ "$CODEX_LIMIT" == "True" ]]; then
+      SEND_MSG="CODE RED: Codex rate limit reached. Sessions blocked until window resets."
+      [[ -f "$SCRIPT_DIR/send-telegram.sh" ]] && bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
+    elif python3 -c "import sys; v=float('${CODEX_7D}'); sys.exit(0 if v >= ${WARN_7DAY} else 1)" 2>/dev/null; then
+      SEND_MSG="Warning: Codex 7-day usage at ${CODEX_7D}%."
+      [[ -f "$SCRIPT_DIR/send-telegram.sh" ]] && bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
+    elif python3 -c "import sys; v=float('${CODEX_5H}'); sys.exit(0 if v >= ${WARN_5H} else 1)" 2>/dev/null; then
+      SEND_MSG="Warning: Codex 5-hour window at ${CODEX_5H}%."
+      [[ -f "$SCRIPT_DIR/send-telegram.sh" ]] && bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
+    fi
+  fi
 fi
 
-# ── Output ───────────────────────────────────────────────────────────────────
-echo "$RESPONSE"
+# ── Output (Claude Max + Codex merged) ───────────────────────────────────────
+_merge_codex "$RESPONSE"

--- a/templates/analyst/config.json
+++ b/templates/analyst/config.json
@@ -22,6 +22,12 @@
       "prompt": "Read HEARTBEAT.md and follow its instructions. Update your heartbeat, check inbox, and work on your highest priority task."
     },
     {
+      "name": "usage-monitor",
+      "type": "recurring",
+      "interval": "2h",
+      "prompt": "Check Claude API usage: run bash $CTX_FRAMEWORK_ROOT/bus/check-usage-api.sh --chat-id 7940429114 --warn-7day 80 --warn-5h 90 2>&1. Parse the JSON output. Rules: (1) If 7-day utilization >= 80% send James a CODE RED via Telegram immediately. (2) If 5-hour >= 90% send a warning. (3) For 7-day: check if the current utilization has crossed a new 10% increment since the last check (e.g. crossed 10%, 20%, 30%... 90%). Read the last logged 7-day value from today's memory file to compare. If a new 10% threshold was crossed, send James a brief Telegram: '7-day usage: X% (resets <date>)'. Same logic applies to codex.utilization_5h and codex.utilization_7d fields. (4) Always log the current levels in your daily memory."
+    },
+    {
       "name": "nightly-metrics",
       "type": "recurring",
       "interval": "24h",

--- a/templates/analyst/config.json
+++ b/templates/analyst/config.json
@@ -25,7 +25,7 @@
       "name": "usage-monitor",
       "type": "recurring",
       "interval": "2h",
-      "prompt": "Check Claude API usage: run bash $CTX_FRAMEWORK_ROOT/bus/check-usage-api.sh --chat-id 7940429114 --warn-7day 80 --warn-5h 90 2>&1. Parse the JSON output. Rules: (1) If 7-day utilization >= 80% send James a CODE RED via Telegram immediately. (2) If 5-hour >= 90% send a warning. (3) For 7-day: check if the current utilization has crossed a new 10% increment since the last check (e.g. crossed 10%, 20%, 30%... 90%). Read the last logged 7-day value from today's memory file to compare. If a new 10% threshold was crossed, send James a brief Telegram: '7-day usage: X% (resets <date>)'. Same logic applies to codex.utilization_5h and codex.utilization_7d fields. (4) Always log the current levels in your daily memory."
+      "prompt": "Check Claude API usage: run cortextos bus check-usage-api --warn-7day 80 --warn-5h 90 2>&1. Parse the JSON output. Rules: (1) If 7-day utilization >= 80% send the orchestrator a CODE RED via Telegram immediately. (2) If 5-hour >= 90% send a warning. (3) For 7-day: check if the current utilization has crossed a new 10% increment since the last check (e.g. crossed 10%, 20%, 30%... 90%). Read the last logged 7-day value from today's memory file to compare. If a new 10% threshold was crossed, send the orchestrator a brief Telegram: '7-day usage: X% (resets <date>)'. Same logic applies to codex.utilization_5h and codex.utilization_7d fields. (4) Always log the current levels in your daily memory."
     },
     {
       "name": "nightly-metrics",

--- a/tests/sprint1-templates.test.ts
+++ b/tests/sprint1-templates.test.ts
@@ -215,11 +215,12 @@ describe('Sprint 1: Template Completeness', () => {
       }
     });
 
-    it('has config.json with 5 analyst crons + ecosystem config', () => {
+    it('has config.json with 6 analyst crons + ecosystem config', () => {
       const config = JSON.parse(readFileSync(join(analystDir, 'config.json'), 'utf-8'));
-      expect(config.crons.length).toBe(5);
+      expect(config.crons.length).toBe(6);
       const cronNames = config.crons.map((c: any) => c.name);
       expect(cronNames).toContain('heartbeat');
+      expect(cronNames).toContain('usage-monitor');
       expect(cronNames).toContain('nightly-metrics');
       expect(cronNames).toContain('auto-commit');
       expect(cronNames).toContain('check-upstream');


### PR DESCRIPTION
## Summary

- **`bus/check-usage-api.sh`**: adds live Codex usage % via the `chatgpt.com/backend-api/wham/usage` endpoint (found in the Codex Rust binary string table). New `_codex_wham_usage()` helper fetches `primary_window.used_percent` (5h) and `secondary_window.used_percent` (7d), auto-refreshes the Codex OAuth token from `~/.codex/auth.json` when near expiry, and caches results for 5 minutes. Output now includes `codex.utilization_5h`, `codex.utilization_7d`, `codex.limit_reached`, and reset timers alongside existing SQLite token counts. Alerts on limit_reached, >=80% 7d, >=90% 5h — same thresholds as Claude Max.
- **`templates/analyst/config.json`**: adds a `usage-monitor` cron (2h interval) that checks both Claude Max and Codex utilization, alerts on new 10% thresholds, and logs current levels to daily memory.

Previously the script only reported Codex plan type, token expiry, and raw SQLite token counts with no percentage or plan-cap awareness. No official OpenAI API exists for this; the endpoint was discovered via binary analysis of the Codex CLI.

## Test plan

- [ ] Run `bash bus/check-usage-api.sh --force` and verify `codex.utilization_5h` and `codex.utilization_7d` appear in JSON output
- [ ] Confirm `codex.limit_reached: false` and `codex.allowed: true` under normal usage
- [ ] Verify 5-minute cache at `$CTX_ROOT/state/usage/codex-wham-cache.json` is written and reused
- [ ] Spin up analyst template agent and confirm `usage-monitor` cron fires at 2h interval

🤖 Generated with [Claude Code](https://claude.com/claude-code)