### PR TITLE
fix(daemon): retry Telegram command registration on restart

### DIFF
--- a/src/bus/metrics.ts
+++ b/src/bus/metrics.ts
@@ -498,34 +498,53 @@ export function collectTelegramCommands(scanDirs: string[]): { command: string; 
 
 /**
  * Register commands with Telegram Bot API.
+ *
+ * The daemon calls this once per agent at startup. A single setMyCommands attempt
+ * is restart-sensitive: when the daemon bounces mid-onboarding (e.g. reloading to
+ * pick up a newly created agent) any in-flight request is killed and the slash menu
+ * never lands, with no retry. We therefore retry on transient failures with a short
+ * backoff so registration survives a flaky network or a slow API response within a
+ * single boot. `attempts` is the total number of tries (default 3).
  */
 export async function registerTelegramCommands(
   botToken: string,
   commands: { command: string; description: string }[],
+  attempts = 3,
 ): Promise<RegisterCommandsResult> {
   if (commands.length === 0) {
     return { status: 'empty', count: 0, commands: [], error: 'No commands found to register' };
   }
 
-  try {
-    // Register under all_private_chats scope so the / menu appears in private bot chats.
-    // The default scope alone is insufficient — Telegram shows commands from the most
-    // specific matching scope, and all_private_chats takes precedence over default.
-    const response = await fetch(`https://api.telegram.org/bot${botToken}/setMyCommands`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ commands, scope: { type: 'all_private_chats' } }),
-    });
+  const totalAttempts = Math.max(1, attempts);
+  let lastError = 'Failed to register commands with Telegram';
 
-    const data = await response.json() as { ok: boolean; description?: string };
-    if (data.ok) {
-      return { status: 'ok', count: commands.length, commands };
-    } else {
-      return { status: 'error', count: 0, commands, error: data.description || 'Failed to register commands with Telegram' };
+  for (let attempt = 1; attempt <= totalAttempts; attempt++) {
+    try {
+      // Register under all_private_chats scope so the / menu appears in private bot chats.
+      // The default scope alone is insufficient — Telegram shows commands from the most
+      // specific matching scope, and all_private_chats takes precedence over default.
+      const response = await fetch(`https://api.telegram.org/bot${botToken}/setMyCommands`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ commands, scope: { type: 'all_private_chats' } }),
+      });
+
+      const data = await response.json() as { ok: boolean; description?: string };
+      if (data.ok) {
+        return { status: 'ok', count: commands.length, commands };
+      }
+      lastError = data.description || 'Failed to register commands with Telegram';
+    } catch (err) {
+      lastError = String(err);
     }
-  } catch (err) {
-    return { status: 'error', count: 0, commands, error: String(err) };
+
+    // Back off before retrying (linear: 500ms, 1000ms, ...), skip after the last try.
+    if (attempt < totalAttempts) {
+      await new Promise((resolve) => setTimeout(resolve, 500 * attempt));
+    }
   }
+
+  return { status: 'error', count: 0, commands, error: lastError };
 }
 
 // --- Internal helpers ---

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -434,8 +434,15 @@ export class AgentManager {
       registerTelegramCommands(botToken, commands).then((result) => {
         if (result.status === 'ok') {
           log(`Telegram commands registered (${result.count} commands)`);
+        } else if (result.status !== 'empty') {
+          // Surface failures instead of swallowing them silently: a failed
+          // registration means the agent's slash menu is missing until the next
+          // restart, so operators need to see it (non-fatal to agent startup).
+          log(`Telegram command registration failed after retries: ${result.error}`);
         }
-      }).catch(() => { /* non-fatal */ });
+      }).catch((err) => {
+        log(`Telegram command registration error: ${String(err)}`);
+      });
     }
 
     // Start Telegram poller if credentials are available and not explicitly disabled.

--- a/tests/sprint5-metrics.test.ts
+++ b/tests/sprint5-metrics.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { existsSync, readFileSync, writeFileSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -7,6 +7,7 @@ import {
   parseUsageOutput,
   storeUsageData,
   collectTelegramCommands,
+  registerTelegramCommands,
 } from '../src/bus/metrics.js';
 
 describe('Sprint 5: Observability & Metrics', () => {
@@ -410,6 +411,54 @@ describe('Sprint 5: Observability & Metrics', () => {
       const cmds = collectTelegramCommands([scanDir]);
       const names = cmds.map((c) => c.command).sort();
       expect(names).toEqual(['claude_only', 'codex_only']);
+    });
+  });
+
+  // setMyCommands was a single fire-and-forget attempt at boot. When the daemon
+  // restarted mid-onboarding the in-flight request was killed and the slash menu
+  // never landed, with no retry. These cover the bounded-retry hardening.
+  describe('registerTelegramCommands retry (restart-resilient setMyCommands)', () => {
+    const sampleCommands = [{ command: 'status', description: 'Show status' }];
+    const originalFetch = global.fetch;
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+    });
+
+    it('returns empty without calling the API when there are no commands', async () => {
+      const fetchMock = vi.fn();
+      global.fetch = fetchMock as unknown as typeof fetch;
+      const result = await registerTelegramCommands('token', []);
+      expect(result.status).toBe('empty');
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('succeeds on the first attempt without retrying', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ json: async () => ({ ok: true }) });
+      global.fetch = fetchMock as unknown as typeof fetch;
+      const result = await registerTelegramCommands('token', sampleCommands);
+      expect(result.status).toBe('ok');
+      expect(result.count).toBe(1);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries after a transient failure and then succeeds', async () => {
+      const fetchMock = vi.fn()
+        .mockRejectedValueOnce(new Error('connection reset'))
+        .mockResolvedValueOnce({ json: async () => ({ ok: true }) });
+      global.fetch = fetchMock as unknown as typeof fetch;
+      const result = await registerTelegramCommands('token', sampleCommands, 3);
+      expect(result.status).toBe('ok');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('returns error after exhausting all attempts and reports the last error', async () => {
+      const fetchMock = vi.fn().mockResolvedValue({ json: async () => ({ ok: false, description: 'Bad Request' }) });
+      global.fetch = fetchMock as unknown as typeof fetch;
+      const result = await registerTelegramCommands('token', sampleCommands, 2);
+      expect(result.status).toBe('error');
+      expect(result.error).toBe('Bad Request');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
     });
   });
 });


### PR DESCRIPTION
## Summary

`setMyCommands` runs once per agent at daemon startup as a single fire-and-forget attempt. When the daemon bounces mid-onboarding (e.g. reloading to pick up a newly created agent), the in-flight request is killed and — with no retry — the slash menu never lands for that bot. The token, collection logic, and Telegram API all work; it is purely a timing gap (single shot at boot, no retry, restart-sensitive), so a manual re-trigger always succeeds instantly.

This hardens the registration:

- **Bounded retry with backoff** in `registerTelegramCommands` (default 3 attempts, linear 500ms/1000ms backoff) so a flaky network or slow API response within a single boot no longer drops the menu.
- **Failures are logged** in the daemon caller (`agent-manager.ts`) instead of being silently swallowed, so a missing menu is visible to operators (still non-fatal to agent startup).

Pairs with the #667 onboarding-marker fix — both close onboarding-reliability gaps.

## Test Plan

- Added retry-path coverage in `tests/sprint5-metrics.test.ts`:
  - succeeds on first attempt without retrying
  - retries after a transient failure and then succeeds
  - returns `error` after exhausting all attempts (reports last error)
  - returns `empty` without calling the API when there are no commands
- `npx vitest run tests/sprint5-metrics.test.ts` → 32 pass
- `npx vitest run tests/unit/daemon/agent-manager.test.ts` → 27 pass
- `npx tsc --noEmit` → no errors
- `npm run build` → success

🤖 Generated with [Claude Code](https://claude.com/claude-code)
