### PR TITLE
test: make the suite hermetic (neutralize ambient CTX_* env, stop repo-root litter)

### DIFF
--- a/tests/setup/hermetic-env.ts
+++ b/tests/setup/hermetic-env.ts
@@ -1,0 +1,25 @@
+/**
+ * Vitest setup: neutralize ambient CTX_* environment variables so the suite
+ * is hermetic no matter which shell launched it.
+ *
+ * Agent shells (and any shell sourcing .cortextos-env) export CTX_* vars
+ * (CTX_FRAMEWORK_ROOT, CTX_PROJECT_ROOT, CTX_AGENT_DIR, CTX_INSTANCE_ID,
+ * CTX_AGENT_NAME, CTX_ORG, CTX_ROOT, ...). Product code branches on these —
+ * e.g. hook-crash-alert's notifyAgents invokes <frameworkRoot>/dist/cli.js
+ * when CTX_FRAMEWORK_ROOT is set and falls back to a bare 'cortextos' PATH
+ * lookup when it is not, and resolveEnv() hard-fails when an inherited
+ * CTX_AGENT_DIR points outside a test's stubbed CTX_FRAMEWORK_ROOT. Tests
+ * written for a clean environment therefore fail from an agent shell with
+ * "the tests are broken" false alarms.
+ *
+ * This file runs (per vitest setupFiles) in every test worker before each
+ * test file is imported, so module-level env reads in product code see the
+ * clean environment too, and child processes spawned by integration tests
+ * inherit it. Tests that need specific CTX_* values set them explicitly
+ * after this runs.
+ */
+for (const key of Object.keys(process.env)) {
+  if (key.startsWith('CTX_')) {
+    delete process.env[key];
+  }
+}

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -8,6 +8,9 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 
 // ---------------------------------------------------------------------------
 // Mock crons.ts I/O BEFORE importing CronScheduler so the module resolution
@@ -51,6 +54,32 @@ function makeCron(overrides: Partial<CronDefinition> = {}): CronDefinition {
 }
 
 const TICK = CronScheduler.TICK_INTERVAL_MS; // 30_000 ms
+
+// ---------------------------------------------------------------------------
+// State-root isolation. The fire path appends to
+// $CTX_ROOT/.cortextOS/state/agents/{agent}/cron-execution.log via
+// appendExecutionLog — which is NOT part of the crons.js mock above. Without
+// CTX_ROOT that resolution falls back to process.cwd() and litters the repo
+// root with .cortextOS/ junk on every run, so each test gets a throwaway
+// tmpdir root instead.
+// ---------------------------------------------------------------------------
+
+let stateRoot: string;
+const originalCtxRoot = process.env.CTX_ROOT;
+
+beforeEach(() => {
+  stateRoot = mkdtempSync(join(tmpdir(), 'cron-sched-state-'));
+  process.env.CTX_ROOT = stateRoot;
+});
+
+afterEach(() => {
+  if (originalCtxRoot !== undefined) {
+    process.env.CTX_ROOT = originalCtxRoot;
+  } else {
+    delete process.env.CTX_ROOT;
+  }
+  rmSync(stateRoot, { recursive: true, force: true });
+});
 
 // ---------------------------------------------------------------------------
 // nextFireFromCron — unit tests for the cron expression parser

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
   test: {
     globals: true,
     testTimeout: 10000,
+    // Strip ambient CTX_* vars (agent shells export them) before each test
+    // file so the suite behaves identically in any shell — see the setup
+    // file for the full rationale.
+    setupFiles: ['tests/setup/hermetic-env.ts'],
     include: [
       'tests/**/*.test.ts',
       'dashboard/src/**/__tests__/**/*.test.ts',


### PR DESCRIPTION
## Problem

Two ways the test suite leaks state with the ambient environment:

1. **Ambient CTX_* vars change test results.** Any shell that sources a
   cortextOS agent environment exports CTX_* vars (CTX_FRAMEWORK_ROOT,
   CTX_AGENT_DIR, CTX_ROOT, ...), and product code branches on them:
   hook-crash-alert's notifyAgents picks the dist/cli.js invocation when
   CTX_FRAMEWORK_ROOT is set, resolveEnv hard-fails when an inherited
   CTX_AGENT_DIR points outside a test's stubbed CTX_FRAMEWORK_ROOT, etc.
   Running the suite from such a shell produces dozens of failures a clean
   terminal never sees. Measured on current main (5a0882d) from a shell
   with 8 CTX_* vars exported: 34 failed tests, all false alarms.

2. **cron-scheduler tests litter the repo root.** The cron execution-log
   path resolves from process.env.CTX_ROOT with a process.cwd() fallback
   (cron-execution-log.ts). cron-scheduler.test.ts exercises that fallback
   (the fire path appends cron-execution.log, which the file's crons.js
   mock does not cover) and leaves `.cortextOS/state/agents/` junk at the
   repo root on every run from a clean shell.

## Fix

- `tests/setup/hermetic-env.ts` (new, wired via vitest `setupFiles`)
  deletes every CTX_*-prefixed env var in each test worker before every
  test file, so module-level env reads and spawned child processes see a
  clean environment. Tests that need specific CTX_* values set them
  explicitly after it runs.
- `cron-scheduler.test.ts` gives every test a throwaway mkdtemp CTX_ROOT
  (same idiom as the other hermetic cron tests) and removes it after.

## Tests

Test-only change. Verified on this branch: full suite gives identical
results from a dirty agent shell (8 CTX_* vars) and a clean env, and
leaves no `.cortextOS/` at the repo root. 1785 passed; the only failure
is the pre-existing dashboard-polling test, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
