### PR TITLE
feat(bus): opt-in --org-repo targeting for auto-commit, with framework-repo guard

### DIFF
--- a/src/bus/index.ts
+++ b/src/bus/index.ts
@@ -9,6 +9,7 @@ export { createApproval, updateApproval, listPendingApprovals } from './approval
 export {
   selfRestart,
   autoCommit,
+  resolveAutoCommitDir,
   checkGoalStaleness,
   postActivity,
   type AutoCommitReport,

--- a/src/bus/system.ts
+++ b/src/bus/system.ts
@@ -1,10 +1,10 @@
 import { execSync, execFileSync } from 'child_process';
-import { existsSync, readFileSync, statSync, appendFileSync, writeFileSync } from 'fs';
-import { join, extname } from 'path';
+import { existsSync, readFileSync, statSync, appendFileSync, writeFileSync, realpathSync } from 'fs';
+import { join, extname, resolve as resolvePath } from 'path';
 import { readdirSync } from 'fs';
 import { ensureDir } from '../utils/atomic.js';
 import { TelegramAPI } from '../telegram/api.js';
-import type { BusPaths } from '../types/index.js';
+import type { BusPaths, CtxEnv } from '../types/index.js';
 
 // --- Types ---
 
@@ -93,9 +93,82 @@ export function hardRestart(paths: BusPaths, agentName: string, reason?: string)
 }
 
 /**
+ * Resolve the org-workspace repo directory for `bus auto-commit --org-repo`.
+ *
+ * In --org-repo mode the snapshot targets the agent's org workspace
+ * (`<projectRoot>/orgs/<org>`), never the framework repo. `orgs/` is
+ * gitignored by the framework repo but still lives inside its work tree, so
+ * git discovery from an org dir that was never `git init`ed silently walks up
+ * to the framework repo; without a guard, a snapshot would then commit
+ * framework-root junk onto the framework branch.
+ *
+ * Throws instead of guessing: no org in env, missing org dir, org dir not a
+ * git repo, or the org dir's git toplevel resolving to the framework repo root
+ * are all hard errors.
+ */
+export function resolveAutoCommitDir(
+  env: Pick<CtxEnv, 'org' | 'projectRoot' | 'frameworkRoot'>,
+): string {
+  const baseRoot = env.projectRoot || env.frameworkRoot;
+  if (!baseRoot) {
+    throw new Error(
+      'auto-commit --org-repo: cannot resolve the org workspace — CTX_PROJECT_ROOT / ' +
+      'CTX_FRAMEWORK_ROOT are not set. Run from an agent directory (with .cortextos-env) ' +
+      'or set them explicitly.',
+    );
+  }
+  if (!env.org) {
+    throw new Error(
+      "auto-commit --org-repo: CTX_ORG is not set. --org-repo snapshots the agent's org " +
+      'workspace (orgs/<org>/) and refuses to guess the target repo.',
+    );
+  }
+
+  const orgRepoDir = join(baseRoot, 'orgs', env.org);
+  if (!existsSync(orgRepoDir)) {
+    throw new Error(`auto-commit --org-repo: org workspace '${orgRepoDir}' does not exist.`);
+  }
+
+  let topLevel: string;
+  try {
+    topLevel = execSync('git rev-parse --show-toplevel', {
+      cwd: orgRepoDir,
+      stdio: 'pipe',
+      encoding: 'utf-8',
+    }).trim();
+  } catch {
+    throw new Error(
+      `auto-commit --org-repo: org workspace '${orgRepoDir}' is not inside a git repository. ` +
+      `Initialize it first (git -C '${orgRepoDir}' init) — refusing to snapshot anything else.`,
+    );
+  }
+
+  // Hard guard: refuse if the resolved repo root is the framework repo root.
+  // git prints physical paths, so compare against the realpath'd framework root.
+  const frameworkRoot = env.frameworkRoot || env.projectRoot;
+  let frameworkRootReal: string;
+  try {
+    frameworkRootReal = realpathSync(frameworkRoot);
+  } catch {
+    frameworkRootReal = resolvePath(frameworkRoot);
+  }
+  if (resolvePath(topLevel) === frameworkRootReal) {
+    throw new Error(
+      `auto-commit --org-repo: REFUSING to run — '${orgRepoDir}' resolves to the FRAMEWORK ` +
+      `repo ('${topLevel}'), not an org repo. The org workspace is not its own git ` +
+      `repository; initialize it (git -C '${orgRepoDir}' init) before snapshotting.`,
+    );
+  }
+
+  return orgRepoDir;
+}
+
+/**
  * Auto-commit safe files in a project directory.
  * Filters out dangerous files (credentials, env, large, binary).
  * Never pushes. Mirrors bash bus/auto-commit.sh.
+ * With `--org-repo` callers resolve the directory via resolveAutoCommitDir()
+ * — this function snapshots whatever directory it is handed.
  */
 export function autoCommit(projectDir: string, dryRun: boolean = false): AutoCommitReport {
   // Check if git repo

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -8,7 +8,7 @@ import { createTask, updateTask, completeTask, claimTask, readTaskAudit, checkTa
 import { saveOutput } from '../bus/save-output.js';
 import { logEvent } from '../bus/event.js';
 import { updateHeartbeat, readAllHeartbeats } from '../bus/heartbeat.js';
-import { selfRestart, hardRestart, autoCommit, checkGoalStaleness, postActivity } from '../bus/system.js';
+import { selfRestart, hardRestart, autoCommit, resolveAutoCommitDir, checkGoalStaleness, postActivity } from '../bus/system.js';
 import { createExperiment, runExperiment, evaluateExperiment, listExperiments, gatherContext, manageCycle, loadExperimentConfig } from '../bus/experiment.js';
 import { browseCatalog, installCommunityItem, prepareSubmission, submitCommunityItem } from '../bus/catalog.js';
 import { collectMetrics, parseUsageOutput, storeUsageData, checkUpstream, collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
@@ -664,9 +664,20 @@ busCommand
   .command('auto-commit')
   .description('Stage safe files for commit (never pushes)')
   .option('--dry-run', 'Show what would be staged without modifying git')
-  .action((opts: { dryRun?: boolean }) => {
+  .option('--org-repo', "Target the agent's org workspace repo (orgs/<org>) instead of the project root; refuses to snapshot the framework repo")
+  .action((opts: { dryRun?: boolean; orgRepo?: boolean }) => {
     const env = resolveEnv();
-    const projectDir = env.projectRoot || env.frameworkRoot || process.cwd();
+    let projectDir: string;
+    if (opts.orgRepo) {
+      try {
+        projectDir = resolveAutoCommitDir(env);
+      } catch (err) {
+        console.error((err as Error).message ?? String(err));
+        process.exit(1);
+      }
+    } else {
+      projectDir = env.projectRoot || env.frameworkRoot || process.cwd();
+    }
     const report = autoCommit(projectDir, opts.dryRun ?? false);
     console.log(JSON.stringify(report));
   });

--- a/tests/unit/bus/system.test.ts
+++ b/tests/unit/bus/system.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, existsSync, readFileSync, mkdirSync, writeFileSync
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { execSync } from 'child_process';
-import { selfRestart, hardRestart, autoCommit, checkGoalStaleness, postActivity } from '../../../src/bus/system';
+import { selfRestart, hardRestart, autoCommit, resolveAutoCommitDir, checkGoalStaleness, postActivity } from '../../../src/bus/system';
 import type { BusPaths } from '../../../src/types';
 
 function makePaths(testDir: string, agent: string = 'test-agent'): BusPaths {
@@ -172,6 +172,96 @@ describe('Bus System', () => {
       const report = autoCommit(gitDir);
       expect(report.status).toBe('nothing_to_stage');
       expect(report.blocked.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('resolveAutoCommitDir', () => {
+    let fwDir: string;
+    let orgDir: string;
+
+    function initRepo(dir: string): void {
+      execSync('git init', { cwd: dir, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: dir, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: dir, stdio: 'pipe' });
+      writeFileSync(join(dir, '.gitkeep'), '');
+      execSync('git add .gitkeep && git commit -m "init"', { cwd: dir, stdio: 'pipe' });
+    }
+
+    beforeEach(() => {
+      // Simulated framework repo containing an org repo at orgs/myorg
+      fwDir = mkdtempSync(join(tmpdir(), 'cortextos-resolve-test-'));
+      initRepo(fwDir);
+      orgDir = join(fwDir, 'orgs', 'myorg');
+      mkdirSync(orgDir, { recursive: true });
+      initRepo(orgDir);
+    });
+
+    afterEach(() => {
+      rmSync(fwDir, { recursive: true, force: true });
+    });
+
+    it('resolves the org repo from agent env, not the framework root', () => {
+      const dir = resolveAutoCommitDir({ org: 'myorg', projectRoot: fwDir, frameworkRoot: fwDir });
+      expect(dir).toBe(orgDir);
+    });
+
+    it('snapshot of resolved dir sees org files, never framework-root files', () => {
+      // Untracked junk at the framework root (e.g. a stale build backup dir)
+      mkdirSync(join(fwDir, 'dist.pre-backup'), { recursive: true });
+      writeFileSync(join(fwDir, 'dist.pre-backup', 'stale.txt'), 'stale');
+      writeFileSync(join(orgDir, 'notes.md'), 'org data');
+
+      const dir = resolveAutoCommitDir({ org: 'myorg', projectRoot: fwDir, frameworkRoot: fwDir });
+      const report = autoCommit(dir, true);
+      expect(report.status).toBe('dry_run');
+      expect(report.staged).toContain('notes.md');
+      expect(report.staged.some(f => f.includes('dist.pre-backup'))).toBe(false);
+    });
+
+    it('refuses when the org dir git-resolves to the framework repo', () => {
+      // Org dir exists but was never git init'ed — discovery walks up to fwDir
+      const bareOrg = join(fwDir, 'orgs', 'bareorg');
+      mkdirSync(bareOrg, { recursive: true });
+
+      expect(() =>
+        resolveAutoCommitDir({ org: 'bareorg', projectRoot: fwDir, frameworkRoot: fwDir }),
+      ).toThrow(/FRAMEWORK repo/);
+    });
+
+    it('refuses when CTX_ORG is not set', () => {
+      expect(() =>
+        resolveAutoCommitDir({ org: '', projectRoot: fwDir, frameworkRoot: fwDir }),
+      ).toThrow(/CTX_ORG/);
+    });
+
+    it('refuses when the org workspace does not exist', () => {
+      expect(() =>
+        resolveAutoCommitDir({ org: 'ghost', projectRoot: fwDir, frameworkRoot: fwDir }),
+      ).toThrow(/does not exist/);
+    });
+
+    it('refuses when the org workspace is not inside any git repository', () => {
+      const plainBase = mkdtempSync(join(tmpdir(), 'cortextos-norepo-test-'));
+      const prevCeiling = process.env.GIT_CEILING_DIRECTORIES;
+      try {
+        mkdirSync(join(plainBase, 'orgs', 'solo'), { recursive: true });
+        // Stop git discovery from walking above the temp dir (e.g. into a
+        // repo that happens to contain the system tmpdir).
+        process.env.GIT_CEILING_DIRECTORIES = plainBase;
+        expect(() =>
+          resolveAutoCommitDir({ org: 'solo', projectRoot: plainBase, frameworkRoot: plainBase }),
+        ).toThrow(/not inside a git repository/);
+      } finally {
+        if (prevCeiling === undefined) delete process.env.GIT_CEILING_DIRECTORIES;
+        else process.env.GIT_CEILING_DIRECTORIES = prevCeiling;
+        rmSync(plainBase, { recursive: true, force: true });
+      }
+    });
+
+    it('refuses when no project or framework root is set', () => {
+      expect(() =>
+        resolveAutoCommitDir({ org: 'myorg', projectRoot: '', frameworkRoot: '' }),
+      ).toThrow(/CTX_PROJECT_ROOT/);
     });
   });
 


### PR DESCRIPTION
## Problem

`bus auto-commit` resolves its target as
`projectRoot || frameworkRoot || cwd` (src/cli/bus.ts). For a standard
agent environment that is the framework repo root. An agent invoking
auto-commit to snapshot its own workspace can therefore stage
framework-checkout junk (an untracked build-backup dir, stray root
files) onto the framework repo instead of its org data.

There is also a subtle trap for anyone pointing auto-commit at an org
workspace manually: `orgs/` is gitignored by the framework repo but
lives inside its work tree, so git discovery from an org dir that was
never `git init`ed silently walks up and resolves to the framework
repo.

## Fix

A new opt-in flag; default behavior is byte-for-byte unchanged.

- `bus auto-commit --org-repo` resolves
  `<projectRoot>/orgs/<org>` deterministically from CTX_ORG +
  CTX_PROJECT_ROOT/CTX_FRAMEWORK_ROOT via a new exported
  `resolveAutoCommitDir(env)`.
- Hard guard: it throws if the resolved dir's git toplevel is the
  framework repo root (the never-initialized-org-dir walk-up case), and
  also refuses on missing org, missing org dir, no roots, or no git
  repo. The CLI prints the error and exits 1.
- `autoCommit(dir)` itself, the report shape, and credential blocking
  are untouched.

## Tests

7 new unit tests: resolves the org repo (not the framework root); a
snapshot of the resolved dir sees org files and never framework-root
junk; refusal on framework walk-up, missing CTX_ORG, missing org dir,
no enclosing git repo (with GIT_CEILING_DIRECTORIES pinning), and no
roots. Full suite green (1792 passed; the only failure is the
pre-existing dashboard-polling test, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
