### PR TITLE
feat(daemon): operator wake notice after host sleep (sustained-uptime detector)

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,6 @@
 import { AgentManager } from './agent-manager.js';
 import { IPCServer } from './ipc-server.js';
+import { SleepWakeDetector, formatDurationShort, hhmmUtc } from './sleep-wake-detector.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
@@ -147,39 +148,48 @@ function getOperatorChatCreds(frameworkRoot: string): { chatId: string; botToken
   return null;
 }
 
-function sendCrashLoopAlertBestEffort(
-  frameworkRoot: string,
-  crashCount: number,
-  errStr: string,
-): boolean {
+/**
+ * Best-effort synchronous Telegram send to the operator chat. Bounded
+ * timeout, never throws. Shared by the crash-loop alert and the wake notice.
+ */
+function sendOperatorTelegramBestEffort(frameworkRoot: string, text: string): boolean {
   const creds = getOperatorChatCreds(frameworkRoot);
   if (!creds) {
-    console.error('[daemon] Crash-loop alert: no operator chat configured ' +
+    console.error('[daemon] Operator telegram: no operator chat configured ' +
       '(set CTX_OPERATOR_CHAT_ID + CTX_OPERATOR_BOT_TOKEN, or ensure at least one agent .env exists)');
     return false;
   }
-  const message =
-    `🚨 CRITICAL: cortextos daemon is crash-looping\n` +
-    `${crashCount} crashes in 15 minutes\n` +
-    `Last error: ${errStr.slice(0, 500)}\n` +
-    `Next alert in 30 min if the pattern continues.`;
   try {
     const r = spawnSync('curl', [
       '-s', '--max-time', '3',
       '-X', 'POST',
       `https://api.telegram.org/bot${creds.botToken}/sendMessage`,
       '-d', `chat_id=${creds.chatId}`,
-      '--data-urlencode', `text=${message}`,
+      '--data-urlencode', `text=${text}`,
     ], { timeout: TELEGRAM_SEND_TIMEOUT_MS, stdio: 'pipe' });
-    if (r.status === 0) {
-      console.error('[daemon] Crash-loop alert sent to operator chat');
-      return true;
-    }
-    console.error('[daemon] Crash-loop alert send failed (non-fatal)');
-    return false;
+    return r.status === 0;
   } catch {
     return false;
   }
+}
+
+function sendCrashLoopAlertBestEffort(
+  frameworkRoot: string,
+  crashCount: number,
+  errStr: string,
+): boolean {
+  const message =
+    `🚨 CRITICAL: cortextos daemon is crash-looping\n` +
+    `${crashCount} crashes in 15 minutes\n` +
+    `Last error: ${errStr.slice(0, 500)}\n` +
+    `Next alert in 30 min if the pattern continues.`;
+  const sent = sendOperatorTelegramBestEffort(frameworkRoot, message);
+  if (sent) {
+    console.error('[daemon] Crash-loop alert sent to operator chat');
+  } else {
+    console.error('[daemon] Crash-loop alert send failed (non-fatal)');
+  }
+  return sent;
 }
 
 /**
@@ -220,6 +230,7 @@ function handleFatal(
 class Daemon {
   private agentManager: AgentManager | null = null;
   private ipcServer: IPCServer | null = null;
+  private wakeDetector: SleepWakeDetector | null = null;
   private instanceId: string;
   private ctxRoot: string;
 
@@ -266,11 +277,37 @@ class Daemon {
     // Discover and start agents
     await this.agentManager.discoverAndStart();
 
+    // Wake notice: after the host sleeps >10 min (clamshell/suspend), send ONE
+    // operator Telegram per sleep episode once uptime is sustained (FullWake).
+    // Queued crons/messages flush right after wake, so this tells the operator
+    // why a burst of catch-up activity is arriving.
+    this.wakeDetector = new SleepWakeDetector({
+      onWake: (ep) => {
+        const gaps = ep.gapCount > 1 ? ` across ${ep.gapCount} sleep intervals` : '';
+        const message =
+          `😴 Fleet host was asleep ${formatDurationShort(ep.totalSleptMs)}` +
+          `${gaps} (${hhmmUtc(ep.sleptFromMs)}–${hhmmUtc(ep.wokeAtMs)} UTC).\n` +
+          `Back online — agents are catching up on queued work.`;
+        const sent = sendOperatorTelegramBestEffort(frameworkRoot, message);
+        console.log(
+          `[daemon] wake-notice: slept ${formatDurationShort(ep.totalSleptMs)} ` +
+          `(${new Date(ep.sleptFromMs).toISOString()} → ${new Date(ep.wokeAtMs).toISOString()}, ` +
+          `${ep.gapCount} gap(s)) — telegram ${sent ? 'sent' : 'NOT sent'}`
+        );
+      },
+      logger: (msg) => console.log(`[daemon] ${msg}`),
+    });
+    this.wakeDetector.start();
+
     console.log(`[daemon] Running (pid: ${process.pid})`);
 
     // Handle shutdown signals
     const shutdown = async () => {
       console.log('[daemon] Shutting down...');
+      if (this.wakeDetector) {
+        this.wakeDetector.stop();
+        this.wakeDetector = null;
+      }
       try {
         if (this.agentManager) {
           await this.agentManager.stopAll();

--- a/src/daemon/sleep-wake-detector.ts
+++ b/src/daemon/sleep-wake-detector.ts
@@ -1,0 +1,165 @@
+/**
+ * sleep-wake-detector.ts — host sleep/wake detection via wall-clock tick gaps.
+ *
+ * Node timers freeze while the host sleeps (clamshell lid-close, suspend).
+ * A short repeating tick therefore observes a wall-clock jump roughly equal
+ * to the time slept. This module turns those jumps into ONE notification per
+ * sleep episode:
+ *
+ *  - a tick gap ≥ gapThresholdMs opens (or extends) a sleep episode;
+ *  - the episode closes only after settleTicks consecutive on-time ticks
+ *    (sustained uptime is the FullWake proxy — cross-platform, no pmset
+ *    dependency). macOS Power Nap dark-wakes are shorter than the settle
+ *    window, so intermittent dark-wakes during one lid-closed stretch merge
+ *    into a single episode instead of emitting a notification per dark-wake;
+ *  - on close, onWake fires once with the episode's full span and the
+ *    cumulative time actually spent asleep across merged gaps.
+ *
+ * The onWake callback is isolated: a throwing callback is logged and never
+ * propagates into the daemon's timer loop.
+ */
+
+export interface SleepEpisode {
+  /** Wall-clock ms of the last on-time tick before the first gap — i.e. when the host fell asleep (±1 tick). */
+  sleptFromMs: number;
+  /** Wall-clock ms of the tick that observed the final gap — i.e. when the host came back. */
+  wokeAtMs: number;
+  /** Cumulative ms spent asleep across all merged gaps in this episode. */
+  totalSleptMs: number;
+  /** Number of distinct gaps merged into this episode (1 = single uninterrupted sleep). */
+  gapCount: number;
+}
+
+export interface SleepWakeDetectorOptions {
+  /** Called exactly once per closed sleep episode. */
+  onWake: (episode: SleepEpisode) => void;
+  /** Minimum tick gap that counts as sleep. Default 10 minutes. */
+  gapThresholdMs?: number;
+  /** Tick cadence. Default 15s. */
+  tickIntervalMs?: number;
+  /** Consecutive on-time ticks required to close an episode. Default 6 (90s sustained uptime). */
+  settleTicks?: number;
+  /** Injectable clock for tests. Default Date.now. */
+  now?: () => number;
+  /** Injectable logger. Default console.log. */
+  logger?: (msg: string) => void;
+}
+
+export const DEFAULT_GAP_THRESHOLD_MS = 10 * 60_000;
+export const DEFAULT_TICK_INTERVAL_MS = 15_000;
+export const DEFAULT_SETTLE_TICKS = 6;
+
+export class SleepWakeDetector {
+  private readonly onWake: (episode: SleepEpisode) => void;
+  private readonly gapThresholdMs: number;
+  private readonly tickIntervalMs: number;
+  private readonly settleTicks: number;
+  private readonly now: () => number;
+  private readonly logger: (msg: string) => void;
+
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+  private lastTickMs = 0;
+  private episode: SleepEpisode | null = null;
+  private settleCount = 0;
+
+  constructor(opts: SleepWakeDetectorOptions) {
+    this.onWake = opts.onWake;
+    this.gapThresholdMs = opts.gapThresholdMs ?? DEFAULT_GAP_THRESHOLD_MS;
+    this.tickIntervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS;
+    this.settleTicks = opts.settleTicks ?? DEFAULT_SETTLE_TICKS;
+    this.now = opts.now ?? Date.now;
+    this.logger = opts.logger ?? ((msg: string) => console.log(msg));
+  }
+
+  start(): void {
+    if (this.tickHandle !== null) return;
+    this.lastTickMs = this.now();
+    this.tickHandle = setInterval(() => this.tick(), this.tickIntervalMs);
+    // Never hold the process open on our account (crash paths, tests).
+    if (typeof this.tickHandle.unref === 'function') this.tickHandle.unref();
+  }
+
+  stop(): void {
+    if (this.tickHandle !== null) {
+      clearInterval(this.tickHandle);
+      this.tickHandle = null;
+    }
+    this.episode = null;
+    this.settleCount = 0;
+  }
+
+  /** True while a sleep episode is open (host recently woke, settle pending). */
+  inSleepAdjacentWindow(): boolean {
+    return this.episode !== null;
+  }
+
+  /**
+   * One detector tick. Runs on the interval; exposed for tests so a fake
+   * clock can drive gap/settle sequences deterministically.
+   */
+  tick(): void {
+    const now = this.now();
+    const gap = now - this.lastTickMs;
+    const prevTickMs = this.lastTickMs;
+    this.lastTickMs = now;
+
+    if (gap >= this.gapThresholdMs) {
+      if (this.episode === null) {
+        this.episode = {
+          sleptFromMs: prevTickMs,
+          wokeAtMs: now,
+          totalSleptMs: gap,
+          gapCount: 1,
+        };
+      } else {
+        // Another gap before settle completed — same lid-closed stretch
+        // (dark-wake pattern). Merge into the open episode.
+        this.episode.wokeAtMs = now;
+        this.episode.totalSleptMs += gap;
+        this.episode.gapCount += 1;
+      }
+      this.settleCount = 0;
+      this.logger(
+        `[sleep-wake] gap ${Math.round(gap / 1000)}s detected ` +
+        `(episode total ${Math.round(this.episode.totalSleptMs / 1000)}s across ${this.episode.gapCount} gap(s)) — settling`
+      );
+      return;
+    }
+
+    if (this.episode !== null) {
+      this.settleCount += 1;
+      if (this.settleCount >= this.settleTicks) {
+        const episode = this.episode;
+        this.episode = null;
+        this.settleCount = 0;
+        try {
+          this.onWake(episode);
+        } catch (err) {
+          this.logger(
+            `[sleep-wake] onWake callback threw (ignored): ` +
+            `${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    }
+  }
+}
+
+/** Format a duration as a compact human string: "3h 29m", "12m", "45s". */
+export function formatDurationShort(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
+/** Format epoch ms as "HH:MM" UTC. */
+export function hhmmUtc(ms: number): string {
+  const d = new Date(ms);
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}

--- a/tests/unit/daemon/sleep-wake-detector.test.ts
+++ b/tests/unit/daemon/sleep-wake-detector.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SleepWakeDetector,
+  formatDurationShort,
+  hhmmUtc,
+  type SleepEpisode,
+} from '../../../src/daemon/sleep-wake-detector.js';
+
+const MIN = 60_000;
+const TICK = 15_000;
+
+/**
+ * Drive the detector with a fake clock. `advanceAndTick(ms)` moves the clock
+ * forward and runs one tick — exactly what the real interval does, except a
+ * host sleep shows up as one tick with a large wall-clock jump.
+ */
+function makeDetector(opts: { gapThresholdMs?: number; settleTicks?: number } = {}) {
+  let nowMs = 1_000_000_000_000;
+  const wakes: SleepEpisode[] = [];
+  const detector = new SleepWakeDetector({
+    onWake: (ep) => wakes.push(ep),
+    gapThresholdMs: opts.gapThresholdMs ?? 10 * MIN,
+    tickIntervalMs: TICK,
+    settleTicks: opts.settleTicks ?? 6,
+    now: () => nowMs,
+    logger: () => {},
+  });
+  detector.start();
+  detector.stop(); // kill the real interval — we drive tick() manually
+  // stop() cleared episode state; re-arm lastTick via start-equivalent:
+  // (start() again would re-create the interval, so set the baseline by ticking once)
+  detector.tick();
+  return {
+    detector,
+    wakes,
+    advanceAndTick(ms: number) {
+      nowMs += ms;
+      detector.tick();
+    },
+  };
+}
+
+describe('SleepWakeDetector', () => {
+  it('emits nothing on a steady tick stream', () => {
+    const d = makeDetector();
+    for (let i = 0; i < 100; i++) d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);
+  });
+
+  it('ignores gaps below the threshold', () => {
+    const d = makeDetector();
+    d.advanceAndTick(9 * MIN); // below 10-min threshold
+    for (let i = 0; i < 10; i++) d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);
+  });
+
+  it('emits one wake after a single sleep gap + settle', () => {
+    const d = makeDetector();
+    d.advanceAndTick(TICK);           // steady baseline
+    d.advanceAndTick(3 * 60 * MIN);   // 3h sleep
+    for (let i = 0; i < 5; i++) d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);  // settle (6 ticks) not yet complete
+    d.advanceAndTick(TICK);           // 6th on-time tick
+    expect(d.wakes).toHaveLength(1);
+    const ep = d.wakes[0];
+    expect(ep.totalSleptMs).toBe(3 * 60 * MIN);
+    expect(ep.gapCount).toBe(1);
+    expect(ep.wokeAtMs - ep.sleptFromMs).toBe(3 * 60 * MIN);
+  });
+
+  it('merges dark-wake interrupted sleep into one episode', () => {
+    const d = makeDetector();
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(60 * MIN);  // sleep 1h
+    d.advanceAndTick(TICK);      // dark-wake tick 1
+    d.advanceAndTick(TICK);      // dark-wake tick 2 (settle=2 < 6)
+    d.advanceAndTick(90 * MIN);  // sleep 1.5h more
+    for (let i = 0; i < 6; i++) d.advanceAndTick(TICK); // full wake + settle
+    expect(d.wakes).toHaveLength(1);
+    const ep = d.wakes[0];
+    expect(ep.gapCount).toBe(2);
+    expect(ep.totalSleptMs).toBe(150 * MIN); // 1h + 1.5h asleep, dark-wake time excluded
+  });
+
+  it('resets the settle counter on each new gap', () => {
+    const d = makeDetector({ settleTicks: 3 });
+    d.advanceAndTick(20 * MIN);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);       // settle 2/3
+    d.advanceAndTick(15 * MIN);   // new gap — settle must restart
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);
+    d.advanceAndTick(TICK);       // settle 3/3
+    expect(d.wakes).toHaveLength(1);
+    expect(d.wakes[0].gapCount).toBe(2);
+  });
+
+  it('reports inSleepAdjacentWindow only while an episode is open', () => {
+    const d = makeDetector({ settleTicks: 2 });
+    expect(d.detector.inSleepAdjacentWindow()).toBe(false);
+    d.advanceAndTick(30 * MIN);
+    expect(d.detector.inSleepAdjacentWindow()).toBe(true);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    expect(d.detector.inSleepAdjacentWindow()).toBe(false);
+    expect(d.wakes).toHaveLength(1);
+  });
+
+  it('swallows onWake exceptions without breaking subsequent detection', () => {
+    let nowMs = 1_000_000_000_000;
+    const wakes: SleepEpisode[] = [];
+    let calls = 0;
+    const detector = new SleepWakeDetector({
+      onWake: (ep) => {
+        calls++;
+        if (calls === 1) throw new Error('boom');
+        wakes.push(ep);
+      },
+      gapThresholdMs: 10 * MIN,
+      settleTicks: 1,
+      now: () => nowMs,
+      logger: () => {},
+    });
+    const tick = (ms: number) => { nowMs += ms; detector.tick(); };
+    detector.tick(); // baseline
+    tick(30 * MIN);
+    expect(() => tick(TICK)).not.toThrow(); // settle=1 → onWake throws, swallowed
+    tick(45 * MIN);
+    tick(TICK);
+    expect(calls).toBe(2);
+    expect(wakes).toHaveLength(1);
+    expect(wakes[0].totalSleptMs).toBe(45 * MIN);
+  });
+
+  it('emits separate wakes for separate episodes', () => {
+    const d = makeDetector({ settleTicks: 2 });
+    d.advanceAndTick(30 * MIN);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(120 * MIN);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(2);
+    expect(d.wakes[0].totalSleptMs).toBe(30 * MIN);
+    expect(d.wakes[1].totalSleptMs).toBe(120 * MIN);
+  });
+});
+
+describe('formatDurationShort', () => {
+  it('formats seconds, minutes, hours', () => {
+    expect(formatDurationShort(45_000)).toBe('45s');
+    expect(formatDurationShort(12 * MIN)).toBe('12m');
+    expect(formatDurationShort(3 * 60 * MIN + 29 * MIN)).toBe('3h 29m');
+    expect(formatDurationShort(2 * 60 * MIN)).toBe('2h');
+  });
+});
+
+describe('hhmmUtc', () => {
+  it('formats epoch ms as zero-padded HH:MM UTC', () => {
+    expect(hhmmUtc(Date.UTC(2026, 6, 9, 10, 29))).toBe('10:29');
+    expect(hhmmUtc(Date.UTC(2026, 6, 9, 3, 5))).toBe('03:05');
+  });
+});


### PR DESCRIPTION
## Problem

When the host machine sleeps (clamshell lid-close, suspend), Node timers freeze fleet-wide. On wake, everything queued during the sleep — cron fires, agent messages, reminders — floods in at once, and the operator gets a burst of catch-up activity on Telegram with no explanation of why the fleet went quiet or what the burst is. (Observed live 2026-07-09: 3.5h lid-closed stretch, ~16 queued cron fires flushing at wake, operator messages sitting unanswered for the whole window.)

## Change

New `SleepWakeDetector` (`src/daemon/sleep-wake-detector.ts`): a 15s wall-clock tick where a gap ≥ 10 min opens a *sleep episode*, and the episode closes only after 90s of **sustained uptime** (6 consecutive on-time ticks). Sustained uptime is the FullWake proxy — cross-platform, no `pmset` dependency — and macOS Power Nap dark-wakes (typically ~30s) are shorter than the settle window, so intermittent dark-wakes during one lid-closed stretch **merge into a single episode** instead of emitting a notice per dark-wake.

On episode close, the daemon sends one operator Telegram:

> 😴 Fleet host was asleep 3h 29m (10:29–13:58 UTC).
> Back online — agents are catching up on queued work.

Implementation notes:
- Telegram send reuses the crash-loop alert's operator-chat resolution (`CTX_OPERATOR_*` env, falling back to the first agent `.env`), extracted into `sendOperatorTelegramBestEffort` — a pure refactor; crash-alert behavior is unchanged.
- Detector timer is `unref()`d so it never holds the process open; `onWake` exceptions are swallowed and logged; the detector stops on daemon shutdown.
- `inSleepAdjacentWindow()` is exposed for a follow-up PR that coalesces same-named queued cron fires at flush time.

## Test evidence

- 10 new unit tests (`tests/unit/daemon/sleep-wake-detector.test.ts`): steady stream, sub-threshold gaps, single-gap episode span math, dark-wake merge (cumulative slept time excludes awake slivers), settle-counter reset, window predicate, throwing callback isolation, multi-episode separation, formatting helpers.
- Full daemon unit suite on this exact branch: 19 files / 383 tests passing locally (includes the refactored crash-alert path). Full-suite CI runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
