### PR TITLE
fix(daemon): require explicit onboarding marker, do not auto-write on heartbeat

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -698,17 +698,7 @@ export class AgentProcess {
   private buildStartupPrompt(): string {
     const onboardedPath = join(this.env.ctxRoot, 'state', this.name, '.onboarded');
     const onboardingPath = join(this.env.agentDir, 'ONBOARDING.md');
-    const heartbeatPath = join(this.env.ctxRoot, 'state', this.name, 'heartbeat.json');
     let onboardingAppend = '';
-
-    // If agent has a heartbeat but no .onboarded marker, they completed onboarding but
-    // forgot to write the marker. Auto-write it so they don't re-onboard next restart.
-    if (!existsSync(onboardedPath) && existsSync(heartbeatPath)) {
-      try {
-        const { writeFileSync } = require('fs');
-        writeFileSync(onboardedPath, '', 'utf-8');
-      } catch { /* ignore */ }
-    }
 
     if (!existsSync(onboardedPath) && existsSync(onboardingPath)) {
       onboardingAppend = ' IMPORTANT: This is your FIRST BOOT. Before doing anything else, read ONBOARDING.md and complete the onboarding protocol.';

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -416,3 +416,53 @@ describe('AgentProcess — CrashLoopPauser (instar-inspired sliding window)', ()
     expect(ap.getStatus().status).not.toBe('halted');
   });
 });
+
+describe('AgentProcess - onboarding marker (do not auto-write .onboarded on heartbeat)', () => {
+  // Regression: buildStartupPrompt used to auto-write the .onboarded marker
+  // whenever a heartbeat.json existed, on the assumption the agent had
+  // onboarded and just forgot the marker. That silently suppressed FIRST BOOT
+  // for agents that were manually scaffolded (heartbeat present) but never
+  // actually ran onboarding. The marker must be explicit: a heartbeat alone
+  // must NOT mark an agent onboarded. This is general daemon behavior (it was
+  // surfaced via a manually-scaffolded opencode agent, but applies to any
+  // runtime).
+  it('does not auto-mark a heartbeat-only agent as onboarded (still routes to FIRST BOOT)', async () => {
+    fsMocks.existsSync.mockImplementation((path: string) => {
+      if (path.endsWith('/.force-fresh')) return false;
+      if (path.endsWith('/.onboarded')) return false;
+      if (path.endsWith('/heartbeat.json')) return true;
+      if (path.endsWith('/ONBOARDING.md')) return true;
+      return false;
+    });
+
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    const prompt = mockPty.spawn.mock.calls[0]?.[1] ?? '';
+    expect(prompt).toContain('FIRST BOOT');
+    expect(prompt).toContain('read ONBOARDING.md and complete the onboarding protocol');
+    // The buggy auto-write must be gone: no .onboarded written from heartbeat presence.
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('/.onboarded'),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('respects an existing .onboarded marker (suppresses FIRST BOOT)', async () => {
+    fsMocks.existsSync.mockImplementation((path: string) => {
+      if (path.endsWith('/.force-fresh')) return false;
+      if (path.endsWith('/.onboarded')) return true;
+      if (path.endsWith('/heartbeat.json')) return true;
+      if (path.endsWith('/ONBOARDING.md')) return true;
+      return false;
+    });
+
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    const prompt = mockPty.spawn.mock.calls[0]?.[1] ?? '';
+    expect(prompt).not.toContain('FIRST BOOT');
+    expect(prompt).not.toContain('complete the onboarding protocol');
+  });
+});


### PR DESCRIPTION
## Summary

`buildStartupPrompt` auto-wrote the `.onboarded` marker whenever `heartbeat.json` existed, on the assumption that an agent with a heartbeat had completed onboarding and merely forgot to write the marker. In practice this silently suppressed FIRST BOOT for agents that were **manually scaffolded** (heartbeat present) but had **never actually run onboarding** — the agent would never be told to read `ONBOARDING.md`.

This requires the marker to be explicit: a heartbeat alone no longer marks an agent onboarded. An existing `.onboarded` marker still suppresses FIRST BOOT, so already-onboarded agents are completely unaffected.

This is **general daemon behavior** — it was surfaced via a manually scaffolded agent, but the fix applies to any runtime.

### Change
- `src/daemon/agent-process.ts`: remove the heartbeat-presence auto-write of `.onboarded` from `buildStartupPrompt` (the marker must be written by completing onboarding, not inferred from a heartbeat).

## Test Plan
Adds two-direction regression coverage in `tests/unit/daemon/agent-process.test.ts`:
- **heartbeat-only / no marker** → still routes to FIRST BOOT, and `.onboarded` is **not** auto-written.
- **existing `.onboarded`** → FIRST BOOT suppressed (backward compatible).

Verified locally on a clean `main` base: `tests/unit/daemon/agent-process.test.ts` 15/15 pass, `tsc --noEmit` clean.