### PR TITLE
fix(fast-checker): inject unhandled callbacks with PTY-injection sanitization

### DIFF
--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -775,7 +775,23 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       return;
     }
 
-    this.log(`Unhandled callback data: ${data}`);
+    // Inject unhandled callbacks as a Telegram message so the agent can process custom button flows
+    if (chatId && this.agent) {
+      const senderName = query.from?.first_name || 'User';
+      const msg = [
+        `=== TELEGRAM from [USER: ${senderName}] (chat_id:${chatId}) ===`,
+        `callback_data: ${data}`,
+        `message_id: ${messageId}`,
+        `Reply using: cortextos bus send-telegram ${chatId} '<your reply>'`,
+      ].join('\n');
+      const injected = this.agent.injectMessage(msg);
+      if (injected && this.telegramApi) {
+        try { await this.telegramApi.answerCallbackQuery(callbackQueryId, 'Got it'); } catch { /* ignore */ }
+      }
+      this.log(`Injected unhandled callback to agent: ${data.slice(0, 60)}`);
+    } else {
+      this.log(`Unhandled callback data (no agent/chatId): ${data}`);
+    }
   }
 
   /**

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -775,12 +775,17 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       return;
     }
 
-    // Inject unhandled callbacks as a Telegram message so the agent can process custom button flows
+    // Inject unhandled callbacks as a Telegram message so the agent can process custom button flows.
+    // senderName (Telegram first_name) and callback_data are untrusted: sanitize both against
+    // PTY-injection before interpolating, matching the text path (sanitizeForPtyInjection at the
+    // `=== TELEGRAM from [USER: ...]` header). This block predates #592; #592's hardening was never
+    // retrofitted here, leaving forged `=== AGENT MESSAGE`/fence-breakout headers un-neutralized.
     if (chatId && this.agent) {
-      const senderName = query.from?.first_name || 'User';
+      const senderName = sanitizeForPtyInjection(query.from?.first_name || 'User');
+      const safeData = sanitizeForPtyInjection(data);
       const msg = [
         `=== TELEGRAM from [USER: ${senderName}] (chat_id:${chatId}) ===`,
-        `callback_data: ${data}`,
+        `callback_data: ${safeData}`,
         `message_id: ${messageId}`,
         `Reply using: cortextos bus send-telegram ${chatId} '<your reply>'`,
       ].join('\n');


### PR DESCRIPTION
## Summary
Two commits, promoted together per James's call (feature + its security hardening as one unit):

1. **Unhandled-callback injection** — inline button taps that no handler claims were silently dropped at the catch-all log line. Now they are injected into the agent session as a Telegram message (sender + callback_data + message_id) and acked via answerCallbackQuery so the button does not spin.
2. **PTY-injection sanitization** — the injected block interpolated the tapping user's first_name and callback_data raw. Both are untrusted; a forged Telegram display name could smuggle a fake `=== AGENT MESSAGE` header or fence-breakout into the agent prompt. Both values now pass through `sanitizeForPtyInjection`, matching the existing text path (#592). Reachability is gated by ALLOWED_USER, so practical exposure was self-inflicted on single-user bots; this closes the defense-in-depth gap for unset-allowed-user / multi-user contexts.

## Test Plan
- Two-phase live sandbox soak (cortext-designer, 9/10): Phase 1 confirmed forged first_name renders raw pre-patch (agent obeyed 0/33 injected directives); Phase 2 confirmed patched output renders quoted/inert; behavioral matrix A1.1-A1.4 green; no regression in npm test (1631 passing, 5 pre-existing skips).
- A1.1 callback-injection path proven live in production (real button tap injected clean, ack fired).
- `npm run build` + `tsc --noEmit` clean on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)