### PR TITLE
fix(hooks): rebase raw agent-dir prefix so a symlinked base path passes the .claude gate

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -252,9 +252,19 @@ export function isClaudeDirOperation(
   // Canonicalize the agent dir first (resolves legitimate symlinks on the install
   // path, e.g. /tmp -> /private/tmp), so the .claude subtree below it is the only
   // thing left to vet.
-  const canonAgentDir = canonicalizePath(resolve(base));
+  const rawAgentDir = resolve(base);
+  const canonAgentDir = canonicalizePath(rawAgentDir);
   const claudeRoot = join(canonAgentDir, '.claude');
-  const target = resolve(canonAgentDir, filePath);
+  let target = resolve(rawAgentDir, filePath);
+
+  // An absolute filePath spelled through the *uncanonicalized* agent dir
+  // (e.g. /var/... when the canonical form is /private/var/...) would fail the
+  // containment check below even for a legitimate write. Rebase the raw
+  // agent-dir prefix onto its canonical form; components at or below .claude
+  // stay unresolved so the symlink-component check still sees them.
+  if (target === rawAgentDir || target.startsWith(rawAgentDir + sep)) {
+    target = join(canonAgentDir, target.slice(rawAgentDir.length));
+  }
 
   // Lexical containment within the agent's own .claude/.
   if (target !== claudeRoot && !target.startsWith(claudeRoot + sep)) return false;


### PR DESCRIPTION
## Problem

`isClaudeDirOperation` canonicalizes the agent dir (so a symlinked install path like `/tmp -> /private/tmp` can't defeat the gate) but then resolves the incoming file path against the canonical dir **without rewriting the path's own raw prefix**:

```ts
const canonAgentDir = canonicalizePath(resolve(base));
const claudeRoot = join(canonAgentDir, '.claude');
const target = resolve(canonAgentDir, filePath); // absolute filePath wins — raw prefix survives
```

An absolute file path spelled through the *uncanonicalized* agent dir fails lexical containment even for a legitimate write inside the agent's own `.claude/`.

**On macOS this bites every run**: `mkdtemp` lands under `/var -> /private/var`, so the unit test **"refuses a write that escapes via a symlink inside .claude (#18, codex)"** fails its sanity assertion (`tests/unit/hooks/hooks.test.ts` — legitimate write returns `false`). In production the effect is fail-safe (legit writes fall to the human gate instead of auto-approving) but not the intended behavior.

## Fix

Rebase the raw agent-dir prefix onto its canonical form before the containment check. Components at or below `.claude` stay **unresolved**, so `hasSymlinkComponent` still sees planted symlinks (live or dangling) and the escape/redirect refusals are unchanged.

## Verification (macOS 15 / darwin)

- Unmodified `main`: `tests/unit/hooks/hooks.test.ts` → 41 pass / **1 fail**
- With this change: **42/42**, and the full suite: **1953 pass / 0 fail** (`npm run build` clean)
- Escape-via-symlink, dangling-symlink, symlinked-`.claude`-root, and prefix-trick cases all still refuse

🤖 Generated with [Claude Code](https://claude.com/claude-code)