### PR TITLE
fix(bus): add gsk_/nfp_/AIza to auto-commit credential patterns

### DIFF
--- a/src/bus/system.ts
+++ b/src/bus/system.ts
@@ -43,7 +43,10 @@ const EXCLUDED_DIR_PREFIXES = [
   '.venv/',
 ];
 
-const CREDENTIAL_PATTERNS = /(?:token=|key=|password=|secret=|sk-|ghp_|xoxb-|AKIA)/;
+// gsk_ (Groq), nfp_ (Nebius), and AIza (Google API) key prefixes are blocked
+// alongside the original set — all three are live-key formats that the
+// previous pattern let through.
+const CREDENTIAL_PATTERNS = /(?:token=|key=|password=|secret=|sk-|ghp_|xoxb-|AKIA|gsk_|nfp_|AIza)/;
 
 const SCRIPT_EXTENSIONS = new Set(['.sh', '.py', '.js']);
 

--- a/tests/unit/bus/system.test.ts
+++ b/tests/unit/bus/system.test.ts
@@ -116,6 +116,19 @@ describe('Bus System', () => {
       expect(report.staged).toContain('readme.md');
     });
 
+    it('blocks Groq (gsk_), Nebius (nfp_), and Google (AIza) key prefixes', () => {
+      writeFileSync(join(gitDir, 'groq.md'), 'gsk_AbCdEfGhIjKlMnOpQrSt1234567890');
+      writeFileSync(join(gitDir, 'nebius.md'), 'nfp_AbCdEfGhIjKlMnOpQrSt1234567890');
+      writeFileSync(join(gitDir, 'google.md'), 'AIzaSyAbCdEfGhIjKlMnOpQrSt1234567890');
+      writeFileSync(join(gitDir, 'clean.md'), 'nothing sensitive here');
+
+      const report = autoCommit(gitDir, true);
+      for (const f of ['groq.md', 'nebius.md', 'google.md']) {
+        expect(report.blocked.some(b => b.includes(f) && b.includes('credential')), f).toBe(true);
+      }
+      expect(report.staged).toContain('clean.md');
+    });
+
     it('allows script files even with credential-like patterns', () => {
       writeFileSync(join(gitDir, 'deploy.sh'), '#!/bin/bash\ntoken=get_from_env');
       writeFileSync(join(gitDir, 'app.py'), 'password=input("Enter:")');


### PR DESCRIPTION
## Problem

`bus auto-commit`'s credential filter (CREDENTIAL_PATTERNS in
src/bus/system.ts) blocks sk-/ghp_/xoxb-/AKIA-prefixed keys but lets
three common live-key formats through:

- `gsk_` (Groq)
- `nfp_` (Nebius)
- `AIza` (Google API)

An agent workspace can realistically contain any of these, and
auto-commit would happily stage them.

## Fix

Add the three prefixes to CREDENTIAL_PATTERNS. No other behavior
change: report shape, script-file allowance, and the existing pattern
set are untouched.

Relationship to the SEC-1 leak-guard: the CI scan and pre-push hook
catch AIza-shaped tokens at push time, but auto-commit is the earlier
line of defense, stopping the key from ever being staged into a commit.
gsk_ and nfp_ are covered nowhere else.

## Tests

New positive test: files containing each of the three prefixes are
blocked with `credential_pattern_detected`, and a clean file in the
same run still stages. Full suite green (1786 passed; the only failure
is the pre-existing dashboard-polling test, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
