### PR TITLE
fix(hooks): harden permission-gate auto-approve against bypass + path escape

### DIFF
--- a/bus/hook-permission-telegram.sh
+++ b/bus/hook-permission-telegram.sh
@@ -35,19 +35,34 @@ if [[ "$TOOL_NAME" == "ExitPlanMode" || "$TOOL_NAME" == "AskUserQuestion" ]]; th
     exit 0
 fi
 
-# Auto-approve .claude/ directory writes - agents need to modify their own configs at runtime
-if [[ "$TOOL_NAME" == "Bash" ]]; then
-    CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
-    if [[ "$CMD" == *".claude/"* ]]; then
-        echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
-        exit 0
-    fi
-fi
+# Auto-approve edits to the agent's OWN .claude/ directory (configs/skills it
+# manages at runtime). Precise path containment — NOT a substring match — because
+# under bypassPermissions this hook is the only approval gate.
+#   - Bash is never auto-approved: a command string can't be proven to touch only
+#     .claude/ (e.g. `rm -rf ~; ls .claude/` contains the substring) (#1).
+#   - Edit/Write only when file_path resolves inside <agentDir>/.claude/, which
+#     defeats ../ traversal and other/arbitrary .claude/ directories (#18).
 if [[ "$TOOL_NAME" == "Edit" || "$TOOL_NAME" == "Write" ]]; then
     FILE_PATH=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""' 2>/dev/null)
-    if [[ "$FILE_PATH" == *"/.claude/"* ]]; then
-        echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
-        exit 0
+    # Require an explicit trust boundary — no pwd fallback, so the auto-approve
+    # scope can't drift to whatever directory the hook happened to start in.
+    # `realpath -m` is GNU-specific; on shells without it (BSD/macOS) skip
+    # auto-approval entirely and let the request go to the human gate (safe).
+    if [[ -n "$FILE_PATH" && -n "${CTX_AGENT_DIR:-}" ]] && realpath -m / >/dev/null 2>&1; then
+        AGENT_DIR="$CTX_AGENT_DIR"
+        # Reject a symlinked .claude root: it would redirect the gate elsewhere.
+        if [[ ! -L "${AGENT_DIR}/.claude" ]]; then
+            CLAUDE_ROOT="$(realpath -m "${AGENT_DIR}/.claude")"
+            case "$FILE_PATH" in
+                /*) ABS_PATH="$FILE_PATH" ;;
+                *)  ABS_PATH="${AGENT_DIR}/${FILE_PATH}" ;;
+            esac
+            RESOLVED="$(realpath -m "$ABS_PATH")"
+            if [[ "$RESOLVED" == "$CLAUDE_ROOT" || "$RESOLVED" == "$CLAUDE_ROOT/"* ]]; then
+                echo '{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}'
+                exit 0
+            fi
+        fi
     fi
 fi
 
@@ -70,8 +85,16 @@ case "$TOOL_NAME" in
 ${CONTENT_PREVIEW}"
         ;;
     Bash)
-        CMD=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null | head -c 200)
-        TOOL_SUMMARY="Command: ${CMD}"
+        # Show up to 1500 chars (was 200) so a benign-looking prefix can't hide a
+        # payload from the human approver; mark truncation explicitly (#39).
+        CMD_FULL=$(echo "$INPUT" | jq -r '.tool_input.command // ""' 2>/dev/null)
+        CMD=$(printf '%s' "$CMD_FULL" | head -c 1500)
+        if [[ ${#CMD_FULL} -gt ${#CMD} ]]; then
+            TOOL_SUMMARY="Command: ${CMD}
+…(preview truncated — the FULL command, not just this preview, runs if you approve)"
+        else
+            TOOL_SUMMARY="Command: ${CMD}"
+        fi
         ;;
     *)
         TOOL_SUMMARY=$(echo "$INPUT" | jq -r '.tool_input // {}' 2>/dev/null | jq -c '.' 2>/dev/null | head -c 200)

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,8 +3,8 @@
  * Each hook reads JSON from stdin, processes it, and writes JSON to stdout.
  */
 
-import { readFileSync, existsSync, watch, statSync, unlinkSync, mkdirSync } from 'fs';
-import { join } from 'path';
+import { readFileSync, existsSync, watch, statSync, unlinkSync, mkdirSync, realpathSync, lstatSync } from 'fs';
+import { join, resolve, sep, dirname, basename } from 'path';
 import { homedir } from 'os';
 import * as crypto from 'crypto';
 
@@ -196,8 +196,14 @@ export function formatToolSummary(toolName: string, toolInput: any): string {
       return `File: ${filePath}\n\n${content}`;
     }
     case 'Bash': {
-      const command = String(toolInput.command || '').slice(0, 200);
-      return `Command: ${command}`;
+      // Show enough of the command for the human approver to judge it. A 200-char
+      // cap let a benign-looking prefix hide a malicious payload past the cut
+      // (#39); the message-level cap still bounds Telegram length. Mark truncation
+      // explicitly so the reviewer knows more of the command will run.
+      const command = String(toolInput.command || '');
+      const shown = command.slice(0, 1500);
+      const more = command.length > shown.length ? '\n…(preview truncated — the FULL command, not just this preview, runs if you approve)' : '';
+      return `Command: ${shown}${more}`;
     }
     default: {
       return JSON.stringify(toolInput).slice(0, 200);
@@ -206,18 +212,101 @@ export function formatToolSummary(toolName: string, toolInput: any): string {
 }
 
 /**
- * Check if a tool operation targets .claude/ directory (auto-approve).
+ * Whether a tool operation may be auto-approved because it edits the agent's
+ * OWN `.claude/` directory (config/skills the agent legitimately manages at
+ * runtime). Under `bypassPermissions` this hook is the only approval gate, so
+ * this check must be precise — not a substring match.
+ *
+ * - Bash is NEVER auto-approved: a shell command string cannot be proven to act
+ *   solely within `.claude/` (e.g. `rm -rf ~; ls .claude/` contains the
+ *   substring), so it always goes to the human gate (#1/#15).
+ * - Edit/Write is auto-approved only when the file_path, resolved to an
+ *   absolute normalized path, is genuinely contained within THIS agent's
+ *   `<agentDir>/.claude/` — defeating `..` traversal and other agents' /
+ *   arbitrary `.claude/` directories (#18).
+ *
+ * Symlinks are resolved on the deepest existing ancestor (the Write target
+ * itself may not exist yet), so a symlink inside `.claude` that points out of
+ * the tree cannot be used to escape — matching the shell hook's `realpath -m`.
+ * A symlinked `.claude` root is rejected outright (it would redirect the gate
+ * to an arbitrary directory). There is NO cwd fallback: without an explicit
+ * agent-dir trust boundary the operation is not auto-approved.
+ *
+ * @param agentDir Base directory of the agent. Defaults to CTX_AGENT_DIR; if
+ *   neither is available, returns false (the request goes to the human gate).
  */
-export function isClaudeDirOperation(toolName: string, toolInput: any): boolean {
-  if (toolName === 'Bash') {
-    const cmd = toolInput.command || '';
-    return cmd.includes('.claude/');
-  }
-  if (toolName === 'Edit' || toolName === 'Write') {
-    const filePath = toolInput.file_path || '';
-    return filePath.includes('/.claude/');
+export function isClaudeDirOperation(
+  toolName: string,
+  toolInput: any,
+  agentDir?: string,
+): boolean {
+  if (toolName !== 'Edit' && toolName !== 'Write') return false;
+  const filePath = toolInput?.file_path;
+  if (typeof filePath !== 'string' || filePath.length === 0) return false;
+
+  // Require an explicit trust boundary — never fall back to cwd, which would let
+  // the auto-approve scope drift to whatever directory the hook started in.
+  const base = agentDir ?? process.env.CTX_AGENT_DIR;
+  if (!base) return false;
+
+  // Canonicalize the agent dir first (resolves legitimate symlinks on the install
+  // path, e.g. /tmp -> /private/tmp), so the .claude subtree below it is the only
+  // thing left to vet.
+  const canonAgentDir = canonicalizePath(resolve(base));
+  const claudeRoot = join(canonAgentDir, '.claude');
+  const target = resolve(canonAgentDir, filePath);
+
+  // Lexical containment within the agent's own .claude/.
+  if (target !== claudeRoot && !target.startsWith(claudeRoot + sep)) return false;
+
+  // Reject if any component at or below .claude is a symlink — live OR dangling.
+  // A planted symlink could otherwise redirect an "inside .claude" write out of
+  // the tree. We lstat each component because realpathSync can't observe a
+  // *dangling* symlink (it throws, and canonicalize would fall back to lexical).
+  return !hasSymlinkComponent(canonAgentDir, target);
+}
+
+/**
+ * Whether any path component strictly below `rootDir` (assumed already
+ * canonical) up to and including `target` is a symlink (live or dangling).
+ * Stops at the first non-existent component — a name that doesn't exist yet
+ * cannot be a symlink, and deeper components can't exist under it.
+ */
+function hasSymlinkComponent(rootDir: string, target: string): boolean {
+  if (!target.startsWith(rootDir + sep)) return false;
+  const rel = target.slice(rootDir.length + 1);
+  let cur = rootDir;
+  for (const part of rel.split(sep).filter(Boolean)) {
+    cur = join(cur, part);
+    try {
+      if (lstatSync(cur).isSymbolicLink()) return true;
+    } catch {
+      break;
+    }
   }
   return false;
+}
+
+/**
+ * Canonicalize an absolute path, resolving symlinks. Because the target may not
+ * exist yet (e.g. a Write that creates a new file), we realpath the deepest
+ * existing ancestor — which resolves any symlinked component — then re-append
+ * the non-existent tail. Falls back to the lexical path if nothing exists.
+ */
+function canonicalizePath(p: string): string {
+  let dir = p;
+  const tail: string[] = [];
+  for (;;) {
+    try {
+      const real = realpathSync(dir);
+      return tail.length ? resolve(real, ...tail.reverse()) : real;
+    } catch {
+      const parent = dirname(dir);
+      if (parent === dir) return p; // reached fs root, nothing on the path exists
+      tail.push(basename(dir));
+      dir = parent;
+    }
+  }
 }
 
 /**

--- a/tests/unit/hooks/hooks.test.ts
+++ b/tests/unit/hooks/hooks.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, symlinkSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -95,25 +95,127 @@ describe('Hook Utilities', () => {
     });
   });
 
-  describe('isClaudeDirOperation', () => {
-    it('auto-approves Bash commands containing .claude/', () => {
-      expect(isClaudeDirOperation('Bash', { command: 'cat .claude/settings.json' })).toBe(true);
+  describe('isClaudeDirOperation (permission-gate hardening)', () => {
+    const agentDir = '/agents/alice';
+
+    it('NEVER auto-approves Bash, even when the command mentions .claude/', () => {
+      // A shell command string cannot be proven to act only within .claude/, and
+      // under bypassPermissions this hook is the only approval gate (#1/#15).
+      expect(isClaudeDirOperation('Bash', { command: 'cat .claude/settings.json' }, agentDir)).toBe(false);
+      expect(isClaudeDirOperation('Bash', { command: 'rm -rf ~/work; ls .claude/' }, agentDir)).toBe(false);
     });
 
-    it('auto-approves Edit with /.claude/ in file_path', () => {
-      expect(isClaudeDirOperation('Edit', { file_path: '/home/user/.claude/CLAUDE.md' })).toBe(true);
+    it('auto-approves Edit/Write within the agent\'s own .claude/ directory', () => {
+      expect(isClaudeDirOperation('Edit', { file_path: '/agents/alice/.claude/settings.json' }, agentDir)).toBe(true);
+      expect(isClaudeDirOperation('Write', { file_path: '/agents/alice/.claude/skills/x/SKILL.md' }, agentDir)).toBe(true);
     });
 
-    it('auto-approves Write with /.claude/ in file_path', () => {
-      expect(isClaudeDirOperation('Write', { file_path: '/project/.claude/settings.json' })).toBe(true);
+    it('resolves a relative file_path against the agent directory', () => {
+      expect(isClaudeDirOperation('Edit', { file_path: '.claude/settings.json' }, agentDir)).toBe(true);
+    });
+
+    it('refuses traversal that escapes the agent\'s .claude/ directory (#18)', () => {
+      expect(isClaudeDirOperation('Write', { file_path: '/agents/alice/.claude/../../etc/passwd' }, agentDir)).toBe(false);
+      expect(isClaudeDirOperation('Edit', { file_path: '/agents/alice/.claude/../.ssh/authorized_keys' }, agentDir)).toBe(false);
+    });
+
+    it('refuses a .claude/ directory that is not the agent\'s own (#18)', () => {
+      expect(isClaudeDirOperation('Edit', { file_path: '/home/victim/.claude/settings.json' }, agentDir)).toBe(false);
+      expect(isClaudeDirOperation('Write', { file_path: '/agents/bob/.claude/settings.json' }, agentDir)).toBe(false);
+    });
+
+    it('refuses the prefix trick (.claude-evil is not .claude)', () => {
+      expect(isClaudeDirOperation('Edit', { file_path: '/agents/alice/.claude-evil/x' }, agentDir)).toBe(false);
     });
 
     it('does not auto-approve regular paths', () => {
-      expect(isClaudeDirOperation('Edit', { file_path: '/home/user/project/src/main.ts' })).toBe(false);
+      expect(isClaudeDirOperation('Edit', { file_path: '/agents/alice/src/main.ts' }, agentDir)).toBe(false);
     });
 
     it('does not auto-approve other tool types', () => {
-      expect(isClaudeDirOperation('Read', { file_path: '/.claude/foo' })).toBe(false);
+      expect(isClaudeDirOperation('Read', { file_path: '/agents/alice/.claude/foo' }, agentDir)).toBe(false);
+    });
+
+    it('refuses a write that escapes via a symlink inside .claude (#18, codex)', () => {
+      const base = mkdtempSync(join(tmpdir(), 'hookperm-'));
+      try {
+        const realAgentDir = join(base, 'agent');
+        mkdirSync(join(realAgentDir, '.claude'), { recursive: true });
+        const outside = join(base, 'outside');
+        mkdirSync(outside, { recursive: true });
+        // .claude/escape is a symlink that leaves the .claude tree.
+        symlinkSync(outside, join(realAgentDir, '.claude', 'escape'));
+
+        // A write "inside" .claude/escape/ actually lands in outside/ — must be refused.
+        expect(isClaudeDirOperation('Write',
+          { file_path: join(realAgentDir, '.claude', 'escape', 'evil.txt') }, realAgentDir)).toBe(false);
+        // Sanity: a genuine (not-yet-existing) file directly inside .claude is still allowed.
+        expect(isClaudeDirOperation('Write',
+          { file_path: join(realAgentDir, '.claude', 'ok.txt') }, realAgentDir)).toBe(true);
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses a symlinked .claude root that redirects the gate (codex)', () => {
+      const base = mkdtempSync(join(tmpdir(), 'hookperm-'));
+      try {
+        const realAgentDir = join(base, 'agent');
+        mkdirSync(realAgentDir, { recursive: true });
+        const outside = join(base, 'outside');
+        mkdirSync(outside, { recursive: true });
+        // .claude itself is a symlink pointing out of the agent tree.
+        symlinkSync(outside, join(realAgentDir, '.claude'));
+        expect(isClaudeDirOperation('Write',
+          { file_path: join(realAgentDir, '.claude', 'x.txt') }, realAgentDir)).toBe(false);
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses a write through a DANGLING symlink inside .claude (codex blocker)', () => {
+      const base = mkdtempSync(join(tmpdir(), 'hookperm-'));
+      try {
+        const realAgentDir = join(base, 'agent');
+        mkdirSync(join(realAgentDir, '.claude'), { recursive: true });
+        // .claude/dangle points at a non-existent target — realpath can't resolve
+        // it, so a lexical check would wrongly treat the path as contained.
+        symlinkSync(join(base, 'does-not-exist'), join(realAgentDir, '.claude', 'dangle'));
+        expect(isClaudeDirOperation('Write',
+          { file_path: join(realAgentDir, '.claude', 'dangle', 'evil.txt') }, realAgentDir)).toBe(false);
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    });
+
+    it('handles a symlinked agent-dir ancestor without leaking (mmax)', () => {
+      const base = mkdtempSync(join(tmpdir(), 'hookperm-'));
+      try {
+        const realRoot = join(base, 'real');
+        mkdirSync(join(realRoot, '.claude'), { recursive: true });
+        const linkDir = join(base, 'link');
+        symlinkSync(realRoot, linkDir); // agentDir reached via a symlink
+        // The agent dir is canonicalized, so a normal relative write to .claude
+        // is still allowed even when agentDir is expressed via the symlink.
+        expect(isClaudeDirOperation('Write',
+          { file_path: '.claude/ok.txt' }, linkDir)).toBe(true);
+        // Traversal still cannot escape the canonicalized .claude root.
+        expect(isClaudeDirOperation('Write',
+          { file_path: '.claude/../../etc/passwd' }, linkDir)).toBe(false);
+      } finally {
+        rmSync(base, { recursive: true, force: true });
+      }
+    });
+
+    it('does not auto-approve without an explicit agent-dir boundary (no cwd fallback)', () => {
+      const saved = process.env.CTX_AGENT_DIR;
+      delete process.env.CTX_AGENT_DIR;
+      try {
+        // No agentDir arg + no CTX_AGENT_DIR → must NOT auto-approve, even for a .claude path.
+        expect(isClaudeDirOperation('Edit', { file_path: '/tmp/.claude/settings.json' })).toBe(false);
+      } finally {
+        if (saved !== undefined) process.env.CTX_AGENT_DIR = saved;
+      }
     });
   });
 
@@ -165,10 +267,19 @@ describe('Hook Utilities', () => {
       expect(summary.indexOf('a'.repeat(301))).toBe(-1);
     });
 
-    it('truncates Bash command at 200 chars', () => {
-      const longCmd = 'x'.repeat(300);
-      const summary = formatToolSummary('Bash', { command: longCmd });
-      expect(summary.length).toBeLessThanOrEqual('Command: '.length + 200);
+    it('shows the full Bash command up to 1500 chars (no early hidden payload, #39)', () => {
+      const cmd = 'x'.repeat(300);
+      const summary = formatToolSummary('Bash', { command: cmd });
+      // 300-char command is well under the cap — shown in full, no truncation marker.
+      expect(summary).toBe(`Command: ${cmd}`);
+    });
+
+    it('marks truncation when a Bash command exceeds 1500 chars (#39)', () => {
+      const cmd = 'x'.repeat(2000);
+      const summary = formatToolSummary('Bash', { command: cmd });
+      expect(summary).toContain('x'.repeat(1500));
+      expect(summary).not.toContain('x'.repeat(1501));
+      expect(summary).toContain('truncated');
     });
 
     it('formats unknown tools as JSON', () => {


### PR DESCRIPTION
## Problem

The `PermissionRequest` hook (`hook-permission-telegram`, TS + shell twin) auto-approves any tool call it classifies as a `.claude/` operation, via a **substring match**. When agents run with a live permission gate (i.e. *not* `--dangerously-skip-permissions`/bypass), this lets an agent skip the human approval gate:

- **Bash:** `cmd.includes('.claude/')` auto-approved **any** command merely containing the substring — e.g. `rm -rf ~/work; ls .claude/`.
- **Edit/Write:** `file_path.includes('/.claude/')` auto-approved writes to **any** `.claude/` anywhere, and was defeated by `../` traversal (`/x/.claude/../../etc/passwd`).

## Fix (`src/hooks/index.ts` + the `bus/` shell twin, kept in parity)

- **Bash is never auto-approved** — a command string can't be proven to act only within `.claude/`, so it always goes to the human gate.
- **Edit/Write is auto-approved only** when `file_path` resolves inside the agent's **own** `<agentDir>/.claude/` (lexical containment on a canonicalized agent dir), rejecting traversal, other agents' / arbitrary `.claude/` dirs, and the `.claude`-prefix trick.
- **Symlink escapes rejected** — any symlink component at/below `.claude` (live **or** dangling) refuses auto-approve (`lstat` per component); a symlinked `.claude` root is rejected. The shell twin uses `realpath -m`, guarded to degrade safely to the human gate where `-m` is unavailable (BSD/macOS).
- **No cwd fallback** — without an explicit `CTX_AGENT_DIR` trust boundary the op is not auto-approved.
- **Bash preview widened 200 → 1500 chars** with an explicit truncation marker, so a benign-looking prefix can't hide a payload from the approver.

## Context

This is the correctness half of the permission gate. A companion PR makes `--dangerously-skip-permissions` configurable at spawn time so the gate (and therefore this logic) can actually be engaged.

## Tests

42 cases: bypass-closed, own-`.claude` allowed, traversal/other-`.claude`/prefix rejected, live + dangling symlink escapes rejected, symlinked root rejected, require-boundary, preview-truncation behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)