### PR TITLE
fix(quota-watchdog): #534 stale-snapshot trap + piped-while state loss; macOS portability (clean, supersedes #560)

### DIFF
--- a/bin/quota-resume.sh
+++ b/bin/quota-resume.sh
@@ -35,8 +35,9 @@ export CTX_ROOT CTX_FRAMEWORK_ROOT CTX_ORG
 export CTX_AGENT_NAME="$BUS_AGENT"
 export CTX_AGENT_DIR="$CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/$BUS_AGENT"
 
-CORTEXTOS=/usr/bin/cortextos
-JQ=/usr/bin/jq
+# Tool paths — env-overridable for portability (macOS Homebrew vs Linux).
+CORTEXTOS="${CORTEXTOS:-$(command -v cortextos || echo /usr/bin/cortextos)}"
+JQ="${JQ:-$(command -v jq || echo /usr/bin/jq)}"
 
 if [ ! -f "$PAUSED_FILE" ]; then
   echo "No paused state at $PAUSED_FILE — watchdog has not tripped (or already resumed)."
@@ -56,8 +57,11 @@ COUNT=$(echo "$AGENTS_JSON" | "$JQ" 'length')
 echo "Resuming $COUNT agents (paused at $PAUSED_AT):"
 log "resume requested: $COUNT agents (paused_at=$PAUSED_AT)"
 
+# Process substitution keeps the loop in the parent shell so FAILED survives —
+# a piped `echo|jq|while` runs the loop in a subshell and silently discards the
+# accumulated failures (#534 Bug B).
 FAILED=()
-echo "$AGENTS_JSON" | "$JQ" -r '.[]' | while IFS= read -r AGENT; do
+while IFS= read -r AGENT; do
   [ -z "$AGENT" ] && continue
   echo "  starting: $AGENT"
   if "$CORTEXTOS" start "$AGENT" >> "$LOG" 2>&1; then
@@ -66,7 +70,13 @@ echo "$AGENTS_JSON" | "$JQ" -r '.[]' | while IFS= read -r AGENT; do
     log "  start failed: $AGENT"
     FAILED+=("$AGENT")
   fi
-done
+done < <(echo "$AGENTS_JSON" | "$JQ" -r '.[]')
+
+if [ "${#FAILED[@]}" -gt 0 ]; then
+  log "resume partial: ${#FAILED[@]} of $COUNT failed: ${FAILED[*]}"
+  MSG="⚠️ Quota resume: ${#FAILED[@]} of $COUNT agents failed to start: ${FAILED[*]}. Investigate and retry manually."
+  "$CORTEXTOS" bus send-telegram "$CHAT_ID" "$MSG" --plain-text >> "$LOG" 2>&1 || true
+fi
 
 # Archive the paused-state file rather than delete (auditability)
 ARCHIVE_DIR="$STATE_DIR/history"

--- a/bin/quota-watchdog.sh
+++ b/bin/quota-watchdog.sh
@@ -47,20 +47,29 @@ export CTX_ROOT CTX_FRAMEWORK_ROOT CTX_ORG
 export CTX_AGENT_NAME="$BUS_AGENT"
 export CTX_AGENT_DIR="$CTX_FRAMEWORK_ROOT/orgs/$CTX_ORG/agents/$BUS_AGENT"
 
-CORTEXTOS=/usr/bin/cortextos
-JQ=/usr/bin/jq
-CCUSAGE=/usr/bin/ccusage
-CLAUDE_CREDS=/root/.claude/.credentials.json
+# Tool paths — env-overridable so the script is portable (macOS Homebrew puts
+# cortextos under /opt/homebrew/bin; ccusage may be absent). Defaults preserve
+# the original Linux layout.
+CORTEXTOS="${CORTEXTOS:-$(command -v cortextos || echo /usr/bin/cortextos)}"
+JQ="${JQ:-$(command -v jq || echo /usr/bin/jq)}"
+CCUSAGE="${CCUSAGE:-$(command -v ccusage || echo /usr/bin/ccusage)}"
+CLAUDE_CREDS="${CLAUDE_CREDS:-$HOME/.claude/.credentials.json}"
 
-# Auto-extract OAuth token from Claude Code's local credentials store if no
-# accounts.json is configured and CLAUDE_CODE_OAUTH_TOKEN isn't already set.
-# Claude Code refreshes that file automatically while any agent runs, so the
-# watchdog gets fresh tokens for free.
+# Acquire an OAuth token for the usage API if not already provided and no
+# accounts.json is configured. Claude Code refreshes the underlying store
+# automatically while any agent runs, so the watchdog gets fresh tokens for free.
+#   - macOS: read from the login Keychain ("Claude Code-credentials").
+#   - Linux: read from the credentials file ($CLAUDE_CREDS).
 if [ -z "${CLAUDE_CODE_OAUTH_TOKEN:-}" ] \
-   && [ ! -f "$CTX_ROOT/state/oauth/accounts.json" ] \
-   && [ -f "$CLAUDE_CREDS" ]; then
-  TOK=$("$JQ" -r '.claudeAiOauth.accessToken // empty' "$CLAUDE_CREDS" 2>/dev/null)
-  [ -n "$TOK" ] && export CLAUDE_CODE_OAUTH_TOKEN="$TOK"
+   && [ ! -f "$CTX_ROOT/state/oauth/accounts.json" ]; then
+  if [ "$(uname)" = "Darwin" ] && command -v security >/dev/null 2>&1; then
+    TOK=$(security find-generic-password -s "Claude Code-credentials" -w 2>/dev/null \
+          | "$JQ" -r '.claudeAiOauth.accessToken // empty' 2>/dev/null)
+    [ -n "$TOK" ] && export CLAUDE_CODE_OAUTH_TOKEN="$TOK"
+  elif [ -f "$CLAUDE_CREDS" ]; then
+    TOK=$("$JQ" -r '.claudeAiOauth.accessToken // empty' "$CLAUDE_CREDS" 2>/dev/null)
+    [ -n "$TOK" ] && export CLAUDE_CODE_OAUTH_TOKEN="$TOK"
+  fi
 fi
 
 # ---------------------------------------------------------------------------
@@ -212,13 +221,26 @@ fi
 
 log "TRIGGER remaining=${REMAINING_PCT}% < ${THRESHOLD_PCT}%"
 
-# Snapshot running agents
-RUNNING_JSON='[]'
+# Snapshot running agents. If the snapshot FAILS, bail rather than fall through
+# and write a stale, empty paused.json that makes the watchdog believe it paused
+# agents it never touched (#534 Bug A).
+RUNNING_JSON=""
 if AGENTS_OUT=$("$CORTEXTOS" bus list-agents 2>/dev/null); then
   RUNNING_JSON=$(echo "$AGENTS_OUT" | "$JQ" -c '[.[] | select(.running == true) | .name]')
-  [ -z "$RUNNING_JSON" ] && RUNNING_JSON='[]'
 fi
+
+if [ -z "$RUNNING_JSON" ]; then
+  log "ERROR: list-agents snapshot failed or returned empty; skipping pause action to avoid stale-paused-state trap (#534 Bug A)"
+  MSG="⚠️ Quota watchdog wanted to trip (remaining=${REMAINING_PCT}%, threshold ${THRESHOLD_PCT}%) but the list-agents snapshot failed. Holding action — NO agents paused, no state written. Investigate cortextos daemon health. Log: $LOG"
+  "$CORTEXTOS" bus send-telegram "$CHAT_ID" "$MSG" --plain-text >> "$LOG" 2>&1 || true
+  exit 0
+fi
+
 COUNT=$(echo "$RUNNING_JSON" | "$JQ" 'length')
+if [ "$COUNT" -eq 0 ]; then
+  log "no running agents to pause; not writing paused-state"
+  exit 0
+fi
 log "running agents: $RUNNING_JSON (count=$COUNT)"
 
 if [ "$DRY_RUN" = "1" ]; then
@@ -228,12 +250,23 @@ if [ "$DRY_RUN" = "1" ]; then
   exit 0
 fi
 
-# Stop each running agent
-echo "$RUNNING_JSON" | "$JQ" -r '.[]' | while IFS= read -r AGENT; do
+# Stop each running agent. Process substitution keeps the loop in the parent
+# shell so STOP_FAILED survives the loop (same subshell-state class as #534 Bug B).
+STOP_FAILED=()
+while IFS= read -r AGENT; do
   [ -z "$AGENT" ] && continue
   log "stop: $AGENT"
-  "$CORTEXTOS" stop "$AGENT" >> "$LOG" 2>&1 || log "  stop failed: $AGENT"
-done
+  if "$CORTEXTOS" stop "$AGENT" >> "$LOG" 2>&1; then
+    :
+  else
+    log "  stop failed: $AGENT"
+    STOP_FAILED+=("$AGENT")
+  fi
+done < <(echo "$RUNNING_JSON" | "$JQ" -r '.[]')
+
+if [ "${#STOP_FAILED[@]}" -gt 0 ]; then
+  log "WARNING: ${#STOP_FAILED[@]} agents failed to stop: ${STOP_FAILED[*]} — paused-state will still record the full intended set"
+fi
 
 # Write paused-state file (schema: paused_at, agents_paused, remaining_pct_at_pause + extras)
 cat > "$PAUSED_FILE" <<EOF

--- a/scripts/self-healing/com.cortextos.quota-watchdog.plist.template
+++ b/scripts/self-healing/com.cortextos.quota-watchdog.plist.template
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.cortextos.quota-watchdog</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>{FRAMEWORK_ROOT}/bin/quota-watchdog.sh</string>
+    </array>
+    <key>StartInterval</key>
+    <integer>300</integer>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>StandardOutPath</key>
+    <string>{HOME}/.cortextos/{INSTANCE}/logs/quota-watchdog.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>{HOME}/.cortextos/{INSTANCE}/logs/quota-watchdog.stderr.log</string>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>{HOME}</string>
+        <key>CTX_INSTANCE_ID</key>
+        <string>{INSTANCE}</string>
+        <key>CTX_ROOT</key>
+        <string>{HOME}/.cortextos/{INSTANCE}</string>
+        <key>CTX_FRAMEWORK_ROOT</key>
+        <string>{FRAMEWORK_ROOT}</string>
+        <key>CTX_ORG</key>
+        <string>{ORG}</string>
+        <key>WATCHDOG_BUS_AGENT</key>
+        <string>{BUS_AGENT}</string>
+        <key>WATCHDOG_CHAT_ID</key>
+        <string>{CHAT_ID}</string>
+        <key>QUOTA_THRESHOLD_PCT</key>
+        <string>10</string>
+        <key>QUOTA_RESUME_PCT</key>
+        <string>50</string>
+    </dict>
+</dict>
+</plist>

--- a/tests/shell/quota-watchdog-534.test.sh
+++ b/tests/shell/quota-watchdog-534.test.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Regression test for issue #534. Runs the REAL scripts under a stubbed cortextos.
+# Usage: test-534.sh <quota-watchdog.sh> <quota-resume.sh>
+set -uo pipefail
+WD="$1"; RS="$2"
+PASS=0; FAIL=0
+ok(){ echo "  PASS: $1"; PASS=$((PASS+1)); }
+bad(){ echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+make_stub(){ # $1=dir
+  cat > "$1/cortextos" <<'EOF'
+#!/bin/bash
+case "$1 $2" in
+  "bus check-usage-api") echo "{\"five_hour_utilization\":${STUB_5H:-0.95},\"seven_day_utilization\":0.5}"; exit 0 ;;
+  "bus list-agents") [ "${STUB_LIST_FAIL:-0}" = "1" ] && exit 1; echo "${STUB_LIST_JSON:-[]}"; exit 0 ;;
+  "bus send-telegram") exit 0 ;;
+  "bus log-event") exit 0 ;;
+esac
+case "$1" in
+  start) [ "$2" = "${STUB_START_FAIL:-}" ] && exit 1; exit 0 ;;
+  stop)  [ "$2" = "${STUB_STOP_FAIL:-}" ]  && exit 1; exit 0 ;;
+esac
+exit 0
+EOF
+  chmod +x "$1/cortextos"
+}
+
+newcase(){ # echoes a fresh CTXROOT, sets globals R/STUB/CTXROOT/PAUSED/WDLOG
+  R=$(mktemp -d /tmp/wd534c.XXXXXX); STUB="$R/stub"; mkdir -p "$STUB"; CTXROOT="$R/ctx"; mkdir -p "$CTXROOT"
+  make_stub "$STUB"
+  PAUSED="$CTXROOT/state/quota-watchdog/paused.json"
+  WDLOG="$CTXROOT/state/quota-watchdog/watchdog.log"
+}
+base_env(){ echo CORTEXTOS="$STUB/cortextos" JQ=/usr/bin/jq CCUSAGE=/nonexistent CLAUDE_CODE_OAUTH_TOKEN=dummy CTX_ROOT="$CTXROOT" CTX_FRAMEWORK_ROOT="$R" CTX_ORG=test QUOTA_THRESHOLD_PCT=10 QUOTA_RESUME_PCT=50; }
+
+echo "== Bug A: snapshot failure must NOT write a stale empty paused.json =="
+newcase
+env $(base_env) STUB_5H=0.95 STUB_LIST_FAIL=1 bash "$WD" >/dev/null 2>&1
+if [ -f "$PAUSED" ]; then
+  pc=$(/usr/bin/jq -r '(.agents_paused // .agents // [])|length' "$PAUSED" 2>/dev/null)
+  bad "Bug A — paused.json written on snapshot failure (agents=$pc)"
+else
+  grep -qi "snapshot failed" "$WDLOG" 2>/dev/null && ok "snapshot failure bailed, no paused.json, logged" || ok "no paused.json on snapshot failure"
+fi
+rm -rf "$R"
+
+echo "== Bug A: zero running agents must NOT write paused.json =="
+newcase
+env $(base_env) STUB_5H=0.95 STUB_LIST_JSON='[]' bash "$WD" >/dev/null 2>&1
+[ -f "$PAUSED" ] && bad "wrote paused.json with zero running agents" || ok "zero running agents → no paused-state"
+rm -rf "$R"
+
+echo "== control: healthy quota must NOT trip =="
+newcase
+env $(base_env) STUB_5H=0.10 STUB_LIST_JSON='[{"name":"a","running":true}]' bash "$WD" >/dev/null 2>&1
+[ -f "$PAUSED" ] && bad "tripped on healthy quota" || ok "no trip on healthy quota (remaining 90%)"
+rm -rf "$R"
+
+echo "== positive: real trip with running agents pauses & records them =="
+newcase
+env $(base_env) STUB_5H=0.95 STUB_LIST_JSON='[{"name":"alpha","running":true},{"name":"beta","running":true}]' bash "$WD" >/dev/null 2>&1
+if [ -f "$PAUSED" ]; then
+  pc=$(/usr/bin/jq -r '(.agents_paused//[])|length' "$PAUSED")
+  [ "$pc" = "2" ] && ok "tripped, recorded 2 paused agents" || bad "recorded $pc agents (want 2)"
+else bad "no paused.json on a legit trip"; fi
+rm -rf "$R"
+
+echo "== Bug B: resume must capture & report start failures =="
+newcase
+mkdir -p "$(dirname "$PAUSED")"
+printf '{"paused_at":"x","agents_paused":["ghost","real"]}' > "$PAUSED"
+env CORTEXTOS="$STUB/cortextos" JQ=/usr/bin/jq CTX_ROOT="$CTXROOT" CTX_FRAMEWORK_ROOT="$R" CTX_ORG=test STUB_START_FAIL=ghost bash "$RS" >/dev/null 2>&1
+if grep -qi "resume partial\|start failed: ghost" "$WDLOG" 2>/dev/null; then
+  ok "resume surfaced the failed agent (parent-shell state preserved)"
+else
+  bad "Bug B — start failure not surfaced after loop"
+fi
+rm -rf "$R"
+
+echo
+echo "RESULT: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Replaces #560 (which accidentally carried 100+ unrelated files because its base branch had drifted far from `main`). This is the same fix cherry-picked cleanly onto current `main` — **4 files only**.

Fixes the two P1 bugs from #534, plus the portability changes needed to run the quota tooling on a non-`/root` (macOS / Homebrew) deployment.

## Bug A — `bin/quota-watchdog.sh` stale-snapshot trap
When `cortextos bus list-agents` fails (daemon mid-restart, IPC timeout), `RUNNING_JSON` stayed `[]` and the script wrote `paused.json` with `agents_paused: []` — the watchdog believed it had paused agents it never touched, while real agents kept burning quota. Now: bail + operator alert on snapshot failure, plus a zero-running-agents bail. The stop loop is moved to a process-substitution `while` so stop failures survive (same class as Bug B).

## Bug B — `bin/quota-resume.sh` piped-while loses state
`echo | jq | while …` ran the loop in a subshell, discarding `FAILED+=()`. Switched to `done < <(…)` + a partial-failure log/Telegram alert.

## Portability (needed for non-/root installs)
- `CORTEXTOS`/`JQ`/`CCUSAGE` resolve via `command -v` with the Linux paths as fallback.
- OAuth token read from the macOS login Keychain on Darwin, falling back to `$CLAUDE_CREDS` (now `$HOME/.claude/.credentials.json`) on Linux.
- New `scripts/self-healing/com.cortextos.quota-watchdog.plist.template` (launchd, every 5 min).

## Tests
`tests/shell/quota-watchdog-534.test.sh` drives the real scripts under a stubbed `cortextos`: Bug A snapshot-fail bail, Bug A zero-agents bail, healthy-quota no-trip, positive trip, Bug B resume failure reporting. **5/5 pass** on `main`'s base.

Closes #534. Supersedes #560.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
