### PR TITLE
fix(dashboard): move execution-log helpers out of route file so production builds pass

### DIFF
--- a/dashboard/src/app/api/workflows/crons/[agent]/[name]/executions/route.ts
+++ b/dashboard/src/app/api/workflows/crons/[agent]/[name]/executions/route.ts
@@ -20,7 +20,7 @@ import { NextRequest } from 'next/server';
 import {
   readExecutionLogPage,
   entriesToCsv,
-} from '@/app/api/workflows/crons/[agent]/executions/route';
+} from '@/lib/cron-execution-log';
 
 export const dynamic = 'force-dynamic';
 

--- a/dashboard/src/app/api/workflows/crons/[agent]/executions/route.ts
+++ b/dashboard/src/app/api/workflows/crons/[agent]/executions/route.ts
@@ -11,128 +11,20 @@
  *   ?status=success|failure|all — filter by outcome (default: all)
  *   ?format=csv|json      — download format; sets Content-Disposition header
  *                           (default: regular JSON array, no download)
+ *
+ * Log reading + CSV helpers live in @/lib/cron-execution-log — route files
+ * may only export route handlers in production builds.
  */
 
-import fs from 'fs';
-import path from 'path';
 import { NextRequest } from 'next/server';
-import { CTX_ROOT } from '@/lib/config';
+import {
+  readExecutionLogPage,
+  entriesToCsv,
+  VALID_AGENT,
+  type StatusFilter,
+} from '@/lib/cron-execution-log';
 
 export const dynamic = 'force-dynamic';
-
-// ---------------------------------------------------------------------------
-// Types
-// ---------------------------------------------------------------------------
-
-type StatusFilter = 'all' | 'success' | 'failure';
-
-export interface CronExecutionLogEntry {
-  ts: string;
-  cron: string;
-  status: 'fired' | 'retried' | 'failed';
-  attempt: number;
-  duration_ms: number;
-  error: string | null;
-}
-
-export interface ExecutionLogPage {
-  entries: CronExecutionLogEntry[];
-  total: number;
-  hasMore: boolean;
-}
-
-// ---------------------------------------------------------------------------
-// File reader with pagination + filter
-// ---------------------------------------------------------------------------
-
-const CRONS_DIR = '.cortextOS/state/agents';
-const VALID_AGENT = /^[a-z0-9_-]+$/i;
-
-export function readExecutionLogPage(
-  agentName: string,
-  cronName: string | undefined,
-  limit: number,
-  offset: number,
-  statusFilter: StatusFilter,
-): ExecutionLogPage {
-  const logPath = path.join(CTX_ROOT, CRONS_DIR, agentName, 'cron-execution.log');
-  if (!fs.existsSync(logPath)) return { entries: [], total: 0, hasMore: false };
-
-  let raw: string;
-  try {
-    raw = fs.readFileSync(logPath, 'utf-8');
-  } catch {
-    return { entries: [], total: 0, hasMore: false };
-  }
-
-  const allEntries: CronExecutionLogEntry[] = [];
-  for (const line of raw.split('\n')) {
-    const trimmed = line.trim();
-    if (!trimmed) continue;
-    try {
-      allEntries.push(JSON.parse(trimmed) as CronExecutionLogEntry);
-    } catch {
-      // skip malformed line
-    }
-  }
-
-  // Filter by cron name
-  let filtered = cronName
-    ? allEntries.filter(e => e.cron === cronName)
-    : allEntries;
-
-  // Filter by status
-  if (statusFilter === 'success') {
-    filtered = filtered.filter(e => e.status === 'fired');
-  } else if (statusFilter === 'failure') {
-    filtered = filtered.filter(e => e.status === 'failed');
-  }
-
-  const total = filtered.length;
-
-  // Pagination: offset=0 → most recent `limit` entries
-  if (limit <= 0) {
-    const safeOffset = Math.min(offset, total);
-    return { entries: filtered.slice(0, total - safeOffset), total, hasMore: false };
-  }
-
-  const safeOffset = Math.max(0, Math.min(offset, total));
-  const end = total - safeOffset;
-  const start = Math.max(0, end - limit);
-  const entries = filtered.slice(start, end);
-  const hasMore = start > 0;
-
-  return { entries, total, hasMore };
-}
-
-// ---------------------------------------------------------------------------
-// CSV serialiser
-// ---------------------------------------------------------------------------
-
-export function entriesToCsv(entries: CronExecutionLogEntry[]): string {
-  const header = 'timestamp,cron,status,attempt,duration_ms,error';
-  const rows = entries.map(e => {
-    const ts = e.ts;
-    const cron = csvEscape(e.cron);
-    const status = e.status;
-    const attempt = e.attempt;
-    const duration = e.duration_ms;
-    const error = csvEscape(e.error ?? '');
-    return `${ts},${cron},${status},${attempt},${duration},${error}`;
-  });
-  return [header, ...rows].join('\n') + '\n';
-}
-
-function csvEscape(value: string): string {
-  if (/[",\n\r]/.test(value)) {
-    return `"${value.replace(/"/g, '""')}"`;
-  }
-  return value;
-}
-
-// ---------------------------------------------------------------------------
-// GET handler
-// ---------------------------------------------------------------------------
 
 export async function GET(
   request: NextRequest,

--- a/dashboard/src/lib/cron-execution-log.ts
+++ b/dashboard/src/lib/cron-execution-log.ts
@@ -1,0 +1,121 @@
+/**
+ * Shared cron execution log reader + CSV serialiser.
+ *
+ * Extracted from app/api/workflows/crons/[agent]/executions/route.ts —
+ * Next.js production builds reject non-handler exports from route files,
+ * so the helpers live here and both executions routes import them.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { CTX_ROOT } from '@/lib/config';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type StatusFilter = 'all' | 'success' | 'failure';
+
+export interface CronExecutionLogEntry {
+  ts: string;
+  cron: string;
+  status: 'fired' | 'retried' | 'failed';
+  attempt: number;
+  duration_ms: number;
+  error: string | null;
+}
+
+export interface ExecutionLogPage {
+  entries: CronExecutionLogEntry[];
+  total: number;
+  hasMore: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// File reader with pagination + filter
+// ---------------------------------------------------------------------------
+
+const CRONS_DIR = '.cortextOS/state/agents';
+export const VALID_AGENT = /^[a-z0-9_-]+$/i;
+
+export function readExecutionLogPage(
+  agentName: string,
+  cronName: string | undefined,
+  limit: number,
+  offset: number,
+  statusFilter: StatusFilter,
+): ExecutionLogPage {
+  const logPath = path.join(CTX_ROOT, CRONS_DIR, agentName, 'cron-execution.log');
+  if (!fs.existsSync(logPath)) return { entries: [], total: 0, hasMore: false };
+
+  let raw: string;
+  try {
+    raw = fs.readFileSync(logPath, 'utf-8');
+  } catch {
+    return { entries: [], total: 0, hasMore: false };
+  }
+
+  const allEntries: CronExecutionLogEntry[] = [];
+  for (const line of raw.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      allEntries.push(JSON.parse(trimmed) as CronExecutionLogEntry);
+    } catch {
+      // skip malformed line
+    }
+  }
+
+  // Filter by cron name
+  let filtered = cronName
+    ? allEntries.filter(e => e.cron === cronName)
+    : allEntries;
+
+  // Filter by status
+  if (statusFilter === 'success') {
+    filtered = filtered.filter(e => e.status === 'fired');
+  } else if (statusFilter === 'failure') {
+    filtered = filtered.filter(e => e.status === 'failed');
+  }
+
+  const total = filtered.length;
+
+  // Pagination: offset=0 → most recent `limit` entries
+  if (limit <= 0) {
+    const safeOffset = Math.min(offset, total);
+    return { entries: filtered.slice(0, total - safeOffset), total, hasMore: false };
+  }
+
+  const safeOffset = Math.max(0, Math.min(offset, total));
+  const end = total - safeOffset;
+  const start = Math.max(0, end - limit);
+  const entries = filtered.slice(start, end);
+  const hasMore = start > 0;
+
+  return { entries, total, hasMore };
+}
+
+// ---------------------------------------------------------------------------
+// CSV serialiser
+// ---------------------------------------------------------------------------
+
+export function entriesToCsv(entries: CronExecutionLogEntry[]): string {
+  const header = 'timestamp,cron,status,attempt,duration_ms,error';
+  const rows = entries.map(e => {
+    const ts = e.ts;
+    const cron = csvEscape(e.cron);
+    const status = e.status;
+    const attempt = e.attempt;
+    const duration = e.duration_ms;
+    const error = csvEscape(e.error ?? '');
+    return `${ts},${cron},${status},${attempt},${duration},${error}`;
+  });
+  return [header, ...rows].join('\n') + '\n';
+}
+
+function csvEscape(value: string): string {
+  if (/[",\n\r]/.test(value)) {
+    return `"${value.replace(/"/g, '""')}"`;
+  }
+  return value;
+}


### PR DESCRIPTION
## Problem

`next build` fails on current `main`:

```
Type error: Route "src/app/api/workflows/crons/[agent]/executions/route.ts" does not match the required types of a Next.js Route.
  "readExecutionLogPage" is not a valid Route export field.
```

Next.js route files may only export HTTP handlers and route-config fields. The agent-level executions route also exports the `readExecutionLogPage` / `entriesToCsv` helpers so the per-cron sibling route can reuse them — fine in dev mode, rejected by the production type check. Net effect: the dashboard cannot be production-built at all, forcing `next dev` deployments (whose untranspiled bundles also break older mobile Safari — how I ran into this).

## Fix

Pure refactor, no behavior change:

- New `dashboard/src/lib/cron-execution-log.ts` — `readExecutionLogPage`, `entriesToCsv`, their types, and `VALID_AGENT` moved verbatim.
- Both executions routes import from the lib; route files now export only handlers.

## Verification

- `next build --webpack` compiles clean on `main` + this change (repro'd the failure first on unmodified `main`).
- All 26 existing tests in `dashboard/src/app/api/workflows/crons/__tests__` pass unmodified (they exercise `route.GET` only).
- Running this in production mode on my own fleet since today.

Note: Turbopack builds can separately fail if an absolute symlink (e.g. a Python venv) exists under the framework root — environment-specific, not addressed here; `--webpack` builds are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)