### PR TITLE
feat(crm-assistant): connect + verify tools in setup, not just detect

### DIFF
--- a/community/agents/agentic-crm-assistant/.claude/skills/agentic-crm-setup/SKILL.md
+++ b/community/agents/agentic-crm-assistant/.claude/skills/agentic-crm-setup/SKILL.md
@@ -81,22 +81,34 @@ This skill turns the generic template into a user's assistant. It is intentional
 - required fields
 - custom tags
 
-## Tool Discovery
+## Tool Discovery + Connect (do NOT hand-wave this)
 
-Run discovery commands and write results to `TOOLS.md`.
+This is the make-or-break step. Detecting a tool is not connecting it. For every
+domain the user names a service for, run the full **`tool-discovery` connect loop**:
+prefer a CLI, research that CLI live if you do not already know it, walk the user
+through install + auth in the conversation, and **verify with a real read** before
+moving on. See `tool-discovery/SKILL.md` for the loop; the short version:
+
+1. Detect what is already installed and authed.
+2. Per domain (email, calendar, contacts, meeting notes, messaging/iMessage,
+   external CRM): ask what service they use.
+3. Prefer CLI > connector/MCP > browser. If you do not know the CLI for the named
+   service, research it (WebSearch/WebFetch its install + auth docs, or read
+   `<cli> --help`) before instructing the user.
+4. Walk them through it on the fly — exact install command, then the exact auth
+   command they run themselves (e.g. `! gog login you@example.com`). Secrets never
+   go in chat.
+5. Verify with a real action (`gog auth status` + list today's calendar; list the
+   latest meeting note; a bounded iMessage read) and report the result in Telegram.
+6. Record each connected tool in `TOOLS.md` with how it was verified. Loop.
+
+Only create a `[HUMAN]` task if the user cannot complete an auth step right now
+(e.g. needs an admin, a paid plan, or credentials they do not have). Make it
+specific — the exact tool, the exact command, and where the credential goes — not
+a generic "connect your tools":
 
 ```bash
-command -v gog >/dev/null && gog --version || true
-command -v gh >/dev/null && gh --version | head -1 || true
-command -v agent-browser >/dev/null && agent-browser --version || true
-ls .mcp.json 2>/dev/null || true
-env | grep -E 'GMAIL|GOOGLE|OUTLOOK|NOTION|CRM|HUBSPOT|PIPEDRIVE|AIRTABLE|OPENAI|GEMINI' | sed 's/=.*/=<configured>/'
-```
-
-If no email/calendar/notes tools are found, create a human task:
-
-```bash
-cortextos bus create-task "[HUMAN] Configure assistant tools" --desc "Connect email, calendar, meeting notes, and optional CRM for $CTX_AGENT_NAME. Do not paste secrets in chat; use connector setup, .env, org secrets.env, or provider CLI auth."
+cortextos bus create-task "[HUMAN] Finish <tool> auth for $CTX_AGENT_NAME" --desc "Run: <exact command>. Credential goes in <exact location>. Do not paste secrets in chat. Blocking: <which workflow this unblocks>."
 ```
 
 ## File Writes
@@ -129,11 +141,18 @@ Ask:
 
 ### Batch 2: Tools
 
-Ask:
+Ask which service they use per domain, then run the Tool Discovery + Connect loop
+above for each one (research the CLI, walk them through auth, verify):
 
-1. Which email/calendar/meeting notes/contact/CRM tools do you use?
-2. Are they already connected through MCP, connectors, CLIs, browser login, or env vars?
-3. Should I use local structured CRM files as the source of truth, an external CRM, or local-first with sync?
+1. Email + calendar — which provider (Gmail/Google, Outlook, other)?
+2. Meeting notes — Granola, Fathom, Fireflies, Zoom, other, none?
+3. Messaging — do you want me to read/handle iMessage or another messenger?
+4. Contacts — Google Contacts, phone export, an external CRM, none?
+5. External CRM — HubSpot/Pipedrive/Airtable/Notion/etc, or local files as source of truth?
+
+Tell them up front: for each one they name, I will find the right CLI, walk you
+through connecting it right here, and confirm it works before moving on. No secrets
+in chat.
 
 ### Batch 3: CRM
 

--- a/community/agents/agentic-crm-assistant/.claude/skills/tool-discovery/SKILL.md
+++ b/community/agents/agentic-crm-assistant/.claude/skills/tool-discovery/SKILL.md
@@ -1,38 +1,112 @@
 ---
 name: tool-discovery
-description: "Discover available email, calendar, contacts, meeting notes, browser, and CRM tools for a tool-agnostic personal assistant."
+description: "Discover, research, and CONNECT the tools a tool-agnostic personal assistant needs — email, calendar, contacts, meeting notes, messaging, CRM. CLI-first, research-driven, verified. Use during setup and whenever a workflow fails because a tool is missing or not authed."
 ---
 
-# Tool Discovery Skill
+# Tool Discovery + Connect Skill
 
-Use during setup and whenever a workflow fails because a tool may be missing.
+Two jobs: (1) detect what is already installed and authed, and (2) for every
+domain the user names a service for, **research the right CLI, walk the user
+through connecting it, and verify it actually works** — in the Telegram
+conversation, on the fly.
 
-## Discover Local CLIs
+Preference order for every domain, always: **CLI > official connector / MCP >
+browser automation.** A CLI is scriptable, auditable, and does not depend on a
+live browser session. Only fall back when the tier above genuinely does not exist.
+
+Never ask for secrets in chat. Hand the user the exact auth command to run
+themselves (in-session with the `! <command>` prefix, or in their own terminal)
+so the token lands in the tool's own secure store, not the transcript.
+
+---
+
+## Step 1 — Detect what is already here
 
 ```bash
 for cmd in gog gh agent-browser peekaboo sqlite3 jq rg; do
-  if command -v "$cmd" >/dev/null; then
-    echo "$cmd: $(command -v "$cmd")"
-  fi
+  if command -v "$cmd" >/dev/null; then echo "$cmd: $(command -v "$cmd")"; fi
 done
-```
-
-## Discover MCP/Connector Hints
-
-```bash
 test -f .mcp.json && cat .mcp.json
-env | grep -E 'GMAIL|GOOGLE|OUTLOOK|NOTION|ZOOM|FATHOM|HUBSPOT|PIPEDRIVE|AIRTABLE|CRM' | sed 's/=.*/=<configured>/'
+env | grep -E 'GMAIL|GOOGLE|OUTLOOK|NOTION|ZOOM|FATHOM|FIREFLIES|GRANOLA|HUBSPOT|PIPEDRIVE|AIRTABLE|CRM' | sed 's/=.*/=<configured>/'
 ```
+
+Anything already installed AND authed: record it and skip to verify. Everything
+else goes through the connect loop below.
+
+---
+
+## Step 2 — The connect loop (run once per domain)
+
+Domains the CRM assistant covers: **email, calendar, contacts, meeting notes,
+messaging (e.g. iMessage), external CRM.** For each one the user says they use:
+
+### 2a. Ask what service they use for this domain
+"What do you use for meeting notes — Granola, Fathom, Fireflies, Zoom, something
+else?" One domain at a time. Wait for the answer on Telegram.
+
+### 2b. Identify the CLI (prefer CLI). Research it if you do not know it.
+- If you already know the CLI (Google -> `gog`, GitHub -> `gh`), use it.
+- If you do NOT know the CLI for the named service, **research it live** before
+  asking the user to do anything:
+  - WebSearch: "<service> official CLI", "<service> command line auth".
+  - WebFetch the tool's install + auth docs.
+  - Confirm the actual command and its auth subcommand (do not guess).
+  - If the service is already installed locally, read its real help:
+    `<cli> --help`, `<cli> auth --help`.
+- Decide the tier: real CLI found -> CLI. No CLI but an MCP/connector exists ->
+  connector. Neither -> browser automation (agent-browser / headed profile) as
+  the last resort, and say so plainly.
+
+### 2c. Walk the user through install + auth (in chat, on the fly)
+Give exact, copy-pasteable steps grounded in what you just researched:
+- Install: the real install command (e.g. `brew install ...`, `npm i -g ...`).
+- Auth: the real auth command, run BY THE USER so no secret hits the chat. Tell
+  them to type it in-session with the `!` prefix, e.g.:
+  `! gog login you@example.com`
+  (Google opens a browser consent, stores a refresh token locally.)
+- If the flow needs an API key/token, tell them exactly where to create it and
+  where it goes (tool config, `.env`, or org `secrets.env`) — never in chat.
+
+### 2d. Verify with a REAL action (do not trust presence)
+Prove the connection works before moving on, with the lightest real read:
+- Email/Calendar (gog): `gog auth status`, then a 1-item read
+  (list 1 recent email / today's events).
+- Messaging (iMessage): a bounded read of the local Messages DB or the messaging
+  CLI's status/list, scoped to a safe test.
+- Meeting notes: list the most recent note/transcript.
+- External CRM: fetch 1 record.
+Report the result in Telegram ("Google connected — I can see your inbox and today's
+calendar"). If verify fails, debug the auth with the user; do not mark it done.
+
+### 2e. Record it, then loop
+Append to `TOOLS.md` and move to the next domain.
+
+---
+
+## Worked examples
+
+- **Google (email + calendar + drive):** CLI = `gog`. Install if missing, then
+  `! gog login <email>`; verify `gog auth status` + list today's calendar.
+- **iMessage (messaging):** macOS local. Prefer a messaging CLI / bounded reads of
+  the local Messages SQLite DB; verify by reading the latest message safely. No
+  outbound sends without the approval rule. If no clean CLI exists, say so and
+  propose the connector/automation fallback.
+- **Meeting notes:** ask which tool (Granola/Fathom/Fireflies/Zoom). Research that
+  tool's CLI or export path live, walk the user through auth, verify by listing the
+  latest transcript.
+
+---
 
 ## Record Results
 
-Append a `## Configured Tools` section to `TOOLS.md` with:
+Append a `## Configured Tools` section to `TOOLS.md` with, per tool:
 
-- provider
-- command or connector name
+- domain + provider
+- command or connector name (the tier used: CLI / connector / browser)
 - account identifier, if safe
 - read/write capability
 - approval requirement
+- **verified:** yes/no + how (the real action you ran)
 - fallback path
 
 Never write secrets to `TOOLS.md`.

--- a/community/agents/agentic-crm-assistant/TOOL_CONNECTIONS.md
+++ b/community/agents/agentic-crm-assistant/TOOL_CONNECTIONS.md
@@ -1,17 +1,28 @@
 # Tool Connections
 
-This template is bring-your-own-tools. Prefer official connectors, MCP servers,
-or provider CLIs when available. Use browser automation only when a supported API
-or connector is unavailable.
+This template is bring-your-own-tools. Preference order for every domain, always:
+**CLI > official connector / MCP > browser automation.** A CLI is scriptable,
+auditable, and does not depend on a live browser session. Use browser automation
+only when neither a CLI nor a connector exists.
+
+Connecting a tool is not the same as detecting one. For each domain, the assistant
+researches the right CLI for the service the user names, walks the user through
+install + auth on the fly, and **verifies with a real read** before moving on. Full
+procedure in `tool-discovery/SKILL.md`.
 
 ## Setup Order
 
-1. Discover installed CLIs and MCP servers with `tool-discovery`.
-2. Ask the user which tools are authoritative for each domain.
-3. Store credentials only in connector configuration, provider auth, `.env`, or
-   org `secrets.env`.
-4. Record configured tools in `TOOLS.md`.
-5. Keep local CRM files as the relationship audit trail unless the user chooses a
+1. Detect installed CLIs and MCP servers with `tool-discovery`.
+2. Ask the user which service they use for each domain.
+3. For each named service: prefer a CLI. If the CLI is unknown, research it live
+   (its install + auth flow) before instructing the user. Fall back to
+   connector/MCP, then browser, only if no CLI exists.
+4. Walk the user through auth in-conversation. Hand them the exact command to run
+   themselves so secrets land in the tool's own store, `.env`, or org
+   `secrets.env` — never in chat.
+5. Verify the connection with a real action and report it. Record configured +
+   verified tools in `TOOLS.md`.
+6. Keep local CRM files as the relationship audit trail unless the user chooses a
    different source of truth.
 
 ## Domains
@@ -21,6 +32,7 @@ or connector is unavailable.
 | Email | Gmail, Outlook, IMAP, provider CLI, MCP | Optional | Needed for inbox triage and relationship interaction extraction. |
 | Calendar | Google Calendar, Outlook Calendar, CalDAV, MCP | Optional | Needed for meeting prep and daily schedule reviews. |
 | Meeting Notes | Granola, Fathom, Fireflies, Zoom transcripts, local files | Optional | Needed for automated meeting-note processing. |
+| Messaging | iMessage (local Messages DB), other messenger CLIs | Optional | Reads for relationship interactions; outbound sends always gated by approval rules. |
 | Contacts | Google Contacts, phone contacts export, external CRM, CSV | Optional | Can seed `crm/contacts.json`. |
 | CRM | HubSpot, Pipedrive, Airtable, Notion, Salesforce, local files | Optional | Local files remain default if no CRM is connected. |
 | Browser | agent-browser, Playwright profile, headed browser | Optional | Use for sites without API access. |


### PR DESCRIPTION
## Summary

The `agentic-crm-assistant` template gathered user preferences well but hand-waved the actual tool connection: `tool-discovery` only **detected** installed tools, and the setup skill's Tools step dead-ended in a generic `[HUMAN]` task. An agent that knew the user's stack still could not get email/calendar/messaging authed and verified.

This reworks the connect UX into a research-driven, **CLI-first, per-domain connect + verify loop**. Once the user names their service for a domain (email/calendar, meeting notes, iMessage/messaging, contacts, external CRM), the assistant prefers a CLI, researches that CLI live if it does not know it, walks the user through install + auth on the fly (the user runs the auth command, so no secret hits chat), then verifies with a real read before moving on. Fallback order: CLI → connector/MCP → browser.

### Changes (3 existing files, docs/skill-only, +147/-42)
- **`TOOL_CONNECTIONS.md`** — explicit preference order `CLI > connector/MCP > browser` for every domain; setup order now names the connect + verify steps; adds a **Messaging** domain (iMessage local reads; outbound sends always gated by approval rules).
- **`tool-discovery/SKILL.md`** — rewrites detect-only into the full connect loop with live CLI research, in-conversation auth, and real-read verification. Worked examples for Google (`gog`) and iMessage.
- **`agentic-crm-setup/SKILL.md`** — Tools step now drives the per-domain connect loop; removes the dead-end generic `[HUMAN]` task.

## Test Plan
- [x] Frontmatter intact on both skills (`name`/`description` present).
- [x] `gog login` / `gog auth status` confirmed to exist — the skill now actually calls them rather than only detecting.
- [x] leak-guard: clean (generic placeholders only — `you@example.com`, `<email>`; no real contacts/paths/secrets).
- [x] Built off clean upstream main; only these 3 files changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)