### PR TITLE
fix(daemon): accept bypass-permissions gate instead of exiting (agent crash-loop)

### DIFF
--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -167,25 +167,36 @@ export class AgentPTY {
       }
     });
 
-    // Claude Code shows a "trust this folder?" prompt on first run in a new directory.
-    // Auto-accept by sending Enter after the prompt appears.
-    // The prompt takes ~3-5s to render; we send Enter at 5s and 8s for reliability.
-    setTimeout(() => {
-      if (this.pty) {
-        const recent = this.outputBuffer.getRecent();
-        if (recent.includes('trust') || recent.includes('Yes')) {
-          this.pty.write('\r');
-        }
+    // Claude Code can show two first-run gates before the agent is usable:
+    //  1. The "Bypass Permissions mode" warning (shown whenever the agent is
+    //     launched with --dangerously-skip-permissions, even after the global
+    //     bypassPermissionsModeAccepted flag is set). Its default cursor sits
+    //     on "1. No, exit" — so a bare Enter EXITS the process (code 1) and the
+    //     agent crash-loops. We must arrow DOWN to "2. Yes, I accept" first.
+    //  2. The "trust this folder?" prompt on first run in a new directory,
+    //     whose default IS the accept option — a bare Enter accepts it.
+    // Both render a few seconds after spawn. Retry on a short schedule and
+    // handle each screen at most once, so repeated key presses can't toggle
+    // the selection back off the accept option.
+    let bypassHandled = false;
+    let trustHandled = false;
+    const handleFirstRunGates = () => {
+      if (!this.pty) return;
+      const recent = this.outputBuffer.getRecent();
+      if (!bypassHandled && recent.includes('Bypass Permissions')) {
+        this.pty.write('\x1b[B'); // arrow down: "1. No, exit" -> "2. Yes, I accept"
+        this.pty.write('\r');     // confirm acceptance
+        bypassHandled = true;
+        return; // give the next tick a chance to clear any trust prompt
       }
-    }, 5000);
-    setTimeout(() => {
-      if (this.pty) {
-        const recent = this.outputBuffer.getRecent();
-        if (recent.includes('trust') || recent.includes('Yes')) {
-          this.pty.write('\r');
-        }
+      if (!trustHandled && recent.includes('trust')) {
+        this.pty.write('\r'); // trust dialog default is the accept option
+        trustHandled = true;
       }
-    }, 8000);
+    };
+    for (const delay of [4000, 6000, 8000, 11000, 14000]) {
+      setTimeout(handleFirstRunGates, delay);
+    }
   }
 
   /**


### PR DESCRIPTION
## Problem

Newly enabled agents never came online — they crash-looped from boot. The daemon log showed each spawn hit `Bootstrap complete` (or failed before it) and then `Exited with code 1`, repeating with escalating backoff until the daily crash limit.

Root cause: when an agent is launched with `--dangerously-skip-permissions`, Claude Code shows a **"Bypass Permissions mode"** warning whose default cursor sits on **`1. No, exit`**. The first-run auto-handler in `agent-pty.ts` pressed a bare **Enter**, which selected *No, exit* → the agent process exited with code 1 every time.

Bare Enter only works for the *trust-this-folder* prompt, whose default IS the accept option. The two gates need different handling, and setting the global `bypassPermissionsModeAccepted` flag does **not** suppress the bypass warning in current Claude Code (2.1.x).

## Fix

In `AgentPTY` first-run handling (`src/pty/agent-pty.ts`):

- On the **bypass screen**, navigate **DOWN** to `2. Yes, I accept` before confirming (`\x1b[B` then `\r`).
- Keep bare **Enter** for the **trust** prompt (its default is accept).
- Handle each gate **at most once** so repeated key presses can't toggle the selection back off the accept option.
- Retry on a short schedule (4/6/8/11/14s) to cover variable render timing.

## Before / After

- **Before:** agent spawns → bypass screen → Enter selects "No, exit" → `Exited with code 1` → crash-loop, agent never reachable on Telegram.
- **After:** agent spawns → bypass screen → ↓ + Enter selects "Yes, I accept" → `Bootstrap complete. Beginning poll loop.` → stable (verified ~1h25m+ continuous uptime).

## Testing

Verified manually during a fresh `/onboarding` run: with the patched `dist/`, the orchestrator agent cleared the bypass gate on first boot and stayed up. No code-1 exits after the fix.