### PR TITLE
feat(pty): make --dangerously-skip-permissions configurable per agent

### DIFF
--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -228,7 +228,24 @@ export class AgentPTY {
       args.push('--continue');
     }
 
-    args.push('--dangerously-skip-permissions');
+    // Skip Claude Code's permission system by default (back-compat: agents have
+    // historically run unattended). Set `dangerously_skip_permissions: false` in
+    // the agent config to KEEP the gate on — then Claude Code's PermissionRequest
+    // flow (and the hook-permission-telegram approval) actually engages. Without
+    // this flag the CLI override would suppress any settings.json permission mode.
+    // Only the literal boolean `false` disables the skip; warn on a non-boolean so
+    // a typo (e.g. the string "false") can't silently leave an agent ungated when
+    // the operator intended to engage the gate.
+    const skipPermissions = this.config.dangerously_skip_permissions;
+    if (skipPermissions !== undefined && typeof skipPermissions !== 'boolean') {
+      console.warn(
+        `[agent-pty] ${this.env.agentName}: dangerously_skip_permissions must be true or false ` +
+        `(got ${JSON.stringify(skipPermissions)}); defaulting to skip-on.`,
+      );
+    }
+    if (skipPermissions !== false) {
+      args.push('--dangerously-skip-permissions');
+    }
 
     if (this.config.model) {
       args.push('--model', this.config.model);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -164,6 +164,14 @@ export interface AgentConfig {
    */
   crash_window?: { seconds: number; max_crashes?: number };
   model?: string;
+  /**
+   * Whether to launch Claude Code with `--dangerously-skip-permissions`.
+   * Defaults to true (back-compat: agents run unattended). Set to false to keep
+   * Claude Code's permission system engaged so the PermissionRequest hook
+   * (hook-permission-telegram) gates tool use instead of everything auto-running.
+   * Only applies to the claude-code runtime (Hermes never passes the flag).
+   */
+  dangerously_skip_permissions?: boolean;
   working_directory?: string;
   enabled?: boolean;
   crons?: CronEntry[];

--- a/tests/unit/pty/agent-pty.test.ts
+++ b/tests/unit/pty/agent-pty.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// node-pty is native; stub it so constructing AgentPTY never touches it.
+vi.mock('node-pty', () => ({ spawn: vi.fn() }));
+
+// existsSync=false → the local/*.md system-prompt block is skipped in buildClaudeArgs.
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  return {
+    ...actual,
+    existsSync: vi.fn().mockReturnValue(false),
+    readFileSync: vi.fn(),
+    readdirSync: vi.fn().mockReturnValue([]),
+  };
+});
+
+const { AgentPTY } = await import('../../../src/pty/agent-pty.js');
+
+const mockEnv = {
+  instanceId: 'test',
+  ctxRoot: '/tmp/test-ctx',
+  frameworkRoot: '/tmp/fw',
+  agentName: 'alice',
+  agentDir: '/tmp/fw/orgs/acme/agents/alice',
+  org: 'acme',
+  projectRoot: '/tmp/fw',
+} as any;
+
+function argsFor(config: any): string[] {
+  const pty = new AgentPTY(mockEnv, config);
+  return (pty as unknown as { buildClaudeArgs(m: 'fresh' | 'continue', p: string): string[] })
+    .buildClaudeArgs('fresh', 'PROMPT');
+}
+
+describe('AgentPTY --dangerously-skip-permissions toggle', () => {
+  it('includes the flag by default (back-compat: skip stays ON)', () => {
+    expect(argsFor({})).toContain('--dangerously-skip-permissions');
+  });
+
+  it('includes the flag when dangerously_skip_permissions is explicitly true', () => {
+    expect(argsFor({ dangerously_skip_permissions: true })).toContain('--dangerously-skip-permissions');
+  });
+
+  it('does NOT include the flag when dangerously_skip_permissions is false (permission gate engaged)', () => {
+    expect(argsFor({ dangerously_skip_permissions: false })).not.toContain('--dangerously-skip-permissions');
+  });
+
+  it('includes the flag when dangerously_skip_permissions is explicitly undefined (treated as default)', () => {
+    expect(argsFor({ dangerously_skip_permissions: undefined })).toContain('--dangerously-skip-permissions');
+  });
+
+  it('fails safe (keeps the flag) and warns on a non-boolean value, e.g. the string "false"', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    try {
+      // A typo'd string must NOT silently disable the skip flag.
+      expect(argsFor({ dangerously_skip_permissions: 'false' as any })).toContain('--dangerously-skip-permissions');
+      expect(warn).toHaveBeenCalled();
+    } finally {
+      warn.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## Problem

`src/pty/agent-pty.ts` hard-codes `--dangerously-skip-permissions` on **every** Claude agent spawn:

```ts
args.push('--dangerously-skip-permissions');
```

That CLI flag overrides `settings.json` entirely and disables all of Claude Code's permission gating. As a result the `PermissionRequest` hook (`hook-permission-telegram`) **can never fire for tool use** — Bash/Edit/Write run unprompted regardless of the user's `permissions` config. The Telegram approval mechanism is effectively dead for Claude agents: an agent runs any command with no gate.

## Fix

Add `AgentConfig.dangerously_skip_permissions` (default `true` — back-compat, agents have historically run unattended, so **no behaviour change for existing deployments**). Set it to `false` to omit the flag at spawn, so Claude Code's permission system engages and the `PermissionRequest` hook actually gates tool use.

- Only the literal boolean `false` disables the skip.
- A non-boolean value (e.g. a typo'd string `"false"`) **warns and falls back to skip-on**, so a misconfiguration can't silently leave an agent ungated when the operator intended to engage the gate.
- Hermes already omits the flag; only the `claude-code` spawn path is affected.

## Companion change

This is the spawn-time half. With the gate engaged, the `PermissionRequest` auto-approve logic in `hook-permission-telegram` becomes live — a separate PR hardens that logic (it previously auto-approved on a `.claude/` **substring** match).

## Tests

`tests/unit/pty/agent-pty.test.ts`: flag present by default / when `true` / when `undefined`; absent when `false`; non-boolean warns and keeps the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)