### PR TITLE
feat(security): auto-install pre-push hook + windowed roster/cron leak-guard (SEC-1 L3)

### DIFF
--- a/.github/scripts/leak-guard.sh
+++ b/.github/scripts/leak-guard.sh
@@ -73,8 +73,23 @@ scan_file() {
   case "$f" in
     tests/*|*.test.*|*.spec.*|*/__tests__/*|*/fixtures/*) ;;
     *)
+      roster_hit=0
       if grep -nEq "$ROSTER_CRON_RE" "$f" 2>/dev/null; then
         report "$f" "fleet roster + cron-schedule table (internal ops detail)"
+        roster_hit=1
+      fi
+      # Windowed heuristic: a multi-line ops table can split an agent name and
+      # its cron expression across adjacent rows, evading the same-line RE above.
+      # Flag when a roster name and a cron expr co-occur within a small window
+      # (WINDOW=3 lines). Only fires when the same-line check did NOT already
+      # report this file, so the roster+cron class is reported at most once.
+      if [ "$roster_hit" -eq 0 ] && awk -v W=3 '
+          /(boris|paul|sentinel|donna|nick)/ { name = NR }
+          /(heartbeat\([0-9]|morning-review|evening-review|human-task-sweep|pr-monitor\([0-9]|\([0-9]+ [0-9*]+ \* \* )/ { cron = NR }
+          (name && cron && name - cron <= W && cron - name <= W) { found = 1; exit }
+          END { exit(found ? 0 : 1) }
+        ' "$f" 2>/dev/null; then
+        report "$f" "fleet roster + cron-schedule within 3 lines (multi-line ops table)"
       fi ;;
   esac
 

--- a/install.mjs
+++ b/install.mjs
@@ -468,6 +468,20 @@ log('Building...');
 runVisible('npm run build', { cwd: INSTALL_DIR });
 ok('Build complete');
 
+// ─── 9b. Install git pre-push hook (build + test gate) ───────────────────────
+// Best-effort: wire up the tracked hook installer so fresh clones get the
+// pre-push build+test gate. Non-fatal — a hook-install failure must never abort
+// the install. setup-hooks.sh is non-clobbering, so this is safe to re-run.
+
+if (!IS_WINDOWS && existsSync(join(INSTALL_DIR, 'scripts', 'setup-hooks.sh'))) {
+  try {
+    run('bash scripts/setup-hooks.sh', { cwd: INSTALL_DIR });
+    ok('Installed git pre-push hook (build + test gate)');
+  } catch {
+    warn('Could not install git pre-push hook — run manually: bash scripts/setup-hooks.sh');
+  }
+}
+
 // ─── 10. Link CLI globally ────────────────────────────────────────────────────
 
 log('Linking cortextos CLI...');

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -29,8 +29,9 @@ install_hook() {
 
   # Non-clobbering: never overwrite an existing hook the user/operator installed
   # (e.g. a local leak-guard pre-push). Only install when there is no hook, or
-  # when the existing hook is byte-identical to ours (already installed).
-  if [[ -e "$dest" ]]; then
+  # when the existing hook is byte-identical to ours (already installed). The
+  # -L catches a broken symlink too, which -e alone would miss (and then clobber).
+  if [[ -e "$dest" || -L "$dest" ]]; then
     if cmp -s "$src" "$dest"; then
       echo "  Already installed: .git/hooks/$name"
     else

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -27,6 +27,18 @@ install_hook() {
     return
   fi
 
+  # Non-clobbering: never overwrite an existing hook the user/operator installed
+  # (e.g. a local leak-guard pre-push). Only install when there is no hook, or
+  # when the existing hook is byte-identical to ours (already installed).
+  if [[ -e "$dest" ]]; then
+    if cmp -s "$src" "$dest"; then
+      echo "  Already installed: .git/hooks/$name"
+    else
+      echo "  Skipped: .git/hooks/$name already exists (leaving your hook in place)"
+    fi
+    return
+  fi
+
   cp "$src" "$dest"
   chmod +x "$dest"
   echo "  Installed: .git/hooks/$name"

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -1,4 +1,5 @@
 import { Command } from 'commander';
+import { execSync } from 'child_process';
 import { existsSync, mkdirSync, writeFileSync, copyFileSync, readFileSync, readdirSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
@@ -210,6 +211,21 @@ export const initCommand = new Command('init')
         if (regenerated > 0) {
           console.log(`  Regenerated SYSTEM.md for ${regenerated} agent(s)`);
         }
+      }
+    }
+
+    // Best-effort: install the tracked git pre-push hook (build + test gate) so
+    // this clone gets the gate without a manual step. Non-fatal — only runs when
+    // the project is a git repo AND ships the installer; setup-hooks.sh is
+    // non-clobbering, so this is safe to run on every init.
+    if (process.platform !== 'win32' &&
+        existsSync(join(projectRoot, '.git')) &&
+        existsSync(join(projectRoot, 'scripts', 'setup-hooks.sh'))) {
+      try {
+        execSync('bash scripts/setup-hooks.sh', { cwd: projectRoot, stdio: 'ignore' });
+        console.log('  Installed git pre-push hook (build + test gate)');
+      } catch {
+        console.log('  Skipped git pre-push hook install (run: bash scripts/setup-hooks.sh)');
       }
     }
 

--- a/tests/leak-guard.test.sh
+++ b/tests/leak-guard.test.sh
@@ -36,6 +36,25 @@ printf '%s\n' "$out" | grep -q 'operator home path' \
 printf '%s\n' "$out" | grep -q 'roster' \
   || { echo "FAIL: roster+cron table not detected in planted leak"; fails=1; }
 
+# (c) Windowed heuristic: a MULTI-LINE ops table splits the agent name and its
+#     cron expression across adjacent rows, evading the same-line RE. The
+#     windowed check (WINDOW=3) must still FLAG it. Non-test path required.
+cat > "$TMP/multiline.md" <<'EOF'
+# Fleet Ops Table
+| Agent    | paul                       |
+| Cadence  | morning-review(0 13 * * *) |
+EOF
+bash "$GUARD" "$TMP/multiline.md" >/dev/null 2>&1 \
+  && { echo "FAIL: scanner PASSED a multi-line roster+cron table (should have failed)"; fails=1; }
+printf '%s\n' "$(bash "$GUARD" "$TMP/multiline.md" 2>&1)" | grep -q 'within 3 lines' \
+  || { echo "FAIL: multi-line roster+cron not caught by windowed check"; fails=1; }
+
+# (d) Control: a roster name and a cron expr FAR apart (well beyond the window)
+#     must stay CLEAN — the window must not over-match across a whole document.
+{ printf '| paul | agent |\n'; for i in $(seq 1 12); do printf 'filler line %s\n' "$i"; done; printf 'morning-review runs daily\n'; } > "$TMP/farapart.md"
+bash "$GUARD" "$TMP/farapart.md" >/dev/null 2>&1 \
+  || { echo "FAIL: windowed check flagged name+cron far apart (false positive)"; fails=1; }
+
 # (b) MUST PASS on the current clean tree.
 bash "$GUARD" --tree HEAD >/dev/null 2>&1 \
   || { echo "FAIL: scanner flagged the CLEAN tree (false positive)"; fails=1; }


### PR DESCRIPTION
## Summary

Two defense-in-depth hardenings on top of the existing SEC-1 leak-guard work (L1 CI scan, L2 branch protection, L4 gitignore). Both are additive and low-risk.

### L3(a) — Auto-install the tracked pre-push build+test gate
`scripts/hooks/pre-push` (runs `npm run build && npm test` before a push) and `scripts/setup-hooks.sh` (its installer) already ship, but nothing wired the installer up — so fresh clones never got the local gate.

- **`scripts/setup-hooks.sh` is now NON-CLOBBERING**: it installs only when no pre-push hook exists, or when the existing one is byte-identical (`cmp -s`). If a *different* hook is already present it is left untouched (prints a skip notice). Idempotent and safe to re-run; never overwrites a user's own hook.
- **`install.mjs`** (new section 9b) and **`cortextos init`** both call the installer **best-effort and NON-FATAL** — a hook-install failure never aborts install or init. Gated on non-Windows + git-repo presence + installer presence.

### L3(b) — Windowed roster+cron heuristic in `leak-guard.sh`
The existing same-line `ROSTER_CRON_RE` misses a leaked ops table that splits an agent name and its cron expression across *adjacent rows*. Added an `awk` windowed scan (**WINDOW=3**) that flags a roster name and a cron expression co-occurring within 3 lines, reusing the exact cron alternatives from the existing regex.

- Fires only when the same-line check did **not**, so the roster+cron class reports at most once per file.
- Inherits the existing test/fixture skip (`tests/*`, `*.test.*`, `*/fixtures/*`, etc.).
- **No new false positives**: `leak-guard.sh --tree HEAD` stays `clean` on the full framework tree.

## Test Plan
- [x] `npm run build` — success; `tsc --noEmit` clean (init.ts `execSync` import typechecks).
- [x] `npm test` — no new failures (the pre-existing/environmental failures reproduce identically on clean HEAD; none touch the 4 changed source files).
- [x] `tests/leak-guard.test.sh` — added cases: a multi-line roster+cron table is **flagged** (`within 3 lines`); a far-apart name+cron control stays **clean**. Existing cases unchanged.
- [x] `leak-guard.sh --tree HEAD` → `leak-guard: clean` (no new false positives).
- [x] Windowed check proven: a synthetic multi-line ops table (name + cron on adjacent lines) is flagged; a control with them 10+ lines apart is clean.
- [x] setup-hooks.sh non-clobber verified: skips when a different hook exists, reports already-installed when identical, installs only when absent.

Note: this is new code (not docs), so it should ride the normal CI + soak cycle rather than a fast merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)