### PR TITLE
docs: teach opencode runtime in agent-management skill + README/CLAUDE

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ npm test
 - `src/` — TypeScript source (bus, cli, daemon, hooks, types, utils)
 - `bus/` — Shell wrapper scripts (delegate to `dist/cli.js bus`)
 - `dashboard/` — Next.js 14 web dashboard
-- `templates/` — Agent templates (agent, orchestrator, analyst)
+- `templates/` — Agent templates (agent, orchestrator, analyst, agent-codex, agent-opencode)
 - `community/` — Community skills and agent catalog
 - `tests/` — Unit, integration, and E2E tests
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Boss:    Done. "morning-inbox" cron set — runs daily at 08:00.
 
 - **Persistent agents** — Claude Code runs 24/7 in PTY sessions, auto-restarting on crash or after 71-hour context rotation.
 - **Multi-agent orchestration** — Orchestrator, Analyst, and specialist agents coordinate via a shared file bus. Tasks, blockers, and approvals flow automatically.
-- **Multi-runtime** — Run agents on `claude-code` (default) or OpenAI's `codex-app-server`. Both runtimes share the same bus, crons, dashboard, and Telegram integration; pick per-agent.
+- **Multi-runtime** — Run agents on `claude-code` (default), OpenAI's `codex-app-server`, or the provider-agnostic `opencode` TUI runtime. All runtimes share the same bus, crons, dashboard, and Telegram integration; pick per-agent.
 - **Telegram + iOS control** — Send commands, approve actions, and get reports from anywhere. Native iOS app coming soon.
 - **Web dashboard** — Full-featured Next.js UI for tasks, approvals, experiments, analytics, and agent fleet health.
 - **Autoresearch (theta wave)** — Agents run autonomous experiments overnight, evaluate results, and surface findings for your review.
@@ -115,6 +115,7 @@ pm2 start ecosystem.config.js && pm2 save && pm2 startup
 | `analyst` | System health, metrics, theta-wave autoresearch, analytics |
 | `agent` | General-purpose worker — use this as the base for specialist agents |
 | `agent-codex` | Codex-runtime worker, scaffolds with `runtime: codex-app-server` and `model: gpt-5-codex` (see `templates/agent-codex/`) |
+| `agent-opencode` | OpenCode-runtime worker, scaffolds with `runtime: opencode` and the context-handoff lifecycle (see `templates/agent-opencode/`) |
 
 Add a codex agent the same way you add a claude agent:
 
@@ -134,9 +135,12 @@ Every agent's `config.json` carries an explicit `runtime` field that the daemon 
 |---|---|---|---|
 | `claude-code` | `ClaudePTY` (default) | claude-sonnet-4-6 | `.claude/skills/<skill>/SKILL.md` |
 | `codex-app-server` | `CodexAppServerPTY` | `gpt-5-codex` | `plugins/cortextos-agent-skills/skills/<skill>/SKILL.md` (linked into `~/.codex/skills/<agent>__<skill>`) |
+| `opencode` | `OpencodePTY` | `openai/gpt-4.1-nano` (set in `config.json`) | `plugins/cortextos-agent-skills/skills/<skill>/SKILL.md` (linked into `.opencode/skills/<skill>`) |
 | `hermes` | `HermesPTY` (experimental) | model per `config.json` | hermes-specific |
 
 Pass `--runtime <kind>` on `add-agent` to set it at scaffold time, or edit the field in `config.json` and restart the agent. The default is `claude-code`. Today only `--template agent` (and the alias `--template agent-codex`) supports `--runtime codex-app-server` — pairing the codex runtime with `--template orchestrator`/`analyst`/`m2c1-worker`/`hermes` errors with a clean message until codex variants of those templates ship.
+
+`opencode` agents run OpenCode's terminal UI as a persistent PTY and are provider-agnostic — set any `provider/model` in `config.json` (default `openai/gpt-4.1-nano`). Scaffold with `--template agent --runtime opencode` (auto-maps to the `agent-opencode` bootstrap) or `--template agent-opencode` directly. OpenCode agents also ship the **context-handoff lifecycle**: the daemon watches each session's context-window usage and, at a configurable threshold (`ctx_handoff_threshold`, default 60%), prompts the agent to write a handoff document under `memory/handoffs/` and hard-restart into a fresh session that resumes from that doc — so long-running agents never lose state to a context overflow. Tune it with `ctx_warning_threshold` (default 30%) and `ctx_handoff_threshold` in `config.json`.
 
 ---
 

--- a/community/agents/research-agent/.claude/skills/agent-management/SKILL.md
+++ b/community/agents/research-agent/.claude/skills/agent-management/SKILL.md
@@ -18,7 +18,7 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 4. **ALWAYS use `cortextos enable` to start agents.** Never manually edit PM2 config.
 5. **NEVER share bot tokens between agents.** Each agent gets its own bot from @BotFather.
 6. **NEVER hardcode chat IDs.** Get them from the actual user via Telegram getUpdates.
-7. **ALWAYS ask the user which runtime** (claude-code vs codex-app-server) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
+7. **ALWAYS ask the user which runtime** (claude-code, codex-app-server, or opencode) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
 
 ---
 
@@ -30,16 +30,26 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"
@@ -404,7 +414,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 | I need to... | Command |
 |---|---|
-| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server` after asking the user which runtime) |
+| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server`, or `--template agent-opencode --runtime opencode`, after asking the user which runtime) |
 | Enable agent | `cortextos enable <agent> --org <org>` |
 | Disable agent | `cortextos disable <agent> --org <org>` |
 | Soft restart (self) | `cortextos bus self-restart --reason "<reason>"` |

--- a/community/agents/security/.claude/skills/agent-management/SKILL.md
+++ b/community/agents/security/.claude/skills/agent-management/SKILL.md
@@ -29,16 +29,26 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"

--- a/community/skills/agent-management/SKILL.md
+++ b/community/skills/agent-management/SKILL.md
@@ -19,7 +19,7 @@ external_calls: ["api.telegram.org"]
 4. **ALWAYS use `cortextos enable` to start agents.** Never manually edit PM2 config.
 5. **NEVER share bot tokens between agents.** Each agent gets its own bot from @BotFather.
 6. **NEVER hardcode chat IDs.** Get them from the actual user via Telegram getUpdates.
-7. **ALWAYS ask the user which runtime** (claude-code vs codex-app-server) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
+7. **ALWAYS ask the user which runtime** (claude-code, codex-app-server, or opencode) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
 
 ---
 
@@ -31,16 +31,26 @@ external_calls: ["api.telegram.org"]
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"
@@ -411,7 +421,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 | I need to... | Command |
 |---|---|
-| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server` after asking the user which runtime) |
+| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server`, or `--template agent-opencode --runtime opencode`, after asking the user which runtime) |
 | Enable agent | `cortextos enable <agent> --org <org>` |
 | Disable agent | `cortextos disable <agent> --org <org>` |
 | Soft restart (self) | `cortextos bus self-restart --reason "<reason>"` |

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
@@ -17,7 +17,7 @@ description: "You need to create a new agent, restart a crashed agent, change an
 4. **ALWAYS use `cortextos enable` to start agents.** Never manually edit PM2 config.
 5. **NEVER share bot tokens between agents.** Each agent gets its own bot from @BotFather.
 6. **NEVER hardcode chat IDs.** Get them from the actual user via Telegram getUpdates.
-7. **ALWAYS ask the user which runtime** (claude-code vs codex-app-server) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
+7. **ALWAYS ask the user which runtime** (claude-code, codex-app-server, or opencode) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
 
 ---
 
@@ -29,16 +29,26 @@ description: "You need to create a new agent, restart a crashed agent, change an
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"
@@ -403,7 +413,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 | I need to... | Command |
 |---|---|
-| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server` after asking the user which runtime) |
+| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server`, or `--template agent-opencode --runtime opencode`, after asking the user which runtime) |
 | Enable agent | `cortextos enable <agent> --org <org>` |
 | Disable agent | `cortextos disable <agent> --org <org>` |
 | Soft restart (self) | `cortextos bus self-restart --reason "<reason>"` |

--- a/templates/agent-opencode/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
+++ b/templates/agent-opencode/plugins/cortextos-agent-skills/skills/agent-management/SKILL.md
@@ -17,7 +17,7 @@ description: "You need to create a new agent, restart a crashed agent, change an
 4. **ALWAYS use `cortextos enable` to start agents.** Never manually edit PM2 config.
 5. **NEVER share bot tokens between agents.** Each agent gets its own bot from @BotFather.
 6. **NEVER hardcode chat IDs.** Get them from the actual user via Telegram getUpdates.
-7. **ALWAYS ask the user which runtime** (claude-code vs codex-app-server) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
+7. **ALWAYS ask the user which runtime** (claude-code, codex-app-server, or opencode) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
 
 ---
 
@@ -29,16 +29,26 @@ description: "You need to create a new agent, restart a crashed agent, change an
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"
@@ -403,7 +413,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 | I need to... | Command |
 |---|---|
-| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server` after asking the user which runtime) |
+| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server`, or `--template agent-opencode --runtime opencode`, after asking the user which runtime) |
 | Enable agent | `cortextos enable <agent> --org <org>` |
 | Disable agent | `cortextos disable <agent> --org <org>` |
 | Soft restart (self) | `cortextos bus self-restart --reason "<reason>"` |

--- a/templates/agent/.claude/skills/agent-management/SKILL.md
+++ b/templates/agent/.claude/skills/agent-management/SKILL.md
@@ -18,7 +18,7 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 4. **ALWAYS use `cortextos enable` to start agents.** Never manually edit PM2 config.
 5. **NEVER share bot tokens between agents.** Each agent gets its own bot from @BotFather.
 6. **NEVER hardcode chat IDs.** Get them from the actual user via Telegram getUpdates.
-7. **ALWAYS ask the user which runtime** (claude-code vs codex-app-server) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
+7. **ALWAYS ask the user which runtime** (claude-code, codex-app-server, or opencode) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
 
 ---
 
@@ -30,16 +30,26 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"
@@ -404,7 +414,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 | I need to... | Command |
 |---|---|
-| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server` after asking the user which runtime) |
+| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server`, or `--template agent-opencode --runtime opencode`, after asking the user which runtime) |
 | Enable agent | `cortextos enable <agent> --org <org>` |
 | Disable agent | `cortextos disable <agent> --org <org>` |
 | Soft restart (self) | `cortextos bus self-restart --reason "<reason>"` |

--- a/templates/analyst/.claude/skills/agent-management/SKILL.md
+++ b/templates/analyst/.claude/skills/agent-management/SKILL.md
@@ -18,7 +18,7 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 4. **ALWAYS use `cortextos enable` to start agents.** Never manually edit PM2 config.
 5. **NEVER share bot tokens between agents.** Each agent gets its own bot from @BotFather.
 6. **NEVER hardcode chat IDs.** Get them from the actual user via Telegram getUpdates.
-7. **ALWAYS ask the user which runtime** (claude-code vs codex-app-server) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
+7. **ALWAYS ask the user which runtime** (claude-code, codex-app-server, or opencode) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
 
 ---
 
@@ -30,16 +30,26 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"
@@ -404,7 +414,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 | I need to... | Command |
 |---|---|
-| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server` after asking the user which runtime) |
+| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server`, or `--template agent-opencode --runtime opencode`, after asking the user which runtime) |
 | Enable agent | `cortextos enable <agent> --org <org>` |
 | Disable agent | `cortextos disable <agent> --org <org>` |
 | Soft restart (self) | `cortextos bus self-restart --reason "<reason>"` |

--- a/templates/orchestrator/.claude/skills/agent-management/SKILL.md
+++ b/templates/orchestrator/.claude/skills/agent-management/SKILL.md
@@ -18,7 +18,7 @@ triggers: ["new agent", "create agent", "spawn agent", "add agent", "restart", "
 4. **ALWAYS use `cortextos enable` to start agents.** Never manually edit PM2 config.
 5. **NEVER share bot tokens between agents.** Each agent gets its own bot from @BotFather.
 6. **NEVER hardcode chat IDs.** Get them from the actual user via Telegram getUpdates.
-7. **ALWAYS ask the user which runtime** (claude-code vs codex-app-server) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
+7. **ALWAYS ask the user which runtime** (claude-code, codex-app-server, or opencode) before scaffolding a new agent. Default to claude-code only if the user has no preference. Never silently pick.
 
 ---
 
@@ -41,16 +41,26 @@ After collecting the bot token and chat ID, always ask the user:
 # Option A: CLI (recommended)
 
 # STEP 0 — REQUIRED BEFORE SCAFFOLDING — Ask the user which runtime:
-#   "Should this agent run on Claude Code (Anthropic) or Codex (OpenAI gpt-5-codex)?"
+#   "Should this agent run on Claude Code (Anthropic), Codex (OpenAI gpt-5-codex),
+#    or OpenCode (provider-agnostic TUI, default model openai/gpt-4.1-nano)?"
 # Default to claude-code if the user has no preference. Never silently pick.
-# Codex agents MUST use the agent-codex template; orchestrator/analyst/m2c1-worker
-# do not have codex variants — the CLI will reject the mismatch.
+# Codex agents MUST use the agent-codex template; OpenCode agents MUST use the
+# agent-opencode template. Passing --template agent auto-maps to the runtime's
+# native bootstrap (agent-codex for codex, agent-opencode for opencode).
+# orchestrator/analyst/m2c1-worker have no codex/opencode variant: codex is
+# rejected outright with those templates; opencode is not blocked but would
+# scaffold a Claude-oriented bootstrap under an opencode runtime, so avoid it.
 
 # claude-code path (the common one):
 cortextos add-agent <name> --template agent --org <org> --runtime claude-code
 
 # codex-app-server path (gpt-5-codex via codex CLI app-server JSONRPC):
 cortextos add-agent <name> --template agent-codex --org <org> --runtime codex-app-server
+
+# opencode path (provider-agnostic OpenCode TUI; ships the context-handoff
+# lifecycle, default-on at 60% of the context window; model set in config.json,
+# default openai/gpt-4.1-nano). --template agent auto-maps to agent-opencode:
+cortextos add-agent <name> --template agent-opencode --org <org> --runtime opencode
 
 # Option B: Manual
 TEMPLATE="agent"  # or "orchestrator" or "analyst"
@@ -415,7 +425,7 @@ cortextos enable "$AGENT" --org "$ORG" --restart
 
 | I need to... | Command |
 |---|---|
-| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server` after asking the user which runtime) |
+| Create new agent | `cortextos add-agent <name> --template agent --org <org> --runtime claude-code` (or `--template agent-codex --runtime codex-app-server`, or `--template agent-opencode --runtime opencode`, after asking the user which runtime) |
 | Enable agent | `cortextos enable <agent> --org <org>` |
 | Disable agent | `cortextos disable <agent> --org <org>` |
 | Soft restart (self) | `cortextos bus self-restart --reason "<reason>"` |


### PR DESCRIPTION
## Summary

The `opencode` runtime and context-handoff lifecycle shipped in #685/#699 (the CLI accepts `--runtime opencode` and auto-maps `--template agent` to the `agent-opencode` bootstrap), but the behavioral/discoverability layer never caught up:

- The **agent-management skill** (which teaches agents how to scaffold other agents) hard-coded a 2-way runtime choice (claude-code vs codex-app-server) across all 8 mirrors, leaving `--runtime opencode` orphaned — an agent told "spin up an opencode agent" had no guidance path.
- **README.md and CLAUDE.md** never mentioned the opencode runtime or the context-handoff lifecycle, so neither was discoverable from the docs.

This is a docs-only PR that closes the behavioral gap so the 3-runtime story (claude-code / codex-app-server / opencode) is complete.

### Changes
- **agent-management SKILL.md (8 mirrors):** STEP 0 now teaches the 3-runtime choice incl opencode and the `--runtime opencode` flow; the runtime CRITICAL RULE and summary-table row are updated. The `security` mirror receives the STEP 0 block only, since it does not carry the other two fragments.
- **README.md:** opencode added to the multi-runtime bullet, the templates table, and the runtime `config.json` table; a new paragraph documents the OpenCode PTY (provider-agnostic, default `openai/gpt-4.1-nano`) and the context-handoff lifecycle (`ctx_handoff_threshold` default 60%, `ctx_warning_threshold` default 30%).
- **CLAUDE.md:** the templates line now lists `agent-codex` and `agent-opencode`.

### Accuracy notes
All runtime/auto-map/threshold facts were verified against `src/cli/add-agent.ts` and `templates/agent-opencode/`. Deliberately **no** `OPENAI_API_KEY` requirement or `sqlite3` dependency is claimed — neither is a cortextOS dependency (OpenCode manages its own provider auth and its own internal DB).

## Test Plan
- [x] `npm run build` — success (docs-only, no TS touched).
- [x] `npm test` — no new failures (the 39 pre-existing/environmental failures reproduce identically on clean HEAD with these changes stashed).
- [x] All 8 agent-management mirrors now contain the `--runtime opencode` STEP 0 block.
- [x] README runtime table renders 4 runtime rows; CLAUDE.md templates line lists both new templates.
- [x] leak-guard: clean (generic `<name>`/`<org>` placeholders only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)