### PR TITLE
feat(daemon): require explicit opt-in for the codex-app-server runtime

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -94,6 +94,26 @@ export class AgentProcess {
       return;
     }
 
+    // Security guard: the codex-app-server runtime loads orgs/<org>/secrets.env
+    // and the agent .env into the codex child unscrubbed (see
+    // codex-app-server-pty.ts buildEnv) and runs sandbox 'danger-full-access'
+    // with approvals 'never' — a full-write-access session holding every org
+    // secret. Require a deliberate per-agent opt-in. Halt (dashboard-visible)
+    // instead of throwing: discoverAndStart() awaits start() with no per-agent
+    // catch, so a boot-time throw would kill the whole daemon over one
+    // misconfigured agent.
+    if (this.config.runtime === 'codex-app-server' && this.config.allow_codex_app_server !== true) {
+      this.log(
+        `REFUSED to start: runtime 'codex-app-server' is blocked by default — it hands the ` +
+        `unscrubbed org/agent secrets env to a codex session running sandbox ` +
+        `'danger-full-access' with approvals 'never'. Set "allow_codex_app_server": true in ` +
+        `this agent's config.json to opt in deliberately.`,
+      );
+      this.status = 'halted';
+      this.notifyStatusChange();
+      return;
+    }
+
     // Apply startup delay
     const delay = this.config.startup_delay || 0;
     if (delay > 0) {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -210,6 +210,16 @@ export interface AgentConfig {
    */
   runtime?: 'claude-code' | 'hermes' | 'codex-app-server' | 'opencode';
   /**
+   * Explicit opt-in required to start an agent with the 'codex-app-server'
+   * runtime. That runtime loads orgs/<org>/secrets.env and the agent .env
+   * into the codex child unscrubbed and runs sandbox 'danger-full-access'
+   * with approvals 'never' — a full-write-access session holding every org
+   * secret. Absent or false, the daemon refuses to construct
+   * CodexAppServerPTY and halts the agent instead (dashboard-visible). See
+   * agent-process.ts start().
+   */
+  allow_codex_app_server?: boolean;
+  /**
    * Optional OpenCode agent name to pass as `opencode --agent <name>`.
    * Only applies to runtime: 'opencode'.
    */

--- a/tests/unit/daemon/agent-process-codex-app-server.test.ts
+++ b/tests/unit/daemon/agent-process-codex-app-server.test.ts
@@ -113,7 +113,7 @@ beforeEach(() => {
 
 describe('AgentProcess codex-app-server runtime', () => {
   it('selects CodexAppServerPTY for runtime codex-app-server', async () => {
-    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     await ap.start();
 
     expect(mockCodexAppServerPty.spawn).toHaveBeenCalledWith('fresh', expect.any(String));
@@ -121,7 +121,7 @@ describe('AgentProcess codex-app-server runtime', () => {
   });
 
   it('wires Telegram handle to CodexAppServerPTY before start', async () => {
-    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     const api = { sendChatAction: vi.fn().mockResolvedValue(undefined) };
 
     ap.setTelegramHandle(api as any, '12345');
@@ -131,7 +131,7 @@ describe('AgentProcess codex-app-server runtime', () => {
   });
 
   it('sends back-online Telegram directly from daemon on fresh start (issue #392)', async () => {
-    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const api = { sendChatAction: vi.fn().mockResolvedValue(undefined), sendMessage };
 
@@ -154,7 +154,7 @@ describe('AgentProcess codex-app-server runtime', () => {
     );
     fsMocks.readFileSync.mockReturnValue(handoffDocPath);
 
-    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const api = { sendChatAction: vi.fn().mockResolvedValue(undefined), sendMessage };
 
@@ -183,7 +183,7 @@ describe('AgentProcess codex-app-server runtime', () => {
   });
 
   it('uses direct kill path on stop, not Claude /exit choreography', async () => {
-    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     await ap.start();
     expect(capturedOnExit).not.toBeNull();
 
@@ -215,7 +215,7 @@ describe('AgentProcess codex-app-server runtime', () => {
       if (path === codexThreadPath) return false;
       return false;
     });
-    const apFresh = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const apFresh = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     await apFresh.start();
     expect(mockCodexAppServerPty.spawn).toHaveBeenLastCalledWith('fresh', expect.any(String));
 
@@ -226,8 +226,54 @@ describe('AgentProcess codex-app-server runtime', () => {
       if (path === codexThreadPath) return true;
       return false;
     });
-    const apContinue = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const apContinue = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     await apContinue.start();
     expect(mockCodexAppServerPty.spawn).toHaveBeenLastCalledWith('continue', expect.any(String));
+  });
+});
+
+describe('AgentProcess codex-app-server opt-in guard', () => {
+  it('refuses to start codex-app-server without allow_codex_app_server (blocks by default)', async () => {
+    const ap = new AgentProcess('codex-app-agent', mockEnv, { runtime: 'codex-app-server' });
+    const statuses: string[] = [];
+    ap.onStatusChanged(s => statuses.push(s.status));
+
+    await ap.start();
+
+    // Note: the PTY mocks share one spawn fn, so this also proves no silent
+    // fallback to AgentPTY happened.
+    expect(mockCodexAppServerPty.spawn).not.toHaveBeenCalled();
+    expect(ap.getStatus().status).toBe('halted');
+    expect(statuses).toContain('halted');
+  });
+
+  it('refuses when allow_codex_app_server is explicitly false', async () => {
+    const ap = new AgentProcess('codex-app-agent', mockEnv, {
+      runtime: 'codex-app-server',
+      allow_codex_app_server: false,
+    });
+    await ap.start();
+
+    expect(mockCodexAppServerPty.spawn).not.toHaveBeenCalled();
+    expect(ap.getStatus().status).toBe('halted');
+  });
+
+  it('starts codex-app-server when allow_codex_app_server is true', async () => {
+    const ap = new AgentProcess('codex-app-agent', mockEnv, {
+      runtime: 'codex-app-server',
+      allow_codex_app_server: true,
+    });
+    await ap.start();
+
+    expect(mockCodexAppServerPty.spawn).toHaveBeenCalledWith('fresh', expect.any(String));
+    expect(ap.getStatus().status).not.toBe('halted');
+  });
+
+  it('does not gate other runtimes (claude-code starts without the flag)', async () => {
+    const ap = new AgentProcess('claude-agent', mockEnv, { runtime: 'claude-code' });
+    await ap.start();
+
+    expect(mockAgentPty.spawn).toHaveBeenCalled();
+    expect(ap.getStatus().status).not.toBe('halted');
   });
 });

--- a/tests/unit/daemon/agent-process-opencode.test.ts
+++ b/tests/unit/daemon/agent-process-opencode.test.ts
@@ -247,7 +247,7 @@ describe('AgentProcess opencode runtime', () => {
         : handoffDocPath,
     );
 
-    const ap = new AgentProcess('codex-agent', mockEnv, { runtime: 'codex-app-server' });
+    const ap = new AgentProcess('codex-agent', mockEnv, { runtime: 'codex-app-server', allow_codex_app_server: true });
     const sendMessage = vi.fn().mockResolvedValue(undefined);
     const api = { sendChatAction: vi.fn().mockResolvedValue(undefined), sendMessage };
 


### PR DESCRIPTION
## Problem

The codex-app-server runtime loads `orgs/<org>/secrets.env` and the
agent `.env` into the codex child unscrubbed
(codex-app-server-pty.ts buildEnv, lines ~1003-1005) and runs
`sandbox: 'danger-full-access'` with `approvalPolicy: 'never'` (lines
~71-77). That is a full-write-access, never-asking session holding
every org secret. Today a single `"runtime": "codex-app-server"` line
in an agent's config.json (one typo, one copy-pasted template) grants
all of that silently.

## Fix

`AgentProcess.start()` now refuses to start a codex-app-server agent
unless its config sets `"allow_codex_app_server": true`. The refusal
halts the agent (status 'halted', dashboard-visible, loud log line)
rather than throwing: `discoverAndStart()` awaits `start()` with no
per-agent catch, so a boot-time throw would take down the whole daemon
over one misconfigured agent.

`codex-app-server-pty.ts` itself is untouched.

## Breaking change (deliberate)

Existing codex-app-server agents halt on the next daemon restart until
their config.json adds `"allow_codex_app_server": true`. The migration
is one line per agent, and the halt log says exactly that. Happy to
discuss softer rollouts (e.g. warn-only for a release) if you prefer.

## Tests

New guard suite: blocks by default, blocks on explicit false, starts
when flagged, and does not gate other runtimes. Existing
codex-app-server tests now opt in, which doubles as proof the default
blocks. Full suite green (1789 passed; the only failure is the
pre-existing dashboard-polling test, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
