### PR TITLE
feat: add voice-agent-factory community skill

### DIFF
--- a/community/catalog.json
+++ b/community/catalog.json
@@ -1,14 +1,21 @@
 {
   "version": "1.0.0",
-  "updated_at": "2026-04-06T00:00:00Z",
+  "updated_at": "2026-06-06T09:30:00Z",
   "items": [
     {
       "name": "agentic-crm-assistant",
-      "description": "Agentic CRM personal assistant — reusable executive/personal assistant template with structured relationship memory, inbox/calendar/meeting workflows, full interactive setup, tool-agnostic connectors, CRM skills, and recurring assistant crons",
+      "description": "Agentic CRM personal assistant \u2014 reusable executive/personal assistant template with structured relationship memory, inbox/calendar/meeting workflows, full interactive setup, tool-agnostic connectors, CRM skills, and recurring assistant crons",
       "author": "cortextos",
       "type": "agent",
       "version": "0.1.0",
-      "tags": ["personal-assistant", "crm", "calendar", "email", "meetings", "relationships"],
+      "tags": [
+        "personal-assistant",
+        "crm",
+        "calendar",
+        "email",
+        "meetings",
+        "relationships"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/agentic-crm-assistant",
@@ -16,11 +23,16 @@
     },
     {
       "name": "orchestrator",
-      "description": "Orchestrator agent — coordinates other agents, handles morning/evening reviews, manages goals and approvals, weekly reporting",
+      "description": "Orchestrator agent \u2014 coordinates other agents, handles morning/evening reviews, manages goals and approvals, weekly reporting",
       "author": "cortextos",
       "type": "agent",
       "version": "1.0.0",
-      "tags": ["orchestrator", "management", "reviews", "goals"],
+      "tags": [
+        "orchestrator",
+        "management",
+        "reviews",
+        "goals"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/orchestrator",
@@ -28,11 +40,16 @@
     },
     {
       "name": "analyst",
-      "description": "Analyst agent — system health, metrics, theta-wave autoresearch, community publishing, upstream sync",
+      "description": "Analyst agent \u2014 system health, metrics, theta-wave autoresearch, community publishing, upstream sync",
       "author": "cortextos",
       "type": "agent",
       "version": "1.0.0",
-      "tags": ["analyst", "metrics", "research", "health"],
+      "tags": [
+        "analyst",
+        "metrics",
+        "research",
+        "health"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/analyst",
@@ -40,11 +57,15 @@
     },
     {
       "name": "agent",
-      "description": "General-purpose worker agent — base template for specialist agents. Handles tasks, Telegram comms, memory, and skill execution",
+      "description": "General-purpose worker agent \u2014 base template for specialist agents. Handles tasks, Telegram comms, memory, and skill execution",
       "author": "cortextos",
       "type": "agent",
       "version": "1.0.0",
-      "tags": ["agent", "worker", "general-purpose"],
+      "tags": [
+        "agent",
+        "worker",
+        "general-purpose"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/agent",
@@ -52,11 +73,16 @@
     },
     {
       "name": "tasks",
-      "description": "Task lifecycle management — create, update, complete tasks with KPI logging. Every significant piece of work gets a task",
+      "description": "Task lifecycle management \u2014 create, update, complete tasks with KPI logging. Every significant piece of work gets a task",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["tasks", "workflow", "kpi", "visibility"],
+      "tags": [
+        "tasks",
+        "workflow",
+        "kpi",
+        "visibility"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/tasks",
@@ -64,11 +90,16 @@
     },
     {
       "name": "comms",
-      "description": "Telegram and agent-to-agent message handling — format reference, reply patterns, callback handling, bidirectional file send/receive",
+      "description": "Telegram and agent-to-agent message handling \u2014 format reference, reply patterns, callback handling, bidirectional file send/receive",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["telegram", "messaging", "comms", "inbox"],
+      "tags": [
+        "telegram",
+        "messaging",
+        "comms",
+        "inbox"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/comms",
@@ -76,11 +107,16 @@
     },
     {
       "name": "autoresearch",
-      "description": "Structured experimentation loop — form hypothesis, make targeted change, measure outcome, keep or discard. Theta wave research cycles",
+      "description": "Structured experimentation loop \u2014 form hypothesis, make targeted change, measure outcome, keep or discard. Theta wave research cycles",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["research", "experiments", "theta-wave", "optimization"],
+      "tags": [
+        "research",
+        "experiments",
+        "theta-wave",
+        "optimization"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/autoresearch",
@@ -88,11 +124,17 @@
     },
     {
       "name": "m2c1-worker",
-      "description": "Autonomous software builds — spawn a dedicated M2C1 worker session to build any project through 12 structured phases",
+      "description": "Autonomous software builds \u2014 spawn a dedicated M2C1 worker session to build any project through 12 structured phases",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["m2c1", "builds", "worker", "autonomous", "software"],
+      "tags": [
+        "m2c1",
+        "builds",
+        "worker",
+        "autonomous",
+        "software"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/m2c1-worker",
@@ -104,7 +146,12 @@
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["workers", "parallel", "spawn", "isolation"],
+      "tags": [
+        "workers",
+        "parallel",
+        "spawn",
+        "isolation"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/worker-agents",
@@ -112,11 +159,16 @@
     },
     {
       "name": "knowledge-base",
-      "description": "RAG-powered org knowledge base — ingest documents, query with natural language, keep institutional knowledge searchable",
+      "description": "RAG-powered org knowledge base \u2014 ingest documents, query with natural language, keep institutional knowledge searchable",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["rag", "knowledge", "search", "memory"],
+      "tags": [
+        "rag",
+        "knowledge",
+        "search",
+        "memory"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/knowledge-base",
@@ -124,11 +176,16 @@
     },
     {
       "name": "approvals",
-      "description": "Human approval gate — request approval before external actions (email, deploy, delete, financial), block until approved",
+      "description": "Human approval gate \u2014 request approval before external actions (email, deploy, delete, financial), block until approved",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["approvals", "safety", "human-in-loop", "guardrails"],
+      "tags": [
+        "approvals",
+        "safety",
+        "human-in-loop",
+        "guardrails"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/approvals",
@@ -136,11 +193,16 @@
     },
     {
       "name": "memory",
-      "description": "Session and long-term memory management — daily memory files, MEMORY.md, KB ingestion for cross-session continuity",
+      "description": "Session and long-term memory management \u2014 daily memory files, MEMORY.md, KB ingestion for cross-session continuity",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["memory", "continuity", "session", "persistence"],
+      "tags": [
+        "memory",
+        "continuity",
+        "session",
+        "persistence"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/memory",
@@ -148,11 +210,16 @@
     },
     {
       "name": "cron-management",
-      "description": "Recurring schedule management — set up crons, persist across restarts, prevent duplicates",
+      "description": "Recurring schedule management \u2014 set up crons, persist across restarts, prevent duplicates",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["cron", "scheduling", "recurring", "automation"],
+      "tags": [
+        "cron",
+        "scheduling",
+        "recurring",
+        "automation"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/cron-management",
@@ -160,11 +227,16 @@
     },
     {
       "name": "heartbeat",
-      "description": "Agent health monitoring — update heartbeat, check stale tasks, log events, prevent showing as DEAD on dashboard",
+      "description": "Agent health monitoring \u2014 update heartbeat, check stale tasks, log events, prevent showing as DEAD on dashboard",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["heartbeat", "health", "monitoring", "dashboard"],
+      "tags": [
+        "heartbeat",
+        "health",
+        "monitoring",
+        "dashboard"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/heartbeat",
@@ -172,11 +244,16 @@
     },
     {
       "name": "human-tasks",
-      "description": "Human task routing — when blocked by a capability gap, create a human task with clear instructions and priority",
+      "description": "Human task routing \u2014 when blocked by a capability gap, create a human task with clear instructions and priority",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["human-tasks", "blockers", "escalation", "routing"],
+      "tags": [
+        "human-tasks",
+        "blockers",
+        "escalation",
+        "routing"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/human-tasks",
@@ -184,11 +261,16 @@
     },
     {
       "name": "agent-management",
-      "description": "Agent lifecycle management — create, start, stop, restart agents, handle crashes and context exhaustion",
+      "description": "Agent lifecycle management \u2014 create, start, stop, restart agents, handle crashes and context exhaustion",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["agents", "lifecycle", "management", "crash-recovery"],
+      "tags": [
+        "agents",
+        "lifecycle",
+        "management",
+        "crash-recovery"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/agent-management",
@@ -196,11 +278,16 @@
     },
     {
       "name": "activity-channel",
-      "description": "Org-wide activity broadcast — post significant completions to the shared activity channel for all agents to see",
+      "description": "Org-wide activity broadcast \u2014 post significant completions to the shared activity channel for all agents to see",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["activity", "broadcast", "org", "visibility"],
+      "tags": [
+        "activity",
+        "broadcast",
+        "org",
+        "visibility"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/activity-channel",
@@ -208,11 +295,16 @@
     },
     {
       "name": "event-logging",
-      "description": "Activity feed logging — log session events, task completions, and milestones so they appear in the dashboard",
+      "description": "Activity feed logging \u2014 log session events, task completions, and milestones so they appear in the dashboard",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["events", "logging", "activity", "dashboard"],
+      "tags": [
+        "events",
+        "logging",
+        "activity",
+        "dashboard"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/event-logging",
@@ -220,11 +312,16 @@
     },
     {
       "name": "system-diagnostics",
-      "description": "Debug stuck systems — diagnose unresponsive agents, stale tasks, bus issues, PTY problems",
+      "description": "Debug stuck systems \u2014 diagnose unresponsive agents, stale tasks, bus issues, PTY problems",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["diagnostics", "debug", "troubleshooting", "health"],
+      "tags": [
+        "diagnostics",
+        "debug",
+        "troubleshooting",
+        "health"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/system-diagnostics",
@@ -232,11 +329,16 @@
     },
     {
       "name": "onboarding",
-      "description": "First-boot onboarding wizard — guides new agents through identity setup, Telegram configuration, and first session startup",
+      "description": "First-boot onboarding wizard \u2014 guides new agents through identity setup, Telegram configuration, and first session startup",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["onboarding", "setup", "first-boot", "configuration"],
+      "tags": [
+        "onboarding",
+        "setup",
+        "first-boot",
+        "configuration"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/onboarding",
@@ -244,11 +346,16 @@
     },
     {
       "name": "morning-review",
-      "description": "Daily morning briefing — overnight recap, task summaries, pending approvals, goal progress, day plan",
+      "description": "Daily morning briefing \u2014 overnight recap, task summaries, pending approvals, goal progress, day plan",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["morning", "briefing", "review", "daily"],
+      "tags": [
+        "morning",
+        "briefing",
+        "review",
+        "daily"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/morning-review",
@@ -256,11 +363,16 @@
     },
     {
       "name": "evening-review",
-      "description": "Daily evening wrap-up — what was shipped, blockers, plan for overnight, goals progress",
+      "description": "Daily evening wrap-up \u2014 what was shipped, blockers, plan for overnight, goals progress",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["evening", "review", "daily", "wrap-up"],
+      "tags": [
+        "evening",
+        "review",
+        "daily",
+        "wrap-up"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/evening-review",
@@ -268,11 +380,16 @@
     },
     {
       "name": "weekly-review",
-      "description": "Weekly performance review — metrics, accomplishments, blockers, next week goals",
+      "description": "Weekly performance review \u2014 metrics, accomplishments, blockers, next week goals",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["weekly", "review", "performance", "metrics"],
+      "tags": [
+        "weekly",
+        "review",
+        "performance",
+        "metrics"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/weekly-review",
@@ -280,11 +397,16 @@
     },
     {
       "name": "theta-wave",
-      "description": "Overnight autonomous research cycles — assign research cycles to agents, monitor results, surface findings",
+      "description": "Overnight autonomous research cycles \u2014 assign research cycles to agents, monitor results, surface findings",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["theta-wave", "research", "overnight", "autonomous"],
+      "tags": [
+        "theta-wave",
+        "research",
+        "overnight",
+        "autonomous"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/theta-wave",
@@ -292,11 +414,16 @@
     },
     {
       "name": "goal-management",
-      "description": "Goal setting and tracking — create goals, assign to agents, track progress, refresh daily",
+      "description": "Goal setting and tracking \u2014 create goals, assign to agents, track progress, refresh daily",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["goals", "strategy", "tracking", "management"],
+      "tags": [
+        "goals",
+        "strategy",
+        "tracking",
+        "management"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/goal-management",
@@ -304,11 +431,16 @@
     },
     {
       "name": "local-version-control",
-      "description": "Git workflow management — commit, branch, PR creation, merge conflict resolution for agent-managed code",
+      "description": "Git workflow management \u2014 commit, branch, PR creation, merge conflict resolution for agent-managed code",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["git", "version-control", "pr", "workflow"],
+      "tags": [
+        "git",
+        "version-control",
+        "pr",
+        "workflow"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/local-version-control",
@@ -316,15 +448,38 @@
     },
     {
       "name": "nighttime-mode",
-      "description": "Night mode behavior — quieter notifications, autonomous work, overnight research execution",
+      "description": "Night mode behavior \u2014 quieter notifications, autonomous work, overnight research execution",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": ["nighttime", "autonomous", "quiet", "overnight"],
+      "tags": [
+        "nighttime",
+        "autonomous",
+        "quiet",
+        "overnight"
+      ],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/nighttime-mode",
       "submitted_at": "2026-04-06T00:00:00Z"
+    },
+    {
+      "name": "voice-agent-factory",
+      "description": "Turn any cortextOS agent into a live ElevenLabs voice agent: mine its real capabilities into a tool catalog, generate a policy-gated gateway dynamically (no pre-built scripts), test on probe-shaped fixtures, provision with tier fallback, verify with real conversations",
+      "author": "cortextos",
+      "type": "skill",
+      "version": "1.0.0",
+      "tags": [
+        "voice",
+        "elevenlabs",
+        "conversational-ai",
+        "gateway",
+        "tools"
+      ],
+      "review_status": "pending",
+      "dependencies": [],
+      "install_path": "community/skills/voice-agent-factory",
+      "submitted_at": "2026-06-06T09:30:00Z"
     }
   ]
 }

--- a/community/catalog.json
+++ b/community/catalog.json
@@ -4,18 +4,11 @@
   "items": [
     {
       "name": "agentic-crm-assistant",
-      "description": "Agentic CRM personal assistant \u2014 reusable executive/personal assistant template with structured relationship memory, inbox/calendar/meeting workflows, full interactive setup, tool-agnostic connectors, CRM skills, and recurring assistant crons",
+      "description": "Agentic CRM personal assistant — reusable executive/personal assistant template with structured relationship memory, inbox/calendar/meeting workflows, full interactive setup, tool-agnostic connectors, CRM skills, and recurring assistant crons",
       "author": "cortextos",
       "type": "agent",
       "version": "0.1.0",
-      "tags": [
-        "personal-assistant",
-        "crm",
-        "calendar",
-        "email",
-        "meetings",
-        "relationships"
-      ],
+      "tags": ["personal-assistant", "crm", "calendar", "email", "meetings", "relationships"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/agentic-crm-assistant",
@@ -23,16 +16,11 @@
     },
     {
       "name": "orchestrator",
-      "description": "Orchestrator agent \u2014 coordinates other agents, handles morning/evening reviews, manages goals and approvals, weekly reporting",
+      "description": "Orchestrator agent — coordinates other agents, handles morning/evening reviews, manages goals and approvals, weekly reporting",
       "author": "cortextos",
       "type": "agent",
       "version": "1.0.0",
-      "tags": [
-        "orchestrator",
-        "management",
-        "reviews",
-        "goals"
-      ],
+      "tags": ["orchestrator", "management", "reviews", "goals"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/orchestrator",
@@ -40,16 +28,11 @@
     },
     {
       "name": "analyst",
-      "description": "Analyst agent \u2014 system health, metrics, theta-wave autoresearch, community publishing, upstream sync",
+      "description": "Analyst agent — system health, metrics, theta-wave autoresearch, community publishing, upstream sync",
       "author": "cortextos",
       "type": "agent",
       "version": "1.0.0",
-      "tags": [
-        "analyst",
-        "metrics",
-        "research",
-        "health"
-      ],
+      "tags": ["analyst", "metrics", "research", "health"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/analyst",
@@ -57,15 +40,11 @@
     },
     {
       "name": "agent",
-      "description": "General-purpose worker agent \u2014 base template for specialist agents. Handles tasks, Telegram comms, memory, and skill execution",
+      "description": "General-purpose worker agent — base template for specialist agents. Handles tasks, Telegram comms, memory, and skill execution",
       "author": "cortextos",
       "type": "agent",
       "version": "1.0.0",
-      "tags": [
-        "agent",
-        "worker",
-        "general-purpose"
-      ],
+      "tags": ["agent", "worker", "general-purpose"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/agents/agent",
@@ -73,16 +52,11 @@
     },
     {
       "name": "tasks",
-      "description": "Task lifecycle management \u2014 create, update, complete tasks with KPI logging. Every significant piece of work gets a task",
+      "description": "Task lifecycle management — create, update, complete tasks with KPI logging. Every significant piece of work gets a task",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "tasks",
-        "workflow",
-        "kpi",
-        "visibility"
-      ],
+      "tags": ["tasks", "workflow", "kpi", "visibility"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/tasks",
@@ -90,16 +64,11 @@
     },
     {
       "name": "comms",
-      "description": "Telegram and agent-to-agent message handling \u2014 format reference, reply patterns, callback handling, bidirectional file send/receive",
+      "description": "Telegram and agent-to-agent message handling — format reference, reply patterns, callback handling, bidirectional file send/receive",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "telegram",
-        "messaging",
-        "comms",
-        "inbox"
-      ],
+      "tags": ["telegram", "messaging", "comms", "inbox"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/comms",
@@ -107,16 +76,11 @@
     },
     {
       "name": "autoresearch",
-      "description": "Structured experimentation loop \u2014 form hypothesis, make targeted change, measure outcome, keep or discard. Theta wave research cycles",
+      "description": "Structured experimentation loop — form hypothesis, make targeted change, measure outcome, keep or discard. Theta wave research cycles",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "research",
-        "experiments",
-        "theta-wave",
-        "optimization"
-      ],
+      "tags": ["research", "experiments", "theta-wave", "optimization"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/autoresearch",
@@ -124,17 +88,11 @@
     },
     {
       "name": "m2c1-worker",
-      "description": "Autonomous software builds \u2014 spawn a dedicated M2C1 worker session to build any project through 12 structured phases",
+      "description": "Autonomous software builds — spawn a dedicated M2C1 worker session to build any project through 12 structured phases",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "m2c1",
-        "builds",
-        "worker",
-        "autonomous",
-        "software"
-      ],
+      "tags": ["m2c1", "builds", "worker", "autonomous", "software"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/m2c1-worker",
@@ -146,12 +104,7 @@
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "workers",
-        "parallel",
-        "spawn",
-        "isolation"
-      ],
+      "tags": ["workers", "parallel", "spawn", "isolation"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/worker-agents",
@@ -159,16 +112,11 @@
     },
     {
       "name": "knowledge-base",
-      "description": "RAG-powered org knowledge base \u2014 ingest documents, query with natural language, keep institutional knowledge searchable",
+      "description": "RAG-powered org knowledge base — ingest documents, query with natural language, keep institutional knowledge searchable",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "rag",
-        "knowledge",
-        "search",
-        "memory"
-      ],
+      "tags": ["rag", "knowledge", "search", "memory"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/knowledge-base",
@@ -176,16 +124,11 @@
     },
     {
       "name": "approvals",
-      "description": "Human approval gate \u2014 request approval before external actions (email, deploy, delete, financial), block until approved",
+      "description": "Human approval gate — request approval before external actions (email, deploy, delete, financial), block until approved",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "approvals",
-        "safety",
-        "human-in-loop",
-        "guardrails"
-      ],
+      "tags": ["approvals", "safety", "human-in-loop", "guardrails"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/approvals",
@@ -193,16 +136,11 @@
     },
     {
       "name": "memory",
-      "description": "Session and long-term memory management \u2014 daily memory files, MEMORY.md, KB ingestion for cross-session continuity",
+      "description": "Session and long-term memory management — daily memory files, MEMORY.md, KB ingestion for cross-session continuity",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "memory",
-        "continuity",
-        "session",
-        "persistence"
-      ],
+      "tags": ["memory", "continuity", "session", "persistence"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/memory",
@@ -210,16 +148,11 @@
     },
     {
       "name": "cron-management",
-      "description": "Recurring schedule management \u2014 set up crons, persist across restarts, prevent duplicates",
+      "description": "Recurring schedule management — set up crons, persist across restarts, prevent duplicates",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "cron",
-        "scheduling",
-        "recurring",
-        "automation"
-      ],
+      "tags": ["cron", "scheduling", "recurring", "automation"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/cron-management",
@@ -227,16 +160,11 @@
     },
     {
       "name": "heartbeat",
-      "description": "Agent health monitoring \u2014 update heartbeat, check stale tasks, log events, prevent showing as DEAD on dashboard",
+      "description": "Agent health monitoring — update heartbeat, check stale tasks, log events, prevent showing as DEAD on dashboard",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "heartbeat",
-        "health",
-        "monitoring",
-        "dashboard"
-      ],
+      "tags": ["heartbeat", "health", "monitoring", "dashboard"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/heartbeat",
@@ -244,16 +172,11 @@
     },
     {
       "name": "human-tasks",
-      "description": "Human task routing \u2014 when blocked by a capability gap, create a human task with clear instructions and priority",
+      "description": "Human task routing — when blocked by a capability gap, create a human task with clear instructions and priority",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "human-tasks",
-        "blockers",
-        "escalation",
-        "routing"
-      ],
+      "tags": ["human-tasks", "blockers", "escalation", "routing"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/human-tasks",
@@ -261,16 +184,11 @@
     },
     {
       "name": "agent-management",
-      "description": "Agent lifecycle management \u2014 create, start, stop, restart agents, handle crashes and context exhaustion",
+      "description": "Agent lifecycle management — create, start, stop, restart agents, handle crashes and context exhaustion",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "agents",
-        "lifecycle",
-        "management",
-        "crash-recovery"
-      ],
+      "tags": ["agents", "lifecycle", "management", "crash-recovery"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/agent-management",
@@ -278,16 +196,11 @@
     },
     {
       "name": "activity-channel",
-      "description": "Org-wide activity broadcast \u2014 post significant completions to the shared activity channel for all agents to see",
+      "description": "Org-wide activity broadcast — post significant completions to the shared activity channel for all agents to see",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "activity",
-        "broadcast",
-        "org",
-        "visibility"
-      ],
+      "tags": ["activity", "broadcast", "org", "visibility"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/activity-channel",
@@ -295,16 +208,11 @@
     },
     {
       "name": "event-logging",
-      "description": "Activity feed logging \u2014 log session events, task completions, and milestones so they appear in the dashboard",
+      "description": "Activity feed logging — log session events, task completions, and milestones so they appear in the dashboard",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "events",
-        "logging",
-        "activity",
-        "dashboard"
-      ],
+      "tags": ["events", "logging", "activity", "dashboard"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/event-logging",
@@ -312,16 +220,11 @@
     },
     {
       "name": "system-diagnostics",
-      "description": "Debug stuck systems \u2014 diagnose unresponsive agents, stale tasks, bus issues, PTY problems",
+      "description": "Debug stuck systems — diagnose unresponsive agents, stale tasks, bus issues, PTY problems",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "diagnostics",
-        "debug",
-        "troubleshooting",
-        "health"
-      ],
+      "tags": ["diagnostics", "debug", "troubleshooting", "health"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/system-diagnostics",
@@ -329,16 +232,11 @@
     },
     {
       "name": "onboarding",
-      "description": "First-boot onboarding wizard \u2014 guides new agents through identity setup, Telegram configuration, and first session startup",
+      "description": "First-boot onboarding wizard — guides new agents through identity setup, Telegram configuration, and first session startup",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "onboarding",
-        "setup",
-        "first-boot",
-        "configuration"
-      ],
+      "tags": ["onboarding", "setup", "first-boot", "configuration"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/onboarding",
@@ -346,16 +244,11 @@
     },
     {
       "name": "morning-review",
-      "description": "Daily morning briefing \u2014 overnight recap, task summaries, pending approvals, goal progress, day plan",
+      "description": "Daily morning briefing — overnight recap, task summaries, pending approvals, goal progress, day plan",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "morning",
-        "briefing",
-        "review",
-        "daily"
-      ],
+      "tags": ["morning", "briefing", "review", "daily"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/morning-review",
@@ -363,16 +256,11 @@
     },
     {
       "name": "evening-review",
-      "description": "Daily evening wrap-up \u2014 what was shipped, blockers, plan for overnight, goals progress",
+      "description": "Daily evening wrap-up — what was shipped, blockers, plan for overnight, goals progress",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "evening",
-        "review",
-        "daily",
-        "wrap-up"
-      ],
+      "tags": ["evening", "review", "daily", "wrap-up"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/evening-review",
@@ -380,16 +268,11 @@
     },
     {
       "name": "weekly-review",
-      "description": "Weekly performance review \u2014 metrics, accomplishments, blockers, next week goals",
+      "description": "Weekly performance review — metrics, accomplishments, blockers, next week goals",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "weekly",
-        "review",
-        "performance",
-        "metrics"
-      ],
+      "tags": ["weekly", "review", "performance", "metrics"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/weekly-review",
@@ -397,16 +280,11 @@
     },
     {
       "name": "theta-wave",
-      "description": "Overnight autonomous research cycles \u2014 assign research cycles to agents, monitor results, surface findings",
+      "description": "Overnight autonomous research cycles — assign research cycles to agents, monitor results, surface findings",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "theta-wave",
-        "research",
-        "overnight",
-        "autonomous"
-      ],
+      "tags": ["theta-wave", "research", "overnight", "autonomous"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/theta-wave",
@@ -414,16 +292,11 @@
     },
     {
       "name": "goal-management",
-      "description": "Goal setting and tracking \u2014 create goals, assign to agents, track progress, refresh daily",
+      "description": "Goal setting and tracking — create goals, assign to agents, track progress, refresh daily",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "goals",
-        "strategy",
-        "tracking",
-        "management"
-      ],
+      "tags": ["goals", "strategy", "tracking", "management"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/goal-management",
@@ -431,16 +304,11 @@
     },
     {
       "name": "local-version-control",
-      "description": "Git workflow management \u2014 commit, branch, PR creation, merge conflict resolution for agent-managed code",
+      "description": "Git workflow management — commit, branch, PR creation, merge conflict resolution for agent-managed code",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "git",
-        "version-control",
-        "pr",
-        "workflow"
-      ],
+      "tags": ["git", "version-control", "pr", "workflow"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/local-version-control",
@@ -448,16 +316,11 @@
     },
     {
       "name": "nighttime-mode",
-      "description": "Night mode behavior \u2014 quieter notifications, autonomous work, overnight research execution",
+      "description": "Night mode behavior — quieter notifications, autonomous work, overnight research execution",
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "nighttime",
-        "autonomous",
-        "quiet",
-        "overnight"
-      ],
+      "tags": ["nighttime", "autonomous", "quiet", "overnight"],
       "review_status": "approved",
       "dependencies": [],
       "install_path": "community/skills/nighttime-mode",
@@ -469,13 +332,7 @@
       "author": "cortextos",
       "type": "skill",
       "version": "1.0.0",
-      "tags": [
-        "voice",
-        "elevenlabs",
-        "conversational-ai",
-        "gateway",
-        "tools"
-      ],
+      "tags": ["voice", "elevenlabs", "conversational-ai", "gateway", "tools"],
       "review_status": "pending",
       "dependencies": [],
       "install_path": "community/skills/voice-agent-factory",

--- a/community/skills/voice-agent-factory/SKILL.md
+++ b/community/skills/voice-agent-factory/SKILL.md
@@ -1,0 +1,215 @@
+---
+name: voice-agent-factory
+description: "Turn ANY cortextOS agent into a live ElevenLabs voice agent: mine its skills, CLIs, MCPs, and transcripts into a tool catalog, distill its skills into a voice persona, dynamically generate a policy-gated gateway and all code per target (NO pre-built scripts), test exhaustively on probe-shaped fixtures, provision on ElevenLabs with automatic tier fallback, and verify end-to-end with real conversations before shipping a link."
+triggers: ["voice agent", "elevenlabs", "voice surface", "talk to my agent", "conversational ai", "voice gateway", "give my agent a voice", "voice tools", "el agent", "convai", "speech interface", "tap to talk"]
+external_calls: ["api.elevenlabs.io", "unpkg.com (EL widget embed)", "trycloudflare.com (quick tunnel)"]
+---
+
+# voice-agent-factory — cortextOS agent -> ElevenLabs voice agent
+
+Run this skill against a target agent and it produces a live, policy-gated voice
+surface: a zero-dependency Node gateway exposing the agent's real capabilities as
+ElevenLabs tools, a widget page, a generated test harness, provisioning scripts,
+and an auditable discovery record.
+
+**ALL CODE IS WRITTEN DYNAMICALLY PER RUN.** There is NO pre-built script library
+or template to copy. The agent running this skill reads the bundled `resources/`
+docs (verified ElevenLabs API surface), then writes every file — gateway, tools,
+tests, provisioning calls — fresh, fit to the target agent's actual capabilities
+as discovered. Two agents with different jobs get completely different tool
+catalogs from the same skill.
+
+Read `resources/REPORT.md` before any ElevenLabs API call: EL is mid-rename
+(ConvAI -> ElevenAgents), doc URLs drift, and the API surface in REPORT is the
+verified one. `resources/GAPS.md` has the server-tool webhook schema + pricing.
+`resources/SOURCES.md` lists primary sources.
+
+## Non-negotiable lessons (each one was hit live during the reference builds)
+
+1. **PROBE, never map from docs.** Every CLI's JSON output shape MUST be captured
+   by running a real safe command before writing a field mapping. (An email tool
+   shipped with empty from/subject because the CLI nests `{headers:{from,...},
+   message:{snippet}}`; a calendar create wraps its response as `{event:{id}}`
+   not `{id}`.)
+2. **Verb-set completeness.** For every NOUN a tool touches, generate the full
+   verb set — list/get/create/update/delete — or record an explicit exclusion
+   with a reason. (A build shipped calendar WRITE with no READ; the operator hit
+   the gap in his first minute of talking.)
+3. **The agent states its limits truthfully — make the truth complete.** The
+   prompt carries an auto-generated "I cannot X from voice" section built from
+   the exclusion list, each with a relay path (usually create_task to the real
+   agent).
+4. **Tier-detect before MCP — and probe the POST, not the GET.** Some tiers
+   return `convai_mcp_servers_disabled` on `POST /v1/convai/mcp-servers` while
+   the GET still 200s. The POST is the gate; fall back to webhook server tools
+   (same gateway, `/tool/<name>` REST skin) without redesign.
+5. **Compact returns.** Voice latency stacks per tool round-trip. Returns carry
+   ids + summaries, bodies capped (~1500 chars), lists capped (~8-15 items), and
+   an `as_of` UTC stamp on anything time-sensitive (the voice LLM does not
+   reliably know today's date).
+6. **Timezone offsets are required in every time input** (description-level
+   rule); the server parses RFC3339 and rejects unparseable times.
+7. **Hard invariants live server-side, not in the prompt.** Draft-only mail (no
+   send path in the code at all), pinned resource ids (not parameters),
+   append-only updates, recipient whitelists. Verbal confirmation is a persona
+   rule; safety is code.
+8. **Tunnel URL is load-bearing.** EL webhook tool URLs embed the tunnel
+   hostname. Never process-manage or casually restart a quick tunnel; on
+   rotation, re-register tools with the new URL and delete the orphans.
+9. **Signed URLs expire (~15 min).** The page mints on load; document the
+   refresh-if-idle quirk to the user.
+10. **Secrets discipline.** API key in org secrets + gateway `.env` (chmod 600,
+    gitignored — verify with `git check-ignore`); the browser only ever sees
+    signed URLs; the gateway bearer secret is generated per deployment
+    (`openssl rand -hex 24`).
+11. **simulate-conversation MOCKS tools — never use it as E2E proof.** EL's
+    `POST /v1/convai/agents/<id>/simulate-conversation` returns `"Tool Called."`
+    for every tool (ToolMockConfig default) and the sim LLM then FABRICATES
+    plausible results — it spoke a member count 2.4x the real number with zero
+    gateway hits in the audit log. Use it for persona/flow checks only. Real
+    verification = text-only WebSocket session (lesson 12).
+12. **Real headless E2E = text-only WS session on the signed URL.** Mint
+    `/api/signed-url`, connect a WebSocket client, send
+    `{"type":"conversation_initiation_client_data","conversation_config_override":
+    {"conversation":{"text_only":true}}}`, then `{"type":"user_message","text":...}`;
+    answer `ping` events with `{"type":"pong","event_id":...}`. Watch for
+    `agent_tool_response` events AND assert the gateway audit log recorded each
+    call with real args. Spoken numbers must match the live data exactly.
+13. **Targets may already have a voice scaffold — coexist, never clobber.** Check
+    `<agentDir>/voice/` first. If occupied, pick new filenames + a free port,
+    reuse existing modules by import only, and append to the existing README
+    rather than overwriting. Also probe `--json` claims in agent docs: some
+    commands emit JSON with no flag at all, some documented flags don't exist.
+14. **Mock and live must share the param-handling path.** Apply filters and
+    transforms AFTER the fixture-or-file load fork so mock tests exercise the
+    same logic (a keyword filter shipped broken in mock because the mock
+    returned early). If a run is halted, write a discovery record (probe shapes,
+    planned catalog, exclusions) before pivoting — it makes the run resumable
+    without re-mining.
+
+## Phase 0 — Inputs and account
+
+- Target agent name + org. Operator contact for the ASK phase.
+- `ELEVENLABS_API_KEY` present (org secrets). Verify: `GET /v1/user` -> tier.
+  Log the tier; it picks the provisioning path (lesson 4).
+- Voice: operator picks, or default `21m00Tcm4TlvDq8ikWAM` (Rachel) — give each
+  agent in a fleet a DISTINCT voice; swappable later via agent PATCH.
+
+## Phase 1 — DISCOVER (the tool engine, part 1: inventory)
+
+Mine four sources, in this order, into `voice-profile.json` candidates:
+
+1. **Skills.** Read every `<agentDir>/.claude/skills/*/SKILL.md` (+ org-level
+   skills the agent's CLAUDE.md references). Extract per skill:
+   - bash blocks -> exact CLI invocations with flags = ground-truth param usage
+   - frontmatter description/triggers -> tool description language
+   - numbered step sequences -> prompt procedure candidates (Phase 3)
+2. **CLIs.** The agent's TOOLS.md registry + every binary the skills invoke. For
+   each command: `--help` parse -> flags, required/optional, enums. Record the
+   account/instance flags the agent actually uses.
+3. **MCPs.** `<agentDir>/.mcp.json` and live-connected servers. `tools/list`
+   each: schemas are ready-made; mark as PROXY backend (the gateway forwards
+   through the same policy gate — never attach an external MCP directly to EL).
+4. **Transcripts + memory.** Last ~14 days of the agent's JSONL transcripts
+   (`~/.claude/projects/<wd-slug>/*.jsonl`, top-level sessions) + memory files.
+   Count tool/command frequency -> rank candidates by REAL usage; extract the
+   top 3 recurring workflows verbatim (they become the anchor chains in Phase
+   4/6). Also: agent config.json (recipients, accounts, data paths, crons).
+
+Fan discovery out to parallel subagents (skills / transcripts / CLI surface) —
+each returns structured raw data, not prose.
+
+## Phase 2 — ASK (only what discovery cannot answer)
+
+3-5 questions max to the operator: top workflows confirm (from transcript
+ranking), what requires verbal confirmation vs auto, anything that must be
+EXCLUDED from voice entirely, voice choice, reach (localhost vs tunnel).
+Propose defaults from discovery so the operator can answer with one word — and
+if the operator is unavailable, proceed on stated defaults without blocking.
+
+## Phase 3 — GENERATE (the tool engine, part 2: synthesis)
+
+Per candidate tool, in dependency order:
+
+1. **Backend classify**: bus-command | CLI-exec | file-access | MCP-proxy.
+2. **Schema derive** from Phase-1 ground truth (flags + skill usage examples).
+3. **PROBE (mandatory, lesson 1)**: run the real command (safe reads live;
+   writes in a fixture/dry-run mode) with JSON output; capture the response
+   shape; generate the field mapping + compact-return transform from the
+   CAPTURED shape. File-backed tools: capture the actual file structure.
+4. **Verb-set matrix (lesson 2)**: per noun, fill read/list/get/create/update/
+   delete or record exclusion + reason in the profile.
+5. **Policy class**: read | write_safe | write_confirm | excluded. Generate the
+   server-side invariant for every write (pin, whitelist, append-only,
+   draft-only, priority caps).
+6. **Description-as-trigger**: when-to-use phrasing + id-threading guidance
+   ("use the exact id returned by X") — the EL description does the job of a
+   skill trigger for the voice LLM.
+
+**System prompt construction:**
+- Persona core from the agent's identity (CLAUDE.md role, SOUL/identity files).
+- Per relevant skill: DISTILL (never paste) into a procedure section — trigger
+  phrase, numbered steps referencing generated tool names, confirm rules.
+- Tool discipline block (chain reads silently, carry ids exactly, readback
+  rules, never round numbers).
+- Truthful-limits section auto-generated from exclusions (lesson 3) with relay
+  paths.
+- Keep lean; 2MB is the EL cap but hundreds of lines is the practical target.
+
+Write the per-agent tree FROM SCRATCH at `<agentDir>/voice/` (lesson 13 if
+occupied): `voice.config.js` (identity + persona + PINNED data paths),
+`src/tools/*` (written per tool, shaped by its backend type and probe captures),
+`mcp-server.js` (written for this agent's tool registry + policy classes),
+`src/policy.js`, `src/session-store.js` (append-only audit JSONL), `tests/`
+(Phase 4), `public/index.html`, `.env` (lesson 10), `el-provision.js` +
+`el-server-tools.js`.
+
+## Phase 4 — TEST (all auto-generated, all must pass before provisioning)
+
+- MCP protocol suite (initialize / tools/list count / unknown-method) — write it
+  fresh against the generated server.
+- Policy matrix: every tool x every class, whitelist negatives, unknown-tool
+  reject, plus a no-orphans check (every policy entry has a catalog tool and
+  vice versa).
+- Per-tool units on mock fixtures (fixtures generated from the Phase-3 probe
+  captures — the mock IS the captured real shape; lesson 14 on shared paths).
+- Anchor chains: the agent's top transcript workflows end-to-end on mocks with
+  id threading asserted.
+- Gateway HTTP: bearer 401 negative, page serves, signed-url clean pre-key state.
+- Then LIVE smokes: every read tool against real data locally before any
+  provisioning; writes as create-then-cleanup.
+
+## Phase 5 — PROVISION
+
+1. Tier probe (lesson 4, POST not GET) -> MCP path or server-tools path.
+2. Start the gateway under a process manager (`<agent>-voice-gateway`); tunnel
+   via a detached quick tunnel (lesson 8); verify tunnel -> gateway health.
+3. Create agent: `POST /v1/convai/agents/create` — a current Claude model,
+   generated prompt, voice. PATCH path for updates.
+4. Tools: server-tools path = `POST /v1/convai/tools` per tool (url = tunnel
+   `/tool/<name>`, bearer header, request_body_schema from the generated
+   schema), then PATCH agent `tool_ids` (GET current ids first, append — never
+   overwrite blind). MCP path = `POST /v1/convai/mcp-servers` with
+   `require_approval_per_tool`.
+5. Live read smokes through the tunnel; write smokes create-then-cleanup.
+
+## Phase 6 — VERIFY (before any link ships)
+
+1. Drive a REAL text-only WebSocket session per top-3 workflow (lesson 12 — NOT
+   simulate-conversation, which mocks tools and fabricates results, lesson 11):
+   assert the expected tools fired via `agent_tool_response` events, the gateway
+   audit log recorded each call with real args, AND the spoken answer matches
+   the live data exactly.
+2. Asymmetry audit (executable lesson-2 checklist): diff the verb-set matrix
+   against the shipped catalog; any silent gap = ship-blocker.
+3. Page check over the tunnel; THEN send the operator the link with: known
+   quirks (15-min signed-url refresh, what voice can never do), the audit-log
+   location, and the recovery runbook (tunnel rotation procedure).
+
+## Outputs
+
+- `<agentDir>/voice/` live gateway + page + tests, process-managed.
+- `voice-profile.json` — the full discovery record (tools, probe shapes, policy
+  classes, verb matrix with exclusions, EL ids, verification evidence). This is
+  the auditable artifact.
+- Operator link + quirks note + recovery runbook.

--- a/community/skills/voice-agent-factory/SKILL.md
+++ b/community/skills/voice-agent-factory/SKILL.md
@@ -19,6 +19,39 @@ tests, provisioning calls — fresh, fit to the target agent's actual capabiliti
 as discovered. Two agents with different jobs get completely different tool
 catalogs from the same skill.
 
+## Prerequisites
+
+- A cortextOS install with the target agent onboarded (`<agentDir>` = the agent's
+  workspace, e.g. `orgs/<org>/agents/<name>/`), and the `cortextos` CLI on PATH.
+- Node >= 18 (the generated gateway and tests are zero-dependency `node:` builtins).
+- An ElevenLabs account + `ELEVENLABS_API_KEY` in your org secrets file. Any paid
+  tier works; the skill tier-detects and picks the right provisioning path. Voice
+  minutes are billed by ElevenLabs — see `resources/GAPS.md` pricing table.
+- For remote reach: `cloudflared` (quick tunnel). Localhost-only runs skip it, but
+  then ElevenLabs webhook tools cannot reach the gateway — server-tools mode
+  REQUIRES a public HTTPS URL. A reverse proxy or other tunnel works equally well.
+- A process manager (pm2 or equivalent) for the gateway. The quick tunnel itself
+  must NOT be process-managed (lesson 8).
+- Browser page: the generated widget page loads the EL embed from unpkg.com at
+  runtime (the one external browser dependency). If you need a no-CDN deployment,
+  vendor `@elevenlabs/convai-widget-embed` locally and point the script tag at it.
+
+## How to run
+
+Tell the agent running this skill: the target agent name + org, the operator
+contact, and (optionally) a voice id. Then follow the phases in order. Minimal
+invocation: "Run voice-agent-factory against <agent> in <org>; I'm the operator."
+
+## What this writes / creates
+
+- Files: `<agentDir>/voice/` (gateway, tools, tests, page, provisioning scripts,
+  `.env` chmod 600 + gitignored, `voice-profile.json`) and an append-only audit
+  log under the agent's docs. Nothing outside the target agent's workspace.
+- Local: one listening port you choose (track one port per agent), a process-manager
+  entry `<agent>-voice-gateway`, optionally a quick-tunnel process.
+- External (ONLY after the Phase 5 gate): an ElevenLabs agent, one EL webhook tool
+  per gateway tool (or an MCP server attachment), and EL voice-minute usage.
+
 Read `resources/REPORT.md` before any ElevenLabs API call: EL is mid-rename
 (ConvAI -> ElevenAgents), doc URLs drift, and the API surface in REPORT is the
 verified one. `resources/GAPS.md` has the server-tool webhook schema + pricing.
@@ -97,6 +130,15 @@ verified one. `resources/GAPS.md` has the server-tool webhook schema + pricing.
 
 ## Phase 1 — DISCOVER (the tool engine, part 1: inventory)
 
+FIRST detect the target's runtime from its `config.json` (`runtime` field).
+The discovery paths below are for `claude-code` agents. For `codex-app-server`
+agents, substitute: skills under the agent's plugin skills dir (e.g.
+`plugins/cortextos-agent-skills/skills/`), identity from AGENTS/IDENTITY/SOUL/
+TOOLS files, and the runtime's own session/transcript store if one exists. If no
+transcript source can be found for the runtime, STOP with an explicit
+unsupported-runtime error naming what was looked for — do not silently
+under-mine the agent (frequency ranking and anchor workflows would be fiction).
+
 Mine four sources, in this order, into `voice-profile.json` candidates:
 
 1. **Skills.** Read every `<agentDir>/.claude/skills/*/SKILL.md` (+ org-level
@@ -125,7 +167,8 @@ each returns structured raw data, not prose.
 ranking), what requires verbal confirmation vs auto, anything that must be
 EXCLUDED from voice entirely, voice choice, reach (localhost vs tunnel).
 Propose defaults from discovery so the operator can answer with one word — and
-if the operator is unavailable, proceed on stated defaults without blocking.
+if the operator is unavailable, proceed on stated defaults for DISCOVERY and
+GENERATION only. Provisioning never proceeds on defaults (Phase 5 gate).
 
 ## Phase 3 — GENERATE (the tool engine, part 2: synthesis)
 
@@ -156,8 +199,10 @@ Per candidate tool, in dependency order:
   paths.
 - Keep lean; 2MB is the EL cap but hundreds of lines is the practical target.
 
-Write the per-agent tree FROM SCRATCH at `<agentDir>/voice/` (lesson 13 if
-occupied): `voice.config.js` (identity + persona + PINNED data paths),
+Generate a new voice scaffold (never copy a prior build's files) under an empty
+`<agentDir>/voice/`; if that directory already exists, coexist per lesson 13 —
+new filenames + a free port inside it, or a `voice/<deployment-name>/` subtree,
+and append to existing docs rather than overwriting. The generated tree: `voice.config.js` (identity + persona + PINNED data paths),
 `src/tools/*` (written per tool, shaped by its backend type and probe captures),
 `mcp-server.js` (written for this agent's tool registry + policy classes),
 `src/policy.js`, `src/session-store.js` (append-only audit JSONL), `tests/`
@@ -181,6 +226,15 @@ occupied): `voice.config.js` (identity + persona + PINNED data paths),
 
 ## Phase 5 — PROVISION
 
+**OPERATOR GATE (hard stop — do not pass on defaults).** Before ANY
+`api.elevenlabs.io` provisioning call, process-manager start, tunnel, or link
+sharing, present the operator with: the discovered tool catalog + policy classes,
+the verb-matrix exclusions, expected EL cost/tier implications (minutes billing,
+concurrency), the tunnel-exposure surface (public HTTPS URL fronting the
+gateway), and every write tool with its server-side invariant. Get explicit
+approval. This is the conscious human checkpoint between "code generated locally"
+and "external paid resources exist + a voice surface is reachable".
+
 1. Tier probe (lesson 4, POST not GET) -> MCP path or server-tools path.
 2. Start the gateway under a process manager (`<agent>-voice-gateway`); tunnel
    via a detached quick tunnel (lesson 8); verify tunnel -> gateway health.
@@ -190,7 +244,11 @@ occupied): `voice.config.js` (identity + persona + PINNED data paths),
    `/tool/<name>`, bearer header, request_body_schema from the generated
    schema), then PATCH agent `tool_ids` (GET current ids first, append — never
    overwrite blind). MCP path = `POST /v1/convai/mcp-servers` with
-   `require_approval_per_tool`.
+   `require_approval_per_tool` — this only CREATES the MCP server config; the
+   agent does not use it until you PATCH the agent's prompt config to include
+   the returned MCP server id (`conversation_config.agent.prompt.mcp_server_ids`
+   — GET current ids first and append, preserving existing entries, exactly as
+   with `tool_ids`).
 5. Live read smokes through the tunnel; write smokes create-then-cleanup.
 
 ## Phase 6 — VERIFY (before any link ships)

--- a/community/skills/voice-agent-factory/resources/GAPS.md
+++ b/community/skills/voice-agent-factory/resources/GAPS.md
@@ -1,0 +1,65 @@
+# Gaps + targeted follow-ups (2026-06-06)
+
+The deep-research verified set left 4 gaps. Two build-critical ones were closed with
+direct fetches of canonical docs (single-source — confidence "documented" not
+"3-vote verified"; re-confirm at first live key-test).
+
+## CLOSED: Server (webhook) tool schema — our PRIMARY mechanism
+
+Fetched /docs/eleven-agents/customization/tools/server-tools:
+
+```json
+{
+  "type": "webhook",
+  "name": "string",
+  "description": "string",
+  "api_schema": {
+    "url": "string",
+    "method": "GET|POST|PUT|PATCH",
+    "path_params_schema": {},
+    "query_params_schema": {},
+    "body_params_schema": {},
+    "headers_schema": {}
+  }
+}
+```
+
+- Param binding: value_type "LLM Prompt" = model extracts values from conversation;
+  path params as {id} in URL, plus query and body params.
+- Body content_type: application/json (default) or x-www-form-urlencoded.
+- Auth options: OAuth2 client-credentials, OAuth2 JWT, Basic, Bearer, Custom Headers
+  with Secret type for sensitive values. -> voice gateway: Bearer/custom-secret
+  header is the fit; secret stored in EL workspace secrets, validated by gateway.
+- Tool response can set dynamic variables for later conversation use (mapping schema
+  not detailed on page).
+- No explicit server-tool timeout documented (MCP's is 30s default/300 max; assume
+  similar order — measure at key-test).
+
+## CLOSED: Pricing + concurrency (pricing question context)
+
+Fetched /pricing/agents (list prices, his dashboard is the truth for his account):
+
+| Plan | Incl. minutes | Extra/min | Concurrent |
+|---|---|---|---|
+| Free | 15 | $0.080 | 4 |
+| Starter | 75 | $0.080 | 6 |
+| Creator | 275 | $0.080 | 10 |
+| Pro | 1,238 | $0.080 | 20 |
+| Scale | 3,738 | $0.080 | 30 |
+| Business | 12,375 | $0.080 | 40 |
+
+- Burst: $0.160/min buys up to 3x concurrency.
+- LLM cost is PASS-THROUGH on top (varies by model — Sonnet 4.5 will bill at actual).
+- Typical usage is 1 concurrent call, conversational minutes — even Starter/Creator
+  tiers cover a lot of a single operator talking to the agent.
+
+## STILL OPEN (close at build time / key-test)
+
+1. Web SDK WebSocket event taxonomy + audio handling details — libraries docs were
+   mid-rename 404s; re-fetch /docs/eleven-agents/libraries/* when building the page.
+2. KB/RAG attachment API exact flow (create-from-url endpoint confirmed to exist;
+   non-enterprise limits ~20MB/300k chars adjacent-source only). A v1 build likely
+   needs no KB — memory-query server tool covers lookups.
+3. Voice settings + turn-taking/interruption config keys; max tools per agent;
+   hard latency figures. Measure empirically at first live session.
+4. Server-tool call timeout (see above — undocumented on page).

--- a/community/skills/voice-agent-factory/resources/GAPS.md
+++ b/community/skills/voice-agent-factory/resources/GAPS.md
@@ -4,7 +4,7 @@ The deep-research verified set left 4 gaps. Two build-critical ones were closed 
 direct fetches of canonical docs (single-source — confidence "documented" not
 "3-vote verified"; re-confirm at first live key-test).
 
-## CLOSED: Server (webhook) tool schema — our PRIMARY mechanism
+## CLOSED: Server (webhook) tool schema — the gateway's PRIMARY mechanism
 
 Fetched /docs/eleven-agents/customization/tools/server-tools:
 
@@ -18,7 +18,7 @@ Fetched /docs/eleven-agents/customization/tools/server-tools:
     "method": "GET|POST|PUT|PATCH",
     "path_params_schema": {},
     "query_params_schema": {},
-    "body_params_schema": {},
+    "request_body_schema": {},
     "headers_schema": {}
   }
 }
@@ -27,6 +27,9 @@ Fetched /docs/eleven-agents/customization/tools/server-tools:
 - Param binding: value_type "LLM Prompt" = model extracts values from conversation;
   path params as {id} in URL, plus query and body params.
 - Body content_type: application/json (default) or x-www-form-urlencoded.
+- Note: current OpenAPI names the POST/PATCH/PUT body schema `request_body_schema`
+  (a `response_body_schema` also exists but is documentation-only — not surfaced
+  to the LLM per current docs).
 - Auth options: OAuth2 client-credentials, OAuth2 JWT, Basic, Bearer, Custom Headers
   with Secret type for sensitive values. -> voice gateway: Bearer/custom-secret
   header is the fit; secret stored in EL workspace secrets, validated by gateway.
@@ -37,7 +40,7 @@ Fetched /docs/eleven-agents/customization/tools/server-tools:
 
 ## CLOSED: Pricing + concurrency (pricing question context)
 
-Fetched /pricing/agents (list prices, his dashboard is the truth for his account):
+Fetched /pricing/agents (list prices; the operator's dashboard is the truth for a given account):
 
 | Plan | Incl. minutes | Extra/min | Concurrent |
 |---|---|---|---|

--- a/community/skills/voice-agent-factory/resources/GAPS.md
+++ b/community/skills/voice-agent-factory/resources/GAPS.md
@@ -19,7 +19,7 @@ Fetched /docs/eleven-agents/customization/tools/server-tools:
     "path_params_schema": {},
     "query_params_schema": {},
     "request_body_schema": {},
-    "headers_schema": {}
+    "request_headers": {}
   }
 }
 ```
@@ -27,6 +27,9 @@ Fetched /docs/eleven-agents/customization/tools/server-tools:
 - Param binding: value_type "LLM Prompt" = model extracts values from conversation;
   path params as {id} in URL, plus query and body params.
 - Body content_type: application/json (default) or x-www-form-urlencoded.
+- Auth may be configured via `auth_connection` / `auth_resolved_params` or via
+  `request_headers` entries depending on the path chosen (see
+  `WebhookToolApiSchemaConfig-Input` in /docs/api-reference/tools/create.md).
 - Note: current OpenAPI names the POST/PATCH/PUT body schema `request_body_schema`
   (a `response_body_schema` also exists but is documentation-only — not surfaced
   to the LLM per current docs).

--- a/community/skills/voice-agent-factory/resources/REPORT.md
+++ b/community/skills/voice-agent-factory/resources/REPORT.md
@@ -1,0 +1,136 @@
+# ElevenLabs Conversational AI — Build-Ready Reference (voice agent builds)
+
+Generated 2026-06-06 via deep-research workflow wf_0b57a6dd-57b (28 sources fetched,
+86 claims extracted, 25 adversarially verified 3-vote, 24 confirmed / 1 refuted,
+synthesized to 11 findings — all unanimous 3-0 against primary ElevenLabs docs).
+Companion files: SOURCES.md (full source list w/ quality ratings), GAPS.md (open
+questions + single-source follow-ups).
+
+NAMING NOTE: ElevenLabs is actively rebranding "Conversational AI" -> "ElevenAgents" /
+"Agents Platform". Doc paths under /agents-platform/ are 404ing and re-resolving to
+/eleven-agents/ or /api-reference/. Expect URL drift; the config surface is the same.
+
+---
+
+## 1. LLM selection (VERIFIED high)
+
+- Multi-provider catalog, set via "Language Model" dropdown in agent create/edit UI
+  (or `conversation_config` in the create API).
+- Anthropic first-party: **Claude Sonnet 4.5, Sonnet 4, Haiku 4.5**, 3.7 Sonnet,
+  3.5 Sonnet, 3 Haiku. Also Gemini 3/2.5/2.0, GPT-5/4.1/4o families, EL-hosted
+  open models (GLM-4.5-Air, Qwen3-30B-A3B, GPT-OSS-120B).
+- EL prompting guide recommends Claude Sonnet 4/4.5 for complex multi-step reasoning
+  and tool orchestration ("highest accuracy and reasoning capability with excellent
+  tool-calling reliability") — supports our Sonnet 4.5 pick for the agent.
+- REFUTED (1-2 vote, excluded): "default LLM is GPT-4o/GLM-4.5-Air, Gemini 2.5 Flash
+  Lite for speed" — do not rely on any claimed default; set the model explicitly.
+
+## 2. System prompt budget (VERIFIED high)
+
+- **Max system prompt size 2MB — SHARED budget** across agent instructions +
+  knowledge-base content + other system-level context.
+- KB has separate larger limits (~20MB/300k chars non-enterprise, adjacent-source
+  only — see GAPS.md) with RAG for larger sets.
+- Build implication: persona prompt + any inlined context must stay well under 2MB;
+  prefer KB/RAG or memory-query tools for bulk context.
+
+## 3. Conversation overrides (VERIFIED high)
+
+- Per-conversation replaceable fields: system prompt, first message, language, LLM,
+  voice ID, text-only mode, TTS stability/speed/similarity-boost.
+- **Disabled by default**; must be enabled PER-FIELD in the agent's Security tab
+  before runtime use. Unsupplied enabled overrides fall back to dashboard defaults.
+- SDK shape (note nesting — system prompt string lives at agent.prompt.prompt):
+
+```js
+Conversation.startSession({
+  overrides: {
+    agent: { prompt: { prompt, llm }, firstMessage, language },
+    tts: { voiceId },
+    conversation: { textOnly: true },
+  },
+})
+```
+
+## 4. Tool mechanisms — four kinds (VERIFIED high)
+
+1. **Client tools** — run in the browser. Config: `type: "client"`, `name`
+   (case-sensitive), `description`, `expects_response` (bool — whether result feeds
+   back into conversation context), `parameters` array of
+   `{id, type, value_type: "llm_prompt", description, required}`.
+   SDK registration: `clientTools: { toolName: async (parameters) => result }`
+   passed to `Conversation.startSession()`.
+2. **Server tools (webhook)** — EL calls our HTTPS endpoint; dynamic params; auth
+   via secrets in headers. Exact JSON schema NOT in verified set — see GAPS.md.
+   This is our PRIMARY mechanism for the voice gateway.
+3. **System tools** — EL-internal (end-call etc.); dedicated docs page.
+4. **MCP tools** (live since changelog 2026-04-27):
+   - Attach: `POST /v1/convai/mcp-servers`, body nests under `config`:
+     required `config.url` (HTTPS only) + `config.name`. Returns
+     id/config/metadata/access_info/dependent_agents.
+   - Approval policy enum: `auto_approve_all` | `require_approval_all` (DEFAULT) |
+     `require_approval_per_tool` (UI: "No Approval" / "Always Ask (Recommended)" /
+     "Fine-Grained Tool Approval").
+   - `response_timeout_secs`: default 30, max 300.
+   - EL disclaims all security responsibility for third-party MCP servers — if we
+     ever expose a cortextOS MCP surface to EL, WE own its auth + hardening.
+
+## 5. Auth + session flow (VERIFIED high)
+
+- API auth: `xi-api-key` header (marked optional in some OpenAPI specs but is the
+  actual mechanism). **Never ships to the browser.**
+- Private agents — two server-minted session paths, both keyed on `agent_id`
+  (accepts `agent_…` or `seng_…` ids):
+  - WebSocket: `GET /v1/convai/conversation/get-signed-url` -> signed URL valid
+    ~15 min (older snake_case `get_signed_url` deprecated).
+  - WebRTC: `GET /v1/convai/conversation/token` -> `TokenResponseModel {token}`,
+    passed to startSession as `conversationToken`.
+- Matches our plan exactly: gateway mints signed URL/token, browser never sees key.
+
+## 6. Web SDK contract (@elevenlabs/client + React) (VERIFIED high)
+
+- Session start: `Conversation.startSession()` with `overrides` (shape above),
+  `clientTools` map of async callbacks, and signed-url/conversationToken for
+  private agents.
+- Client-tool return values become conversation context when `expects_response`
+  is enabled.
+- Full WebSocket event taxonomy not in verified set (libraries docs were among the
+  404-drift pages) — see GAPS.md; re-fetch /docs/eleven-agents/libraries on build.
+
+## 7. Programmatic agent CRUD (VERIFIED high)
+
+- Create: `POST https://api.elevenlabs.io/v1/convai/agents/create` with
+  `xi-api-key` -> `CreateAgentResponseModel` incl. `agent_id`.
+- Update endpoint documented at /docs/api-reference/agents/update (sibling
+  get/delete implied by the /v1/convai/* CRUD namespace; only create + update
+  pages were in the verified/fetched set).
+
+## 8. NOT covered by verified claims (open — GAPS.md)
+
+- Pricing per tier + concurrency limits (section 7 of the brief): zero verified
+  claims. /pricing/agents was fetched but its claims didn't survive to synthesis.
+- Server-tool exact webhook JSON schema + call timeout.
+- KB/RAG attachment API details (create-from-url endpoint exists in source list).
+- Voice settings + turn-taking/interruption config keys; max tools per agent;
+  latency figures.
+
+---
+
+## Capability mapping (plan -> verified config)
+
+| Agent capability | EL mechanism | Status |
+|---|---|---|
+| Persona | system prompt (2MB shared budget) via agents/create | VERIFIED |
+| Brain | Claude Sonnet 4.5 first-party, Language Model dropdown / API | VERIFIED |
+| Tap-to-talk browser | @elevenlabs/client startSession + signed URL | VERIFIED |
+| Key isolation | server-minted get-signed-url / token, xi-api-key server-side | VERIFIED |
+| Bus actions (status/memory/task/message) | server tools -> our gateway | mechanism verified, exact schema GAP |
+| Mid-call UI actions (if any) | client tools map | VERIFIED |
+| Bulk context | KB + RAG (separate limits) | partial — attachment API GAP |
+| Per-session tuning | overrides (enable per-field in Security tab first) | VERIFIED |
+| Future MCP path | POST /v1/convai/mcp-servers, require_approval_all default | VERIFIED |
+
+Build-blocking gaps: server-tool schema (close by fetching
+/docs/eleven-agents/customization/tools/server-tools at build time or first key-test)
+and pricing/concurrency (account-specific - confirm on the operator's dashboard, which
+beats public pricing pages anyway).

--- a/community/skills/voice-agent-factory/resources/REPORT.md
+++ b/community/skills/voice-agent-factory/resources/REPORT.md
@@ -1,8 +1,8 @@
 # ElevenLabs Conversational AI — Build-Ready Reference (voice agent builds)
 
-Generated 2026-06-06 via deep-research workflow wf_0b57a6dd-57b (28 sources fetched,
-86 claims extracted, 25 adversarially verified 3-vote, 24 confirmed / 1 refuted,
-synthesized to 11 findings — all unanimous 3-0 against primary ElevenLabs docs).
+Research snapshot generated 2026-06-06 (28 sources fetched, 86 claims extracted,
+25 adversarially verified 3-vote, 24 confirmed / 1 refuted, synthesized to 11
+findings — all unanimous against primary ElevenLabs docs).
 Companion files: SOURCES.md (full source list w/ quality ratings), GAPS.md (open
 questions + single-source follow-ups).
 
@@ -21,7 +21,7 @@ NAMING NOTE: ElevenLabs is actively rebranding "Conversational AI" -> "ElevenAge
   open models (GLM-4.5-Air, Qwen3-30B-A3B, GPT-OSS-120B).
 - EL prompting guide recommends Claude Sonnet 4/4.5 for complex multi-step reasoning
   and tool orchestration ("highest accuracy and reasoning capability with excellent
-  tool-calling reliability") — supports our Sonnet 4.5 pick for the agent.
+  tool-calling reliability") — supports the Sonnet 4.5 pick for the agent.
 - REFUTED (1-2 vote, excluded): "default LLM is GPT-4o/GLM-4.5-Air, Gemini 2.5 Flash
   Lite for speed" — do not rely on any claimed default; set the model explicitly.
 
@@ -60,9 +60,9 @@ Conversation.startSession({
    `{id, type, value_type: "llm_prompt", description, required}`.
    SDK registration: `clientTools: { toolName: async (parameters) => result }`
    passed to `Conversation.startSession()`.
-2. **Server tools (webhook)** — EL calls our HTTPS endpoint; dynamic params; auth
-   via secrets in headers. Exact JSON schema NOT in verified set — see GAPS.md.
-   This is our PRIMARY mechanism for the voice gateway.
+2. **Server tools (webhook)** — EL calls the gateway's HTTPS endpoint; dynamic
+   params; auth via secrets in headers. Exact JSON schema NOT in verified set —
+   see GAPS.md. This is the PRIMARY mechanism for the voice gateway.
 3. **System tools** — EL-internal (end-call etc.); dedicated docs page.
 4. **MCP tools** (live since changelog 2026-04-27):
    - Attach: `POST /v1/convai/mcp-servers`, body nests under `config`:
@@ -72,8 +72,8 @@ Conversation.startSession({
      `require_approval_per_tool` (UI: "No Approval" / "Always Ask (Recommended)" /
      "Fine-Grained Tool Approval").
    - `response_timeout_secs`: default 30, max 300.
-   - EL disclaims all security responsibility for third-party MCP servers — if we
-     ever expose a cortextOS MCP surface to EL, WE own its auth + hardening.
+   - EL disclaims all security responsibility for third-party MCP servers — if a
+     cortextOS MCP surface is exposed to EL, the implementer owns its auth + hardening.
 
 ## 5. Auth + session flow (VERIFIED high)
 
@@ -85,7 +85,7 @@ Conversation.startSession({
     ~15 min (older snake_case `get_signed_url` deprecated).
   - WebRTC: `GET /v1/convai/conversation/token` -> `TokenResponseModel {token}`,
     passed to startSession as `conversationToken`.
-- Matches our plan exactly: gateway mints signed URL/token, browser never sees key.
+- Matches the gateway design exactly: gateway mints signed URL/token, browser never sees key.
 
 ## 6. Web SDK contract (@elevenlabs/client + React) (VERIFIED high)
 
@@ -105,14 +105,15 @@ Conversation.startSession({
   get/delete implied by the /v1/convai/* CRUD namespace; only create + update
   pages were in the verified/fetched set).
 
-## 8. NOT covered by verified claims (open — GAPS.md)
+## 8. NOT covered by verified claims — status
 
-- Pricing per tier + concurrency limits (section 7 of the brief): zero verified
-  claims. /pricing/agents was fetched but its claims didn't survive to synthesis.
-- Server-tool exact webhook JSON schema + call timeout.
-- KB/RAG attachment API details (create-from-url endpoint exists in source list).
+- Pricing per tier + concurrency limits: CLOSED by GAPS.md single-source follow-up
+  (re-confirm at first live key-test; account dashboard is the truth).
+- Server-tool exact webhook JSON schema: CLOSED by GAPS.md (request_body_schema);
+  call timeout still unmeasured — measure at key-test.
+- KB/RAG attachment API details (create-from-url endpoint exists in source list) — open.
 - Voice settings + turn-taking/interruption config keys; max tools per agent;
-  latency figures.
+  latency figures — open.
 
 ---
 
@@ -124,7 +125,7 @@ Conversation.startSession({
 | Brain | Claude Sonnet 4.5 first-party, Language Model dropdown / API | VERIFIED |
 | Tap-to-talk browser | @elevenlabs/client startSession + signed URL | VERIFIED |
 | Key isolation | server-minted get-signed-url / token, xi-api-key server-side | VERIFIED |
-| Bus actions (status/memory/task/message) | server tools -> our gateway | mechanism verified, exact schema GAP |
+| Bus actions (status/memory/task/message) | server tools -> the gateway | mechanism verified, exact schema GAP |
 | Mid-call UI actions (if any) | client tools map | VERIFIED |
 | Bulk context | KB + RAG (separate limits) | partial — attachment API GAP |
 | Per-session tuning | overrides (enable per-field in Security tab first) | VERIFIED |

--- a/community/skills/voice-agent-factory/resources/REPORT.md
+++ b/community/skills/voice-agent-factory/resources/REPORT.md
@@ -131,7 +131,8 @@ Conversation.startSession({
 | Per-session tuning | overrides (enable per-field in Security tab first) | VERIFIED |
 | Future MCP path | POST /v1/convai/mcp-servers, require_approval_all default | VERIFIED |
 
-Build-blocking gaps: server-tool schema (close by fetching
-/docs/eleven-agents/customization/tools/server-tools at build time or first key-test)
-and pricing/concurrency (account-specific - confirm on the operator's dashboard, which
-beats public pricing pages anyway).
+Remaining build-time / key-test checks: WebSocket event taxonomy + audio handling,
+KB/RAG attachment flow (if used), voice settings / turn-taking / max-tools / latency
+figures, and server-tool call-timeout measurement. Server-tool schema and
+pricing/concurrency are CLOSED in GAPS.md — re-confirm at key-test (docs drift;
+the account dashboard beats public pricing pages).

--- a/community/skills/voice-agent-factory/resources/SOURCES.md
+++ b/community/skills/voice-agent-factory/resources/SOURCES.md
@@ -1,6 +1,6 @@
 # Sources — ElevenLabs Conversational AI research (2026-06-06)
 
-Workflow wf_0b57a6dd-57b: 28 fetched, quality-rated by the harness. "unreliable" below
+Research snapshot 2026-06-06: 28 sources fetched, quality-rated. "unreliable" below
 mostly = 404-drift from the Conversational AI -> ElevenAgents docs rename, not bad
 content; canonical replacements listed where resolved.
 

--- a/community/skills/voice-agent-factory/resources/SOURCES.md
+++ b/community/skills/voice-agent-factory/resources/SOURCES.md
@@ -24,7 +24,7 @@ content; canonical replacements listed where resolved.
 
 ## 404-drift / unreliable at fetch time (re-resolve under /docs/eleven-agents/)
 
-- /docs/agents-platform/customization/tools/server-tools — SERVER TOOL SCHEMA (build-time re-fetch REQUIRED)
+- /docs/agents-platform/customization/tools/server-tools — server-tool schema — resolved in GAPS; re-confirm at key-test because docs drift
 - /docs/agents-platform/customization/authentication — auth guide (content corroborated via api-reference)
 - /docs/conversational-ai/libraries/web-sockets, /docs/agents-platform/libraries/java-script — SDK/WebSocket events (build-time re-fetch)
 - /docs/conversational-ai/guides/llm-cascading, /docs/changelog, /docs/agents-platform/customization/tools

--- a/community/skills/voice-agent-factory/resources/SOURCES.md
+++ b/community/skills/voice-agent-factory/resources/SOURCES.md
@@ -1,0 +1,41 @@
+# Sources — ElevenLabs Conversational AI research (2026-06-06)
+
+Workflow wf_0b57a6dd-57b: 28 fetched, quality-rated by the harness. "unreliable" below
+mostly = 404-drift from the Conversational AI -> ElevenAgents docs rename, not bad
+content; canonical replacements listed where resolved.
+
+## Primary (claims survived 3-vote verification)
+
+- https://elevenlabs.io/docs/eleven-agents/customization/llm — LLM catalog, 2MB prompt budget
+- https://elevenlabs.io/docs/eleven-agents/customization/personalization/overrides — overrides + SDK shape
+- https://elevenlabs.io/blog/claude-sonnet-4-is-now-available-in-conversational-ai — Claude first-party
+- https://elevenlabs.io/docs/eleven-agents/best-practices/prompting-guide — model recommendations, tool surface
+- https://elevenlabs.io/docs/agents-platform/customization/tools/mcp/security — MCP security + approval UI labels
+- https://elevenlabs.io/docs/agents-platform/api-reference/mcp/create — MCP server attach (canonical: /docs/api-reference/mcp/create)
+- https://elevenlabs.io/docs/eleven-agents/customization/tools/client-tools — client tool schema + SDK map
+- https://elevenlabs.io/docs/api-reference/conversations/get-signed-url — signed URL endpoint
+- https://elevenlabs.io/docs/eleven-agents/api-reference/conversations/get-webrtc-token — WebRTC token
+- https://elevenlabs.io/docs/api-reference/agents/create — agents create CRUD
+- https://elevenlabs.io/docs/api-reference/agents/update — agents update CRUD
+- https://elevenlabs.io/docs/eleven-agents/customization/knowledge-base/rag — RAG (claims fetched, partial survival)
+- https://elevenlabs.io/docs/api-reference/knowledge-base/create-from-url — KB ingestion endpoint
+- https://elevenlabs.io/pricing/agents — pricing page (claims did NOT survive to synthesis — re-check live)
+- https://elevenlabs.io/blog/how-do-you-optimize-latency-for-conversational-ai — latency practices
+
+## 404-drift / unreliable at fetch time (re-resolve under /docs/eleven-agents/)
+
+- /docs/agents-platform/customization/tools/server-tools — SERVER TOOL SCHEMA (build-time re-fetch REQUIRED)
+- /docs/agents-platform/customization/authentication — auth guide (content corroborated via api-reference)
+- /docs/conversational-ai/libraries/web-sockets, /docs/agents-platform/libraries/java-script — SDK/WebSocket events (build-time re-fetch)
+- /docs/conversational-ai/guides/llm-cascading, /docs/changelog, /docs/agents-platform/customization/tools
+- help.elevenlabs.io concurrency articles (both name-variants)
+
+## Third-party blogs (corroboration only, not load-bearing)
+
+- simbavoice.ai concurrency comparison, deepgram.com production-limits post,
+  aividpipeline.com agents guide 2026
+
+## Refuted (excluded from report)
+
+- "Default LLM = GPT-4o/GLM-4.5-Air; Gemini 2.5 Flash Lite for speed" — 1-2 vote.
+  Always set the model explicitly.


### PR DESCRIPTION
## Summary

Adds **voice-agent-factory** to the community skills catalog: a six-phase pipeline that turns any cortextOS agent into a live ElevenLabs voice agent.

- DISCOVER: mine the target agent's skills, CLIs, MCPs, and 14 days of transcripts into a ranked tool-candidate inventory
- ASK: 3-5 operator questions with discovery-derived defaults
- GENERATE: every file written dynamically per target (no pre-built scripts) - policy-gated zero-dependency gateway, per-tool server-side invariants, verb-set completeness matrix with recorded exclusions, distilled voice persona with truthful-limits section
- TEST: auto-generated harness on probe-shaped fixtures (protocol, policy matrix, anchor chains, HTTP)
- PROVISION: tier-detect (POST probe, not GET) with automatic server-tools webhook fallback when MCP is unavailable
- VERIFY: real text-only WebSocket conversations asserted against the gateway audit log - explicitly NOT simulate-conversation, which mocks tools and fabricates results

Encodes 14 lessons hit live across two reference builds (an assistant agent and a content agent, 17 and 18 tools). Bundled resources: verified EL API reference, server-tool webhook schema + pricing notes, primary sources. All content sanitized - no internal paths, names, ids, or endpoints.

## Test Plan

- [x] Skill validated end-to-end by a real factory run: 18-tool gateway generated for a content agent, 30/30 generated tests pass, 11 live read smokes, 3 anchor workflows proven over real EL WebSocket sessions with audit-log artifacts and exact-data spoken answers
- [x] Sanitization sweep: zero hits for internal paths/names/ids/tunnels/emails in shipped files
- [x] catalog.json entry added (review_status: pending), JSON valid
- [ ] Community review

🤖 Generated with [Claude Code](https://claude.com/claude-code)