### PR TITLE
fix(daemon): reconcile required hooks into agent settings at start

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -6,6 +6,7 @@ import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { migrateCronsForAgent } from './cron-migration.js';
+import { ensureRequiredHooks } from './hook-reconciler.js';
 import type { CronDefinition } from '../types/index.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
@@ -291,6 +292,10 @@ export class AgentManager {
     if (!config) {
       config = this.loadAgentConfig(agentDir);
     }
+
+    // Reconcile required hooks into the agent's settings (agents spawned
+    // from older templates may lack them — 2026-07-09 stall diagnosis #1).
+    ensureRequiredHooks(agentDir, (msg) => console.log(`[agent-manager] ${name}: ${msg}`));
 
     const env: CtxEnv = {
       instanceId: this.instanceId,

--- a/src/daemon/hook-reconciler.ts
+++ b/src/daemon/hook-reconciler.ts
@@ -1,0 +1,107 @@
+/**
+ * Hook reconciler — ensures every agent's .claude/settings.json carries the
+ * cortextOS-required hooks, regardless of which template version the agent
+ * was originally spawned from.
+ *
+ * Background (2026-07-09 stall diagnosis, secondary finding #1): agents
+ * created before a template gained a hook never receive it — kirk and spock
+ * lacked the Stop → hook-idle-flag entry entirely, so last_idle.flag never
+ * wrote and the fast-checker's turn-end signal was silently absent for those
+ * agents. Settings were written once at spawn and never reconciled.
+ *
+ * Called from AgentManager.startAgent() so the guarantee holds on every
+ * agent start. Additive only: existing hook entries (including user-added
+ * ones) are never modified or removed; a required hook is appended only when
+ * no entry for that event already runs the same command. Malformed settings
+ * files are left untouched (loud log) rather than clobbered.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { atomicWriteSync } from '../utils/atomic.js';
+
+interface RequiredHook {
+  /** Hook event name, e.g. "Stop" */
+  event: string;
+  /** Command line for the hook */
+  command: string;
+  /** Timeout in seconds */
+  timeout: number;
+}
+
+/**
+ * Hooks every cortextOS agent must have. Keep in sync with
+ * templates/agent/.claude/settings.json — this list is the enforcement for
+ * agents spawned from older template versions.
+ */
+export const REQUIRED_HOOKS: RequiredHook[] = [
+  // Turn-end signal: fast-checker liveness/typing detection and the
+  // delivery-confirmation loop both consume last_idle.flag transitions.
+  { event: 'Stop', command: 'cortextos bus hook-idle-flag', timeout: 5 },
+];
+
+interface HookCommandEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+}
+interface HookGroup {
+  matcher?: string;
+  hooks: HookCommandEntry[];
+}
+
+/**
+ * Ensure required hooks exist in <agentDir>/.claude/settings.json.
+ * Returns the list of hook commands that were added (empty = no change).
+ */
+export function ensureRequiredHooks(
+  agentDir: string,
+  log: (msg: string) => void = () => {}
+): string[] {
+  const settingsPath = join(agentDir, '.claude', 'settings.json');
+  if (!existsSync(settingsPath)) {
+    // No settings file at all — an agent dir this bare is not something the
+    // reconciler should invent config for; leave it to the spawn path.
+    log(`hook-reconciler: no settings.json at ${settingsPath}, skipping`);
+    return [];
+  }
+
+  let raw: string;
+  let settings: Record<string, unknown>;
+  try {
+    raw = readFileSync(settingsPath, 'utf-8');
+    settings = JSON.parse(raw);
+  } catch (err) {
+    log(`hook-reconciler: settings.json unreadable/malformed at ${settingsPath} — leaving untouched (${err})`);
+    return [];
+  }
+  if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) {
+    log(`hook-reconciler: settings.json root is not an object at ${settingsPath} — leaving untouched`);
+    return [];
+  }
+
+  const hooks = (settings.hooks ?? {}) as Record<string, HookGroup[]>;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    log(`hook-reconciler: settings.hooks is not an object at ${settingsPath} — leaving untouched`);
+    return [];
+  }
+
+  const added: string[] = [];
+  for (const req of REQUIRED_HOOKS) {
+    const groups: HookGroup[] = Array.isArray(hooks[req.event]) ? hooks[req.event] : [];
+    const present = groups.some(g =>
+      Array.isArray(g?.hooks) &&
+      g.hooks.some(h => typeof h?.command === 'string' && h.command.includes(req.command))
+    );
+    if (present) continue;
+    groups.push({ hooks: [{ type: 'command', command: req.command, timeout: req.timeout }] });
+    hooks[req.event] = groups;
+    added.push(`${req.event} → ${req.command}`);
+  }
+
+  if (added.length === 0) return [];
+
+  settings.hooks = hooks;
+  atomicWriteSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', true);
+  log(`hook-reconciler: added missing hook(s): ${added.join(', ')}`);
+  return added;
+}

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,4 +1,5 @@
 import { AgentManager } from './agent-manager.js';
+import { installTimestampedConsole } from './log-timestamps.js';
 import { IPCServer } from './ipc-server.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
@@ -230,6 +231,7 @@ class Daemon {
   }
 
   async start(): Promise<void> {
+    installTimestampedConsole();
     // Force restrictive default permissions for everything the daemon writes:
     // 0700 dirs, 0600 files. Belt-and-suspenders for explicit chmod calls.
     if (process.platform !== 'win32') {

--- a/src/daemon/log-timestamps.ts
+++ b/src/daemon/log-timestamps.ts
@@ -1,0 +1,30 @@
+/**
+ * Timestamped console for the daemon process.
+ *
+ * Every daemon log line (console.log/warn/error across index.ts, fast-checker,
+ * agent-manager, etc.) gets an ISO-8601 UTC prefix so stall/incident windows can
+ * be reconstructed from the out-log alone, without cross-referencing pmset or
+ * bus stores. Installed once at daemon startup; idempotent.
+ */
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+
+type ConsoleMethod = 'log' | 'warn' | 'error';
+
+/**
+ * Wrap console.log/warn/error to prefix each call with an ISO UTC timestamp.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function installTimestampedConsole(): void {
+  const g = globalThis as Record<PropertyKey, unknown>;
+  if (g[INSTALLED]) return;
+  g[INSTALLED] = true;
+
+  const methods: ConsoleMethod[] = ['log', 'warn', 'error'];
+  for (const m of methods) {
+    const original = console[m].bind(console);
+    console[m] = (...args: unknown[]) => {
+      original(`[${new Date().toISOString()}]`, ...args);
+    };
+  }
+}

--- a/tests/unit/daemon/hook-reconciler.test.ts
+++ b/tests/unit/daemon/hook-reconciler.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ensureRequiredHooks, REQUIRED_HOOKS } from '../../../src/daemon/hook-reconciler.js';
+
+const STOP_CMD = 'cortextos bus hook-idle-flag';
+
+function agentDirWith(settings: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hook-reconciler-'));
+  mkdirSync(join(dir, '.claude'), { recursive: true });
+  writeFileSync(
+    join(dir, '.claude', 'settings.json'),
+    typeof settings === 'string' ? settings : JSON.stringify(settings, null, 2)
+  );
+  return dir;
+}
+function readSettings(dir: string): Record<string, any> {
+  return JSON.parse(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8'));
+}
+
+describe('ensureRequiredHooks', () => {
+  let dirs: string[] = [];
+  afterEach(() => { dirs.forEach(d => rmSync(d, { recursive: true, force: true })); dirs = []; });
+  const track = (d: string) => { dirs.push(d); return d; };
+
+  it('adds the Stop hook when the event is entirely missing (kirk/spock case)', () => {
+    const dir = track(agentDirWith({ hooks: { PreToolUse: [] } }));
+    const added = ensureRequiredHooks(dir);
+    expect(added).toEqual([`Stop → ${STOP_CMD}`]);
+    const s = readSettings(dir);
+    expect(s.hooks.Stop).toHaveLength(1);
+    expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
+    expect(s.hooks.Stop[0].hooks[0].timeout).toBe(5);
+    expect(s.hooks.PreToolUse).toEqual([]); // untouched
+  });
+
+  it('adds hooks key when settings has none at all', () => {
+    const dir = track(agentDirWith({ model: 'opus' }));
+    const added = ensureRequiredHooks(dir);
+    expect(added.length).toBe(REQUIRED_HOOKS.length);
+    const s = readSettings(dir);
+    expect(s.model).toBe('opus');
+    expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
+  });
+
+  it('is idempotent — hook already present means no change', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: STOP_CMD, timeout: 5 }] }] },
+    }));
+    const before = readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8');
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8')).toBe(before);
+  });
+
+  it('detects presence by command substring within existing Stop groups', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [
+        { type: 'command', command: 'some-other-hook' },
+        { type: 'command', command: `${STOP_CMD} --extra-arg` },
+      ] }] },
+    }));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+  });
+
+  it('preserves existing user hooks when appending', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'user-custom-stop' }] }] },
+    }));
+    const added = ensureRequiredHooks(dir);
+    expect(added).toHaveLength(1);
+    const s = readSettings(dir);
+    expect(s.hooks.Stop).toHaveLength(2);
+    expect(s.hooks.Stop[0].hooks[0].command).toBe('user-custom-stop');
+    expect(s.hooks.Stop[1].hooks[0].command).toBe(STOP_CMD);
+  });
+
+  it('leaves malformed JSON untouched and reports nothing added', () => {
+    const dir = track(agentDirWith('{ not json ]]'));
+    const logs: string[] = [];
+    expect(ensureRequiredHooks(dir, m => logs.push(m))).toEqual([]);
+    expect(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8')).toBe('{ not json ]]');
+    expect(logs.join(' ')).toMatch(/malformed|unreadable/);
+  });
+
+  it('skips when settings.json does not exist (no invention)', () => {
+    const dir = track(mkdtempSync(join(tmpdir(), 'hook-reconciler-')));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(existsSync(join(dir, '.claude', 'settings.json'))).toBe(false);
+  });
+
+  it('leaves non-object hooks value untouched', () => {
+    const dir = track(agentDirWith({ hooks: 'weird' }));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(readSettings(dir).hooks).toBe('weird');
+  });
+});

--- a/tests/unit/daemon/log-timestamps.test.ts
+++ b/tests/unit/daemon/log-timestamps.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { installTimestampedConsole } from '../../../src/daemon/log-timestamps.js';
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+const ISO_PREFIX = /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]$/;
+
+describe('installTimestampedConsole', () => {
+  const originals = { log: console.log, warn: console.warn, error: console.error };
+
+  beforeEach(() => {
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  afterEach(() => {
+    console.log = originals.log;
+    console.warn = originals.warn;
+    console.error = originals.error;
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  it('prefixes console.log lines with an ISO-8601 UTC timestamp', () => {
+    installTimestampedConsole();
+    const spy = vi.fn();
+    // Capture what the wrapper forwards by re-wrapping the (already bound) sink:
+    // install() bound the ORIGINAL console.log, so intercept via a fresh install.
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('[daemon] hello', 42);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [ts, msg, num] = spy.mock.calls[0];
+    expect(String(ts)).toMatch(ISO_PREFIX);
+    expect(msg).toBe('[daemon] hello');
+    expect(num).toBe(42);
+  });
+
+  it('prefixes warn and error the same way', () => {
+    const warnSpy = vi.fn();
+    const errSpy = vi.fn();
+    console.warn = warnSpy;
+    console.error = errSpy;
+    installTimestampedConsole();
+    console.warn('w');
+    console.error('e');
+    expect(String(warnSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(String(errSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(warnSpy.mock.calls[0][1]).toBe('w');
+    expect(errSpy.mock.calls[0][1]).toBe('e');
+  });
+
+  it('is idempotent — double install does not double-prefix', () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    installTimestampedConsole();
+    console.log('once');
+    expect(spy).toHaveBeenCalledTimes(1);
+    const call = spy.mock.calls[0];
+    expect(call.length).toBe(2); // [timestamp, 'once'] — not [ts, ts, 'once']
+    expect(String(call[0])).toMatch(ISO_PREFIX);
+    expect(call[1]).toBe('once');
+  });
+
+  it('timestamp advances between calls (not frozen at install time)', async () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('a');
+    await new Promise(r => setTimeout(r, 5));
+    console.log('b');
+    const t1 = Date.parse(String(spy.mock.calls[0][0]).slice(1, -1));
+    const t2 = Date.parse(String(spy.mock.calls[1][0]).slice(1, -1));
+    expect(t2).toBeGreaterThanOrEqual(t1);
+    expect(Number.isNaN(t1)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Problem
Agent `.claude/settings.json` is written once at spawn from the template and never reconciled. Agents spawned before a template gained a hook never receive it. Live evidence: two of five fleet agents lacked the `Stop → cortextos bus hook-idle-flag` entry entirely, so `last_idle.flag` never wrote and the fast-checker's turn-end signal was silently absent for exactly those agents (2026-07-09 stall diagnosis, secondary finding #1 — independently confirmed on-disk by a second agent).

## Fix
`ensureRequiredHooks(agentDir)` runs on every `startAgent()`:
- **Additive-only**: appends a required hook only when no entry for that event already runs the same command (substring match); existing user hooks never modified or removed
- **Atomic write** with `.bak` backup
- **Malformed/missing settings left untouched** (loud log) — never clobbers
- `REQUIRED_HOOKS` is the single enforcement list, kept in sync with the template

## Evidence
- 8 unit tests: missing-event add, no-hooks-key add, idempotence, substring presence, user-hook preservation, malformed-JSON safety, missing-file skip, non-object hooks safety
- Independent cross-verify: reviewer confirmed the root cause against their own agent's settings file and read the write path line-by-line

## Deploy note (honest gap)
Hooks take effect when an agent's session next starts — reconciliation at `startAgent` means the fix lands naturally on the next restart cycle; operators should sequence staggered restarts.

Part 2/4 of the injection-stall batch — stacked on #755 (this branch contains its commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)