### PR TITLE
feat(daemon): context-handoff mechanism, default-on at 60% window

### DIFF
--- a/src/daemon/context-handoff-lease.ts
+++ b/src/daemon/context-handoff-lease.ts
@@ -1,0 +1,201 @@
+import { existsSync, readFileSync } from 'fs';
+import { createHash, randomUUID } from 'crypto';
+import { join } from 'path';
+import { atomicWriteSync } from '../utils/atomic.js';
+
+const DEFAULT_MAX_CONCURRENT = 2;
+const LEASE_TTL_MS = 10 * 60_000;
+const QUEUE_TTL_MS = 30 * 60_000;
+const QUEUE_STAGGER_MS = 15_000;
+const QUEUE_JITTER_MS = 15_000;
+
+interface HandoffLeaseEntry {
+  agent: string;
+  lease_id: string;
+  acquired_at: number;
+  expires_at: number;
+}
+
+interface HandoffQueueEntry {
+  agent: string;
+  requested_at: number;
+  not_before: number;
+}
+
+interface HandoffLeaseState {
+  version: 1;
+  updated_at: string;
+  active: HandoffLeaseEntry[];
+  queue: HandoffQueueEntry[];
+}
+
+export type HandoffLeaseDecision =
+  | { status: 'acquired'; leaseId: string; activeCount: number; queuedCount: number }
+  | { status: 'queued'; position: number; waitMs: number; activeCount: number; queuedCount: number };
+
+export interface HandoffLeaseOptions {
+  ctxRoot: string;
+  agentName: string;
+  now?: number;
+  maxConcurrent?: number;
+}
+
+export function contextHandoffLeasePath(ctxRoot: string): string {
+  return join(ctxRoot, 'state', 'context-handoff-leases.json');
+}
+
+export function requestContextHandoffLease(options: HandoffLeaseOptions): HandoffLeaseDecision {
+  const now = options.now ?? Date.now();
+  const maxConcurrent = options.maxConcurrent ?? DEFAULT_MAX_CONCURRENT;
+  const statePath = contextHandoffLeasePath(options.ctxRoot);
+  const state = readLeaseState(statePath, now);
+
+  const existingActive = state.active.find((entry) => entry.agent === options.agentName);
+  if (existingActive) {
+    writeLeaseState(statePath, state);
+    return {
+      status: 'acquired',
+      leaseId: existingActive.lease_id,
+      activeCount: state.active.length,
+      queuedCount: state.queue.length,
+    };
+  }
+
+  const existingQueued = state.queue.find((entry) => entry.agent === options.agentName);
+  if (!existingQueued && state.active.length >= maxConcurrent) {
+    state.queue.push({
+      agent: options.agentName,
+      requested_at: now,
+      not_before: now + (state.queue.length + 1) * QUEUE_STAGGER_MS + deterministicJitter(options.agentName),
+    });
+  }
+
+  const queueIndex = state.queue.findIndex((entry) => entry.agent === options.agentName);
+  const canAcquireDirectly = state.queue.length === 0 && state.active.length < maxConcurrent;
+  const canAcquireFromQueue = queueIndex === 0
+    && state.active.length < maxConcurrent
+    && state.queue[0].not_before <= now;
+
+  if (canAcquireDirectly || canAcquireFromQueue) {
+    if (canAcquireFromQueue) state.queue.shift();
+    const leaseId = randomUUID();
+    state.active.push({
+      agent: options.agentName,
+      lease_id: leaseId,
+      acquired_at: now,
+      expires_at: now + LEASE_TTL_MS,
+    });
+    writeLeaseState(statePath, state);
+    return {
+      status: 'acquired',
+      leaseId,
+      activeCount: state.active.length,
+      queuedCount: state.queue.length,
+    };
+  }
+
+  const queued = state.queue.find((entry) => entry.agent === options.agentName)
+    ?? existingQueued
+    ?? {
+      agent: options.agentName,
+      requested_at: now,
+      not_before: now + QUEUE_STAGGER_MS + deterministicJitter(options.agentName),
+    };
+  if (!state.queue.some((entry) => entry.agent === options.agentName)) {
+    state.queue.push(queued);
+  }
+  const position = state.queue.findIndex((entry) => entry.agent === options.agentName) + 1;
+  writeLeaseState(statePath, state);
+  return {
+    status: 'queued',
+    position,
+    waitMs: Math.max(0, queued.not_before - now),
+    activeCount: state.active.length,
+    queuedCount: state.queue.length,
+  };
+}
+
+export function releaseContextHandoffLease(ctxRoot: string, agentName: string, leaseId?: string): void {
+  const statePath = contextHandoffLeasePath(ctxRoot);
+  const state = readLeaseState(statePath, Date.now());
+  state.active = state.active.filter((entry) =>
+    entry.agent !== agentName || (leaseId !== undefined && entry.lease_id !== leaseId));
+  state.queue = state.queue.filter((entry) => entry.agent !== agentName);
+  writeLeaseState(statePath, state);
+}
+
+/**
+ * Read-only check: does this agent currently hold an active lease or a queue entry?
+ * Lets a caller decide whether a release-by-name is actually needed without paying the
+ * lease-file write that releaseContextHandoffLease always incurs — so a per-tick caller
+ * can stay read-only in the common (no stale lease) case. Expired/stale entries are
+ * filtered by readLeaseState, so this reflects only live holdings.
+ */
+export function agentHoldsContextHandoffLease(ctxRoot: string, agentName: string, now: number = Date.now()): boolean {
+  const state = readLeaseState(contextHandoffLeasePath(ctxRoot), now);
+  return state.active.some((entry) => entry.agent === agentName)
+    || state.queue.some((entry) => entry.agent === agentName);
+}
+
+function readLeaseState(statePath: string, now: number): HandoffLeaseState {
+  let state: HandoffLeaseState = {
+    version: 1,
+    updated_at: new Date(now).toISOString(),
+    active: [],
+    queue: [],
+  };
+  try {
+    if (existsSync(statePath)) {
+      const parsed = JSON.parse(readFileSync(statePath, 'utf-8')) as Partial<HandoffLeaseState>;
+      state = {
+        version: 1,
+        updated_at: typeof parsed.updated_at === 'string' ? parsed.updated_at : new Date(now).toISOString(),
+        active: Array.isArray(parsed.active) ? parsed.active.filter(isLeaseEntry) : [],
+        queue: Array.isArray(parsed.queue) ? parsed.queue.filter(isQueueEntry) : [],
+      };
+    }
+  } catch {
+    state = {
+      version: 1,
+      updated_at: new Date(now).toISOString(),
+      active: [],
+      queue: [],
+    };
+  }
+
+  state.active = state.active.filter((entry) => entry.expires_at > now);
+  state.queue = state.queue.filter((entry) => now - entry.requested_at <= QUEUE_TTL_MS);
+  state.updated_at = new Date(now).toISOString();
+  return state;
+}
+
+function writeLeaseState(statePath: string, state: HandoffLeaseState): void {
+  // Atomic write (temp file + rename) so a concurrent reader never observes a torn or
+  // partial lease file — this fleet state is read by every agent's FastChecker on each
+  // tick. atomicWriteSync handles directory creation and appends the trailing newline.
+  atomicWriteSync(statePath, JSON.stringify(state, null, 2));
+}
+
+function deterministicJitter(agentName: string): number {
+  const hex = createHash('sha256').update(agentName).digest('hex').slice(0, 8);
+  return parseInt(hex, 16) % QUEUE_JITTER_MS;
+}
+
+function isLeaseEntry(value: unknown): value is HandoffLeaseEntry {
+  if (!isRecord(value)) return false;
+  return typeof value.agent === 'string'
+    && typeof value.lease_id === 'string'
+    && typeof value.acquired_at === 'number'
+    && typeof value.expires_at === 'number';
+}
+
+function isQueueEntry(value: unknown): value is HandoffQueueEntry {
+  if (!isRecord(value)) return false;
+  return typeof value.agent === 'string'
+    && typeof value.requested_at === 'number'
+    && typeof value.not_before === 'number';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -10,6 +10,7 @@ import { AgentProcess } from './agent-process.js';
 import type { TelegramAPI } from '../telegram/api.js';
 import { KEYS } from '../pty/inject.js';
 import { stripControlChars, sanitizeForPtyInjection, wrapFenceSafe } from '../utils/validate.js';
+import { agentHoldsContextHandoffLease, releaseContextHandoffLease, requestContextHandoffLease } from './context-handoff-lease.js';
 
 type LogFn = (msg: string) => void;
 
@@ -54,7 +55,10 @@ export class FastChecker {
   private ctxHandoffFiredAt: number = 0;    // fires once per session (0 = not yet)
   private ctxHandoffDeadlineAt: number = 0; // timestamp after which force-restart fires
   private ctxLastSessionId: string | null = null; // detects new session → clears stale deadline
+  private ctxHandoffLeaseId: string | null = null;
+  private ctxHandoffQueuedLogAt: number = 0;
   private ctxCircuitRestarts: number[] = []; // timestamps of recent context-triggered restarts
+  private ctxHandoffFires: number[] = [];    // timestamps of recent Tier-2 handoff fires (cooperative-restart loop backstop)
   private ctxCircuitBrokenAt: number | null = null; // when circuit tripped (null = healthy)
   // Persisted to disk so --continue restarts don't reset the circuit breaker
   private ctxCircuitFile: string = '';
@@ -918,8 +922,12 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     } catch { /* keep stale values */ }
     const config = this.agent.getConfig();
     return {
-      warn: config.ctx_warning_threshold ?? 70,
-      handoff: config.ctx_handoff_threshold ?? 80,
+      // Context-handoff is ON by default for every runtime/agent: an unset
+      // threshold falls back to 30% warning / 60% handoff (a percentage of the
+      // ACTIVE model's context window, so it adapts to window size). An explicit
+      // ctx_handoff_threshold <= 0 is the deliberate opt-out (see checkContextStatus).
+      warn: config.ctx_warning_threshold ?? 30,
+      handoff: config.ctx_handoff_threshold ?? 60,
     };
   }
 
@@ -936,6 +944,7 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       if (now - this.ctxCircuitBrokenAt >= 30 * 60_000) {
         this.ctxCircuitBrokenAt = null;
         this.ctxCircuitRestarts = [];
+        this.ctxHandoffFires = [];
         this.saveCtxCircuit();
         this.log('Context circuit breaker reset after 30min pause');
       } else {
@@ -962,6 +971,17 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       // 5-min deadline timer would otherwise fire on the fresh low-context session.
       const incomingSessionId = typeof data.session_id === 'string' ? data.session_id : null;
       if (incomingSessionId && incomingSessionId !== this.ctxLastSessionId) {
+        // Release any context-handoff lease held by this agent on a fresh session.
+        // This MUST be unconditional — released by agent name, not gated on
+        // ctxLastSessionId or the in-memory ctxHandoffLeaseId. A handoff restart can
+        // reset this monitor's per-agent state (both fields back to null), so gating
+        // release on either leaks the lease until its 10-min TTL and starves the fleet
+        // handoff queue: completed handoffs never free their slot, and queued agents
+        // above threshold wait up to a full TTL for a slot. A fresh session never needs
+        // a lease acquired by a prior session of the same agent; release-by-name is a
+        // no-op when none is held and also clears any stale queue entry.
+        releaseContextHandoffLease(this.paths.ctxRoot, this.agent.name);
+        this.ctxHandoffLeaseId = null;
         if (this.ctxLastSessionId !== null) {
           this.ctxHandoffFiredAt = 0;
           this.ctxHandoffDeadlineAt = 0;
@@ -972,21 +992,57 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       }
     } catch { return; }
 
-    // Check PTY output for hard API overflow errors (always act regardless of threshold config)
+    // Check PTY output for hard API overflow errors (always act regardless of threshold config).
+    // Guard: only treat the banner phrase as a *live* overflow when context usage actually
+    // corroborates it (exceeds 200k, or pct genuinely high). The same phrase appears as benign
+    // text in memory files, source, and chat that *document* this mechanism — without this guard
+    // a fresh boot re-reading those at low context force-restarts on every boot, producing a loop.
+    const ctxCorroboratesOverflow = exceeds200k || (pct !== null && pct >= 85);
     const recentOutput = this.agent.getOutputBuffer()?.getRecent(8000) ?? '';
-    if (/extra usage.*?1[Mm] context|conversation too long.*?compaction/i.test(recentOutput)) {
-      this.log('Context overflow error detected in PTY output — force restarting');
+    if (ctxCorroboratesOverflow && /extra usage.*?1[Mm] context|conversation too long.*?compaction/i.test(recentOutput)) {
+      this.log('Context overflow error detected in PTY output at high context — force restarting');
       this.forceContextRestart('API overflow error in PTY output');
       return;
     }
 
     const { warn, handoff } = this.getCtxThresholds();
 
-    // No threshold configured — observe-only mode (log but don't act)
-    if (this.agent.getConfig().ctx_handoff_threshold === undefined) return;
+    // Default-ON: an UNSET ctx_handoff_threshold uses the 60% default from
+    // getCtxThresholds (handoff on for every agent with no config). An explicit
+    // ctx_handoff_threshold <= 0 is the deliberate opt-out (observe-only: log,
+    // never act). This is the only disable path now that default is on.
+    const configuredHandoff = this.agent.getConfig().ctx_handoff_threshold;
+    if (configuredHandoff !== undefined && configuredHandoff <= 0) return;
 
     const effectivePct = pct ?? (exceeds200k ? 101 : null);
     if (effectivePct === null) return;
+
+    // Session-id-independent leaked-lease release (the Claude null-session_id edge).
+    // The new-session detection above only releases a leaked lease when the bridge
+    // reports a non-null session_id. hook-context-status writes `session_id ?? null`,
+    // so a fresh Claude session reports session_id:null, that block is skipped, and a
+    // lease leaked by the agent's prior session sits in `active` until its 10-min TTL —
+    // starving the fleet handoff queue on the majority (Claude) path. Release it by name
+    // here, gated on the precise safety condition rather than the session_id proxy:
+    //   (1) effectivePct < handoff — the agent is NOT mid-handoff, so it cannot
+    //       legitimately need a handoff lease this tick; and
+    //   (2) ctxHandoffLeaseId === null — this monitor did not itself acquire the live
+    //       lease. A lease acquired by the CURRENT session always sets ctxHandoffLeaseId
+    //       synchronously at the Tier 2 acquire below (and resets context_status to 0%,
+    //       so the very next tick is below-threshold-but-lease-held). The only way to
+    //       hold a lease with this field null is that a prior session acquired it and a
+    //       full respawn recreated this monitor with null state — i.e. the leaked lease.
+    //       This is exactly the guarantee the original non-null-session_id gate gave,
+    //       without the proxy. A read-only existence check runs first so idle ticks
+    //       never pay the lease-file write.
+    if (
+      effectivePct < handoff
+      && this.ctxHandoffLeaseId === null
+      && agentHoldsContextHandoffLease(this.paths.ctxRoot, this.agent.name, now)
+    ) {
+      releaseContextHandoffLease(this.paths.ctxRoot, this.agent.name);
+      this.log('Released leaked context-handoff lease by name (fresh below-threshold session)');
+    }
 
     // Tier 3: deadline exceeded — force restart if agent ignored handoff prompt
     if (this.ctxHandoffDeadlineAt > 0 && now > this.ctxHandoffDeadlineAt) {
@@ -1007,7 +1063,51 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
 
     // Tier 2: handoff (fires once per session lifecycle)
     if (effectivePct >= handoff && this.ctxHandoffFiredAt === 0) {
+      const lease = requestContextHandoffLease({
+        ctxRoot: this.paths.ctxRoot,
+        agentName: this.agent.name,
+      });
+      if (lease.status === 'queued') {
+        if (now - this.ctxHandoffQueuedLogAt > 60_000) {
+          this.ctxHandoffQueuedLogAt = now;
+          this.log(
+            `Context handoff queued at ${Math.round(effectivePct)}% `
+            + `(position ${lease.position}, active ${lease.activeCount}, queued ${lease.queuedCount}, wait ~${Math.ceil(lease.waitMs / 1000)}s)`,
+          );
+        }
+        return;
+      }
+      this.ctxHandoffLeaseId = lease.leaseId;
       this.ctxHandoffFiredAt = now;
+
+      // Cooperative-restart loop backstop. A handoff normally fires ONCE per session and
+      // the fresh session drops well below threshold, so legitimate usage never re-fires
+      // soon. If a runtime fails to reset context on the handoff restart (e.g. a
+      // thread-persistence regression), the fresh session immediately re-crosses the
+      // threshold and re-fires every cycle — a self-sustaining treadmill the restart
+      // circuit breaker misses because these are COOPERATIVE handoff restarts, not Tier-3
+      // force-restarts. Count handoff fires in a persisted 15min window (survives the
+      // restart); if they reach the cap, trip the circuit breaker (30min pause) instead of
+      // handing off again, so any handoff loop self-limits regardless of cause. Cap 3 is
+      // above the benign 1-2 fires a single very-large turn can produce before settling.
+      this.ctxHandoffFires = this.ctxHandoffFires.filter(t => now - t < 15 * 60_000);
+      this.ctxHandoffFires.push(now);
+      this.saveCtxCircuit();
+      if (this.ctxHandoffFires.length >= 3) {
+        this.ctxCircuitBrokenAt = now;
+        this.saveCtxCircuit();
+        // Release the lease we just acquired — we are pausing, not handing off.
+        releaseContextHandoffLease(this.paths.ctxRoot, this.agent.name);
+        this.ctxHandoffLeaseId = null;
+        this.ctxHandoffFiredAt = 0;
+        const msg = `Context handoff loop detected for ${this.agent.name}: ${this.ctxHandoffFires.length} handoffs in 15min — a runtime may not be resetting context on restart. Auto-handoff paused 30min. Check logs/${this.agent.name}/restarts.log.`;
+        this.log(msg);
+        if (this.telegramApi && this.chatId) {
+          this.telegramApi.sendMessage(this.chatId, msg).catch(() => {});
+        }
+        return;
+      }
+
       this.ctxHandoffDeadlineAt = now + 5 * 60_000; // 5min grace for agent to cooperate
       // Reset context_status.json so the new session doesn't re-trigger immediately
       const statusPath = join(this.paths.stateDir, 'context_status.json');
@@ -1076,6 +1176,19 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     this.ctxHandoffFiredAt = 0;
     this.ctxHandoffDeadlineAt = 0;
     this.ctxWarningFiredAt = 0;
+
+    // Release this dying session's context-handoff lease on teardown. This restart is
+    // IN-PROCESS — sessionRefresh() below does stop()+start() on the same AgentProcess
+    // and does NOT recreate this FastChecker, so ctxHandoffLeaseId survives into the
+    // fresh session. The by-name cleanup in checkContextStatus is gated on
+    // ctxHandoffLeaseId === null, so without this it would skip a lease this session
+    // leaked when the fresh session reports session_id:null (the Tier-3 arm of the
+    // Claude null-session_id leak — the agent ignored the 5-min handoff prompt and was
+    // force-restarted). Release by name and clear the in-memory id HERE, before the
+    // restart spawns the new session, so we free the dying session's own lease — never
+    // a lease the fresh session might later acquire.
+    releaseContextHandoffLease(this.paths.ctxRoot, this.agent.name);
+    this.ctxHandoffLeaseId = null;
 
     // Write .force-fresh + .restart-planned (hardRestart from src/bus/system.ts)
     hardRestart(this.paths, this.agent.name, `CONTEXT-FORCE-RESTART: ${reason}`);
@@ -1151,6 +1264,7 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       if (!existsSync(this.ctxCircuitFile)) return;
       const data = JSON.parse(readFileSync(this.ctxCircuitFile, 'utf-8'));
       this.ctxCircuitRestarts = Array.isArray(data.restarts) ? data.restarts : [];
+      this.ctxHandoffFires = Array.isArray(data.handoffFires) ? data.handoffFires : [];
       this.ctxCircuitBrokenAt = typeof data.brokenAt === 'number' ? data.brokenAt : null;
     } catch {
       // Start fresh on error
@@ -1164,6 +1278,7 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     try {
       writeFileSync(this.ctxCircuitFile, JSON.stringify({
         restarts: this.ctxCircuitRestarts,
+        handoffFires: this.ctxHandoffFires,
         brokenAt: this.ctxCircuitBrokenAt,
       }), 'utf-8');
     } catch {

--- a/src/pty/codex-app-server-pty.ts
+++ b/src/pty/codex-app-server-pty.ts
@@ -478,25 +478,31 @@ export class CodexAppServerPTY {
   }
 
   private async startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> {
-    const persisted = this.readThreadState();
-    if (persisted) {
-      try {
-        const resumed = await this.request<ThreadResponse>('thread/resume', {
-          threadId: persisted.threadId,
-          cwd: this._cwd,
-          ...THREAD_PERMISSION_OVERRIDES,
-          config: { features: { goals: true } },
-          excludeTurns: true,
-          persistExtendedHistory: true,
-        });
-        this.setThreadId(resumed.result?.thread.id || persisted.threadId);
-        return;
-      } catch (err) {
-        this._outputBuffer.push(`[codex-app-server] persisted resume failed: ${err}\n`);
-      }
-    }
-
+    // Only resume a persisted thread in CONTINUE mode. A context-handoff /
+    // .force-fresh restart runs in FRESH mode and MUST start a brand-new codex
+    // thread: resuming the persisted thread retains the full context window, so
+    // the handoff never lowers usage, the agent immediately re-crosses the
+    // threshold, and it re-fires — a restart treadmill (caught by cortext-designer
+    // PR-A live validation 2026-06-29; resuming was previously unconditional here).
     if (mode === 'continue') {
+      const persisted = this.readThreadState();
+      if (persisted) {
+        try {
+          const resumed = await this.request<ThreadResponse>('thread/resume', {
+            threadId: persisted.threadId,
+            cwd: this._cwd,
+            ...THREAD_PERMISSION_OVERRIDES,
+            config: { features: { goals: true } },
+            excludeTurns: true,
+            persistExtendedHistory: true,
+          });
+          this.setThreadId(resumed.result?.thread.id || persisted.threadId);
+          return;
+        } catch (err) {
+          this._outputBuffer.push(`[codex-app-server] persisted resume failed: ${err}\n`);
+        }
+      }
+
       const latest = await this.findLatestThreadForCwd();
       if (latest) {
         const resumed = await this.request<ThreadResponse>('thread/resume', {
@@ -783,34 +789,38 @@ export class CodexAppServerPTY {
    * monitor. Writes atomically; failures are non-fatal (observability only).
    *
    * Mapping (per codex schema ThreadTokenUsageUpdatedNotification):
-   *   - used_percentage = total.totalTokens / cap * 100  (clamped to [0, 100])
+   *   - used_percentage = last.totalTokens / cap * 100  (clamped to [0, 100])
    *   - context_window_size = modelContextWindow ?? config.codex_context_cap ?? 256000
-   *   - exceeds_200k_tokens = total.totalTokens > 200000
-   *   - current_usage.{input,output,cache_read} from total.{input,output,cachedInput}Tokens
+   *   - exceeds_200k_tokens = last.totalTokens > 200000
+   *   - current_usage.{input,output,cache_read} from last.{input,output,cachedInput}Tokens
    *   - session_id = current threadId
+   *
+   * `total` is lifetime cumulative across the app-server thread and can grow far
+   * beyond the active model window. Context handoff must use the current window
+   * occupancy (`last`) so long-lived threads do not report false 100%.
    */
   private writeContextStatus(params: Record<string, unknown>): void {
     const tokenUsage = isRecord(params.tokenUsage) ? params.tokenUsage : null;
     if (!tokenUsage) return;
-    const total = isRecord(tokenUsage.total) ? tokenUsage.total : null;
-    if (!total) return;
-    const totalTokens = typeof total.totalTokens === 'number' ? total.totalTokens : null;
-    if (totalTokens === null) return;
+    const current = isRecord(tokenUsage.last) ? tokenUsage.last : null;
+    const currentTokens = current && typeof current.totalTokens === 'number' ? current.totalTokens : null;
 
     const modelContextWindow = typeof tokenUsage.modelContextWindow === 'number'
       ? tokenUsage.modelContextWindow
       : null;
     const cap = modelContextWindow ?? this._config.codex_context_cap ?? 256000;
-    const usedPct = cap > 0 ? Math.min(100, (totalTokens / cap) * 100) : null;
+    const usedPct = cap > 0 && currentTokens !== null
+      ? Math.min(100, (currentTokens / cap) * 100)
+      : null;
 
-    const inputTokens = typeof total.inputTokens === 'number' ? total.inputTokens : 0;
-    const outputTokens = typeof total.outputTokens === 'number' ? total.outputTokens : 0;
-    const cachedInputTokens = typeof total.cachedInputTokens === 'number' ? total.cachedInputTokens : 0;
+    const inputTokens = current && typeof current.inputTokens === 'number' ? current.inputTokens : 0;
+    const outputTokens = current && typeof current.outputTokens === 'number' ? current.outputTokens : 0;
+    const cachedInputTokens = current && typeof current.cachedInputTokens === 'number' ? current.cachedInputTokens : 0;
 
     const payload = JSON.stringify({
       used_percentage: usedPct,
       context_window_size: cap,
-      exceeds_200k_tokens: totalTokens > 200000,
+      exceeds_200k_tokens: currentTokens !== null ? currentTokens > 200000 : false,
       current_usage: {
         input_tokens: inputTokens,
         output_tokens: outputTokens,

--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -10,6 +10,12 @@
     ],
     "defaultMode": "bypassPermissions"
   },
+  "statusLine": {
+    "type": "command",
+    "command": "cortextos bus hook-context-status",
+    "refreshInterval": 5,
+    "timeout": 2
+  },
   "hooks": {
     "PermissionRequest": [
       {

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -10,6 +10,12 @@
     ],
     "defaultMode": "bypassPermissions"
   },
+  "statusLine": {
+    "type": "command",
+    "command": "cortextos bus hook-context-status",
+    "refreshInterval": 5,
+    "timeout": 2
+  },
   "hooks": {
     "PermissionRequest": [
       {

--- a/templates/orchestrator/.claude/settings.json
+++ b/templates/orchestrator/.claude/settings.json
@@ -10,6 +10,12 @@
     ],
     "defaultMode": "bypassPermissions"
   },
+  "statusLine": {
+    "type": "command",
+    "command": "cortextos bus hook-context-status",
+    "refreshInterval": 5,
+    "timeout": 2
+  },
   "hooks": {
     "PermissionRequest": [
       {

--- a/tests/e2e/lifecycle-codex.test.ts
+++ b/tests/e2e/lifecycle-codex.test.ts
@@ -134,12 +134,16 @@ describe('E2E codex lifecycle (mock-codex.js + WsUnixJsonRpcClient)', () => {
       threadId: string;
       turnId: string;
       tokenUsage: {
+        last: { inputTokens: number; outputTokens: number; totalTokens: number; cachedInputTokens: number };
         total: { inputTokens: number; outputTokens: number; totalTokens: number; cachedInputTokens: number };
         modelContextWindow: number;
       };
     };
     expect(params.threadId).toBe(threadId);
     expect(typeof params.turnId).toBe('string');
+    expect(params.tokenUsage.last.inputTokens).toBeGreaterThan(0);
+    expect(params.tokenUsage.last.outputTokens).toBeGreaterThan(0);
+    expect(params.tokenUsage.last.totalTokens).toBeGreaterThan(0);
     expect(params.tokenUsage.total.inputTokens).toBeGreaterThan(0);
     expect(params.tokenUsage.total.outputTokens).toBeGreaterThan(0);
     expect(params.tokenUsage.total.totalTokens).toBeGreaterThan(0);

--- a/tests/unit/daemon/context-handoff-lease.test.ts
+++ b/tests/unit/daemon/context-handoff-lease.test.ts
@@ -1,0 +1,253 @@
+import { describe, expect, it, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { FastChecker } from '../../../src/daemon/fast-checker.js';
+import type { BusPaths } from '../../../src/types/index.js';
+import {
+  contextHandoffLeasePath,
+  releaseContextHandoffLease,
+  requestContextHandoffLease,
+} from '../../../src/daemon/context-handoff-lease.js';
+
+describe('context handoff fleet lease', () => {
+  let ctxRoot: string;
+
+  beforeEach(() => {
+    ctxRoot = mkdtempSync(join(tmpdir(), 'handoff-lease-'));
+  });
+
+  afterEach(() => {
+    rmSync(ctxRoot, { recursive: true, force: true });
+  });
+
+  it('drains a 6-agent herd without exceeding max concurrent handoffs', () => {
+    const now = Date.now();
+    const agents = ['agent-a', 'agent-b', 'agent-c', 'agent-d', 'agent-e', 'agent-f'];
+
+    const firstWave = agents.map((agentName) =>
+      requestContextHandoffLease({ ctxRoot, agentName, now, maxConcurrent: 2 }));
+
+    expect(firstWave.filter((decision) => decision.status === 'acquired')).toHaveLength(2);
+    expect(firstWave.filter((decision) => decision.status === 'queued')).toHaveLength(4);
+    expect(readState().active).toHaveLength(2);
+    expect(readState().queue).toHaveLength(4);
+    expect(readState().queue.every((entry: any) => entry.not_before > entry.requested_at)).toBe(true);
+
+    releaseContextHandoffLease(ctxRoot, 'agent-a', (firstWave[0] as any).leaseId);
+    releaseContextHandoffLease(ctxRoot, 'agent-b', (firstWave[1] as any).leaseId);
+
+    const secondWave = agents.slice(2).map((agentName) =>
+      requestContextHandoffLease({ ctxRoot, agentName, now: now + 90_000, maxConcurrent: 2 }));
+    expect(secondWave.filter((decision) => decision.status === 'acquired')).toHaveLength(2);
+    expect(readState().active).toHaveLength(2);
+
+    const activeSecond = readState().active.map((entry: any) => entry.agent);
+    for (const agent of activeSecond) {
+      releaseContextHandoffLease(ctxRoot, agent);
+    }
+
+    const thirdWave = agents.slice(4).map((agentName) =>
+      requestContextHandoffLease({ ctxRoot, agentName, now: now + 180_000, maxConcurrent: 2 }));
+    expect(thirdWave.filter((decision) => decision.status === 'acquired')).toHaveLength(2);
+    expect(readState().active).toHaveLength(2);
+    expect(readState().queue).toHaveLength(0);
+  });
+
+  it('returns an existing active lease id for duplicate requests from the same agent', () => {
+    const first = requestContextHandoffLease({ ctxRoot, agentName: 'agent-a', now: 1000, maxConcurrent: 2 });
+    const second = requestContextHandoffLease({ ctxRoot, agentName: 'agent-a', now: 2000, maxConcurrent: 2 });
+
+    expect(first.status).toBe('acquired');
+    expect(second.status).toBe('acquired');
+    expect((second as any).leaseId).toBe((first as any).leaseId);
+    expect(readState().active).toHaveLength(1);
+  });
+
+  it('limits actual FastChecker handoff prompts when six agents cross at once', async () => {
+    const agents = ['agent-a', 'agent-b', 'agent-c', 'agent-d', 'agent-e', 'agent-f'];
+    const records = agents.map((agentName) => createChecker(agentName));
+
+    await Promise.all(records.map((record) =>
+      (record.checker as any).checkContextStatus()));
+
+    expect(records.filter((record) => handoffPrompts(record).length === 1)).toHaveLength(2);
+    expect(records.filter((record) => handoffPrompts(record).length === 0)).toHaveLength(4);
+    expect(readState().active).toHaveLength(2);
+    expect(readState().queue).toHaveLength(4);
+
+    for (const active of readState().active as Array<{ agent: string; lease_id: string }>) {
+      releaseContextHandoffLease(ctxRoot, active.agent, active.lease_id);
+    }
+
+    await Promise.all(records.map((record) =>
+      (record.checker as any).checkContextStatus()));
+    expect(records.filter((record) => handoffPrompts(record).length === 1)).toHaveLength(2);
+
+    const queuedAgents = records
+      .filter((record) => handoffPrompts(record).length === 0)
+      .map((record) => record.agentName);
+    for (const queuedAgent of queuedAgents) {
+      const state = readState();
+      const queued = state.queue.find((entry: any) => entry.agent === queuedAgent);
+      if (queued) queued.not_before = 0;
+      writeFileSync(contextHandoffLeasePath(ctxRoot), `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+    }
+
+    await Promise.all(records.map((record) =>
+      (record.checker as any).checkContextStatus()));
+    expect(records.filter((record) => handoffPrompts(record).length === 1)).toHaveLength(4);
+
+    for (const active of readState().active as Array<{ agent: string; lease_id: string }>) {
+      releaseContextHandoffLease(ctxRoot, active.agent, active.lease_id);
+    }
+    for (const queuedAgent of records
+      .filter((record) => handoffPrompts(record).length === 0)
+      .map((record) => record.agentName)) {
+      const state = readState();
+      const queued = state.queue.find((entry: any) => entry.agent === queuedAgent);
+      if (queued) queued.not_before = 0;
+      writeFileSync(contextHandoffLeasePath(ctxRoot), `${JSON.stringify(state, null, 2)}\n`, 'utf-8');
+    }
+
+    await Promise.all(records.map((record) =>
+      (record.checker as any).checkContextStatus()));
+    expect(records.filter((record) => handoffPrompts(record).length === 1)).toHaveLength(6);
+    expect(readState().active).toHaveLength(2);
+    expect(readState().queue).toHaveLength(0);
+  });
+
+  it('releases a leaked lease by name on fresh-session bootstrap, not at TTL', async () => {
+    // A prior session of agent-a handed off and leaked its lease: a context handoff
+    // restarts the agent, recreating the monitor's per-agent state (ctxLastSessionId
+    // and the in-memory lease id back to null), so the old gated release never fired
+    // and the lease sat in `active` until its 10-min TTL.
+    requestContextHandoffLease({ ctxRoot, agentName: 'agent-a', now: Date.now(), maxConcurrent: 2 });
+    expect(readState().active.map((entry: any) => entry.agent)).toContain('agent-a');
+
+    // The restarted agent comes back as a fresh low-context session. A brand-new
+    // FastChecker instance models the recreated monitor (both fields null).
+    const restarted = createChecker('agent-a', { pct: 5, sessionId: 'sess-new' });
+    await (restarted.checker as any).checkContextStatus();
+
+    // The leaked lease must be released by NAME on the new-session bootstrap — not
+    // held to the TTL — so downstream queued agents can drain immediately. Under the
+    // old release path (gated on the lost in-memory lease id) agent-a would still be
+    // active here.
+    expect(readState().active.map((entry: any) => entry.agent)).not.toContain('agent-a');
+  });
+
+  it('releases a leaked lease by name on a fresh below-threshold session reporting NULL session_id', async () => {
+    // The Claude null-session_id edge (the actual F3 case): hook-context-status writes
+    // `session_id ?? null`, so a fresh Claude session reports session_id ABSENT/null.
+    // The non-null-session_id new-session path never fires, so a lease leaked by the
+    // agent's prior session must still be released by name on a below-threshold tick —
+    // not held to the 10-min TTL. createChecker omits session_id entirely => null.
+    requestContextHandoffLease({ ctxRoot, agentName: 'agent-a', now: Date.now(), maxConcurrent: 2 });
+    expect(readState().active.map((entry: any) => entry.agent)).toContain('agent-a');
+
+    const restarted = createChecker('agent-a', { pct: 5 }); // no sessionId => session_id null
+    await (restarted.checker as any).checkContextStatus();
+
+    expect(readState().active.map((entry: any) => entry.agent)).not.toContain('agent-a');
+  });
+
+  it('does NOT release a lease the current session legitimately holds (over-release guard)', async () => {
+    // Guard against over-release: a lease acquired by THIS live session (ctxHandoffLeaseId
+    // set) must never be freed by the by-name cleanup, even though the session reports
+    // below-threshold (context_status is reset to 0% right after a Tier-2 acquire). Freeing
+    // it would hand the slot to a queued agent while this agent is still mid-handoff.
+    const lease = requestContextHandoffLease({ ctxRoot, agentName: 'agent-a', now: Date.now(), maxConcurrent: 2 });
+    expect(lease.status).toBe('acquired');
+
+    const record = createChecker('agent-a', { pct: 5, sessionId: 'sess-1' });
+    // Model a monitor that acquired the lease this session: in-memory lease id set, and
+    // ctxLastSessionId already this session so the new-session release path stays inert.
+    (record.checker as any).ctxHandoffLeaseId = (lease as any).leaseId;
+    (record.checker as any).ctxLastSessionId = 'sess-1';
+    await (record.checker as any).checkContextStatus();
+
+    expect(readState().active.map((entry: any) => entry.agent)).toContain('agent-a');
+  });
+
+  it('releases the dying session lease on a Tier-3 forceContextRestart teardown', async () => {
+    // Tier-3 arm of the null-session_id leak: forceContextRestart restarts IN-PROCESS
+    // (sessionRefresh does not recreate this FastChecker), so ctxHandoffLeaseId survives
+    // into the fresh session and the checkContextStatus by-name cleanup (gated on
+    // ctxHandoffLeaseId === null) would never fire for a fresh session reporting
+    // session_id:null. The dying session must release its OWN lease on teardown — before
+    // the restart spawns the new session — not wait for the 10-min TTL.
+    const lease = requestContextHandoffLease({ ctxRoot, agentName: 'agent-a', now: Date.now(), maxConcurrent: 2 });
+    expect(lease.status).toBe('acquired');
+    expect(readState().active.map((entry: any) => entry.agent)).toContain('agent-a');
+
+    const record = createChecker('agent-a', { pct: 90, sessionId: 'sess-old' });
+    // Model the live session that acquired the lease this session.
+    (record.checker as any).ctxHandoffLeaseId = (lease as any).leaseId;
+    // forceContextRestart releases synchronously, before the async sessionRefresh.
+    (record.checker as any).forceContextRestart('ctx 90% — handoff not completed within 5min');
+
+    expect(readState().active.map((entry: any) => entry.agent)).not.toContain('agent-a');
+    expect((record.checker as any).ctxHandoffLeaseId).toBeNull();
+  });
+
+  function readState(): any {
+    return JSON.parse(readFileSync(contextHandoffLeasePath(ctxRoot), 'utf-8'));
+  }
+
+  function createChecker(
+    agentName: string,
+    opts: { pct?: number; sessionId?: string } = {},
+  ): { agentName: string; checker: FastChecker; injectMessage: ReturnType<typeof vi.fn> } {
+    const stateDir = join(ctxRoot, 'state', agentName);
+    const agentDir = join(ctxRoot, 'agents', agentName);
+    mkdirSync(stateDir, { recursive: true });
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'config.json'), JSON.stringify({}), 'utf-8');
+    const status: Record<string, unknown> = {
+      // Default crosses the handoff threshold (default-ON at 60%) so the herd test
+      // fires handoffs without each call having to pass an explicit pct.
+      used_percentage: opts.pct ?? 70,
+      exceeds_200k_tokens: false,
+      written_at: new Date().toISOString(),
+    };
+    if (opts.sessionId) status.session_id = opts.sessionId;
+    writeFileSync(
+      join(stateDir, 'context_status.json'),
+      JSON.stringify(status),
+      'utf-8',
+    );
+    const injectMessage = vi.fn();
+    const agent = {
+      name: agentName,
+      injectMessage,
+      getConfig: () => ({}),
+      getAgentDir: () => agentDir,
+      getOutputBuffer: () => ({ getRecent: () => '' }),
+      sessionRefresh: () => Promise.resolve(),
+    } as any;
+    const paths: BusPaths = {
+      ctxRoot,
+      inbox: join(ctxRoot, 'inbox'),
+      inflight: join(ctxRoot, 'inflight'),
+      processed: join(ctxRoot, 'processed'),
+      logDir: join(ctxRoot, 'logs', agentName),
+      stateDir,
+      taskDir: join(ctxRoot, 'tasks'),
+      approvalDir: join(ctxRoot, 'approvals'),
+      analyticsDir: join(ctxRoot, 'analytics'),
+      heartbeatDir: join(ctxRoot, 'heartbeats'),
+    };
+    for (const dir of Object.values(paths)) mkdirSync(dir, { recursive: true });
+    const checker = new FastChecker(agent, paths, '/tmp/framework', {
+      log: () => {},
+    });
+    return { agentName, checker, injectMessage };
+  }
+
+  function handoffPrompts(record: { injectMessage: ReturnType<typeof vi.fn> }): string[] {
+    return record.injectMessage.mock.calls
+      .map((call) => String(call[0]))
+      .filter((message) => message.includes('[CONTEXT HANDOFF REQUIRED]'));
+  }
+});

--- a/tests/unit/daemon/context-monitor.test.ts
+++ b/tests/unit/daemon/context-monitor.test.ts
@@ -163,6 +163,88 @@ describe('context monitor circuit breaker', () => {
   });
 });
 
+// --- Overflow-banner backstop self-referential guard ---
+
+describe('overflow-banner backstop corroboration guard', () => {
+  // Mirrors the hard overflow backstop in fast-checker.ts (~line 977). The PTY
+  // banner regex is a backstop that force-restarts when Claude's live context-
+  // overflow banner appears in an agent's terminal. Without the
+  // ctxCorroboratesOverflow gate, the regex matched those banner phrases as benign
+  // TEXT — so any agent that merely READ or DISCUSSED the overflow/compaction
+  // mechanism (memory files, daemon source, chat) printed the strings into its own
+  // PTY buffer and force-restarted itself at low context. Because the watchdog is
+  // shared, multiple agents investigating the compaction mechanism at once could
+  // cascade across runtimes. The gate requires usage to corroborate the banner:
+  // exceeds_200k OR pct >= 85.
+  const OVERFLOW_BANNER_RE = /extra usage.*?1[Mm] context|conversation too long.*?compaction/i;
+
+  // NEW (guarded) detector — gates the banner regex on real high context.
+  function forceRestartsOnOverflow(recentOutput: string, pct: number | null, exceeds200k: boolean): boolean {
+    const ctxCorroboratesOverflow = exceeds200k || (pct !== null && pct >= 85);
+    return ctxCorroboratesOverflow && OVERFLOW_BANNER_RE.test(recentOutput);
+  }
+
+  // OLD (pre-fix) detector — regex only, no context gate. Kept here ONLY to prove
+  // the regression test has teeth: each real cascade string below MUST trip this,
+  // and MUST NOT trip the guarded detector at low context. A test that passed on
+  // both code paths would prove nothing.
+  function oldDetectorRestarts(recentOutput: string): boolean {
+    return OVERFLOW_BANNER_RE.test(recentOutput);
+  }
+
+  // The real same-line banner strings that triggered the false-positive. The regex
+  // has no /s flag, so both tokens must share a line.
+  const CASCADE_STRINGS = [
+    // an agent's own answer describing the mechanism to the user
+    'Context compaction/handoff — YES. The daemon watches compaction signals ("conversation too long…compaction") at threshold',
+    // an agent's memory entry documenting the bug, quoting the regex pattern
+    '## Self-Referential Overflow False-Positive — detector trips on conversation too long.*compaction in its own output',
+    // an agent's diagnosis, quoting the pattern verbatim
+    'fast-checker.ts has an unconditional regex that force-restarts on text matching conversation too long.*compaction',
+  ];
+
+  it('TEETH: every real cascade string trips the OLD detector (reproduces the bug)', () => {
+    // If any of these did NOT match, the test would be a no-op green.
+    for (const s of CASCADE_STRINGS) {
+      expect(oldDetectorRestarts(s)).toBe(true);
+    }
+  });
+
+  it('ROOT CAUSE: the same real cascade strings at LOW context do NOT force-restart on the fix', () => {
+    // Each of these benign quotes looped an agent on old code; the guard kills it.
+    for (const s of CASCADE_STRINGS) {
+      expect(forceRestartsOnOverflow(s, 12, false)).toBe(false);
+      expect(forceRestartsOnOverflow(s, 70, false)).toBe(false);
+      expect(forceRestartsOnOverflow(s, 84, false)).toBe(false);
+    }
+  });
+
+  it('genuine overflow (pct >= 85) with the banner DOES force-restart (backstop preserved)', () => {
+    // Boundary: 84 is safe (covered above), 85 acts.
+    expect(forceRestartsOnOverflow(CASCADE_STRINGS[0], 85, false)).toBe(true);
+    expect(forceRestartsOnOverflow(CASCADE_STRINGS[0], 99, false)).toBe(true);
+  });
+
+  it('genuine overflow (exceeds_200k, null pct) with the banner DOES force-restart', () => {
+    expect(forceRestartsOnOverflow(CASCADE_STRINGS[0], null, true)).toBe(true);
+  });
+
+  it('high context with NO banner phrase does NOT force-restart (regex still required)', () => {
+    expect(forceRestartsOnOverflow('ordinary work output, nothing about overflow', 99, true)).toBe(false);
+  });
+
+  it('the "extra usage / 1M context" banner variant is gated the same way', () => {
+    const variant = 'error: enable extra usage to access the 1M context window';
+    expect(forceRestartsOnOverflow(variant, 20, false)).toBe(false); // low context, benign
+    expect(forceRestartsOnOverflow(variant, 90, false)).toBe(true);  // genuine overflow
+  });
+
+  it('AGENTS.md-style boot text quoting the phrase at low context is safe', () => {
+    const bootText = 'fast-checker watches context % and compaction signals ("conversation too long...compaction")';
+    expect(forceRestartsOnOverflow(bootText, 8, false)).toBe(false);
+  });
+});
+
 // --- Handoff block consumption ---
 
 describe('consumeHandoffBlock', () => {

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -898,4 +898,112 @@ describe('FastChecker', () => {
       expect(injected).toContain('````');
     });
   });
+
+  // Truth table for the context-handoff default-ON behavior shipped by PR-A.
+  // Guards two invariants people's downloaded agents depend on:
+  //   T1  unset ctx_handoff_threshold => default-ON at 60% (warn 30) of the model window.
+  //   T7  ctx_handoff_threshold <= 0  => deliberate opt-out (observe-only, never acts).
+  // Exercises the REAL checkContextStatus + getCtxThresholds (not a re-implementation),
+  // so flipping the 60 default back to 40, or breaking the <=0 opt-out, fails here.
+  describe('context-handoff default truth table (PR-A)', () => {
+    // Agent mock with the surface getCtxThresholds/checkContextStatus touch.
+    // getConfig() returns a stable reference so getCtxThresholds can mutate it
+    // from config.json the same way the real AgentProcess does.
+    function makeCtxAgent(name = 'ctx-agent') {
+      const config: any = {};
+      return {
+        name,
+        isBootstrapped: vi.fn().mockReturnValue(true),
+        injectMessage: vi.fn().mockReturnValue(true),
+        write: vi.fn(),
+        getAgentDir: () => testDir,
+        getConfig: () => config,
+        getOutputBuffer: () => ({ getRecent: () => '' }),
+        sessionRefresh: vi.fn().mockResolvedValue(undefined),
+      } as any;
+    }
+
+    function writeConfig(cfg: Record<string, unknown>) {
+      writeFileSync(join(testDir, 'config.json'), JSON.stringify(cfg), 'utf-8');
+    }
+
+    function writeCtxStatus(pct: number) {
+      writeFileSync(
+        join(paths.stateDir, 'context_status.json'),
+        JSON.stringify({ used_percentage: pct, exceeds_200k_tokens: false, written_at: new Date().toISOString() }),
+        'utf-8',
+      );
+    }
+
+    function injected(agent: any): string[] {
+      return agent.injectMessage.mock.calls.map((c: any[]) => c[0] as string);
+    }
+
+    it('T1: unset threshold defaults to handoff 60 / warn 30', () => {
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      writeConfig({});
+      expect((checker as any).getCtxThresholds()).toEqual({ warn: 30, handoff: 60 });
+    });
+
+    it('T1: default-ON fires a handoff at 60%', async () => {
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      writeConfig({});
+      writeCtxStatus(60);
+      await (checker as any).checkContextStatus();
+      expect(injected(agent).some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(true);
+      expect((checker as any).ctxHandoffFiredAt).toBeGreaterThan(0);
+    });
+
+    it('T1: at 59% it warns (not handoff) and names the 60% trigger', async () => {
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      writeConfig({});
+      writeCtxStatus(59);
+      await (checker as any).checkContextStatus();
+      const msgs = injected(agent);
+      expect(msgs.some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(false);
+      expect(msgs.some(m => m.includes('Handoff triggers at 60%'))).toBe(true);
+      expect((checker as any).ctxHandoffFiredAt).toBe(0);
+    });
+
+    it('T7: ctx_handoff_threshold <= 0 opts out — no warning, no handoff', async () => {
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      writeConfig({ ctx_handoff_threshold: 0 });
+      writeCtxStatus(90);
+      await (checker as any).checkContextStatus();
+      expect(agent.injectMessage).not.toHaveBeenCalled();
+      expect((checker as any).ctxHandoffFiredAt).toBe(0);
+    });
+
+    it('explicit threshold is still honored (config overrides the default)', async () => {
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      writeConfig({ ctx_handoff_threshold: 50 });
+      writeCtxStatus(55);
+      await (checker as any).checkContextStatus();
+      expect(injected(agent).some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(true);
+    });
+
+    it('cooperative-restart loop backstop trips the breaker after repeated handoff fires', async () => {
+      // Treadmill simulation: a runtime that does not reset context on the handoff
+      // restart re-crosses the threshold every cycle. Each cycle is a fresh session
+      // (ctxHandoffFiredAt back to 0) but the persisted handoff-fire window accumulates.
+      // The first two fires hand off normally (a benign 1-2 settle); the third trips the
+      // circuit breaker (30min pause) instead of handing off again, so the loop self-limits.
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      writeConfig({});
+      for (let i = 0; i < 3; i++) {
+        writeCtxStatus(70);
+        (checker as any).ctxHandoffFiredAt = 0; // simulate the fresh session re-crossing
+        await (checker as any).checkContextStatus();
+      }
+      const handoffPrompts = injected(agent).filter(m => m.includes('CONTEXT HANDOFF REQUIRED'));
+      expect(handoffPrompts.length).toBe(2); // 3rd fire tripped the breaker instead of handing off
+      expect((checker as any).ctxCircuitBrokenAt).not.toBeNull();
+    });
+  });
 });

--- a/tests/unit/pty/codex-app-server-pty.test.ts
+++ b/tests/unit/pty/codex-app-server-pty.test.ts
@@ -832,30 +832,35 @@ describe('CodexAppServerPTY thread lifecycle', () => {
     });
   });
 
-  it('resumes the persisted thread in fresh mode when state exists', async () => {
+  it('starts a NEW thread in fresh mode even when persisted state exists (treadmill fix)', async () => {
+    // Regression guard: a context-handoff / .force-fresh restart runs in FRESH
+    // mode and MUST NOT resume the persisted thread. Resuming retains the full
+    // context window, so the handoff never lowers usage and the agent re-crosses
+    // the threshold and re-fires — a restart treadmill (cortext-designer PR-A
+    // live validation 2026-06-29). Fresh mode must thread/start a brand-new thread.
     fsMocks.existsSync.mockReturnValue(true);
     fsMocks.readFileSync.mockReturnValue(JSON.stringify({
       threadId: 'persisted-fresh-thread',
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       updatedAt: '2026-05-07T00:00:00Z',
     }));
-    requestMock.mockResolvedValue({ result: { thread: { id: 'persisted-fresh-thread' } } });
+    requestMock.mockResolvedValue({ result: { thread: { id: 'new-fresh-thread' } } });
     const pty = new CodexAppServerPTY(mockEnv, {});
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('fresh');
 
-    expect(requestMock).toHaveBeenCalledWith('thread/resume', {
-      threadId: 'persisted-fresh-thread',
+    expect(requestMock).toHaveBeenCalledWith('thread/start', {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       approvalPolicy: 'never',
       sandbox: 'danger-full-access',
       config: { features: { goals: true } },
-      excludeTurns: true,
+      sessionStartSource: 'startup',
+      experimentalRawEvents: false,
       persistExtendedHistory: true,
     });
     expect(requestMock).not.toHaveBeenCalledWith(
-      'thread/start',
+      'thread/resume',
       expect.anything(),
     );
   });
@@ -930,7 +935,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
     const pty = new CodexAppServerPTY(mockEnv, {});
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
-      last: { cachedInputTokens: 0, inputTokens: 1000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 1000 },
+      last: { cachedInputTokens: 5000, inputTokens: 60000, outputTokens: 4000, reasoningOutputTokens: 1000, totalTokens: 70000 },
       total: { cachedInputTokens: 5000, inputTokens: 60000, outputTokens: 4000, reasoningOutputTokens: 1000, totalTokens: 70000 },
       modelContextWindow: 200000,
     });
@@ -956,8 +961,8 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
     const pty = new CodexAppServerPTY(mockEnv, {});
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
-      last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
-      total: { cachedInputTokens: 0, inputTokens: 64000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 64000 },
+      last: { cachedInputTokens: 0, inputTokens: 64000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 64000 },
+      total: { cachedInputTokens: 0, inputTokens: 640000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 640000 },
       modelContextWindow: null,
     });
 
@@ -970,8 +975,8 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
     const pty = new CodexAppServerPTY(mockEnv, { codex_context_cap: 100000 });
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
-      last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
-      total: { cachedInputTokens: 0, inputTokens: 50000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 50000 },
+      last: { cachedInputTokens: 0, inputTokens: 50000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 50000 },
+      total: { cachedInputTokens: 0, inputTokens: 500000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 500000 },
       modelContextWindow: null,
     });
 
@@ -984,8 +989,8 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
     const pty = new CodexAppServerPTY(mockEnv, {});
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
-      last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
-      total: { cachedInputTokens: 0, inputTokens: 210000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 210000 },
+      last: { cachedInputTokens: 0, inputTokens: 210000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 210000 },
+      total: { cachedInputTokens: 0, inputTokens: 2100000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 2100000 },
       modelContextWindow: 1000000,
     });
 
@@ -997,13 +1002,52 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
     const pty = new CodexAppServerPTY(mockEnv, {});
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
-      last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
-      total: { cachedInputTokens: 0, inputTokens: 300000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 300000 },
+      last: { cachedInputTokens: 0, inputTokens: 300000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 300000 },
+      total: { cachedInputTokens: 0, inputTokens: 3000000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 3000000 },
       modelContextWindow: 256000,
     });
 
     const payload = lastWrittenPayload()!;
     expect(payload.used_percentage).toBe(100);
+  });
+
+  it('uses current-window last tokens instead of lifetime total tokens', () => {
+    const pty = new CodexAppServerPTY(mockEnv, {});
+    (pty as unknown as { _threadId: string })._threadId = 'thread-9';
+    feedTokenUsage(pty, {
+      last: { cachedInputTokens: 30000, inputTokens: 80000, outputTokens: 2000, reasoningOutputTokens: 0, totalTokens: 82000 },
+      total: { cachedInputTokens: 312000000, inputTokens: 323000000, outputTokens: 880000, reasoningOutputTokens: 0, totalTokens: 324000000 },
+      modelContextWindow: 258400,
+    });
+
+    const payload = lastWrittenPayload()!;
+    expect(payload.used_percentage).toBeCloseTo((82000 / 258400) * 100, 5);
+    expect(payload.used_percentage).not.toBe(100);
+    expect(payload.current_usage).toEqual({
+      input_tokens: 80000,
+      output_tokens: 2000,
+      cache_read_input_tokens: 30000,
+      cache_creation_input_tokens: 0,
+    });
+  });
+
+  it('writes null used_percentage instead of false-100 when current-window data is missing', () => {
+    const pty = new CodexAppServerPTY(mockEnv, {});
+    (pty as unknown as { _threadId: string })._threadId = 'thread-9';
+    feedTokenUsage(pty, {
+      total: { cachedInputTokens: 312000000, inputTokens: 323000000, outputTokens: 880000, reasoningOutputTokens: 0, totalTokens: 324000000 },
+      modelContextWindow: 258400,
+    });
+
+    const payload = lastWrittenPayload()!;
+    expect(payload.used_percentage).toBeNull();
+    expect(payload.exceeds_200k_tokens).toBe(false);
+    expect(payload.current_usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+    });
   });
 
   it('skips the write when params.tokenUsage is missing', () => {
@@ -1016,7 +1060,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
     expect(atomicWriteSyncMock).not.toHaveBeenCalled();
   });
 
-  it('skips the write when total.totalTokens is missing', () => {
+  it('writes null used_percentage when total.totalTokens is missing', () => {
     const pty = new CodexAppServerPTY(mockEnv, {});
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
@@ -1024,7 +1068,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
       total: { cachedInputTokens: 0, inputTokens: 100, outputTokens: 0, reasoningOutputTokens: 0 },
       modelContextWindow: 200000,
     });
-    expect(atomicWriteSyncMock).not.toHaveBeenCalled();
+    expect(lastWrittenPayload()?.used_percentage).toBe(0);
   });
 
   it('still emits the event log line even on a successful context write', () => {


### PR DESCRIPTION
## Summary

Make the runtime-agnostic context-handoff mechanism ship **enabled by default** so any install/pull restarts an agent before native compaction, writes a resume-ready handoff doc, and reboots fresh from it.

Previously an unset `ctx_handoff_threshold` meant observe-only. Now it defaults to **warn 30% / handoff 60%** of the active model's real context window (so it adapts per model). Opt out with `ctx_handoff_threshold <= 0`.

- Default-on at 60% of the model context window (fast-checker)
- Wire the statusLine context-status writer into the Claude templates so used-percentage is reported for the threshold computation
- Report current (not lifetime) context usage from the codex adapter
- Rate-limit concurrent handoffs with a release-safe lease (cap 2, queue the rest; release by name, session-id independent, on fresh session)
- Gate the PTY overflow backstop on real high context to avoid false 100%
- **codex:** a context-handoff (fresh) restart now starts a genuinely new thread — only resume a persisted codex thread in `continue` mode. Resuming on a fresh restart retained the full context window, so the handoff never lowered usage and the agent immediately re-crossed the threshold and re-fired (a restart treadmill).
- **Loop backstop:** the context circuit breaker now also counts Tier-2 handoff fires in a persisted 15-min window and trips (30-min pause + alert) at the cap, so any handoff loop self-limits regardless of cause (the breaker previously only counted Tier-3 force-restarts).

## Test Plan

Validated on a clean clone of this repo + this PR, driving live agents' context up with realistic prompts (not synthetic file pokes):

- **Unit:** build clean; affected suites green (158/158 across the changed files); truth-table asserts the default-ON contract (unset => warn 30 / handoff 60, `<= 0` opt-out, explicit threshold honored) and the loop backstop trips at the cap.
- **Claude runtime (live):** context driven to 60% — handoff fired once at 60%, warning at 30%, wrote a 5-section resume doc, hard-fresh restart (not `--continue`), resumed from the doc, kept working through it. ~0% overshoot (statusLine is continuous).
- **Codex runtime (live):** handoff fires once, a new thread is minted each restart, context resets and holds, no treadmill; turn-boundary overshoot stays well under native-compaction headroom. The loop backstop trips precisely at the cap (pause + alert + lease release) when a loop is forced.
- 24h stability soak (claude + codex) in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
