### PR TITLE
fix(daemon): evaluate cron expressions in UTC, not host-local time

### DIFF
--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -36,6 +36,14 @@ import { appendExecutionLog } from './cron-execution-log.js';
 // Cron expression parser — no external deps.
 // Supports: *, */N, comma-lists, and ranges for each of the 5 standard fields.
 // Fields: minute hour dom month dow (day-of-week: 0=Sunday … 6=Saturday).
+//
+// TIMEZONE: cron expressions are evaluated in UTC, NOT the daemon's local
+// timezone. The org timezone is UTC (see SYSTEM.md) and all cron schedules are
+// authored as UTC wall-clock times. Matching against UTC fields makes fire
+// times deterministic regardless of the host machine's system timezone — a
+// daemon running in America/New_York (UTC-4) must still fire "0 13 * * *" at
+// 13:00 UTC, not 17:00 UTC. Interpreting in local time caused fixed-hour crons
+// to fire exactly one UTC-offset late (4h on EDT).
 // ---------------------------------------------------------------------------
 
 /**
@@ -74,7 +82,10 @@ function expandField(field: string, min: number, max: number): number[] {
  * expression, starting from `fromMs` (exclusive — the next fire must be
  * strictly after fromMs, rounded forward to the next whole minute).
  *
- * @param expr   - 5-field cron expression ("min hour dom month dow").
+ * Cron fields are matched against UTC wall-clock components (see the TIMEZONE
+ * note above), so the returned instant is independent of the host timezone.
+ *
+ * @param expr   - 5-field cron expression ("min hour dom month dow"), UTC.
  * @param fromMs - Starting epoch time in milliseconds.
  * @returns      Epoch ms of the next matching minute, or NaN if unparseable.
  */
@@ -104,11 +115,11 @@ export function nextFireFromCron(expr: string, fromMs: number): number {
 
   for (let i = 0; i < MAX_MINUTES; i++) {
     const d = new Date(candidate);
-    const m  = d.getMinutes();
-    const h  = d.getHours();
-    const dy = d.getDate();
-    const mo = d.getMonth() + 1; // 1-12
-    const dw = d.getDay();       // 0-6
+    const m  = d.getUTCMinutes();
+    const h  = d.getUTCHours();
+    const dy = d.getUTCDate();
+    const mo = d.getUTCMonth() + 1; // 1-12
+    const dw = d.getUTCDay();       // 0-6
 
     if (
       months.includes(mo) &&

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -55,22 +55,25 @@ const TICK = CronScheduler.TICK_INTERVAL_MS; // 30_000 ms
 // ---------------------------------------------------------------------------
 // nextFireFromCron — unit tests for the cron expression parser
 //
-// These tests are timezone-agnostic: rather than hardcoding UTC epoch ms
-// values (which would break on machines not set to UTC), we verify:
+// Cron expressions are evaluated in UTC (see the TIMEZONE note in
+// cron-scheduler.ts). These tests verify against UTC wall-clock fields so they
+// pass on any host timezone — the whole point of the fix is that fire times no
+// longer depend on the machine's system zone. We assert:
 //   (a) the result is a valid number,
-//   (b) the local-time fields (hour, minute, day-of-week) of the result
-//       match what the cron expression requests.
+//   (b) the UTC fields (hour, minute, day-of-week) of the result match what the
+//       cron expression requests,
+//   (c) for a known absolute instant, the result is the exact expected epoch ms.
 // ---------------------------------------------------------------------------
 
-/** Pull the local-time components out of an epoch-ms value. */
-function localOf(ms: number) {
+/** Pull the UTC components out of an epoch-ms value. */
+function utcOf(ms: number) {
   const d = new Date(ms);
   return {
-    minutes:    d.getMinutes(),
-    hours:      d.getHours(),
-    date:       d.getDate(),
-    month:      d.getMonth() + 1,
-    dayOfWeek:  d.getDay(),
+    minutes:    d.getUTCMinutes(),
+    hours:      d.getUTCHours(),
+    date:       d.getUTCDate(),
+    month:      d.getUTCMonth() + 1,
+    dayOfWeek:  d.getUTCDay(),
   };
 }
 
@@ -84,84 +87,101 @@ describe('nextFireFromCron', () => {
     expect(next).toBeGreaterThan(fromMs);
     expect(next).toBeLessThanOrEqual(fromMs + 5 * 60_000 + 60_000);
     // The minute must be a multiple of 5
-    expect(localOf(next).minutes % 5).toBe(0);
+    expect(utcOf(next).minutes % 5).toBe(0);
     // Seconds must be zero (whole minute)
     expect(next % 60_000).toBe(0);
   });
 
-  it('computes next fire at local hour 13 for "0 13 * * *" when before 13:00 today', () => {
-    // Construct a "from" time that is in local hour 12 today.
+  it('computes next fire at UTC hour 13 for "0 13 * * *" when before 13:00 UTC today', () => {
+    // Construct a "from" time that is in UTC hour 12 today.
     const ref = new Date();
-    ref.setHours(12, 0, 0, 0);
+    ref.setUTCHours(12, 0, 0, 0);
     const fromMs = ref.getTime();
 
     const next = nextFireFromCron('0 13 * * *', fromMs);
     expect(next).not.toBeNaN();
 
-    const loc = localOf(next);
-    expect(loc.hours).toBe(13);
-    expect(loc.minutes).toBe(0);
-    // Must be the same calendar date (still today)
-    expect(loc.date).toBe(new Date(fromMs).getDate());
+    const utc = utcOf(next);
+    expect(utc.hours).toBe(13);
+    expect(utc.minutes).toBe(0);
+    // Must be the same calendar date (still today, in UTC)
+    expect(utc.date).toBe(new Date(fromMs).getUTCDate());
   });
 
-  it('wraps to next day when local hour 13 has already passed today', () => {
-    // Construct a "from" time in local hour 14 today.
+  it('wraps to next day when UTC hour 13 has already passed today', () => {
+    // Construct a "from" time in UTC hour 14 today.
     const ref = new Date();
-    ref.setHours(14, 0, 0, 0);
+    ref.setUTCHours(14, 0, 0, 0);
     const fromMs = ref.getTime();
 
     const next = nextFireFromCron('0 13 * * *', fromMs);
     expect(next).not.toBeNaN();
 
-    const loc = localOf(next);
-    expect(loc.hours).toBe(13);
-    expect(loc.minutes).toBe(0);
+    const utc = utcOf(next);
+    expect(utc.hours).toBe(13);
+    expect(utc.minutes).toBe(0);
     // Must be tomorrow (date + 1), accounting for month wrap
     const expectedDate = new Date(fromMs);
-    expectedDate.setDate(expectedDate.getDate() + 1);
-    expect(loc.date).toBe(expectedDate.getDate());
+    expectedDate.setUTCDate(expectedDate.getUTCDate() + 1);
+    expect(utc.date).toBe(expectedDate.getUTCDate());
   });
 
-  it('handles comma-list: "0 0,6,12,18 * * *" — picks the next matching hour', () => {
-    // Set from = local 05:00 so next matching hour is 6.
+  // Regression: fixed-hour crons must fire at the requested UTC instant
+  // regardless of the host timezone. Before the fix, fields were matched in
+  // local time, so a daemon in America/New_York (UTC-4 / EDT) fired
+  // "0 13 * * *" at 17:00 UTC — exactly 4h late. Using an absolute epoch
+  // reference makes this assertion exact and machine-timezone-independent.
+  it('fires "0 13 * * *" at exactly 13:00 UTC (not host-local 13:00)', () => {
+    const fromMs = Date.UTC(2026, 5, 24, 12, 0, 0); // 2026-06-24 12:00:00 UTC
+    const next = nextFireFromCron('0 13 * * *', fromMs);
+    expect(next).toBe(Date.UTC(2026, 5, 24, 13, 0, 0));
+  });
+
+  it('fires "0 1 * * *" (evening brief) at exactly 01:00 UTC next day', () => {
+    const fromMs = Date.UTC(2026, 5, 24, 2, 0, 0); // just after 01:00 UTC
+    const next = nextFireFromCron('0 1 * * *', fromMs);
+    expect(next).toBe(Date.UTC(2026, 5, 25, 1, 0, 0));
+  });
+
+  it('handles comma-list: "0 0,6,12,18 * * *" — picks the next matching UTC hour', () => {
+    // Set from = UTC 05:00 so next matching hour is 6.
     const ref = new Date();
-    ref.setHours(5, 0, 0, 0);
+    ref.setUTCHours(5, 0, 0, 0);
     const fromMs = ref.getTime();
 
     const next = nextFireFromCron('0 0,6,12,18 * * *', fromMs);
     expect(next).not.toBeNaN();
 
-    const loc = localOf(next);
-    expect([0, 6, 12, 18]).toContain(loc.hours);
-    expect(loc.minutes).toBe(0);
+    const utc = utcOf(next);
+    expect([0, 6, 12, 18]).toContain(utc.hours);
+    expect(utc.minutes).toBe(0);
     expect(next).toBeGreaterThan(fromMs);
   });
 
-  it('handles ranges: "0 8-10 * * *" — fires within [8,9,10] local hours', () => {
+  it('handles ranges: "0 8-10 * * *" — fires within [8,9,10] UTC hours', () => {
     const ref = new Date();
-    ref.setHours(7, 59, 0, 0);
+    ref.setUTCHours(7, 59, 0, 0);
     const fromMs = ref.getTime();
 
     const next = nextFireFromCron('0 8-10 * * *', fromMs);
     expect(next).not.toBeNaN();
 
-    const loc = localOf(next);
-    expect(loc.hours).toBeGreaterThanOrEqual(8);
-    expect(loc.hours).toBeLessThanOrEqual(10);
-    expect(loc.minutes).toBe(0);
+    const utc = utcOf(next);
+    expect(utc.hours).toBeGreaterThanOrEqual(8);
+    expect(utc.hours).toBeLessThanOrEqual(10);
+    expect(utc.minutes).toBe(0);
   });
 
-  it('handles day-of-week restriction: "0 16 * * 1" — fires on a Monday', () => {
+  it('handles day-of-week restriction: "0 16 * * 1" — fires on a Monday (UTC)', () => {
     const fromMs = Date.now();
     const next = nextFireFromCron('0 16 * * 1', fromMs);
     expect(next).not.toBeNaN();
     expect(next).toBeGreaterThan(fromMs);
 
-    const loc = localOf(next);
-    expect(loc.dayOfWeek).toBe(1); // Monday
-    expect(loc.hours).toBe(16);
-    expect(loc.minutes).toBe(0);
+    const utc = utcOf(next);
+    expect(utc.dayOfWeek).toBe(1); // Monday
+    expect(utc.hours).toBe(16);
+    expect(utc.minutes).toBe(0);
     // Must be within the next 7 days
     expect(next - fromMs).toBeLessThanOrEqual(8 * 24 * 60 * 60_000);
   });


### PR DESCRIPTION
## Root cause

Fixed-hour cron expressions fired at the wrong time. `nextFireFromCron` in `src/daemon/cron-scheduler.ts` matched cron fields against the daemon process's **local** wall-clock (`Date.getHours/getDate/getDay`). The host's system timezone is `America/New_York` (UTC-4 / EDT), but the org timezone is UTC and all cron schedules are authored as UTC times.

Result: `morning-brief` = `0 13 * * *` (intended 13:00 UTC = 9am ET) was matched as 13:00 **EDT** = 17:00 UTC = **1pm ET — exactly 4h late**. `evening-brief` = `0 1 * * *` shifted the same 4h. Interval (`4h`) and `*/N` crons never reference a wall-clock hour, so they fired correctly — which is why only the fixed-hour daily briefs drifted.

This is **not** a scheduler eval-cadence problem: the scheduler already ticks every 30s. The lag was purely the UTC-vs-local offset.

## Fix

Evaluate cron expressions in **UTC** (`getUTC*` getters) so fire times are deterministic regardless of the host's system timezone. The minute-walk reference (`startMs`) is already epoch-based, so only the field-matching getters needed changing.

`ipc-server.computeNextFire` reuses `nextFireFromCron`, so the dashboard's next-fire display inherits the fix automatically. `cron-health` only uses interval durations (unaffected).

## Tests

- Updated `nextFireFromCron` tests to assert **UTC** fields (the new contract).
- Added two absolute-instant regression tests that pin `0 13 * * *` → 13:00 UTC and `0 1 * * *` → 01:00 UTC. These **pass even under `TZ=America/New_York`**, proving timezone-independence.
- `cron-scheduler.test.ts`: 30/30 pass (verified under both default and EDT host TZ).
- `npm run build` clean.

### Note on full suite
34 pre-existing test failures (`bus-crons`, `upgrade-cron-teaching`, `bus/hooks`, `hook-crash-alert`, `hooks` symlink) are **environmental** (daemon-not-running, fixture/permission dependent) and **identical on clean `main`**. This change introduces **zero** new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)