### PR TITLE
feat(security): server-side leak-guard CI check (SEC-1 L1/L4)

### DIFF
--- a/.github/scripts/leak-guard.sh
+++ b/.github/scripts/leak-guard.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+#
+# leak-guard.sh — server-side operational-leak scanner for the PUBLIC repo.
+#
+# Catches the class of leak where internal fleet operational detail (agent
+# roster + cron schedules, operator home paths, real org content, secrets) gets
+# committed to the public framework repo. This is the server-side backstop that
+# a local pre-push hook cannot provide: it runs in CI on every pull_request and
+# push to main, so it covers fork PRs and GitHub UI-merges too.
+#
+# DESIGN: block on the LEAK SHAPE, not on framework convention. The framework
+# legitimately uses agent names (boris/paul/...) as doc placeholders and `lifeos`
+# as a test-fixture org name in hundreds of lines — those are NOT leaks and must
+# NOT trip this guard. We match only high-signal shapes that never appear in
+# legitimate framework code.
+#
+# Usage:
+#   leak-guard.sh <file>...        scan the given files
+#   leak-guard.sh --tree <ref>     scan every tracked file at <ref>
+# Exit 0 = clean, exit 1 = leak(s) found (details on stderr).
+
+set -uo pipefail
+
+fail=0
+report() { printf '::error file=%s::LEAK-GUARD: %s\n' "$1" "$2" >&2; printf '  %s: %s\n' "$1" "$2" >&2; fail=1; }
+
+# ---- Patterns (each is high-signal for a real leak, low false-positive) ----
+
+# 1. Operator home paths — the real operator's machine paths never belong in
+#    the public framework. Match the KNOWN operator identities specifically so
+#    generic example paths (/Users/foo, /home/victim, /Users/.../) do not FP.
+#    Extend OPERATOR_USERS as needed; this is the exact leaked-path class.
+OPERATOR_USERS='cortextos'
+HOME_PATH_RE="(/Users/(${OPERATOR_USERS})/|/home/(${OPERATOR_USERS})/)"
+
+# 2. Fleet-roster + cron-schedule TABLE shape — the phase-report leak. A line
+#    naming an agent alongside a cron schedule expression. Framework SOURCE and
+#    TEST fixtures legitimately build agent+cron structures, so this check is
+#    scoped to non-test files only (see scan_file) — the leak was in docs/.
+ROSTER_CRON_RE='(boris|paul|sentinel|donna|nick)[^\n]*(heartbeat\([0-9]|morning-review|evening-review|human-task-sweep|pr-monitor\([0-9]|\([0-9]+ [0-9*]+ \* \* )'
+
+# 3. Secret shapes — real credentials. Obvious placeholders (xxxx/1234567890/
+#    example) are excluded per-line in scan_file so doc token examples do not FP.
+SECRET_RE='(sk-ant-[A-Za-z0-9_-]{20}|sbp_[a-f0-9]{40}|[0-9]{8,}:AA[A-Za-z0-9_-]{30}|AIza[A-Za-z0-9_-]{35}|apify_api_[A-Za-z0-9]{30})'
+SECRET_PLACEHOLDER='x{6,}|1234567890|123456789|EXAMPLE|example|YOUR_|<[a-z]|placeholder|xxxx'
+
+# 4. Operational-artifact PATH shapes — dev reports that should never be public.
+ARTIFACT_PATH_RE='(^|/)(docs/phase-reports/|[A-Za-z0-9_-]*INSTALL_REPORT\.md$|PHASE[0-9]+-[A-Z-]+-REPORT\.md$)'
+
+scan_file() {
+  local f="$1"
+  # Skip this guard's own script + workflow (they legitimately contain patterns).
+  case "$f" in
+    .github/scripts/leak-guard.sh|.github/workflows/leak-guard.yml) return ;;
+  esac
+
+  # Path-shape check (applies to any path).
+  if printf '%s' "$f" | grep -qE "$ARTIFACT_PATH_RE"; then
+    report "$f" "operational-artifact path (dev report — must not be in public repo)"
+  fi
+
+  # Content checks only for existing, non-binary files.
+  [ -f "$f" ] || return
+  grep -Iq . "$f" 2>/dev/null || return   # skip binary
+
+  # Operator home path — any match is a real leak (operator-specific pattern).
+  if grep -nEq "$HOME_PATH_RE" "$f" 2>/dev/null; then
+    report "$f" "operator home path: $(grep -nE "$HOME_PATH_RE" "$f" | head -1 | tr -s ' ' | cut -c1-100)"
+  fi
+
+  # Roster+cron table — scope OUT test files/fixtures (they legitimately build
+  # agent+cron structures); the leak class was operational docs, not tests.
+  case "$f" in
+    tests/*|*.test.*|*.spec.*|*/__tests__/*|*/fixtures/*) ;;
+    *)
+      if grep -nEq "$ROSTER_CRON_RE" "$f" 2>/dev/null; then
+        report "$f" "fleet roster + cron-schedule table (internal ops detail)"
+      fi ;;
+  esac
+
+  # Secret shapes — skip lines that are obvious placeholders/examples.
+  while IFS= read -r line; do
+    printf '%s' "$line" | grep -qE "$SECRET_PLACEHOLDER" && continue
+    report "$f" "secret-shaped token: $(printf '%s' "$line" | cut -c1-60)"
+  done < <(grep -nE "$SECRET_RE" "$f" 2>/dev/null)
+}
+
+if [ "${1:-}" = "--tree" ]; then
+  ref="${2:-HEAD}"
+  while IFS= read -r f; do scan_file "$f"; done < <(git ls-tree -r --name-only "$ref")
+else
+  for f in "$@"; do scan_file "$f"; done
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "" >&2
+  echo "leak-guard FAILED: operational leak(s) detected above. If a match is a" >&2
+  echo "false positive on legitimate framework content, refine the pattern in" >&2
+  echo ".github/scripts/leak-guard.sh — do NOT bypass the check." >&2
+  exit 1
+fi
+echo "leak-guard: clean"
+exit 0

--- a/.github/workflows/leak-guard.yml
+++ b/.github/workflows/leak-guard.yml
@@ -1,0 +1,42 @@
+name: Leak Guard
+
+# Server-side operational-leak backstop. Runs on every PR (incl. forks) and on
+# push to main, so it covers the paths a LOCAL pre-push hook cannot: fork PRs
+# and GitHub UI-merges. Intended to be a REQUIRED status check on main.
+#
+# SECURITY: uses `pull_request` (NOT `pull_request_target`) so fork PRs run with
+# a read-only token and NO repo secrets — the scanner only needs to read the
+# diff and fail. pull_request_target would expose secrets to untrusted fork code.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  leak-guard:
+    name: Operational-leak scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Scan for operational leaks
+        run: |
+          chmod +x .github/scripts/leak-guard.sh
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base="origin/${{ github.base_ref }}"
+            git fetch origin "${{ github.base_ref }}" --quiet
+            files=$(git diff --name-only --diff-filter=ACMR "$base"...HEAD)
+            if [ -z "$files" ]; then echo "No changed files to scan."; exit 0; fi
+            echo "Scanning changed files:"; echo "$files"
+            echo "$files" | xargs .github/scripts/leak-guard.sh
+          else
+            .github/scripts/leak-guard.sh --tree HEAD
+          fi
+
+      - name: Prove the scanner (falsifiability test)
+        run: bash tests/leak-guard.test.sh

--- a/.gitignore
+++ b/.gitignore
@@ -60,5 +60,10 @@ dashboard/test-*.py
 !community/agents/research-agent/
 !community/agents/research-agent/**
 
-# Leaked internal ops report - never re-track (removed 2026-07-01)
+# Internal ops/dev reports — never public (2026-07-01 leak remediation, SEC-1 L4).
+# docs/ is already ignored above; these cover root-level and phase-report globs
+# so a dev artifact cannot re-track outside docs/. Real user docs live elsewhere.
 WINDOWS_INSTALL_REPORT.md
+*INSTALL_REPORT.md
+/PHASE*-REPORT.md
+docs/phase-reports/

--- a/tests/leak-guard.test.sh
+++ b/tests/leak-guard.test.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Falsifiability test for the leak-guard scanner (.github/scripts/leak-guard.sh).
+#
+# A scanner nobody has watched FAIL on a real leak is unproven. This asserts:
+#   (a) it FAILS on a planted leak carrying the exact shape that leaked on
+#       2026-07-01 — agent roster + a cron-timing table + an operator abs-path;
+#   (b) it PASSES on the current clean tree (no false positives on the
+#       legitimate framework convention: agent-name placeholders, lifeos
+#       test fixtures, obvious placeholder tokens).
+#
+# The planted leak is generated in a temp dir at runtime — never committed —
+# because a committed file carrying the operator path would itself trip the
+# tree scan. The operator username is split ("cortex""tos") so THIS test file
+# carries no operator-path literal.
+
+set -uo pipefail
+cd "$(dirname "$0")/.."
+GUARD=".github/scripts/leak-guard.sh"
+TMP=$(mktemp -d); trap 'rm -rf "$TMP"' EXIT
+U="cortex""tos"
+fails=0
+
+cat > "$TMP/planted.md" <<EOF
+# Phase Multi-Agent Report
+| Agents simulated | 5 (boris, paul, sentinel, donna, nick) |
+| paul | 6 | heartbeat(4h), morning-review(0 13 * * *), evening-review(0 1 * * *) |
+Checked at /Users/$U/cortextos/orgs/lifeos/agents/boris/AGENTS.md
+EOF
+
+# (a) MUST FAIL on the planted leak, and report BOTH detections.
+out=$(bash "$GUARD" "$TMP/planted.md" 2>&1) \
+  && { echo "FAIL: scanner PASSED a planted leak (should have failed)"; fails=1; }
+printf '%s\n' "$out" | grep -q 'operator home path' \
+  || { echo "FAIL: operator home path not detected in planted leak"; fails=1; }
+printf '%s\n' "$out" | grep -q 'roster' \
+  || { echo "FAIL: roster+cron table not detected in planted leak"; fails=1; }
+
+# (b) MUST PASS on the current clean tree.
+bash "$GUARD" --tree HEAD >/dev/null 2>&1 \
+  || { echo "FAIL: scanner flagged the CLEAN tree (false positive)"; fails=1; }
+
+if [ "$fails" -eq 0 ]; then echo "leak-guard.test: PASS"; else echo "leak-guard.test: FAIL"; exit 1; fi


### PR DESCRIPTION
## Summary

Server-side prevention for the 2026-07-01 fleet-metadata leak (13 dev-report files exposing the agent roster + cron schedules + operator paths on public `main`, since removed via history scrub). This is **SEC-1 layers L1 + L4**; L2 and L3 are noted below.

**L1 — the lock (`.github/workflows/leak-guard.yml` + `.github/scripts/leak-guard.sh`)**
A CI check on every `pull_request` (fork-safe: `pull_request`, NOT `pull_request_target`, so fork code runs read-only with no secrets) and `push` to `main`. It is the backstop a local pre-push hook cannot provide — it covers **fork PRs and GitHub UI-merges**, the exact paths that let the leak persist on open PR branches. Intended as a **required status check** (L2, post-merge).

Design principle: block on the operational **leak shape**, never on legitimate framework convention. The framework legitimately uses agent names (`boris`/`paul`/…) as doc placeholders and `lifeos` as a test-fixture org name across hundreds of lines — those are NOT leaks and must not trip the guard.

**Blocklist patterns (verbatim — this is the load-bearing control, please review coverage):**
- **Operator home paths** — `/Users/(cortextos)/` and `/home/(cortextos)/` (the real operator identity; `OPERATOR_USERS` is extensible). Generic examples like `/Users/foo`, `/home/victim`, `/Users/.../` do not match.
- **Fleet roster + cron table** — `(boris|paul|sentinel|donna|nick)` on the same line as a cron schedule (`heartbeat(Nh)`, `morning-review`, `evening-review`, `(0 13 * * *)` etc.). **Scoped OUT of test files/fixtures** (`tests/**`, `*.test.*`, `*.spec.*`, `__tests__`, `fixtures`) which legitimately build agent+cron structures — the leak class was operational docs.
- **Secret shapes** — `sk-ant-…`, `sbp_…`, Telegram `NNNNNNNN:AA…`, `AIza…`, `apify_api_…`; obvious placeholders (`xxxx`, `1234567890`, `EXAMPLE`, `YOUR_`, `<…`, `placeholder`) are skipped so doc token examples do not FP.
- **Artifact paths** — `docs/phase-reports/`, `*INSTALL_REPORT.md`, `PHASE*-…-REPORT.md`.

**L4 — broadened `.gitignore`** so root-level `*INSTALL_REPORT.md` / `PHASE*-REPORT.md` / `docs/phase-reports/` dev artifacts cannot re-track.

## Test plan

`tests/leak-guard.test.sh` (a **falsifiability proof**, run by the workflow):
- **MUST FAIL** on a planted leak carrying the exact leaked shape (roster + cron-timing table + operator abs-path), asserting BOTH the home-path and roster detections fire. Fixture is generated in a temp dir at runtime (never committed — a committed operator-path file would itself trip the scan).
- **MUST PASS** on the current clean tree (no false positives).

Proven locally: planted leak → exit 1 (both detections); clean tree → exit 0. `leak-guard.test: PASS`.

## Follow-ups (not in this PR)

- **L2 (branch protection):** make `leak-guard` a required status check on `main` + PR-only + admin-only force-push. This only registers after the check runs once (post-merge), and it changes the merge flow for the whole nightly PR cycle — so it is a deliberate post-merge step gated on an explicit go, applied via `gh api` (admin access confirmed).
- **L3 (clone-time hook activation):** set `core.hooksPath` to the tracked `scripts/hooks/` in `install.mjs`/`init.ts` so the existing pre-push hook is active on every clone (today it is tracked but never installed). Fast-follow. Honest caveat: local hooks are bypassable via `--no-verify` and UI-merge — **L1 (server-side) is the real backstop**, L3 is defense-in-depth.
- **Fork exposure (#692):** the leak also lives on an external fork PR (`fil-up/cortextos`), which cannot be force-pushed from here — separate human-coordination track.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
