### PR TITLE
fix(cli): error boundary so action failures don't crash the process

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -71,4 +71,13 @@ const crashAlertCommand = new Command('crash-alert')
   });
 program.addCommand(crashAlertCommand);
 
-program.parse();
+// Use parseAsync + a catch so a thrown Error from any action handler (e.g.
+// "Task <id> not found" from complete-task/update-task) prints a clean one-line
+// message and exits non-zero, instead of escaping as an uncaught exception that
+// crashes with a full stack trace (the sync program.parse() had no error
+// boundary). commander v14 awaits action results, so sync throws surface here as
+// rejections. Keeps a task's status transition from silently "sticking" on error.
+program.parseAsync(process.argv).catch((err: unknown) => {
+  console.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+});

--- a/tests/integration/cli-error-boundary.test.ts
+++ b/tests/integration/cli-error-boundary.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { join } from 'node:path';
+
+// Regression test for the CLI error boundary. Before the fix, src/cli/index.ts
+// ended with a synchronous `program.parse()` and NO catch, so any Error thrown
+// by an action handler (e.g. "Task <id> not found" from complete-task /
+// update-task) escaped as an uncaught exception — crashing with a full JS stack
+// trace + "Node.js vX" footer and leaving task transitions looking "stuck".
+// The fix uses `program.parseAsync().catch()` to print a clean one-line message
+// and exit(1). We run the real source via tsx so no prior build step is needed.
+
+const ROOT = join(__dirname, '..', '..');
+const TSX = join(ROOT, 'node_modules', '.bin', 'tsx');
+const ENTRY = join(ROOT, 'src', 'cli', 'index.ts');
+
+function runCli(args: string[]) {
+  return spawnSync(TSX, [ENTRY, ...args], { encoding: 'utf8', cwd: ROOT });
+}
+
+const NO_STACK = /^\s+at\s.+\(/m; // a JS stack frame line
+const CRASH_FOOTER = /Node\.js v\d/; // the uncaught-exception process crash footer
+
+describe('CLI error boundary — index.ts parseAsync().catch()', () => {
+  it('complete-task with an unknown id → clean error, exit 1, no stack/crash', () => {
+    const r = runCli(['bus', 'complete-task', 'nonexistent-task-id-xyz', '--result', 'x']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/not found/i);
+    expect(r.stderr).not.toMatch(NO_STACK);
+    expect(r.stderr).not.toMatch(CRASH_FOOTER);
+  }, 30000);
+
+  it('update-task <id> completed with an unknown id → clean error, exit 1', () => {
+    const r = runCli(['bus', 'update-task', 'nonexistent-task-id-xyz', 'completed']);
+    expect(r.status).toBe(1);
+    expect(r.stderr).toMatch(/not found/i);
+    expect(r.stderr).not.toMatch(NO_STACK);
+    expect(r.stderr).not.toMatch(CRASH_FOOTER);
+  }, 30000);
+});


### PR DESCRIPTION
> Clean re-cut of the previous mis-based PR (#727, closed). This branch is cut from **current `upstream/main`** and contains **exactly 2 files** (`git diff --stat upstream/main` = `src/cli/index.ts` +11/-1, `tests/integration/cli-error-boundary.test.ts` +40; total +50/-1).

## Problem
`src/cli/index.ts` ended with a synchronous `program.parse()` and **no error boundary**. Any `Error` thrown by an action handler — e.g. `Task <id> not found` from `bus complete-task` / `bus update-task` — escaped as an **uncaught exception**, crashing with a full JS stack trace + `Node.js vX` footer (louder on Node v25) and a non-zero exit. Happy paths worked, so it looked intermittent; on the error path a task's status transition appeared "stuck" on the dashboard.

## Fix
```ts
program.parseAsync(process.argv).catch((err: unknown) => {
  console.error(err instanceof Error ? err.message : String(err));
  process.exit(1);
});
```
commander v14 awaits action results, so a synchronous throw in any action surfaces here as a rejection → clean one-line stderr + `exit(1)` instead of a crash. Covers **all** subcommands (incl. `bus complete-task` / `update-task`).

Before → after:
```
$ cortextos bus complete-task bad-id --result x
# before: throw new Error(...) + "at completeTask (...)" stack + "Node.js v25.5.0"  (crash)
# after:  Task bad-id not found in any org under /…/orgs/   (exit 1, clean)
```

## Tests
`tests/integration/cli-error-boundary.test.ts` spawns the real source via `tsx` (no build step needed → runs in the CI test job): unknown-id `complete-task` and `update-task … completed` each assert `exit 1` + a clean `not found` message + **no** stack frame / `Node.js vX` footer. `npm run build` + `npm run typecheck` clean; test 2/2 pass.

## Scope
One entry-point change + one test. Low blast-radius; success paths unaffected (`bus --help` + normal commands verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)