### PR TITLE
fix(daemon): timestamp every daemon log line (ISO-8601 UTC)

### DIFF
--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,4 +1,5 @@
 import { AgentManager } from './agent-manager.js';
+import { installTimestampedConsole } from './log-timestamps.js';
 import { IPCServer } from './ipc-server.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
@@ -230,6 +231,7 @@ class Daemon {
   }
 
   async start(): Promise<void> {
+    installTimestampedConsole();
     // Force restrictive default permissions for everything the daemon writes:
     // 0700 dirs, 0600 files. Belt-and-suspenders for explicit chmod calls.
     if (process.platform !== 'win32') {

--- a/src/daemon/log-timestamps.ts
+++ b/src/daemon/log-timestamps.ts
@@ -1,0 +1,30 @@
+/**
+ * Timestamped console for the daemon process.
+ *
+ * Every daemon log line (console.log/warn/error across index.ts, fast-checker,
+ * agent-manager, etc.) gets an ISO-8601 UTC prefix so stall/incident windows can
+ * be reconstructed from the out-log alone, without cross-referencing pmset or
+ * bus stores. Installed once at daemon startup; idempotent.
+ */
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+
+type ConsoleMethod = 'log' | 'warn' | 'error';
+
+/**
+ * Wrap console.log/warn/error to prefix each call with an ISO UTC timestamp.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function installTimestampedConsole(): void {
+  const g = globalThis as Record<PropertyKey, unknown>;
+  if (g[INSTALLED]) return;
+  g[INSTALLED] = true;
+
+  const methods: ConsoleMethod[] = ['log', 'warn', 'error'];
+  for (const m of methods) {
+    const original = console[m].bind(console);
+    console[m] = (...args: unknown[]) => {
+      original(`[${new Date().toISOString()}]`, ...args);
+    };
+  }
+}

--- a/tests/unit/daemon/log-timestamps.test.ts
+++ b/tests/unit/daemon/log-timestamps.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { installTimestampedConsole } from '../../../src/daemon/log-timestamps.js';
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+const ISO_PREFIX = /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]$/;
+
+describe('installTimestampedConsole', () => {
+  const originals = { log: console.log, warn: console.warn, error: console.error };
+
+  beforeEach(() => {
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  afterEach(() => {
+    console.log = originals.log;
+    console.warn = originals.warn;
+    console.error = originals.error;
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  it('prefixes console.log lines with an ISO-8601 UTC timestamp', () => {
+    installTimestampedConsole();
+    const spy = vi.fn();
+    // Capture what the wrapper forwards by re-wrapping the (already bound) sink:
+    // install() bound the ORIGINAL console.log, so intercept via a fresh install.
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('[daemon] hello', 42);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [ts, msg, num] = spy.mock.calls[0];
+    expect(String(ts)).toMatch(ISO_PREFIX);
+    expect(msg).toBe('[daemon] hello');
+    expect(num).toBe(42);
+  });
+
+  it('prefixes warn and error the same way', () => {
+    const warnSpy = vi.fn();
+    const errSpy = vi.fn();
+    console.warn = warnSpy;
+    console.error = errSpy;
+    installTimestampedConsole();
+    console.warn('w');
+    console.error('e');
+    expect(String(warnSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(String(errSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(warnSpy.mock.calls[0][1]).toBe('w');
+    expect(errSpy.mock.calls[0][1]).toBe('e');
+  });
+
+  it('is idempotent — double install does not double-prefix', () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    installTimestampedConsole();
+    console.log('once');
+    expect(spy).toHaveBeenCalledTimes(1);
+    const call = spy.mock.calls[0];
+    expect(call.length).toBe(2); // [timestamp, 'once'] — not [ts, ts, 'once']
+    expect(String(call[0])).toMatch(ISO_PREFIX);
+    expect(call[1]).toBe('once');
+  });
+
+  it('timestamp advances between calls (not frozen at install time)', async () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('a');
+    await new Promise(r => setTimeout(r, 5));
+    console.log('b');
+    const t1 = Date.parse(String(spy.mock.calls[0][0]).slice(1, -1));
+    const t2 = Date.parse(String(spy.mock.calls[1][0]).slice(1, -1));
+    expect(t2).toBeGreaterThanOrEqual(t1);
+    expect(Number.isNaN(t1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
Both 2026-07-09 fleet-stall diagnoses had to reconstruct incident timing from side channels (pmset sleep logs, bus store timestamps) because daemon out-log lines carry no timestamps.

## Fix
`installTimestampedConsole()` — installed once at daemon startup, wraps `console.log/warn/error` with an ISO-8601 UTC prefix. Idempotent (Symbol-guarded), covers every daemon module without touching call sites, timestamp evaluated per call.

## Evidence
- 4 new unit tests (prefix format, warn/error coverage, idempotence, advancing clock)
- Daemon suite green on the stack (538/538 daemon+pty, independently reproduced by a second agent on a fresh clone)
- Note: full unit sweep shows 28 pre-existing failures in 4 non-daemon files, identical on clean `main` @ 5a0882d (documented in #746)

Part 1/4 of the injection-stall fix batch (#745/#746-style stack). Adversarially cross-verified before opening (independent agent re-ran specs + suite).

🤖 Generated with [Claude Code](https://claude.com/claude-code)