### PR TITLE
fix(dashboard): auto-populate Max plan usage widget (Claude + Codex) from usage cache

### DIFF
--- a/dashboard/src/app/(dashboard)/analytics/page.tsx
+++ b/dashboard/src/app/(dashboard)/analytics/page.tsx
@@ -13,7 +13,7 @@ import { AgentEffectiveness } from '@/components/analytics/agent-effectiveness';
 import { CostTracking } from '@/components/analytics/cost-tracking';
 import { GoalProgress } from '@/components/analytics/goal-progress';
 import { FleetHealth } from '@/components/analytics/fleet-health';
-import { getFleetHealth, getLatestSnapshot, getPlanUsage, getUsageHistory } from '@/lib/data/reports';
+import { getFleetHealth, getLatestSnapshot, getPlanUsage, getUsageHistory, getCodexUsage } from '@/lib/data/reports';
 
 export default async function AnalyticsPage({
   searchParams,
@@ -29,7 +29,7 @@ export default async function AnalyticsPage({
   syncCostsLazy();
 
   // Fetch all data in parallel
-  const [taskData, agentStats, dailyCosts, dailyCostByModel, monthCost, goalsData, fleetHealth, planUsage, usageHistory] =
+  const [taskData, agentStats, dailyCosts, dailyCostByModel, monthCost, goalsData, fleetHealth, planUsage, usageHistory, codexUsage] =
     await Promise.all([
       Promise.resolve(getTaskThroughput(30, org || undefined)),
       Promise.resolve(getAgentEffectiveness(org || undefined)),
@@ -40,6 +40,7 @@ export default async function AnalyticsPage({
       Promise.resolve(getFleetHealth(org || 'default')),
       Promise.resolve(getPlanUsage()),
       Promise.resolve(getUsageHistory(7)),
+      Promise.resolve(getCodexUsage()),
     ]);
 
   // Project monthly cost: (month-to-date / days elapsed) * days in month
@@ -77,6 +78,7 @@ export default async function AnalyticsPage({
         projectedMonthly={projectedMonthly}
         planUsage={planUsage}
         usageHistory={usageHistory}
+        codexUsage={codexUsage}
       />
 
       {/* Goal Progress - only show when specific org selected */}

--- a/dashboard/src/components/analytics/cost-tracking.tsx
+++ b/dashboard/src/components/analytics/cost-tracking.tsx
@@ -19,6 +19,13 @@ interface UsageHistoryPoint {
   sonnet_pct: number;
 }
 
+interface CodexUsageData {
+  plan_type: string;
+  timestamp: string;
+  five_hour: { used_pct: number; resets: string };
+  seven_day: { used_pct: number; resets: string };
+}
+
 interface CostTrackingProps {
   dailyCosts: Array<{ date: string; cost: number }>;
   dailyCostByModel: Array<Record<string, unknown>>;
@@ -26,6 +33,7 @@ interface CostTrackingProps {
   projectedMonthly: number;
   planUsage?: PlanUsageData | null;
   usageHistory?: UsageHistoryPoint[];
+  codexUsage?: CodexUsageData | null;
 }
 
 function UsageBar({ pct, label, sublabel }: { pct: number; label: string; sublabel?: string }) {
@@ -51,6 +59,7 @@ export function CostTracking({
   projectedMonthly,
   planUsage,
   usageHistory,
+  codexUsage,
 }: CostTrackingProps) {
   const modelKeys = Object.keys(MODEL_COLORS); // opus, sonnet, haiku
   const modelColorValues = modelKeys.map((k) => MODEL_COLORS[k]);
@@ -100,6 +109,34 @@ export function CostTracking({
           )}
         </CardContent>
       </Card>
+
+      {/* Codex (ChatGPT) Plan Usage */}
+      {codexUsage && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-sm font-medium uppercase tracking-wider text-muted-foreground">
+              Codex Plan Usage{codexUsage.plan_type ? ` (${codexUsage.plan_type})` : ''}
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-4">
+              <UsageBar
+                pct={codexUsage.seven_day.used_pct}
+                label="Weekly (7-day)"
+                sublabel={codexUsage.seven_day.resets ? `Resets ${codexUsage.seven_day.resets}` : undefined}
+              />
+              <UsageBar
+                pct={codexUsage.five_hour.used_pct}
+                label="Current Session (5h)"
+                sublabel={codexUsage.five_hour.resets ? `Resets ${codexUsage.five_hour.resets}` : undefined}
+              />
+              <p className="text-[10px] text-muted-foreground">
+                Last updated: {new Date(codexUsage.timestamp).toLocaleString()}
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* Usage History Chart */}
       {usageHistory && usageHistory.length >= 2 ? (

--- a/dashboard/src/lib/data/reports.ts
+++ b/dashboard/src/lib/data/reports.ts
@@ -269,6 +269,38 @@ export interface PlanUsage {
   week_sonnet: { used_pct: number };
 }
 
+export interface CodexUsage {
+  plan_type: string;
+  timestamp: string;
+  five_hour: { used_pct: number; resets: string };
+  seven_day: { used_pct: number; resets: string };
+}
+
+/**
+ * Codex (ChatGPT) plan usage, read from the wham cache the usage-monitor cron
+ * keeps fresh. primary_window is the 5h limit, secondary_window the 7d limit;
+ * reset_at is a unix epoch (seconds).
+ */
+export function getCodexUsage(): CodexUsage | null {
+  const cacheFile = path.join(CTX_ROOT, 'state', 'usage', 'codex-wham-cache.json');
+  if (!fs.existsSync(cacheFile)) return null;
+  try {
+    const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+    const rl = cache.rate_limit;
+    if (!rl) return null;
+    const fmtEpoch = (s?: number | null): string =>
+      s ? new Date(s * 1000).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric' }) : '';
+    return {
+      plan_type: cache.plan_type ?? 'codex',
+      timestamp: fs.statSync(cacheFile).mtime.toISOString(),
+      five_hour: { used_pct: rl.primary_window?.used_percent ?? 0, resets: fmtEpoch(rl.primary_window?.reset_at) },
+      seven_day: { used_pct: rl.secondary_window?.used_percent ?? 0, resets: fmtEpoch(rl.secondary_window?.reset_at) },
+    };
+  } catch {
+    return null;
+  }
+}
+
 export function getPlanUsage(): PlanUsage | null {
   // Primary: an explicit `cortextos bus scrape-usage` snapshot. Preserves the
   // manual /usage paste path and the daily JSONL history series.

--- a/dashboard/src/lib/data/reports.ts
+++ b/dashboard/src/lib/data/reports.ts
@@ -270,10 +270,42 @@ export interface PlanUsage {
 }
 
 export function getPlanUsage(): PlanUsage | null {
+  // Primary: an explicit `cortextos bus scrape-usage` snapshot. Preserves the
+  // manual /usage paste path and the daily JSONL history series.
   const file = path.join(CTX_ROOT, 'state', 'usage', 'latest.json');
-  if (!fs.existsSync(file)) return null;
+  if (fs.existsSync(file)) {
+    try {
+      return JSON.parse(fs.readFileSync(file, 'utf-8'));
+    } catch {
+      // fall through to the live API cache
+    }
+  }
+
+  // Fallback: the OAuth usage cache that the usage-monitor cron keeps fresh.
+  // This auto-populates the widget with no manual scrape. The cache exposes 5h /
+  // 7d / 7d-sonnet utilization, which map onto session / week-all-models / week-sonnet.
+  const cacheFile = path.join(CTX_ROOT, 'state', 'usage', 'api-cache.json');
+  if (!fs.existsSync(cacheFile)) return null;
   try {
-    return JSON.parse(fs.readFileSync(file, 'utf-8'));
+    const cache = JSON.parse(fs.readFileSync(cacheFile, 'utf-8'));
+    if (cache.five_hour == null && cache.seven_day == null) return null;
+    const fmtReset = (iso?: string | null): string =>
+      iso ? new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', hour: 'numeric' }) : '';
+    return {
+      agent: 'claude-max',
+      timestamp: fs.statSync(cacheFile).mtime.toISOString(),
+      session: {
+        used_pct: cache.five_hour?.utilization ?? 0,
+        resets: fmtReset(cache.five_hour?.resets_at),
+      },
+      week_all_models: {
+        used_pct: cache.seven_day?.utilization ?? 0,
+        resets: fmtReset(cache.seven_day?.resets_at),
+      },
+      week_sonnet: {
+        used_pct: cache.seven_day_sonnet?.utilization ?? 0,
+      },
+    };
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

The dashboard **Max Plan Usage** widget reads `state/usage/latest.json`, which is only written by a manual `cortextos bus scrape-usage` paste. Without that one-time step the widget shows "Plan usage tracking not configured" indefinitely — even though the `usage-monitor` cron already maintains a fresh OAuth usage cache at `state/usage/api-cache.json`.

`getPlanUsage()` now falls back to `api-cache.json` when `latest.json` is absent, mapping its `five_hour` / `seven_day` / `seven_day_sonnet` utilization onto the widget's `session` / `week_all_models` / `week_sonnet` fields (friendly reset dates; cache file mtime as the timestamp). `latest.json` stays primary, so the manual scrape path and the daily history series are unchanged — this only fixes the empty default state.

## Test Plan

- Verified the mapping against a real `api-cache.json` (5h 1% → session, 7d 44% → week-all-models, 7d-sonnet 7% → week-sonnet, reset dates formatted).
- `npx tsc --noEmit` (dashboard) → no errors.
- Backward compatible: `latest.json` still takes precedence; absent/invalid cache returns `null` (same empty state as before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
