### PR TITLE
fix(bus): manage-cycle operates on the target agent's config, not the caller's

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -20,7 +20,7 @@ import { nextFireFromCron } from '../daemon/cron-scheduler.js';
 import { queryKnowledgeBase, ingestKnowledgeBase, ensureKBDirs } from '../bus/knowledge-base.js';
 import { checkUsageApi, refreshOAuthToken, rotateOAuth, loadAccounts, ALERT_5H, ALERT_7D } from '../bus/oauth.js';
 import { resolvePaths } from '../utils/paths.js';
-import { resolveEnv } from '../utils/env.js';
+import { resolveEnv, resolveTargetAgentDir } from '../utils/env.js';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { logOutboundMessage, cacheLastSent } from '../telegram/logging.js';
@@ -813,7 +813,24 @@ busCommand
   .option('--cycle <name>', 'Cycle name')
   .action((action: string, agent: string, opts: { metric?: string; metricType?: string; surface?: string; direction?: string; window?: string; measurement?: string; loopInterval?: string; enabled?: string; cycle?: string }) => {
     const env = resolveEnv();
-    const agentDir = env.agentDir || process.cwd();
+    // Cycles live in the TARGET agent's experiments/config.json — the file
+    // the autoresearch skill reads in that agent's session. Writing to the
+    // caller's dir instead silently created a second registry the target
+    // never reads.
+    let agentDir: string | null = null;
+    try {
+      agentDir = resolveTargetAgentDir(env, agent);
+    } catch (err) {
+      console.error((err as Error).message);
+      process.exit(1);
+    }
+    if (!agentDir && agent === env.agentName) {
+      agentDir = env.agentDir || process.cwd();
+    }
+    if (!agentDir) {
+      console.error(`Cannot resolve agent directory for '${agent}'. Cycles are stored in the target agent's experiments/config.json — check the agent name.`);
+      process.exit(1);
+    }
     if (opts.direction && opts.direction !== 'higher' && opts.direction !== 'lower') {
       console.error(`Invalid --direction '${opts.direction}'. Must be 'higher' or 'lower'`);
       process.exit(1);

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -136,6 +136,43 @@ export function resolveEnv(overrides?: Partial<CtxEnv>): CtxEnv {
 }
 
 /**
+ * Resolve another agent's directory from the caller's environment.
+ *
+ * Commands that take a target agent argument (e.g. manage-cycle) must
+ * operate on the TARGET agent's files, not the caller's — writing to the
+ * caller's dir creates a second, diverging registry the target never reads
+ * (manage-cycle create was a silent no-op for autoresearch). Targets
+ * are resolved as a sibling of the caller's agentDir first (matches every
+ * deployment layout), then via the same projectRoot conventions resolveEnv
+ * uses. Returns null when no candidate directory exists on disk, so callers
+ * can fail loudly instead of writing into a directory no agent reads.
+ * Throws on invalid agent names (path-traversal guard).
+ */
+export function resolveTargetAgentDir(env: CtxEnv, targetAgent: string): string | null {
+  validateAgentName(targetAgent);
+  if (targetAgent === env.agentName && env.agentDir) {
+    return env.agentDir;
+  }
+  const candidates: string[] = [];
+  if (env.agentDir) {
+    candidates.push(join(env.agentDir, '..', targetAgent));
+  }
+  if (env.projectRoot && env.org) {
+    candidates.push(join(env.projectRoot, 'orgs', env.org, 'agents', targetAgent));
+  }
+  if (env.projectRoot) {
+    candidates.push(join(env.projectRoot, 'agents', targetAgent));
+  }
+  for (const candidate of candidates) {
+    const dir = resolvePath(candidate);
+    if (existsSync(dir)) {
+      return dir;
+    }
+  }
+  return null;
+}
+
+/**
  * Write .cortextos-env file for backward compatibility with bash bus scripts.
  * Per D6: maintain this pattern.
  */

--- a/tests/unit/utils/resolve-target-agent-dir.test.ts
+++ b/tests/unit/utils/resolve-target-agent-dir.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { resolveTargetAgentDir } from '../../../src/utils/env.js';
+import type { CtxEnv } from '../../../src/types/index.js';
+
+describe('resolveTargetAgentDir', () => {
+  const testRoot = join(tmpdir(), `cortextos-target-dir-${Date.now()}`);
+  const agentsDir = join(testRoot, 'orgs', 'testorg', 'agents');
+
+  const baseEnv = (overrides?: Partial<CtxEnv>): CtxEnv => ({
+    instanceId: 'default',
+    ctxRoot: join(testRoot, '.cortextos'),
+    frameworkRoot: testRoot,
+    agentName: 'caller',
+    agentDir: join(agentsDir, 'caller'),
+    org: 'testorg',
+    projectRoot: testRoot,
+    ...overrides,
+  });
+
+  beforeEach(() => {
+    mkdirSync(join(agentsDir, 'caller'), { recursive: true });
+    mkdirSync(join(agentsDir, 'target'), { recursive: true });
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(testRoot, { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  });
+
+  it('returns the caller agentDir when target is the caller', () => {
+    expect(resolveTargetAgentDir(baseEnv(), 'caller')).toBe(join(agentsDir, 'caller'));
+  });
+
+  it('resolves a sibling agent of the caller agentDir', () => {
+    expect(resolveTargetAgentDir(baseEnv(), 'target')).toBe(join(agentsDir, 'target'));
+  });
+
+  it('falls back to projectRoot org convention when caller agentDir is empty', () => {
+    const env = baseEnv({ agentDir: '' });
+    expect(resolveTargetAgentDir(env, 'target')).toBe(join(agentsDir, 'target'));
+  });
+
+  it('falls back to flat agents layout without org', () => {
+    const flatDir = join(testRoot, 'agents', 'flatbot');
+    mkdirSync(flatDir, { recursive: true });
+    const env = baseEnv({ agentDir: '', org: '' });
+    expect(resolveTargetAgentDir(env, 'flatbot')).toBe(flatDir);
+  });
+
+  it('returns null when the target directory does not exist', () => {
+    expect(resolveTargetAgentDir(baseEnv(), 'ghost')).toBeNull();
+  });
+
+  it('returns null when env has no usable roots', () => {
+    const env = baseEnv({ agentDir: '', projectRoot: '', org: '' });
+    expect(resolveTargetAgentDir(env, 'target')).toBeNull();
+  });
+
+  it('throws on path-traversal agent names', () => {
+    expect(() => resolveTargetAgentDir(baseEnv(), '../evil')).toThrow('Invalid agent name');
+    expect(() => resolveTargetAgentDir(baseEnv(), 'a/b')).toThrow('Invalid agent name');
+    expect(() => resolveTargetAgentDir(baseEnv(), '')).toThrow('Invalid agent name');
+  });
+});


### PR DESCRIPTION
## Summary

`manage-cycle <action> <agent>` resolved its working directory from the **caller's** environment (`env.agentDir`) and ignored the target agent argument entirely. A cycle "created for skoolio" by an orchestrating agent landed in the caller's own `experiments/config.json` — a second registry the target agent's autoresearch loop never reads. The result was a silent no-op: "created" cycles with zero entries in the file the skill actually loops on, no experiment, no error. (Found TW51; root of a multi-cycle autoresearch execution gap. In our deployment the orchestrating agent's config had accumulated 23 cycles targeting 7 other agents, none of which those agents could see.)

- New `resolveTargetAgentDir(env, target)` in `src/utils/env.ts`: resolves the target as a sibling of the caller's `agentDir` first (matches every deployment layout), then via the same `projectRoot` conventions `resolveEnv` uses; validates the agent name as a path-traversal guard; returns `null` when no candidate directory exists
- `manage-cycle` handler resolves the target dir and fails loudly (`exit 1` with a pointer to where cycles live) instead of writing a registry nobody reads; self-targeting keeps the previous `process.cwd()` fallback for bare invocations
- All four actions (create/modify/remove/list) now consistently operate on the target agent's config

Not in scope (flagging): reconciling already-diverged registries is an operational migration (the interim workaround hand-writes the per-agent config), and `manage-cycle create` does not dedupe same-name cycles — both follow-ups if wanted.

## Test Plan

- 7 new unit tests in `tests/unit/utils/resolve-target-agent-dir.test.ts`: caller self-resolution, sibling resolution, projectRoot org fallback, flat-layout fallback, nonexistent target returns null, rootless env returns null, path-traversal names throw
- `npx vitest run tests/unit/utils/resolve-target-agent-dir.test.ts tests/sprint3-experiments.test.ts`: 34/34 pass
- Full suite vs clean upstream/main baseline: identical 39 pre-existing environment failures, zero regressions, +7 new passing
- `npm run build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)