### PR TITLE
feat(daemon): coalesce same-named cron fires queued during host sleep

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -6,6 +6,7 @@ import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { migrateCronsForAgent } from './cron-migration.js';
+import { appendExecutionLog } from './cron-execution-log.js';
 import type { CronDefinition } from '../types/index.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
@@ -27,6 +28,18 @@ export class AgentManager {
   private workers: Map<string, WorkerProcess> = new Map();
   /** Daemon-level cron scheduler registry: one CronScheduler per enabled agent. */
   private cronSchedulers: Map<string, CronScheduler> = new Map();
+  /**
+   * Cron fires queued while the host is in a sleep-adjacent window, awaiting
+   * coalesced delivery at FullWake. Keyed by agent name; drained by
+   * drainCoalescedCronFires() when the SleepWakeDetector closes an episode.
+   */
+  private pendingCronFires: Map<string, Array<{ cron: string; prompt: string; firedAt: string }>> = new Map();
+  /**
+   * Wired by the daemon after the SleepWakeDetector starts. Defaults to
+   * "never in a sleep window" so cron delivery is byte-identical to current
+   * behavior until (and unless) a detector is attached.
+   */
+  private sleepWindowPredicate: () => boolean = () => false;
   // Tracks agents that received a start request while still stopping.
   // stopAgent() honors these after cleanup completes so restart-all is race-free.
   private pendingRestarts: Set<string> = new Set();
@@ -1145,6 +1158,17 @@ export class AgentManager {
       // Without the salt, every recurring cron after its first fire would be
       // dedup-rejected and treated as a dispatch failure.
       const firedAt = new Date().toISOString();
+
+      // Sleep-adjacent window (host recently woke, or is dark-waking mid-sleep):
+      // queue recurring fires for coalesced delivery at FullWake instead of
+      // stacking [CRON FIRED] blocks into a PTY nothing is consuming. One-shot
+      // crons (fire_at) fire at most once ever — no flood risk — and stay on
+      // the direct path so a lost queue can never lose them.
+      if (this.shouldQueueCronFire(cron)) {
+        this.queueCronFireForCoalescing(agentName, cron.name, prompt, firedAt);
+        return;
+      }
+
       const injection = `[CRON FIRED ${firedAt}] ${cron.name}: ${prompt}`;
       const injected = this.injectAgent(agentName, injection);
       if (!injected) {
@@ -1163,6 +1187,113 @@ export class AgentManager {
 
     const count = scheduler.getNextFireTimes().length;
     console.log(`[daemon] Loaded ${count} external cron(s) for agent "${agentName}" from crons.json`);
+  }
+
+  // -------------------------------------------------------------------------
+  // Coalesced cron delivery (host-sleep wake flush)
+  // -------------------------------------------------------------------------
+
+  /**
+   * Wire the host sleep/wake signal. The predicate is polled on every cron
+   * fire; exceptions are treated as "not in a sleep window" so a broken
+   * detector can only ever degrade to current (direct-inject) behavior.
+   */
+  setSleepWindowPredicate(predicate: () => boolean): void {
+    this.sleepWindowPredicate = predicate;
+  }
+
+  /** True when this fire should be queued for coalesced delivery instead of injected now. */
+  shouldQueueCronFire(cron: CronDefinition): boolean {
+    if (cron.fire_at) return false; // one-shots always deliver directly
+    try {
+      return this.sleepWindowPredicate();
+    } catch {
+      return false;
+    }
+  }
+
+  /** Queue one recurring-cron fire for coalesced delivery at FullWake. */
+  queueCronFireForCoalescing(agentName: string, cronName: string, prompt: string, firedAt: string): void {
+    const queue = this.pendingCronFires.get(agentName) ?? [];
+    queue.push({ cron: cronName, prompt, firedAt });
+    this.pendingCronFires.set(agentName, queue);
+    console.log(
+      `[agent-manager] cron "${cronName}" fire queued for coalesced delivery ` +
+      `(sleep-adjacent window) — ${queue.length} pending for "${agentName}"`
+    );
+  }
+
+  /**
+   * Deliver all queued cron fires, collapsing same-named fires per agent into
+   * ONE injection that names the count and span. Called by the daemon when the
+   * SleepWakeDetector closes a sleep episode (FullWake). Distinct cron names
+   * stay separate; a single queued fire is delivered byte-identical to the
+   * normal direct format. Collapsed (undelivered) fires get a 'coalesced'
+   * execution-log entry so the audit trail stays complete.
+   */
+  async drainCoalescedCronFires(): Promise<void> {
+    for (const [agentName, fires] of [...this.pendingCronFires]) {
+      this.pendingCronFires.delete(agentName);
+
+      // Group by cron name, preserving fire order within each group.
+      const groups = new Map<string, Array<{ cron: string; prompt: string; firedAt: string }>>();
+      for (const f of fires) {
+        const g = groups.get(f.cron);
+        if (g) g.push(f);
+        else groups.set(f.cron, [f]);
+      }
+
+      for (const [cronName, group] of groups) {
+        const latest = group[group.length - 1];
+        const injection = group.length === 1
+          ? `[CRON FIRED ${latest.firedAt}] ${cronName}: ${latest.prompt}`
+          : `[CRON FIRED ${latest.firedAt}] ${cronName}: ${latest.prompt}\n` +
+            `(coalesced: ${group.length} fires queued between ${group[0].firedAt} and ` +
+            `${latest.firedAt} while the host was asleep — handle ONCE, not ${group.length} times)`;
+
+        const start = Date.now();
+        const delivered = await this.injectWithRetry(agentName, injection);
+        const nowIso = new Date().toISOString();
+
+        for (const f of group.slice(0, -1)) {
+          appendExecutionLog(agentName, {
+            ts: nowIso,
+            cron: cronName,
+            status: 'coalesced',
+            attempt: 1,
+            duration_ms: 0,
+            error: `queued at ${f.firedAt}; coalesced into delivery of ${latest.firedAt}`,
+          });
+        }
+        if (!delivered) {
+          appendExecutionLog(agentName, {
+            ts: nowIso,
+            cron: cronName,
+            status: 'failed',
+            attempt: AgentManager.COALESCE_RETRY_DELAYS_MS.length + 1,
+            duration_ms: Date.now() - start,
+            error: `coalesced delivery failed after retries — next scheduled fire covers it`,
+          });
+          console.log(
+            `[agent-manager] coalesced delivery of "${cronName}" to "${agentName}" failed after retries`
+          );
+        }
+      }
+    }
+  }
+
+  /** Backoff schedule for coalesced-delivery injection retries. */
+  static readonly COALESCE_RETRY_DELAYS_MS = [1_000, 4_000, 16_000];
+
+  private async injectWithRetry(agentName: string, text: string): Promise<boolean> {
+    const delays = AgentManager.COALESCE_RETRY_DELAYS_MS;
+    for (let attempt = 0; attempt <= delays.length; attempt++) {
+      if (this.injectAgent(agentName, text)) return true;
+      if (attempt < delays.length) {
+        await new Promise<void>(resolve => setTimeout(resolve, delays[attempt]));
+      }
+    }
+    return false;
   }
 
   /**

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,6 @@
 import { AgentManager } from './agent-manager.js';
 import { IPCServer } from './ipc-server.js';
+import { SleepWakeDetector, formatDurationShort, hhmmUtc } from './sleep-wake-detector.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
@@ -147,39 +148,48 @@ function getOperatorChatCreds(frameworkRoot: string): { chatId: string; botToken
   return null;
 }
 
-function sendCrashLoopAlertBestEffort(
-  frameworkRoot: string,
-  crashCount: number,
-  errStr: string,
-): boolean {
+/**
+ * Best-effort synchronous Telegram send to the operator chat. Bounded
+ * timeout, never throws. Shared by the crash-loop alert and the wake notice.
+ */
+function sendOperatorTelegramBestEffort(frameworkRoot: string, text: string): boolean {
   const creds = getOperatorChatCreds(frameworkRoot);
   if (!creds) {
-    console.error('[daemon] Crash-loop alert: no operator chat configured ' +
+    console.error('[daemon] Operator telegram: no operator chat configured ' +
       '(set CTX_OPERATOR_CHAT_ID + CTX_OPERATOR_BOT_TOKEN, or ensure at least one agent .env exists)');
     return false;
   }
-  const message =
-    `🚨 CRITICAL: cortextos daemon is crash-looping\n` +
-    `${crashCount} crashes in 15 minutes\n` +
-    `Last error: ${errStr.slice(0, 500)}\n` +
-    `Next alert in 30 min if the pattern continues.`;
   try {
     const r = spawnSync('curl', [
       '-s', '--max-time', '3',
       '-X', 'POST',
       `https://api.telegram.org/bot${creds.botToken}/sendMessage`,
       '-d', `chat_id=${creds.chatId}`,
-      '--data-urlencode', `text=${message}`,
+      '--data-urlencode', `text=${text}`,
     ], { timeout: TELEGRAM_SEND_TIMEOUT_MS, stdio: 'pipe' });
-    if (r.status === 0) {
-      console.error('[daemon] Crash-loop alert sent to operator chat');
-      return true;
-    }
-    console.error('[daemon] Crash-loop alert send failed (non-fatal)');
-    return false;
+    return r.status === 0;
   } catch {
     return false;
   }
+}
+
+function sendCrashLoopAlertBestEffort(
+  frameworkRoot: string,
+  crashCount: number,
+  errStr: string,
+): boolean {
+  const message =
+    `🚨 CRITICAL: cortextos daemon is crash-looping\n` +
+    `${crashCount} crashes in 15 minutes\n` +
+    `Last error: ${errStr.slice(0, 500)}\n` +
+    `Next alert in 30 min if the pattern continues.`;
+  const sent = sendOperatorTelegramBestEffort(frameworkRoot, message);
+  if (sent) {
+    console.error('[daemon] Crash-loop alert sent to operator chat');
+  } else {
+    console.error('[daemon] Crash-loop alert send failed (non-fatal)');
+  }
+  return sent;
 }
 
 /**
@@ -220,6 +230,7 @@ function handleFatal(
 class Daemon {
   private agentManager: AgentManager | null = null;
   private ipcServer: IPCServer | null = null;
+  private wakeDetector: SleepWakeDetector | null = null;
   private instanceId: string;
   private ctxRoot: string;
 
@@ -266,11 +277,37 @@ class Daemon {
     // Discover and start agents
     await this.agentManager.discoverAndStart();
 
+    // Wake notice: after the host sleeps >10 min (clamshell/suspend), send ONE
+    // operator Telegram per sleep episode once uptime is sustained (FullWake).
+    // Queued crons/messages flush right after wake, so this tells the operator
+    // why a burst of catch-up activity is arriving.
+    this.wakeDetector = new SleepWakeDetector({
+      onWake: (ep) => {
+        const gaps = ep.gapCount > 1 ? ` across ${ep.gapCount} sleep intervals` : '';
+        const message =
+          `😴 Fleet host was asleep ${formatDurationShort(ep.totalSleptMs)}` +
+          `${gaps} (${hhmmUtc(ep.sleptFromMs)}–${hhmmUtc(ep.wokeAtMs)} UTC).\n` +
+          `Back online — agents are catching up on queued work.`;
+        const sent = sendOperatorTelegramBestEffort(frameworkRoot, message);
+        console.log(
+          `[daemon] wake-notice: slept ${formatDurationShort(ep.totalSleptMs)} ` +
+          `(${new Date(ep.sleptFromMs).toISOString()} → ${new Date(ep.wokeAtMs).toISOString()}, ` +
+          `${ep.gapCount} gap(s)) — telegram ${sent ? 'sent' : 'NOT sent'}`
+        );
+      },
+      logger: (msg) => console.log(`[daemon] ${msg}`),
+    });
+    this.wakeDetector.start();
+
     console.log(`[daemon] Running (pid: ${process.pid})`);
 
     // Handle shutdown signals
     const shutdown = async () => {
       console.log('[daemon] Shutting down...');
+      if (this.wakeDetector) {
+        this.wakeDetector.stop();
+        this.wakeDetector = null;
+      }
       try {
         if (this.agentManager) {
           await this.agentManager.stopAll();

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -294,10 +294,20 @@ class Daemon {
           `(${new Date(ep.sleptFromMs).toISOString()} → ${new Date(ep.wokeAtMs).toISOString()}, ` +
           `${ep.gapCount} gap(s)) — telegram ${sent ? 'sent' : 'NOT sent'}`
         );
+        // FullWake: deliver cron fires queued during the episode, same-named
+        // fires collapsed to one injection per agent (count + span noted).
+        if (this.agentManager) {
+          void this.agentManager.drainCoalescedCronFires().catch(err => {
+            console.error('[daemon] coalesced cron drain failed:', err);
+          });
+        }
       },
       logger: (msg) => console.log(`[daemon] ${msg}`),
     });
     this.wakeDetector.start();
+    // Route cron fires into the coalescing queue while a sleep episode is open.
+    const detectorForPredicate = this.wakeDetector;
+    this.agentManager.setSleepWindowPredicate(() => detectorForPredicate.inSleepAdjacentWindow());
 
     console.log(`[daemon] Running (pid: ${process.pid})`);
 

--- a/src/daemon/sleep-wake-detector.ts
+++ b/src/daemon/sleep-wake-detector.ts
@@ -1,0 +1,165 @@
+/**
+ * sleep-wake-detector.ts — host sleep/wake detection via wall-clock tick gaps.
+ *
+ * Node timers freeze while the host sleeps (clamshell lid-close, suspend).
+ * A short repeating tick therefore observes a wall-clock jump roughly equal
+ * to the time slept. This module turns those jumps into ONE notification per
+ * sleep episode:
+ *
+ *  - a tick gap ≥ gapThresholdMs opens (or extends) a sleep episode;
+ *  - the episode closes only after settleTicks consecutive on-time ticks
+ *    (sustained uptime is the FullWake proxy — cross-platform, no pmset
+ *    dependency). macOS Power Nap dark-wakes are shorter than the settle
+ *    window, so intermittent dark-wakes during one lid-closed stretch merge
+ *    into a single episode instead of emitting a notification per dark-wake;
+ *  - on close, onWake fires once with the episode's full span and the
+ *    cumulative time actually spent asleep across merged gaps.
+ *
+ * The onWake callback is isolated: a throwing callback is logged and never
+ * propagates into the daemon's timer loop.
+ */
+
+export interface SleepEpisode {
+  /** Wall-clock ms of the last on-time tick before the first gap — i.e. when the host fell asleep (±1 tick). */
+  sleptFromMs: number;
+  /** Wall-clock ms of the tick that observed the final gap — i.e. when the host came back. */
+  wokeAtMs: number;
+  /** Cumulative ms spent asleep across all merged gaps in this episode. */
+  totalSleptMs: number;
+  /** Number of distinct gaps merged into this episode (1 = single uninterrupted sleep). */
+  gapCount: number;
+}
+
+export interface SleepWakeDetectorOptions {
+  /** Called exactly once per closed sleep episode. */
+  onWake: (episode: SleepEpisode) => void;
+  /** Minimum tick gap that counts as sleep. Default 10 minutes. */
+  gapThresholdMs?: number;
+  /** Tick cadence. Default 15s. */
+  tickIntervalMs?: number;
+  /** Consecutive on-time ticks required to close an episode. Default 6 (90s sustained uptime). */
+  settleTicks?: number;
+  /** Injectable clock for tests. Default Date.now. */
+  now?: () => number;
+  /** Injectable logger. Default console.log. */
+  logger?: (msg: string) => void;
+}
+
+export const DEFAULT_GAP_THRESHOLD_MS = 10 * 60_000;
+export const DEFAULT_TICK_INTERVAL_MS = 15_000;
+export const DEFAULT_SETTLE_TICKS = 6;
+
+export class SleepWakeDetector {
+  private readonly onWake: (episode: SleepEpisode) => void;
+  private readonly gapThresholdMs: number;
+  private readonly tickIntervalMs: number;
+  private readonly settleTicks: number;
+  private readonly now: () => number;
+  private readonly logger: (msg: string) => void;
+
+  private tickHandle: ReturnType<typeof setInterval> | null = null;
+  private lastTickMs = 0;
+  private episode: SleepEpisode | null = null;
+  private settleCount = 0;
+
+  constructor(opts: SleepWakeDetectorOptions) {
+    this.onWake = opts.onWake;
+    this.gapThresholdMs = opts.gapThresholdMs ?? DEFAULT_GAP_THRESHOLD_MS;
+    this.tickIntervalMs = opts.tickIntervalMs ?? DEFAULT_TICK_INTERVAL_MS;
+    this.settleTicks = opts.settleTicks ?? DEFAULT_SETTLE_TICKS;
+    this.now = opts.now ?? Date.now;
+    this.logger = opts.logger ?? ((msg: string) => console.log(msg));
+  }
+
+  start(): void {
+    if (this.tickHandle !== null) return;
+    this.lastTickMs = this.now();
+    this.tickHandle = setInterval(() => this.tick(), this.tickIntervalMs);
+    // Never hold the process open on our account (crash paths, tests).
+    if (typeof this.tickHandle.unref === 'function') this.tickHandle.unref();
+  }
+
+  stop(): void {
+    if (this.tickHandle !== null) {
+      clearInterval(this.tickHandle);
+      this.tickHandle = null;
+    }
+    this.episode = null;
+    this.settleCount = 0;
+  }
+
+  /** True while a sleep episode is open (host recently woke, settle pending). */
+  inSleepAdjacentWindow(): boolean {
+    return this.episode !== null;
+  }
+
+  /**
+   * One detector tick. Runs on the interval; exposed for tests so a fake
+   * clock can drive gap/settle sequences deterministically.
+   */
+  tick(): void {
+    const now = this.now();
+    const gap = now - this.lastTickMs;
+    const prevTickMs = this.lastTickMs;
+    this.lastTickMs = now;
+
+    if (gap >= this.gapThresholdMs) {
+      if (this.episode === null) {
+        this.episode = {
+          sleptFromMs: prevTickMs,
+          wokeAtMs: now,
+          totalSleptMs: gap,
+          gapCount: 1,
+        };
+      } else {
+        // Another gap before settle completed — same lid-closed stretch
+        // (dark-wake pattern). Merge into the open episode.
+        this.episode.wokeAtMs = now;
+        this.episode.totalSleptMs += gap;
+        this.episode.gapCount += 1;
+      }
+      this.settleCount = 0;
+      this.logger(
+        `[sleep-wake] gap ${Math.round(gap / 1000)}s detected ` +
+        `(episode total ${Math.round(this.episode.totalSleptMs / 1000)}s across ${this.episode.gapCount} gap(s)) — settling`
+      );
+      return;
+    }
+
+    if (this.episode !== null) {
+      this.settleCount += 1;
+      if (this.settleCount >= this.settleTicks) {
+        const episode = this.episode;
+        this.episode = null;
+        this.settleCount = 0;
+        try {
+          this.onWake(episode);
+        } catch (err) {
+          this.logger(
+            `[sleep-wake] onWake callback threw (ignored): ` +
+            `${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+    }
+  }
+}
+
+/** Format a duration as a compact human string: "3h 29m", "12m", "45s". */
+export function formatDurationShort(ms: number): string {
+  const totalSeconds = Math.round(ms / 1000);
+  if (totalSeconds < 60) return `${totalSeconds}s`;
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  if (totalMinutes < 60) return `${totalMinutes}m`;
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+  return minutes === 0 ? `${hours}h` : `${hours}h ${minutes}m`;
+}
+
+/** Format epoch ms as "HH:MM" UTC. */
+export function hhmmUtc(ms: number): string {
+  const d = new Date(ms);
+  const hh = String(d.getUTCHours()).padStart(2, '0');
+  const mm = String(d.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -437,9 +437,13 @@ export interface CronDefinition {
  * It is append-only; log rotation prunes to the last 1 000 lines.
  *
  * Status semantics:
- *   "fired"   — the fire attempt succeeded on this attempt.
- *   "retried" — this attempt failed but more retries remain (see `error`).
- *   "failed"  — final failure after exhausting all retries (see `error`).
+ *   "fired"     — the fire attempt succeeded on this attempt.
+ *   "retried"   — this attempt failed but more retries remain (see `error`).
+ *   "failed"    — final failure after exhausting all retries (see `error`).
+ *   "coalesced" — the fire was queued during a host-sleep window and collapsed
+ *                 into a single delivery with its same-named siblings at wake
+ *                 (the delivered sibling logs its own entry; see `error` for
+ *                 the queue/delivery timestamps).
  */
 export interface CronExecutionLogEntry {
   /** ISO 8601 UTC timestamp of the fire attempt. */
@@ -447,7 +451,7 @@ export interface CronExecutionLogEntry {
   /** Cron name (matches CronDefinition.name). */
   cron: string;
   /** Outcome of this attempt. */
-  status: 'fired' | 'retried' | 'failed';
+  status: 'fired' | 'retried' | 'failed' | 'coalesced';
   /** Attempt index (1-based). */
   attempt: number;
   /** Wall-clock duration of the fire attempt in milliseconds. */

--- a/tests/unit/daemon/cron-coalescing.test.ts
+++ b/tests/unit/daemon/cron-coalescing.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { CronDefinition } from '../../../src/types/index.js';
+
+// Mock the PTY/Telegram layers — same shape as agent-manager-inspect-op.test.ts
+// so AgentManager constructs without spawning anything real.
+vi.mock('../../../src/daemon/agent-process.js', () => ({
+  AgentProcess: class {
+    name: string;
+    dir: string;
+    constructor(name: string, dir: string) { this.name = name; this.dir = dir; }
+    async start() { /* no-op */ }
+    async stop() { /* no-op */ }
+    getStatus() { return { name: this.name, status: 'stopped' }; }
+    onExit() { /* no-op */ }
+  },
+}));
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class { start() {} stop() {} wake() {} },
+}));
+vi.mock('../../../src/telegram/api.js', () => ({ TelegramAPI: class { constructor() {} } }));
+vi.mock('../../../src/telegram/poller.js', () => ({ TelegramPoller: class { start() {} stop() {} } }));
+vi.mock('../../../src/daemon/cron-execution-log.js', () => ({
+  appendExecutionLog: vi.fn(),
+}));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+const { appendExecutionLog } = await import('../../../src/daemon/cron-execution-log.js');
+
+function makeManager() {
+  const testDir = mkdtempSync(join(tmpdir(), 'coalesce-test-'));
+  const manager = new AgentManager('test-instance', testDir, testDir, 'testorg');
+  return { manager, testDir };
+}
+
+const recurringCron = (name: string): CronDefinition =>
+  ({ name, prompt: `run ${name}`, schedule: '15m', enabled: true } as CronDefinition);
+const onceCron = (name: string): CronDefinition =>
+  ({ name, prompt: `run ${name}`, schedule: '', enabled: true, fire_at: '2026-07-09T10:23:00Z' } as CronDefinition);
+
+describe('AgentManager cron coalescing', () => {
+  let testDir: string;
+  let manager: InstanceType<typeof AgentManager>;
+
+  beforeEach(() => {
+    ({ manager, testDir } = makeManager());
+    vi.mocked(appendExecutionLog).mockClear();
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('shouldQueueCronFire', () => {
+    it('is false by default (no detector wired) — behavior identical to current', () => {
+      expect(manager.shouldQueueCronFire(recurringCron('heartbeat'))).toBe(false);
+    });
+
+    it('is true for recurring crons while the sleep window is open', () => {
+      manager.setSleepWindowPredicate(() => true);
+      expect(manager.shouldQueueCronFire(recurringCron('heartbeat'))).toBe(true);
+    });
+
+    it('is always false for one-shot (fire_at) crons', () => {
+      manager.setSleepWindowPredicate(() => true);
+      expect(manager.shouldQueueCronFire(onceCron('remind-user'))).toBe(false);
+    });
+
+    it('treats a throwing predicate as "not in a window"', () => {
+      manager.setSleepWindowPredicate(() => { throw new Error('detector broken'); });
+      expect(manager.shouldQueueCronFire(recurringCron('heartbeat'))).toBe(false);
+    });
+  });
+
+  describe('drainCoalescedCronFires', () => {
+    it('is a no-op with an empty queue', async () => {
+      const inject = vi.spyOn(manager, 'injectAgent').mockReturnValue(true);
+      await manager.drainCoalescedCronFires();
+      expect(inject).not.toHaveBeenCalled();
+    });
+
+    it('collapses same-named fires into ONE injection with count and span; distinct names stay separate', async () => {
+      const inject = vi.spyOn(manager, 'injectAgent').mockReturnValue(true);
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T10:50:00Z');
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T11:05:00Z');
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T11:20:00Z');
+      manager.queueCronFireForCoalescing('kirk', 'heartbeat', 'do heartbeat', '2026-07-09T12:00:00Z');
+
+      await manager.drainCoalescedCronFires();
+
+      expect(inject).toHaveBeenCalledTimes(2);
+      const texts = inject.mock.calls.map(c => c[1]);
+      const vipText = texts.find(t => t.includes('vip-scan'))!;
+      expect(vipText).toContain('[CRON FIRED 2026-07-09T11:20:00Z] vip-scan: scan vips');
+      expect(vipText).toContain('coalesced: 3 fires');
+      expect(vipText).toContain('between 2026-07-09T10:50:00Z and 2026-07-09T11:20:00Z');
+      expect(vipText).toContain('handle ONCE');
+      const hbText = texts.find(t => t.includes('heartbeat'))!;
+      // single fire → byte-identical to the normal direct format, no coalesce note
+      expect(hbText).toBe('[CRON FIRED 2026-07-09T12:00:00Z] heartbeat: do heartbeat');
+    });
+
+    it('logs a coalesced execution-log entry for each collapsed fire, none for the delivered one', async () => {
+      vi.spyOn(manager, 'injectAgent').mockReturnValue(true);
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T10:50:00Z');
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T11:05:00Z');
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T11:20:00Z');
+
+      await manager.drainCoalescedCronFires();
+
+      const coalesced = vi.mocked(appendExecutionLog).mock.calls
+        .filter(c => c[1].status === 'coalesced');
+      expect(coalesced).toHaveLength(2); // 3 fires → 2 collapsed + 1 delivered
+      expect(coalesced[0][0]).toBe('kirk');
+      expect(coalesced[0][1].error).toContain('queued at 2026-07-09T10:50:00Z');
+      expect(coalesced[0][1].error).toContain('coalesced into delivery of 2026-07-09T11:20:00Z');
+    });
+
+    it('clears the queue: a second drain injects nothing', async () => {
+      const inject = vi.spyOn(manager, 'injectAgent').mockReturnValue(true);
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T10:50:00Z');
+      await manager.drainCoalescedCronFires();
+      inject.mockClear();
+      await manager.drainCoalescedCronFires();
+      expect(inject).not.toHaveBeenCalled();
+    });
+
+    it('drains queues for multiple agents independently', async () => {
+      const inject = vi.spyOn(manager, 'injectAgent').mockReturnValue(true);
+      manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T10:50:00Z');
+      manager.queueCronFireForCoalescing('scotty', 'file-drop-monitor', 'check drops', '2026-07-09T11:07:00Z');
+      await manager.drainCoalescedCronFires();
+      const agents = inject.mock.calls.map(c => c[0]);
+      expect(agents).toContain('kirk');
+      expect(agents).toContain('scotty');
+    });
+
+    it('retries failed injection with backoff, then logs a failed entry', async () => {
+      vi.useFakeTimers();
+      try {
+        const inject = vi.spyOn(manager, 'injectAgent').mockReturnValue(false);
+        manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T10:50:00Z');
+
+        const drain = manager.drainCoalescedCronFires();
+        await vi.advanceTimersByTimeAsync(1_000 + 4_000 + 16_000);
+        await drain;
+
+        expect(inject).toHaveBeenCalledTimes(4); // initial + 3 retries
+        const failed = vi.mocked(appendExecutionLog).mock.calls
+          .filter(c => c[1].status === 'failed');
+        expect(failed).toHaveLength(1);
+        expect(failed[0][1].error).toContain('next scheduled fire covers it');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('recovers when a retry succeeds mid-backoff', async () => {
+      vi.useFakeTimers();
+      try {
+        const inject = vi.spyOn(manager, 'injectAgent')
+          .mockReturnValueOnce(false)
+          .mockReturnValue(true);
+        manager.queueCronFireForCoalescing('kirk', 'vip-scan', 'scan vips', '2026-07-09T10:50:00Z');
+
+        const drain = manager.drainCoalescedCronFires();
+        await vi.advanceTimersByTimeAsync(1_000);
+        await drain;
+
+        expect(inject).toHaveBeenCalledTimes(2);
+        const failed = vi.mocked(appendExecutionLog).mock.calls
+          .filter(c => c[1].status === 'failed');
+        expect(failed).toHaveLength(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+  });
+});

--- a/tests/unit/daemon/sleep-wake-detector.test.ts
+++ b/tests/unit/daemon/sleep-wake-detector.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  SleepWakeDetector,
+  formatDurationShort,
+  hhmmUtc,
+  type SleepEpisode,
+} from '../../../src/daemon/sleep-wake-detector.js';
+
+const MIN = 60_000;
+const TICK = 15_000;
+
+/**
+ * Drive the detector with a fake clock. `advanceAndTick(ms)` moves the clock
+ * forward and runs one tick — exactly what the real interval does, except a
+ * host sleep shows up as one tick with a large wall-clock jump.
+ */
+function makeDetector(opts: { gapThresholdMs?: number; settleTicks?: number } = {}) {
+  let nowMs = 1_000_000_000_000;
+  const wakes: SleepEpisode[] = [];
+  const detector = new SleepWakeDetector({
+    onWake: (ep) => wakes.push(ep),
+    gapThresholdMs: opts.gapThresholdMs ?? 10 * MIN,
+    tickIntervalMs: TICK,
+    settleTicks: opts.settleTicks ?? 6,
+    now: () => nowMs,
+    logger: () => {},
+  });
+  detector.start();
+  detector.stop(); // kill the real interval — we drive tick() manually
+  // stop() cleared episode state; re-arm lastTick via start-equivalent:
+  // (start() again would re-create the interval, so set the baseline by ticking once)
+  detector.tick();
+  return {
+    detector,
+    wakes,
+    advanceAndTick(ms: number) {
+      nowMs += ms;
+      detector.tick();
+    },
+  };
+}
+
+describe('SleepWakeDetector', () => {
+  it('emits nothing on a steady tick stream', () => {
+    const d = makeDetector();
+    for (let i = 0; i < 100; i++) d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);
+  });
+
+  it('ignores gaps below the threshold', () => {
+    const d = makeDetector();
+    d.advanceAndTick(9 * MIN); // below 10-min threshold
+    for (let i = 0; i < 10; i++) d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);
+  });
+
+  it('emits one wake after a single sleep gap + settle', () => {
+    const d = makeDetector();
+    d.advanceAndTick(TICK);           // steady baseline
+    d.advanceAndTick(3 * 60 * MIN);   // 3h sleep
+    for (let i = 0; i < 5; i++) d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);  // settle (6 ticks) not yet complete
+    d.advanceAndTick(TICK);           // 6th on-time tick
+    expect(d.wakes).toHaveLength(1);
+    const ep = d.wakes[0];
+    expect(ep.totalSleptMs).toBe(3 * 60 * MIN);
+    expect(ep.gapCount).toBe(1);
+    expect(ep.wokeAtMs - ep.sleptFromMs).toBe(3 * 60 * MIN);
+  });
+
+  it('merges dark-wake interrupted sleep into one episode', () => {
+    const d = makeDetector();
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(60 * MIN);  // sleep 1h
+    d.advanceAndTick(TICK);      // dark-wake tick 1
+    d.advanceAndTick(TICK);      // dark-wake tick 2 (settle=2 < 6)
+    d.advanceAndTick(90 * MIN);  // sleep 1.5h more
+    for (let i = 0; i < 6; i++) d.advanceAndTick(TICK); // full wake + settle
+    expect(d.wakes).toHaveLength(1);
+    const ep = d.wakes[0];
+    expect(ep.gapCount).toBe(2);
+    expect(ep.totalSleptMs).toBe(150 * MIN); // 1h + 1.5h asleep, dark-wake time excluded
+  });
+
+  it('resets the settle counter on each new gap', () => {
+    const d = makeDetector({ settleTicks: 3 });
+    d.advanceAndTick(20 * MIN);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);       // settle 2/3
+    d.advanceAndTick(15 * MIN);   // new gap — settle must restart
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(0);
+    d.advanceAndTick(TICK);       // settle 3/3
+    expect(d.wakes).toHaveLength(1);
+    expect(d.wakes[0].gapCount).toBe(2);
+  });
+
+  it('reports inSleepAdjacentWindow only while an episode is open', () => {
+    const d = makeDetector({ settleTicks: 2 });
+    expect(d.detector.inSleepAdjacentWindow()).toBe(false);
+    d.advanceAndTick(30 * MIN);
+    expect(d.detector.inSleepAdjacentWindow()).toBe(true);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    expect(d.detector.inSleepAdjacentWindow()).toBe(false);
+    expect(d.wakes).toHaveLength(1);
+  });
+
+  it('swallows onWake exceptions without breaking subsequent detection', () => {
+    let nowMs = 1_000_000_000_000;
+    const wakes: SleepEpisode[] = [];
+    let calls = 0;
+    const detector = new SleepWakeDetector({
+      onWake: (ep) => {
+        calls++;
+        if (calls === 1) throw new Error('boom');
+        wakes.push(ep);
+      },
+      gapThresholdMs: 10 * MIN,
+      settleTicks: 1,
+      now: () => nowMs,
+      logger: () => {},
+    });
+    const tick = (ms: number) => { nowMs += ms; detector.tick(); };
+    detector.tick(); // baseline
+    tick(30 * MIN);
+    expect(() => tick(TICK)).not.toThrow(); // settle=1 → onWake throws, swallowed
+    tick(45 * MIN);
+    tick(TICK);
+    expect(calls).toBe(2);
+    expect(wakes).toHaveLength(1);
+    expect(wakes[0].totalSleptMs).toBe(45 * MIN);
+  });
+
+  it('emits separate wakes for separate episodes', () => {
+    const d = makeDetector({ settleTicks: 2 });
+    d.advanceAndTick(30 * MIN);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(120 * MIN);
+    d.advanceAndTick(TICK);
+    d.advanceAndTick(TICK);
+    expect(d.wakes).toHaveLength(2);
+    expect(d.wakes[0].totalSleptMs).toBe(30 * MIN);
+    expect(d.wakes[1].totalSleptMs).toBe(120 * MIN);
+  });
+});
+
+describe('formatDurationShort', () => {
+  it('formats seconds, minutes, hours', () => {
+    expect(formatDurationShort(45_000)).toBe('45s');
+    expect(formatDurationShort(12 * MIN)).toBe('12m');
+    expect(formatDurationShort(3 * 60 * MIN + 29 * MIN)).toBe('3h 29m');
+    expect(formatDurationShort(2 * 60 * MIN)).toBe('2h');
+  });
+});
+
+describe('hhmmUtc', () => {
+  it('formats epoch ms as zero-padded HH:MM UTC', () => {
+    expect(hhmmUtc(Date.UTC(2026, 6, 9, 10, 29))).toBe('10:29');
+    expect(hhmmUtc(Date.UTC(2026, 6, 9, 3, 5))).toBe('03:05');
+  });
+});


### PR DESCRIPTION
**Depends on #745** (stacked branch — the first commit here IS #745's `SleepWakeDetector`; only the second commit is new). Suggest reviewing/merging #745 first, after which this PR shows only the coalescing commit.

## Problem

During a lid-closed stretch, macOS Power Nap dark-wakes let the daemon's cron scheduler dispatch fires into agent PTYs that nothing is consuming. At full wake, the session flushes them all at once — observed live 2026-07-09: a 15-min cron stacked ~14 separate `[CRON FIRED]` blocks over a 3.5h sleep, and the agent then processed 14 identical prompts back-to-back. The scheduler itself is not the flood source (it already has a single-catch-up-per-cron policy); the stacking happens at the delivery boundary.

## Change

While the `SleepWakeDetector` (#745) reports an open sleep episode, recurring-cron fires are **queued per agent** instead of injected. When the episode closes at FullWake, same-named fires collapse into **one injection** carrying the latest prompt plus count and span:

```
[CRON FIRED 2026-07-09T13:20:00Z] vip-scan: <prompt>
(coalesced: 14 fires queued between 10:50:00Z and 13:20:00Z while the host was asleep — handle ONCE, not 14 times)
```

Distinct cron names stay separate. A single queued fire is delivered **byte-identical** to the normal direct format.

## Semantics kept / documented

- **CronScheduler untouched.** The normal (awake) delivery path is byte-identical; with no detector wired, the predicate defaults to `false` and nothing changes at all.
- **One-shot crons (`fire_at`) are exempt from queueing** — they fire at most once ever (no flood risk), and keeping them on the direct path means the only unrecoverable class can never be lost from a dropped queue.
- **Bounded loss window, self-healing:** a daemon crash mid-episode drops queued recurring deliveries; the next scheduled slot fires anyway within one interval.
- **Audit trail complete:** collapsed fires get `coalesced` execution-log entries (new status union member, additive); a failed coalesced delivery retries on the scheduler's backoff schedule (1s/4s/16s) then logs `failed`.
- **Known leak, bounded:** a fire dispatched in the first ~15s of a dark-wake (before the detector's next tick observes the gap) still goes direct — at most one uncoalesced fire per cron per wake.

## Test evidence

- 11 new unit tests (`tests/unit/daemon/cron-coalescing.test.ts`): predicate gating (default-off, window-open, once-cron exemption, throwing detector degrades to direct), same-name collapse with count+span, distinct-name separation, single-fire byte-identity, queue clearing, multi-agent drains, retry-then-failed logging, mid-backoff recovery.
- Full daemon unit suite on this exact branch: 20 files / 394 tests passing locally.
- Honest scope note: the repo's full `tests/unit` sweep has 28 pre-existing failures in 4 non-daemon files (`bus/hooks`, `cli/bus-crons`, `hooks/*`) that reproduce identically on clean upstream `main` (5a0882d) with no changes — verified by running both trees back-to-back. Not introduced here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
