### PR TITLE
fix(daemon): delivery-confirmation loop — verify turn-start, retry Enter, ack-on-confirm

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -2471,6 +2471,11 @@ busCommand
   .action(() => runHook('hook-idle-flag'));
 
 busCommand
+  .command('hook-prompt-flag')
+  .description('UserPromptSubmit hook: writes last_prompt.flag timestamp so the daemon delivery-confirmation loop knows a turn started')
+  .action(() => runHook('hook-prompt-flag'));
+
+busCommand
   .command('hook-loop-detector')
   .description('PreToolUse hook: detects and blocks repeated tool loops (same-args repetition + ping-pong alternation)')
   .action(() => runHook('hook-loop-detector'));

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -6,6 +6,7 @@ import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { migrateCronsForAgent } from './cron-migration.js';
+import { ensureRequiredHooks } from './hook-reconciler.js';
 import type { CronDefinition } from '../types/index.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
@@ -291,6 +292,10 @@ export class AgentManager {
     if (!config) {
       config = this.loadAgentConfig(agentDir);
     }
+
+    // Reconcile required hooks into the agent's settings (agents spawned
+    // from older templates may lack them — 2026-07-09 stall diagnosis #1).
+    ensureRequiredHooks(agentDir, (msg) => console.log(`[agent-manager] ${name}: ${msg}`));
 
     const env: CtxEnv = {
       instanceId: this.instanceId,

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -976,6 +976,13 @@ export class AgentManager {
   }
 
   /**
+   * Live roster with orgs — consumed by the daemon staleness detector.
+   */
+  getAgentRoster(): Array<{ name: string; org: string }> {
+    return [...this.agents.entries()].map(([name, v]) => ({ name, org: v.process.org }));
+  }
+
+  /**
    * Return the CronScheduler for a given agent (for testing / introspection).
    * Returns undefined if no scheduler is running for that agent.
    */

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -21,6 +21,8 @@ type LogFn = (msg: string) => void;
  */
 export class AgentProcess {
   readonly name: string;
+  /** Agent's org (read-only view of env.org) — used by fast-checker heartbeat writes. */
+  get org(): string { return this.env.org; }
   private env: CtxEnv;
   private config: AgentConfig;
   private pty: AgentPTY | CodexAppServerPTY | null = null;

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -441,6 +441,9 @@ export class AgentProcess {
     const res = await loop;
     if (!res.confirmed) {
       this.log(`DELIVERY_FAILED: no turn-start after ${res.enterAttempts} Enter attempts — content may be stuck in the input box`);
+      // The un-ACKed message will redeliver with identical content; drop the
+      // dedup hash so the retry is not silently swallowed as a duplicate.
+      this.dedup.forget(content);
     }
     return { ok: true, ...res };
   }

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -171,7 +171,9 @@ export class AgentProcess {
     });
 
     try {
+      const spawnedAtMs = Date.now(); // before spawn: the boot prompt may submit while spawn() awaits bootstrap
       await this.pty.spawn(mode, prompt);
+      this.startBootDeliveryCheck(spawnedAtMs);
       // Codex exec-per-turn race: the new PTY's onExit can fire BEFORE this
       // line if `codex exec` completes its prompt quickly (CodexAppServerPTY's spawn
       // resolves once exec is launched, but the process may exit moments
@@ -361,6 +363,124 @@ export class AgentProcess {
    */
   injectMessage(content: string): boolean {
     return this.injectMessageDetailed(content).ok;
+  }
+
+  private promptFlagPath(): string {
+    return join(this.env.ctxRoot, 'state', this.name, 'last_prompt.flag');
+  }
+
+  /** mtime of last_prompt.flag in ms epoch; 0 when it has never been written. */
+  promptFlagMtimeMs(): number {
+    try {
+      return statSync(this.promptFlagPath()).mtimeMs;
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * Inject with delivery confirmation (2026-07-09 dropped-Enter stall class).
+   *
+   * confirmed values:
+   *   true  — turn-start signal observed (UserPromptSubmit hook fired)
+   *   false — Enter retries exhausted with no turn-start: DELIVERY FAILED,
+   *           content likely sitting in the input box; caller must NOT ack
+   *   null  — no confirmation channel for this agent (hook never seen for
+   *           this agent, or runtime opts out): legacy fire-and-forget path
+   */
+  async injectMessageConfirmedDetailed(
+    content: string,
+  ): Promise<
+    | { ok: true; confirmed: boolean | null; enterAttempts: number }
+    | { ok: false; code: 'NOT_RUNNING' | 'DEDUPED'; message: string }
+  > {
+    if (!this.pty || this.status !== 'running') {
+      return { ok: false, code: 'NOT_RUNNING', message: `agent "${this.name}" is registered but not running (status: ${this.status})` };
+    }
+    if (this.dedup.isDuplicate(content)) {
+      this.log('Dedup: skipping duplicate message');
+      return { ok: false, code: 'DEDUPED', message: `inject for "${this.name}" deduped — content matches MessageDedup hash window` };
+    }
+
+    // The confirmation channel is the UserPromptSubmit hook's flag. If it has
+    // never been written for this agent, the session predates the hook (or
+    // the settings lack it) — requiring confirmation would deadlock acks, so
+    // fall back to the legacy path.
+    const hookSeen = this.promptFlagMtimeMs() > 0;
+    const confirmable =
+      hookSeen &&
+      'injectMessageConfirmed' in this.pty &&
+      typeof (this.pty as { injectMessageConfirmed?: unknown }).injectMessageConfirmed === 'function';
+
+    if (!confirmable) {
+      if ('injectMessage' in this.pty && typeof this.pty.injectMessage === 'function') {
+        this.pty.injectMessage(content);
+      } else {
+        injectMessageIntoPty((data) => this.pty?.write(data), content);
+      }
+      return { ok: true, confirmed: null, enterAttempts: 1 };
+    }
+
+    const injectedAt = Date.now();
+    const pty = this.pty as unknown as {
+      injectMessageConfirmed: (
+        c: string,
+        o: { isConfirmed: () => boolean; log?: (m: string) => void },
+      ) => Promise<{ confirmed: boolean; enterAttempts: number }> | null;
+      injectMessage: (c: string) => void;
+    };
+    const loop = pty.injectMessageConfirmed(content, {
+      isConfirmed: () => this.promptFlagMtimeMs() > injectedAt,
+      log: (m) => this.log(m),
+    });
+    if (loop === null) {
+      // Runtime opted out (OpenCode) — use its own paste path.
+      pty.injectMessage(content);
+      return { ok: true, confirmed: null, enterAttempts: 1 };
+    }
+    const res = await loop;
+    if (!res.confirmed) {
+      this.log(`DELIVERY_FAILED: no turn-start after ${res.enterAttempts} Enter attempts — content may be stuck in the input box`);
+    }
+    return { ok: true, ...res };
+  }
+
+  /**
+   * Boot-prompt delivery check. The startup/continue prompt is passed as a
+   * CLI argument, but its submission can still be lost to the same
+   * turn-boundary race as injected messages (observed: mccoy boot stall
+   * 2026-07-10 06:05-08:08Z). After bootstrap, verify a turn actually
+   * started (last_prompt.flag advanced past spawn time); if not, re-send
+   * Enter up to 3 times, then log DELIVERY_FAILED loudly.
+   */
+  private startBootDeliveryCheck(spawnedAtMs: number): void {
+    if (this.promptFlagMtimeMs() === 0) return; // hook never seen — no signal to check
+    const pty = this.pty as unknown as { sendEnter?: () => void } | null;
+    if (!pty || typeof pty.sendEnter !== 'function') return;
+
+    const INITIAL_GRACE_MS = 30_000;
+    const RETRY_INTERVAL_MS = 10_000;
+    const MAX_RETRIES = 3;
+    let retries = 0;
+
+    const check = () => {
+      if (!this.pty || this.status !== 'running') return;
+      if (this.promptFlagMtimeMs() > spawnedAtMs) return; // boot prompt submitted
+      if (retries >= MAX_RETRIES) {
+        this.log('DELIVERY_FAILED: boot prompt never started a turn after Enter retries');
+        return;
+      }
+      retries++;
+      this.log(`Boot-prompt delivery check: no turn-start yet — sending Enter (retry ${retries}/${MAX_RETRIES})`);
+      try {
+        (this.pty as unknown as { sendEnter: () => void }).sendEnter();
+      } catch { /* pty torn down */ }
+      const timer = setTimeout(check, RETRY_INTERVAL_MS);
+      timer.unref?.();
+    };
+
+    const timer = setTimeout(check, INITIAL_GRACE_MS);
+    timer.unref?.();
   }
 
   /**

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, existsSync, writeFileSync, unlinkSync, statSync } from 'fs';
-import { execFile } from 'child_process';
+import { updateHeartbeat } from '../bus/heartbeat.js';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { hardRestart } from '../bus/system.js';
@@ -129,9 +129,17 @@ export class FastChecker {
     const agentName = this.agent.name;
     this.heartbeatTimer = setInterval(() => {
       const ts = new Date().toISOString();
-      execFile('cortextos', ['bus', 'update-heartbeat', `[watchdog] ${agentName} alive — idle session ${ts}`], (err) => {
-        if (err) this.log(`Heartbeat watchdog error: ${err.message}`);
-      });
+      // In-process write with EXPLICIT agentName. The previous execFile
+      // shell-out inherited the daemon's env/cwd, where CTX_AGENT_NAME is
+      // unset — resolveEnv fell back to basename(cwd), so every agent's
+      // watchdog beat landed in one phantom state dir named after the
+      // framework checkout instead of the agent (2026-07-10 diagnosis,
+      // addendum 3). In-process removes the ambient-env failure class.
+      try {
+        updateHeartbeat(this.paths, agentName, `[watchdog] ${agentName} alive — idle session ${ts}`, { org: this.agent.org });
+      } catch (err) {
+        this.log(`Heartbeat watchdog error: ${err}`);
+      }
     }, HEARTBEAT_INTERVAL_MS);
 
     while (this.running) {

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -212,13 +212,19 @@ export class FastChecker {
 
     // Inject if there's anything
     if (messageBlock) {
-      const injected = this.agent.injectMessage(messageBlock);
-      if (injected) {
-        // ACK inbox messages
+      const result =
+        typeof this.agent.injectMessageConfirmedDetailed === 'function'
+          ? await this.agent.injectMessageConfirmedDetailed(messageBlock)
+          : ({ ok: this.agent.injectMessage(messageBlock), confirmed: null, enterAttempts: 1 } as const);
+      if (result.ok && result.confirmed !== false) {
+        // ACK only once delivery is confirmed (turn started) or when no
+        // confirmation channel exists (legacy sessions, confirmed === null).
+        // Ack-on-write was how messages got marked delivered while the
+        // content sat in a stuck input box (2026-07-09 stall class).
         for (const id of ackIds) {
           ackInbox(this.paths, id);
         }
-        this.log(`Injected ${messageBlock.length} bytes`);
+        this.log(`Injected ${messageBlock.length} bytes${result.confirmed === true ? ` (delivery confirmed, ${result.enterAttempts} Enter attempt${result.enterAttempts > 1 ? 's' : ''})` : ''}`);
         // Only update typing timestamp for Telegram messages, not inbox/cron.
         // Inbox messages (agent-to-agent, session continuations) must not
         // restart the typing indicator after Stop has cleared it.

--- a/src/daemon/hook-reconciler.ts
+++ b/src/daemon/hook-reconciler.ts
@@ -1,0 +1,107 @@
+/**
+ * Hook reconciler — ensures every agent's .claude/settings.json carries the
+ * cortextOS-required hooks, regardless of which template version the agent
+ * was originally spawned from.
+ *
+ * Background (2026-07-09 stall diagnosis, secondary finding #1): agents
+ * created before a template gained a hook never receive it — kirk and spock
+ * lacked the Stop → hook-idle-flag entry entirely, so last_idle.flag never
+ * wrote and the fast-checker's turn-end signal was silently absent for those
+ * agents. Settings were written once at spawn and never reconciled.
+ *
+ * Called from AgentManager.startAgent() so the guarantee holds on every
+ * agent start. Additive only: existing hook entries (including user-added
+ * ones) are never modified or removed; a required hook is appended only when
+ * no entry for that event already runs the same command. Malformed settings
+ * files are left untouched (loud log) rather than clobbered.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { atomicWriteSync } from '../utils/atomic.js';
+
+interface RequiredHook {
+  /** Hook event name, e.g. "Stop" */
+  event: string;
+  /** Command line for the hook */
+  command: string;
+  /** Timeout in seconds */
+  timeout: number;
+}
+
+/**
+ * Hooks every cortextOS agent must have. Keep in sync with
+ * templates/agent/.claude/settings.json — this list is the enforcement for
+ * agents spawned from older template versions.
+ */
+export const REQUIRED_HOOKS: RequiredHook[] = [
+  // Turn-end signal: fast-checker liveness/typing detection and the
+  // delivery-confirmation loop both consume last_idle.flag transitions.
+  { event: 'Stop', command: 'cortextos bus hook-idle-flag', timeout: 5 },
+];
+
+interface HookCommandEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+}
+interface HookGroup {
+  matcher?: string;
+  hooks: HookCommandEntry[];
+}
+
+/**
+ * Ensure required hooks exist in <agentDir>/.claude/settings.json.
+ * Returns the list of hook commands that were added (empty = no change).
+ */
+export function ensureRequiredHooks(
+  agentDir: string,
+  log: (msg: string) => void = () => {}
+): string[] {
+  const settingsPath = join(agentDir, '.claude', 'settings.json');
+  if (!existsSync(settingsPath)) {
+    // No settings file at all — an agent dir this bare is not something the
+    // reconciler should invent config for; leave it to the spawn path.
+    log(`hook-reconciler: no settings.json at ${settingsPath}, skipping`);
+    return [];
+  }
+
+  let raw: string;
+  let settings: Record<string, unknown>;
+  try {
+    raw = readFileSync(settingsPath, 'utf-8');
+    settings = JSON.parse(raw);
+  } catch (err) {
+    log(`hook-reconciler: settings.json unreadable/malformed at ${settingsPath} — leaving untouched (${err})`);
+    return [];
+  }
+  if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) {
+    log(`hook-reconciler: settings.json root is not an object at ${settingsPath} — leaving untouched`);
+    return [];
+  }
+
+  const hooks = (settings.hooks ?? {}) as Record<string, HookGroup[]>;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    log(`hook-reconciler: settings.hooks is not an object at ${settingsPath} — leaving untouched`);
+    return [];
+  }
+
+  const added: string[] = [];
+  for (const req of REQUIRED_HOOKS) {
+    const groups: HookGroup[] = Array.isArray(hooks[req.event]) ? hooks[req.event] : [];
+    const present = groups.some(g =>
+      Array.isArray(g?.hooks) &&
+      g.hooks.some(h => typeof h?.command === 'string' && h.command.includes(req.command))
+    );
+    if (present) continue;
+    groups.push({ hooks: [{ type: 'command', command: req.command, timeout: req.timeout }] });
+    hooks[req.event] = groups;
+    added.push(`${req.event} → ${req.command}`);
+  }
+
+  if (added.length === 0) return [];
+
+  settings.hooks = hooks;
+  atomicWriteSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', true);
+  log(`hook-reconciler: added missing hook(s): ${added.join(', ')}`);
+  return added;
+}

--- a/src/daemon/hook-reconciler.ts
+++ b/src/daemon/hook-reconciler.ts
@@ -37,6 +37,9 @@ export const REQUIRED_HOOKS: RequiredHook[] = [
   // Turn-end signal: fast-checker liveness/typing detection and the
   // delivery-confirmation loop both consume last_idle.flag transitions.
   { event: 'Stop', command: 'cortextos bus hook-idle-flag', timeout: 5 },
+  // Turn-start signal: the delivery-confirmation loop watches last_prompt.flag
+  // to verify an injected message actually submitted.
+  { event: 'UserPromptSubmit', command: 'cortextos bus hook-prompt-flag', timeout: 5 },
 ];
 
 interface HookCommandEntry {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,4 +1,5 @@
 import { AgentManager } from './agent-manager.js';
+import { installTimestampedConsole } from './log-timestamps.js';
 import { IPCServer } from './ipc-server.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
@@ -230,6 +231,7 @@ class Daemon {
   }
 
   async start(): Promise<void> {
+    installTimestampedConsole();
     // Force restrictive default permissions for everything the daemon writes:
     // 0700 dirs, 0600 files. Belt-and-suspenders for explicit chmod calls.
     if (process.platform !== 'win32') {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,6 @@
 import { AgentManager } from './agent-manager.js';
 import { installTimestampedConsole } from './log-timestamps.js';
+import { StalenessDetector } from './staleness-detector.js';
 import { IPCServer } from './ipc-server.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
@@ -224,6 +225,8 @@ class Daemon {
   private instanceId: string;
   private ctxRoot: string;
 
+  private stalenessDetector: StalenessDetector | null = null;
+
   constructor() {
     this.instanceId = process.env.CTX_INSTANCE_ID || 'default';
     // Always derive ctxRoot from instanceId to avoid inheriting a parent cortextOS's CTX_ROOT
@@ -267,6 +270,16 @@ class Daemon {
 
     // Discover and start agents
     await this.agentManager.discoverAndStart();
+
+    // Dual-source staleness detector: non-session wake trigger for the
+    // injection-stall class (flags only when heartbeat AND cron fires AND
+    // idle flag are all silent past threshold).
+    this.stalenessDetector = new StalenessDetector({
+      instanceId: this.instanceId,
+      ctxRoot: this.ctxRoot,
+      listAgents: () => this.agentManager!.getAgentRoster(),
+    });
+    this.stalenessDetector.start();
 
     console.log(`[daemon] Running (pid: ${process.pid})`);
 

--- a/src/daemon/log-timestamps.ts
+++ b/src/daemon/log-timestamps.ts
@@ -1,0 +1,30 @@
+/**
+ * Timestamped console for the daemon process.
+ *
+ * Every daemon log line (console.log/warn/error across index.ts, fast-checker,
+ * agent-manager, etc.) gets an ISO-8601 UTC prefix so stall/incident windows can
+ * be reconstructed from the out-log alone, without cross-referencing pmset or
+ * bus stores. Installed once at daemon startup; idempotent.
+ */
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+
+type ConsoleMethod = 'log' | 'warn' | 'error';
+
+/**
+ * Wrap console.log/warn/error to prefix each call with an ISO UTC timestamp.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function installTimestampedConsole(): void {
+  const g = globalThis as Record<PropertyKey, unknown>;
+  if (g[INSTALLED]) return;
+  g[INSTALLED] = true;
+
+  const methods: ConsoleMethod[] = ['log', 'warn', 'error'];
+  for (const m of methods) {
+    const original = console[m].bind(console);
+    console[m] = (...args: unknown[]) => {
+      original(`[${new Date().toISOString()}]`, ...args);
+    };
+  }
+}

--- a/src/daemon/staleness-detector.ts
+++ b/src/daemon/staleness-detector.ts
@@ -1,0 +1,178 @@
+/**
+ * Dual-source staleness detector.
+ *
+ * Heartbeat-only staleness produced a persistent false-positive class: cron
+ * prompts that lack an update-heartbeat line leave heartbeat.json untouched
+ * while cron-fire records prove continuous liveness (2026-07-10 binding
+ * amendment). And when a stall IS real, the fleet-standard peer-notify
+ * mitigation shares the failure mode — a stalled peer cannot notify anyone
+ * (stall #3 datum). This detector is the non-session trigger.
+ *
+ * Rule: an agent is flagged stale ONLY when EVERY liveness source has been
+ * silent for more than the threshold (default 45 min):
+ *   1. heartbeat.json last_heartbeat  (agent- or watchdog-written)
+ *   2. cron-state.json most recent fire (any recorded fire = liveness beat)
+ *   3. last_idle.flag mtime            (Stop hook turn-end signal)
+ *
+ * On staleness: write the .urgent-signal wake file + bus message via
+ * notifyAgent (the resubmit mechanism that recovered every observed stall),
+ * log loudly, and hold a per-agent cooldown so a genuinely wedged agent is
+ * prodded at most once per threshold window.
+ */
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import { notifyAgent } from '../bus/agents.js';
+import { readCronState } from '../bus/cron-state.js';
+import { resolvePaths } from '../utils/paths.js';
+
+export const DEFAULT_STALE_THRESHOLD_MS = 45 * 60 * 1000;
+export const DEFAULT_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+
+export interface LivenessSources {
+  /** ms epoch of heartbeat.json last_heartbeat (undefined = no signal ever) */
+  heartbeatAt?: number;
+  /** ms epoch of the most recent recorded cron fire */
+  lastCronFireAt?: number;
+  /** ms epoch of last_idle.flag write (Stop hook turn-end) */
+  idleFlagAt?: number;
+}
+
+export interface StalenessVerdict {
+  stale: boolean;
+  /** ms since the freshest available signal; Infinity when no source exists */
+  ageMs: number;
+  /** which source was freshest, for the log line */
+  freshestSource: 'heartbeat' | 'cron-fire' | 'idle-flag' | 'none';
+}
+
+/**
+ * Pure staleness rule: stale iff every AVAILABLE source is older than the
+ * threshold. An agent with NO sources at all is never flagged (nothing to
+ * distinguish "new agent" from "broken state dir" — flagging would wake
+ * agents that simply have not written anything yet).
+ */
+export function assessStaleness(
+  sources: LivenessSources,
+  nowMs: number,
+  thresholdMs: number = DEFAULT_STALE_THRESHOLD_MS,
+): StalenessVerdict {
+  const entries: Array<[StalenessVerdict['freshestSource'], number]> = [];
+  if (sources.heartbeatAt !== undefined) entries.push(['heartbeat', sources.heartbeatAt]);
+  if (sources.lastCronFireAt !== undefined) entries.push(['cron-fire', sources.lastCronFireAt]);
+  if (sources.idleFlagAt !== undefined) entries.push(['idle-flag', sources.idleFlagAt]);
+
+  if (entries.length === 0) return { stale: false, ageMs: Infinity, freshestSource: 'none' };
+
+  let freshest = entries[0];
+  for (const e of entries) if (e[1] > freshest[1]) freshest = e;
+  const ageMs = nowMs - freshest[1];
+  return { stale: ageMs > thresholdMs, ageMs, freshestSource: freshest[0] };
+}
+
+/** Read the three liveness sources for one agent from its state dir. */
+export function readLivenessSources(stateDir: string): LivenessSources {
+  const out: LivenessSources = {};
+
+  const hbPath = join(stateDir, 'heartbeat.json');
+  if (existsSync(hbPath)) {
+    try {
+      const hb = JSON.parse(readFileSync(hbPath, 'utf-8'));
+      const t = Date.parse(hb.last_heartbeat);
+      out.heartbeatAt = Number.isNaN(t) ? statSync(hbPath).mtimeMs : t;
+    } catch {
+      try { out.heartbeatAt = statSync(hbPath).mtimeMs; } catch { /* gone */ }
+    }
+  }
+
+  try {
+    const cronState = readCronState(stateDir);
+    let latest: number | undefined;
+    for (const entry of cronState.crons) {
+      const t = Date.parse(entry.last_fire ?? '');
+      if (!Number.isNaN(t) && (latest === undefined || t > latest)) latest = t;
+    }
+    if (latest !== undefined) out.lastCronFireAt = latest;
+  } catch { /* no cron state */ }
+
+  const flagPath = join(stateDir, 'last_idle.flag');
+  if (existsSync(flagPath)) {
+    try { out.idleFlagAt = statSync(flagPath).mtimeMs; } catch { /* gone */ }
+  }
+
+  return out;
+}
+
+export interface StalenessDetectorOptions {
+  instanceId: string;
+  ctxRoot: string;
+  /** Live roster: agent names (with orgs) currently running under the daemon */
+  listAgents: () => Array<{ name: string; org: string }>;
+  log?: (msg: string) => void;
+  thresholdMs?: number;
+  checkIntervalMs?: number;
+  /** Injectable for tests */
+  notify?: typeof notifyAgent;
+  now?: () => number;
+}
+
+export class StalenessDetector {
+  private timer: NodeJS.Timeout | null = null;
+  private lastProddedAt: Map<string, number> = new Map();
+  private readonly opts: Required<Pick<StalenessDetectorOptions, 'thresholdMs' | 'checkIntervalMs'>> & StalenessDetectorOptions;
+
+  constructor(options: StalenessDetectorOptions) {
+    this.opts = {
+      thresholdMs: DEFAULT_STALE_THRESHOLD_MS,
+      checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
+      ...options,
+    };
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.checkOnce(), this.opts.checkIntervalMs);
+    // Unref so the detector never keeps a shutting-down daemon alive
+    this.timer.unref?.();
+    (this.opts.log ?? console.log)(
+      `[staleness] detector started (threshold ${Math.round(this.opts.thresholdMs / 60000)} min, check every ${Math.round(this.opts.checkIntervalMs / 60000)} min)`
+    );
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  /** One sweep over the live roster. Exposed for tests. */
+  checkOnce(): void {
+    const log = this.opts.log ?? console.log;
+    const now = (this.opts.now ?? Date.now)();
+    const notify = this.opts.notify ?? notifyAgent;
+
+    for (const { name, org } of this.opts.listAgents()) {
+      const stateDir = join(this.opts.ctxRoot, 'state', name);
+      const sources = readLivenessSources(stateDir);
+      const verdict = assessStaleness(sources, now, this.opts.thresholdMs);
+      if (!verdict.stale) continue;
+
+      const lastProd = this.lastProddedAt.get(name) ?? 0;
+      if (now - lastProd < this.opts.thresholdMs) continue; // cooldown
+
+      const ageMin = Math.round(verdict.ageMs / 60000);
+      log(`[staleness] ${name}: ALL liveness sources silent ${ageMin} min (freshest: ${verdict.freshestSource}) — sending wake signal`);
+      try {
+        const paths = resolvePaths(name, this.opts.instanceId, org);
+        notify(
+          paths,
+          'daemon',
+          name,
+          `daemon staleness detector: all liveness sources (heartbeat, cron fires, idle flag) silent ${ageMin} min. ` +
+          `If you receive this, your session likely had undelivered input — process your queue, update your heartbeat, and note the gap in your log.`,
+          this.opts.ctxRoot,
+        );
+        this.lastProddedAt.set(name, now);
+      } catch (err) {
+        log(`[staleness] ${name}: wake signal failed: ${err}`);
+      }
+    }
+  }
+}

--- a/src/hooks/hook-prompt-flag.ts
+++ b/src/hooks/hook-prompt-flag.ts
@@ -1,0 +1,27 @@
+/**
+ * UserPromptSubmit hook - writes a Unix timestamp to last_prompt.flag.
+ *
+ * This is the turn-START signal, the counterpart of hook-idle-flag's Stop
+ * (turn-end) signal. The daemon's delivery-confirmation loop watches this
+ * flag after injecting a message: flag advances past the injection time =
+ * the prompt actually submitted and a turn began; no advance = the content
+ * is sitting in the CLI input box with a dropped Enter (2026-07-09 stall
+ * class) and the injector retries Enter.
+ */
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+async function main(): Promise<void> {
+  const agentName = process.env.CTX_AGENT_NAME;
+  const instanceId = process.env.CTX_INSTANCE_ID || 'default';
+  if (!agentName) return;
+
+  const stateDir = join(homedir(), '.cortextos', instanceId, 'state', agentName);
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'last_prompt.flag'), String(Math.floor(Date.now() / 1000)), 'utf-8');
+  } catch { /* ignore */ }
+}
+
+main().catch(() => process.exit(0));

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -3,7 +3,8 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
-import { injectMessage as injectMessageIntoPty } from './inject.js';
+import { injectMessage as injectMessageIntoPty, injectMessageConfirmed as injectMessageConfirmedIntoPty, KEYS } from './inject.js';
+import type { ConfirmedInjectOptions, ConfirmedInjectResult } from './inject.js';
 
 // node-pty types
 interface IPty {
@@ -310,6 +311,27 @@ export class AgentPTY {
    */
   injectMessage(content: string): void {
     injectMessageIntoPty((data) => this.write(data), content);
+  }
+
+  /**
+   * Confirmed injection: paste + Enter with turn-start verification and
+   * Enter retries (see injectMessageConfirmed in inject.ts). Runtime
+   * subclasses whose paste semantics differ (OpenCode) return null to tell
+   * the caller to use their own injectMessage() path instead.
+   */
+  injectMessageConfirmed(
+    content: string,
+    options: ConfirmedInjectOptions,
+  ): Promise<ConfirmedInjectResult> | null {
+    return injectMessageConfirmedIntoPty((data) => this.write(data), content, options);
+  }
+
+  /**
+   * Send a bare Enter — used by the boot-prompt delivery check to re-submit
+   * a prompt stuck in the input box. No-op against an empty input box.
+   */
+  sendEnter(): void {
+    this.write(KEYS.ENTER);
   }
 
   /**

--- a/src/pty/inject.ts
+++ b/src/pty/inject.ts
@@ -179,3 +179,102 @@ export async function toggleAndSubmit(
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/**
+ * Result of a confirmed injection attempt.
+ */
+export interface ConfirmedInjectResult {
+  /** true = turn-start confirmed; false = every Enter retry exhausted */
+  confirmed: boolean;
+  /** how many Enters were sent (1 = first attempt confirmed) */
+  enterAttempts: number;
+}
+
+export interface ConfirmedInjectOptions {
+  /** Returns true once the runtime shows the prompt actually submitted */
+  isConfirmed: () => boolean;
+  /** ms before the first Enter (mirrors injectMessage default) */
+  enterDelay?: number;
+  /** ms to poll isConfirmed() after each Enter before retrying */
+  attemptTimeoutMs?: number;
+  /** poll granularity */
+  pollMs?: number;
+  /** total Enter attempts (first + retries) */
+  maxEnterAttempts?: number;
+  log?: (msg: string) => void;
+  /** injectable for tests */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Inject a message and CONFIRM it submitted, retrying Enter when it did not.
+ *
+ * The fire-and-forget injectMessage() above sends Enter 300 ms after the
+ * paste and swallows failures — "the dropped Enter is the acceptable cost."
+ * The 2026-07-09 fleet stalls showed the real cost: when the Enter fails to
+ * submit, the pasted content sits in the CLI input box, the session looks
+ * idle, every later injection appends to the same unsubmitted box, and the
+ * whole backlog flushes as one batch whenever any later Enter finally lands.
+ *
+ * This variant closes the loop: paste once, then send Enter and poll a
+ * turn-start signal (last_prompt.flag via the UserPromptSubmit hook); no
+ * signal within the window → send Enter again (idempotent against a loaded
+ * input box — an empty box treats it as a no-op) up to maxEnterAttempts.
+ * Defaults: 3 attempts × 9 s ≈ 28 s worst case, inside the 30-second
+ * delivery gate.
+ */
+export async function injectMessageConfirmed(
+  write: (data: string) => void,
+  content: string,
+  options: ConfirmedInjectOptions,
+): Promise<ConfirmedInjectResult> {
+  const {
+    isConfirmed,
+    enterDelay = 300,
+    attemptTimeoutMs = 9000,
+    pollMs = 500,
+    maxEnterAttempts = 3,
+    log = () => {},
+    sleep: doSleep = sleep,
+  } = options;
+
+  const MAX_CHUNK = 4096;
+  if (content.length <= MAX_CHUNK) {
+    write(PASTE_START + content + PASTE_END);
+  } else {
+    write(PASTE_START);
+    for (let i = 0; i < content.length; i += MAX_CHUNK) {
+      write(content.slice(i, i + MAX_CHUNK));
+    }
+    write(PASTE_END);
+  }
+  await doSleep(enterDelay);
+
+  let enterAttempts = 0;
+  while (enterAttempts < maxEnterAttempts) {
+    enterAttempts++;
+    try {
+      write(KEYS.ENTER);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log(`[inject] Enter attempt ${enterAttempts} failed (pty likely torn down): ${msg}`);
+      return { confirmed: false, enterAttempts };
+    }
+
+    const deadline = attemptTimeoutMs;
+    let waited = 0;
+    while (waited < deadline) {
+      await doSleep(pollMs);
+      waited += pollMs;
+      if (isConfirmed()) {
+        if (enterAttempts > 1) {
+          log(`[inject] delivery confirmed after ${enterAttempts} Enter attempts`);
+        }
+        return { confirmed: true, enterAttempts };
+      }
+    }
+    log(`[inject] no turn-start signal ${deadline} ms after Enter attempt ${enterAttempts}/${maxEnterAttempts} — retrying`);
+  }
+
+  return { confirmed: false, enterAttempts };
+}

--- a/src/pty/inject.ts
+++ b/src/pty/inject.ts
@@ -43,6 +43,17 @@ export class MessageDedup {
     return false;
   }
 
+  /**
+   * Forget one content hash so the same content can inject again.
+   * Used when delivery confirmation fails: the un-ACKed message redelivers
+   * with identical content, which isDuplicate() would otherwise drop.
+   */
+  forget(content: string): void {
+    const hash = createHash('md5').update(content).digest('hex');
+    const idx = this.hashes.indexOf(hash);
+    if (idx >= 0) this.hashes.splice(idx, 1);
+  }
+
   clear(): void {
     this.hashes = [];
   }

--- a/src/pty/opencode-pty.ts
+++ b/src/pty/opencode-pty.ts
@@ -148,6 +148,13 @@ export class OpencodePTY extends AgentPTY {
     }
   }
 
+  override injectMessageConfirmed(): null {
+    // OpenCode's TUI paste path differs from Claude Code's; the Enter-retry
+    // confirmation loop is not validated there. Callers fall back to
+    // injectMessage().
+    return null;
+  }
+
   override injectMessage(content: string): void {
     // OpenCode v1.17.9's TUI does not reliably surface content delivered with
     // bracketed paste (`ESC[200~ ... ESC[201~`): sandbox validation showed the

--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -91,6 +91,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-prompt-flag",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -91,6 +91,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-prompt-flag",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/unit/daemon/delivery-confirmation.test.ts
+++ b/tests/unit/daemon/delivery-confirmation.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { injectMessageConfirmed, KEYS } from '../../../src/pty/inject.js';
+
+// No real timers: inject a zero-delay sleep and drive confirmation state.
+const instantSleep = () => Promise.resolve();
+
+describe('injectMessageConfirmed', () => {
+  it('confirms on first Enter when the turn-start signal appears', async () => {
+    const writes: string[] = [];
+    let submitted = false;
+    const res = await injectMessageConfirmed(
+      d => {
+        writes.push(d);
+        if (d === KEYS.ENTER) submitted = true;
+      },
+      'hello',
+      { isConfirmed: () => submitted, sleep: instantSleep },
+    );
+    expect(res).toEqual({ confirmed: true, enterAttempts: 1 });
+    expect(writes[0]).toContain('hello');
+    expect(writes.filter(w => w === KEYS.ENTER)).toHaveLength(1);
+  });
+
+  it('retries Enter when the first submit is dropped, then confirms', async () => {
+    const writes: string[] = [];
+    let enters = 0;
+    let submitted = false;
+    const res = await injectMessageConfirmed(
+      d => {
+        writes.push(d);
+        if (d === KEYS.ENTER) {
+          enters++;
+          if (enters === 2) submitted = true; // first Enter dropped, second lands
+        }
+      },
+      'stall-class message',
+      { isConfirmed: () => submitted, sleep: instantSleep },
+    );
+    expect(res).toEqual({ confirmed: true, enterAttempts: 2 });
+    expect(writes.filter(w => w === KEYS.ENTER)).toHaveLength(2);
+  });
+
+  it('gives up after maxEnterAttempts and reports confirmed:false (DELIVERY_FAILED)', async () => {
+    const logs: string[] = [];
+    const res = await injectMessageConfirmed(
+      () => {},
+      'never submits',
+      { isConfirmed: () => false, sleep: instantSleep, maxEnterAttempts: 3, log: m => logs.push(m) },
+    );
+    expect(res).toEqual({ confirmed: false, enterAttempts: 3 });
+    expect(logs.join('\n')).toMatch(/no turn-start signal/);
+  });
+
+  it('chunked paste for large content still runs the confirmation loop', async () => {
+    const writes: string[] = [];
+    let submitted = false;
+    const big = 'x'.repeat(10_000);
+    const res = await injectMessageConfirmed(
+      d => {
+        writes.push(d);
+        if (d === KEYS.ENTER) submitted = true;
+      },
+      big,
+      { isConfirmed: () => submitted, sleep: instantSleep },
+    );
+    expect(res.confirmed).toBe(true);
+    expect(writes.join('').includes(big)).toBe(true);
+  });
+
+  it('a torn PTY on Enter returns confirmed:false instead of throwing', async () => {
+    let pasted = false;
+    const res = await injectMessageConfirmed(
+      d => {
+        if (d === KEYS.ENTER) throw new Error('pty torn down');
+        pasted = true;
+      },
+      'msg',
+      { isConfirmed: () => false, sleep: instantSleep, log: () => {} },
+    );
+    expect(pasted).toBe(true);
+    expect(res.confirmed).toBe(false);
+  });
+
+  it('worst-case wall clock stays within the 30s delivery gate (3 × 9s + delay)', async () => {
+    // Sum the sleeps the loop would take instead of running real timers.
+    let totalMs = 0;
+    const accountingSleep = (ms: number) => { totalMs += ms; return Promise.resolve(); };
+    await injectMessageConfirmed(() => {}, 'x', {
+      isConfirmed: () => false,
+      sleep: accountingSleep,
+    });
+    expect(totalMs).toBeLessThanOrEqual(30_000);
+  });
+});
+
+describe('fast-checker ack-on-confirm contract', () => {
+  // The pollCycle ack rule: ack when ok && confirmed !== false.
+  const shouldAck = (r: { ok: boolean; confirmed: boolean | null }) => r.ok && r.confirmed !== false;
+
+  it('acks on confirmed delivery', () => {
+    expect(shouldAck({ ok: true, confirmed: true })).toBe(true);
+  });
+  it('acks on legacy path (no confirmation channel)', () => {
+    expect(shouldAck({ ok: true, confirmed: null })).toBe(true);
+  });
+  it('does NOT ack on DELIVERY_FAILED — message must redeliver', () => {
+    expect(shouldAck({ ok: true, confirmed: false })).toBe(false);
+  });
+  it('does NOT ack when injection itself failed', () => {
+    expect(shouldAck({ ok: false, confirmed: null })).toBe(false);
+  });
+});

--- a/tests/unit/daemon/delivery-confirmation.test.ts
+++ b/tests/unit/daemon/delivery-confirmation.test.ts
@@ -110,3 +110,22 @@ describe('fast-checker ack-on-confirm contract', () => {
     expect(shouldAck({ ok: false, confirmed: null })).toBe(false);
   });
 });
+
+describe('MessageDedup.forget — redelivery after DELIVERY_FAILED', () => {
+  it('forgotten content can inject again; unforgotten stays deduped', async () => {
+    const { MessageDedup } = await import('../../../src/pty/inject.js');
+    const dedup = new MessageDedup();
+    expect(dedup.isDuplicate('msg-a')).toBe(false); // first sight records it
+    expect(dedup.isDuplicate('msg-a')).toBe(true);  // redelivery would be dropped
+    dedup.forget('msg-a');
+    expect(dedup.isDuplicate('msg-a')).toBe(false); // retry path open again
+    expect(dedup.isDuplicate('msg-a')).toBe(true);
+  });
+
+  it('forget of unseen content is a no-op', async () => {
+    const { MessageDedup } = await import('../../../src/pty/inject.js');
+    const dedup = new MessageDedup();
+    dedup.forget('never-seen');
+    expect(dedup.isDuplicate('other')).toBe(false);
+  });
+});

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('child_process', () => ({ execFile: vi.fn() }));
+vi.mock('../../../src/bus/heartbeat.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  updateHeartbeat: vi.fn(),
+}));
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -804,48 +808,56 @@ describe('FastChecker', () => {
     beforeEach(() => { vi.useFakeTimers(); });
     afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
 
-    it('fires exec after bootstrap at 50-min interval', async () => {
-      const { execFile } = await import('child_process');
+    it('writes an in-process heartbeat for the NAMED agent at 50-min interval', async () => {
+      const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
       const agent = createMockAgent('my-agent');
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
-      expect(execFile).toHaveBeenCalledWith(
-        'cortextos',
-        expect.arrayContaining(['bus', 'update-heartbeat', expect.stringContaining('[watchdog] my-agent alive — idle session')]),
-        expect.any(Function),
+      expect(updateHeartbeat).toHaveBeenCalledWith(
+        paths,
+        'my-agent',
+        expect.stringContaining('[watchdog] my-agent alive — idle session'),
+        expect.objectContaining({}),
       );
       checker.stop();
       checker.wake();
     });
 
-    it('clears timer on stop — no further exec calls after stop', async () => {
+    it('never shells out for the watchdog beat (regression: phantom basename-cwd agent)', async () => {
       const { execFile } = await import('child_process');
-      const execMock = execFile as ReturnType<typeof vi.fn>;
       const agent = createMockAgent('my-agent');
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
-      const callsBefore = execMock.mock.calls.length;
+      expect(execFile).not.toHaveBeenCalled();
+      checker.stop();
+      checker.wake();
+    });
+
+    it('clears timer on stop — no further beats after stop', async () => {
+      const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
+      const hbMock = updateHeartbeat as ReturnType<typeof vi.fn>;
+      const agent = createMockAgent('my-agent');
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      checker.start();
+      await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
+      const callsBefore = hbMock.mock.calls.length;
       expect(callsBefore).toBeGreaterThan(0);
       checker.stop();
       checker.wake();
       await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
-      expect(execMock.mock.calls.length).toBe(callsBefore);
+      expect(hbMock.mock.calls.length).toBe(callsBefore);
     });
 
     it('does not fire before bootstrap completes', async () => {
-      const { execFile } = await import('child_process');
+      const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
       const agent = createMockAgent('my-agent');
       agent.isBootstrapped.mockReturnValue(false);
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(20 * 1000);
-      expect(execFile).not.toHaveBeenCalledWith(
-        'cortextos',
-        expect.arrayContaining([expect.stringContaining('[watchdog]')]),
-        expect.any(Function),
-      );
+      expect(updateHeartbeat).not.toHaveBeenCalled();
       checker.stop();
       checker.wake();
     });

--- a/tests/unit/daemon/hook-reconciler.test.ts
+++ b/tests/unit/daemon/hook-reconciler.test.ts
@@ -27,7 +27,8 @@ describe('ensureRequiredHooks', () => {
   it('adds the Stop hook when the event is entirely missing (kirk/spock case)', () => {
     const dir = track(agentDirWith({ hooks: { PreToolUse: [] } }));
     const added = ensureRequiredHooks(dir);
-    expect(added).toEqual([`Stop → ${STOP_CMD}`]);
+    expect(added).toContain(`Stop → ${STOP_CMD}`);
+    expect(added).toHaveLength(REQUIRED_HOOKS.length);
     const s = readSettings(dir);
     expect(s.hooks.Stop).toHaveLength(1);
     expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
@@ -44,9 +45,11 @@ describe('ensureRequiredHooks', () => {
     expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
   });
 
-  it('is idempotent — hook already present means no change', () => {
+  it('is idempotent — hooks already present mean no change', () => {
     const dir = track(agentDirWith({
-      hooks: { Stop: [{ hooks: [{ type: 'command', command: STOP_CMD, timeout: 5 }] }] },
+      hooks: Object.fromEntries(REQUIRED_HOOKS.map(r => [
+        r.event, [{ hooks: [{ type: 'command', command: r.command, timeout: r.timeout }] }],
+      ])),
     }));
     const before = readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8');
     expect(ensureRequiredHooks(dir)).toEqual([]);
@@ -55,10 +58,13 @@ describe('ensureRequiredHooks', () => {
 
   it('detects presence by command substring within existing Stop groups', () => {
     const dir = track(agentDirWith({
-      hooks: { Stop: [{ hooks: [
-        { type: 'command', command: 'some-other-hook' },
-        { type: 'command', command: `${STOP_CMD} --extra-arg` },
-      ] }] },
+      hooks: {
+        Stop: [{ hooks: [
+          { type: 'command', command: 'some-other-hook' },
+          { type: 'command', command: `${STOP_CMD} --extra-arg` },
+        ] }],
+        UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'cortextos bus hook-prompt-flag' }] }],
+      },
     }));
     expect(ensureRequiredHooks(dir)).toEqual([]);
   });
@@ -68,7 +74,7 @@ describe('ensureRequiredHooks', () => {
       hooks: { Stop: [{ hooks: [{ type: 'command', command: 'user-custom-stop' }] }] },
     }));
     const added = ensureRequiredHooks(dir);
-    expect(added).toHaveLength(1);
+    expect(added).toContain(`Stop → ${STOP_CMD}`);
     const s = readSettings(dir);
     expect(s.hooks.Stop).toHaveLength(2);
     expect(s.hooks.Stop[0].hooks[0].command).toBe('user-custom-stop');

--- a/tests/unit/daemon/hook-reconciler.test.ts
+++ b/tests/unit/daemon/hook-reconciler.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ensureRequiredHooks, REQUIRED_HOOKS } from '../../../src/daemon/hook-reconciler.js';
+
+const STOP_CMD = 'cortextos bus hook-idle-flag';
+
+function agentDirWith(settings: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hook-reconciler-'));
+  mkdirSync(join(dir, '.claude'), { recursive: true });
+  writeFileSync(
+    join(dir, '.claude', 'settings.json'),
+    typeof settings === 'string' ? settings : JSON.stringify(settings, null, 2)
+  );
+  return dir;
+}
+function readSettings(dir: string): Record<string, any> {
+  return JSON.parse(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8'));
+}
+
+describe('ensureRequiredHooks', () => {
+  let dirs: string[] = [];
+  afterEach(() => { dirs.forEach(d => rmSync(d, { recursive: true, force: true })); dirs = []; });
+  const track = (d: string) => { dirs.push(d); return d; };
+
+  it('adds the Stop hook when the event is entirely missing (kirk/spock case)', () => {
+    const dir = track(agentDirWith({ hooks: { PreToolUse: [] } }));
+    const added = ensureRequiredHooks(dir);
+    expect(added).toEqual([`Stop → ${STOP_CMD}`]);
+    const s = readSettings(dir);
+    expect(s.hooks.Stop).toHaveLength(1);
+    expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
+    expect(s.hooks.Stop[0].hooks[0].timeout).toBe(5);
+    expect(s.hooks.PreToolUse).toEqual([]); // untouched
+  });
+
+  it('adds hooks key when settings has none at all', () => {
+    const dir = track(agentDirWith({ model: 'opus' }));
+    const added = ensureRequiredHooks(dir);
+    expect(added.length).toBe(REQUIRED_HOOKS.length);
+    const s = readSettings(dir);
+    expect(s.model).toBe('opus');
+    expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
+  });
+
+  it('is idempotent — hook already present means no change', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: STOP_CMD, timeout: 5 }] }] },
+    }));
+    const before = readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8');
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8')).toBe(before);
+  });
+
+  it('detects presence by command substring within existing Stop groups', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [
+        { type: 'command', command: 'some-other-hook' },
+        { type: 'command', command: `${STOP_CMD} --extra-arg` },
+      ] }] },
+    }));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+  });
+
+  it('preserves existing user hooks when appending', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'user-custom-stop' }] }] },
+    }));
+    const added = ensureRequiredHooks(dir);
+    expect(added).toHaveLength(1);
+    const s = readSettings(dir);
+    expect(s.hooks.Stop).toHaveLength(2);
+    expect(s.hooks.Stop[0].hooks[0].command).toBe('user-custom-stop');
+    expect(s.hooks.Stop[1].hooks[0].command).toBe(STOP_CMD);
+  });
+
+  it('leaves malformed JSON untouched and reports nothing added', () => {
+    const dir = track(agentDirWith('{ not json ]]'));
+    const logs: string[] = [];
+    expect(ensureRequiredHooks(dir, m => logs.push(m))).toEqual([]);
+    expect(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8')).toBe('{ not json ]]');
+    expect(logs.join(' ')).toMatch(/malformed|unreadable/);
+  });
+
+  it('skips when settings.json does not exist (no invention)', () => {
+    const dir = track(mkdtempSync(join(tmpdir(), 'hook-reconciler-')));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(existsSync(join(dir, '.claude', 'settings.json'))).toBe(false);
+  });
+
+  it('leaves non-object hooks value untouched', () => {
+    const dir = track(agentDirWith({ hooks: 'weird' }));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(readSettings(dir).hooks).toBe('weird');
+  });
+});

--- a/tests/unit/daemon/log-timestamps.test.ts
+++ b/tests/unit/daemon/log-timestamps.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { installTimestampedConsole } from '../../../src/daemon/log-timestamps.js';
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+const ISO_PREFIX = /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]$/;
+
+describe('installTimestampedConsole', () => {
+  const originals = { log: console.log, warn: console.warn, error: console.error };
+
+  beforeEach(() => {
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  afterEach(() => {
+    console.log = originals.log;
+    console.warn = originals.warn;
+    console.error = originals.error;
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  it('prefixes console.log lines with an ISO-8601 UTC timestamp', () => {
+    installTimestampedConsole();
+    const spy = vi.fn();
+    // Capture what the wrapper forwards by re-wrapping the (already bound) sink:
+    // install() bound the ORIGINAL console.log, so intercept via a fresh install.
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('[daemon] hello', 42);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [ts, msg, num] = spy.mock.calls[0];
+    expect(String(ts)).toMatch(ISO_PREFIX);
+    expect(msg).toBe('[daemon] hello');
+    expect(num).toBe(42);
+  });
+
+  it('prefixes warn and error the same way', () => {
+    const warnSpy = vi.fn();
+    const errSpy = vi.fn();
+    console.warn = warnSpy;
+    console.error = errSpy;
+    installTimestampedConsole();
+    console.warn('w');
+    console.error('e');
+    expect(String(warnSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(String(errSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(warnSpy.mock.calls[0][1]).toBe('w');
+    expect(errSpy.mock.calls[0][1]).toBe('e');
+  });
+
+  it('is idempotent — double install does not double-prefix', () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    installTimestampedConsole();
+    console.log('once');
+    expect(spy).toHaveBeenCalledTimes(1);
+    const call = spy.mock.calls[0];
+    expect(call.length).toBe(2); // [timestamp, 'once'] — not [ts, ts, 'once']
+    expect(String(call[0])).toMatch(ISO_PREFIX);
+    expect(call[1]).toBe('once');
+  });
+
+  it('timestamp advances between calls (not frozen at install time)', async () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('a');
+    await new Promise(r => setTimeout(r, 5));
+    console.log('b');
+    const t1 = Date.parse(String(spy.mock.calls[0][0]).slice(1, -1));
+    const t2 = Date.parse(String(spy.mock.calls[1][0]).slice(1, -1));
+    expect(t2).toBeGreaterThanOrEqual(t1);
+    expect(Number.isNaN(t1)).toBe(false);
+  });
+});

--- a/tests/unit/daemon/staleness-detector.test.ts
+++ b/tests/unit/daemon/staleness-detector.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, existsSync, readFileSync } from 'fs';
+import { join, basename } from 'path';
+import { tmpdir } from 'os';
+import {
+  assessStaleness,
+  readLivenessSources,
+  StalenessDetector,
+  DEFAULT_STALE_THRESHOLD_MS,
+} from '../../../src/daemon/staleness-detector.js';
+
+const MIN = 60_000;
+const NOW = 1_800_000_000_000;
+
+describe('assessStaleness (pure rule)', () => {
+  it('fresh heartbeat alone = not stale', () => {
+    const v = assessStaleness({ heartbeatAt: NOW - 5 * MIN }, NOW);
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('heartbeat');
+  });
+
+  it('stale heartbeat but FRESH CRON FIRE = not stale (the 2026-07-09 false-positive class)', () => {
+    const v = assessStaleness(
+      { heartbeatAt: NOW - 165 * MIN, lastCronFireAt: NOW - 10 * MIN },
+      NOW,
+    );
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('cron-fire');
+  });
+
+  it('stale heartbeat + stale cron + fresh idle flag = not stale', () => {
+    const v = assessStaleness(
+      { heartbeatAt: NOW - 90 * MIN, lastCronFireAt: NOW - 80 * MIN, idleFlagAt: NOW - 2 * MIN },
+      NOW,
+    );
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('idle-flag');
+  });
+
+  it('ALL sources silent past threshold = stale', () => {
+    const v = assessStaleness(
+      { heartbeatAt: NOW - 90 * MIN, lastCronFireAt: NOW - 50 * MIN, idleFlagAt: NOW - 46 * MIN },
+      NOW,
+    );
+    expect(v.stale).toBe(true);
+    expect(v.ageMs).toBe(46 * MIN);
+  });
+
+  it('exactly at threshold = not stale (strictly greater)', () => {
+    const v = assessStaleness({ heartbeatAt: NOW - DEFAULT_STALE_THRESHOLD_MS }, NOW);
+    expect(v.stale).toBe(false);
+  });
+
+  it('no sources at all = never stale (new agent, nothing to judge)', () => {
+    const v = assessStaleness({}, NOW);
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('none');
+  });
+});
+
+describe('readLivenessSources', () => {
+  let dirs: string[] = [];
+  afterEach(() => { dirs.forEach(d => rmSync(d, { recursive: true, force: true })); dirs = []; });
+  const stateDir = () => { const d = mkdtempSync(join(tmpdir(), 'stale-src-')); dirs.push(d); return d; };
+
+  it('reads heartbeat.json last_heartbeat, cron-state latest fire, idle flag mtime', () => {
+    const dir = stateDir();
+    writeFileSync(join(dir, 'heartbeat.json'),
+      JSON.stringify({ agent: 'x', last_heartbeat: '2026-07-10T10:00:00Z' }));
+    writeFileSync(join(dir, 'cron-state.json'), JSON.stringify({
+      updated_at: '2026-07-10T10:22:00Z',
+      crons: [
+        { name: 'heartbeat', last_fire: '2026-07-10T09:59:00Z' },
+        { name: 'file-drop', last_fire: '2026-07-10T10:22:00Z' },
+      ],
+    }));
+    writeFileSync(join(dir, 'last_idle.flag'), '1783684800');
+    const t = new Date('2026-07-10T10:30:00Z');
+    utimesSync(join(dir, 'last_idle.flag'), t, t);
+
+    const s = readLivenessSources(dir);
+    expect(s.heartbeatAt).toBe(Date.parse('2026-07-10T10:00:00Z'));
+    expect(s.lastCronFireAt).toBe(Date.parse('2026-07-10T10:22:00Z')); // latest of the two
+    expect(Math.abs((s.idleFlagAt ?? 0) - t.getTime())).toBeLessThan(2000);
+  });
+
+  it('returns empty object for a bare state dir', () => {
+    expect(readLivenessSources(stateDir())).toEqual({});
+  });
+
+  it('malformed heartbeat.json falls back to file mtime', () => {
+    const dir = stateDir();
+    writeFileSync(join(dir, 'heartbeat.json'), '{corrupt');
+    const s = readLivenessSources(dir);
+    expect(typeof s.heartbeatAt).toBe('number');
+  });
+});
+
+describe('StalenessDetector sweep', () => {
+  let dirs: string[] = [];
+  afterEach(() => { dirs.forEach(d => rmSync(d, { recursive: true, force: true })); dirs = []; });
+
+  function ctxWithAgent(name: string, hbAgeMin: number, now: number) {
+    const ctxRoot = mkdtempSync(join(tmpdir(), 'stale-ctx-'));
+    dirs.push(ctxRoot);
+    const stateDir = join(ctxRoot, 'state', name);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'heartbeat.json'), JSON.stringify({
+      agent: name,
+      last_heartbeat: new Date(now - hbAgeMin * MIN).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    }));
+    return ctxRoot;
+  }
+
+  it('prods a stale agent once and then respects the cooldown', () => {
+    const now = NOW;
+    const ctxRoot = ctxWithAgent('kirk', 120, now);
+    const notify = vi.fn();
+    const logs: string[] = [];
+    const det = new StalenessDetector({
+      instanceId: 'default',
+      ctxRoot,
+      listAgents: () => [{ name: 'kirk', org: '360i' }],
+      notify: notify as never,
+      now: () => now,
+      log: m => logs.push(m),
+    });
+    det.checkOnce();
+    det.checkOnce(); // same instant — cooldown must suppress
+    expect(notify).toHaveBeenCalledTimes(1);
+    const [, from, target, message] = notify.mock.calls[0];
+    expect(from).toBe('daemon');
+    expect(target).toBe('kirk');
+    expect(message).toMatch(/staleness detector/);
+    expect(logs.join('\n')).toMatch(/ALL liveness sources silent/);
+  });
+
+  it('does NOT prod when a cron fire is fresh even with stale heartbeat', () => {
+    const now = NOW;
+    const ctxRoot = ctxWithAgent('scotty', 120, now);
+    writeFileSync(join(ctxRoot, 'state', 'scotty', 'cron-state.json'), JSON.stringify({
+      updated_at: new Date(now).toISOString(),
+      crons: [{ name: 'file-drop', last_fire: new Date(now - 5 * MIN).toISOString() }],
+    }));
+    const notify = vi.fn();
+    const det = new StalenessDetector({
+      instanceId: 'default', ctxRoot,
+      listAgents: () => [{ name: 'scotty', org: '360i' }],
+      notify: notify as never, now: () => now, log: () => {},
+    });
+    det.checkOnce();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('regression (addendum 3): watchdog-class beat via updateHeartbeat writes the NAMED agent dir and no basename-cwd phantom dir appears', async () => {
+    const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
+    const { resolvePaths } = await import('../../../src/utils/paths.js');
+    // Simulate the daemon environment: cwd basename is the framework checkout
+    const paths = resolvePaths('scotty', 'default');
+    // Write to an isolated fake state dir instead of the real one:
+    const ctxRoot = mkdtempSync(join(tmpdir(), 'stale-reg-'));
+    dirs.push(ctxRoot);
+    const fakePaths = { ...paths, stateDir: join(ctxRoot, 'state', 'scotty') };
+    const before = Date.now();
+    updateHeartbeat(fakePaths as never, 'scotty', '[watchdog] scotty alive — idle session test', { org: '360i' });
+    const hbPath = join(ctxRoot, 'state', 'scotty', 'heartbeat.json');
+    expect(existsSync(hbPath)).toBe(true);
+    const hb = JSON.parse(readFileSync(hbPath, 'utf-8'));
+    expect(hb.agent).toBe('scotty'); // named agent, not basename(cwd)
+    expect(Date.parse(hb.last_heartbeat)).toBeGreaterThanOrEqual(before - 1000);
+    // No phantom dir named after the process cwd basename:
+    expect(existsSync(join(ctxRoot, 'state', basename(process.cwd())))).toBe(false);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     'hooks/hook-compact-telegram': 'src/hooks/hook-compact-telegram.ts',
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
+    'hooks/hook-prompt-flag': 'src/hooks/hook-prompt-flag.ts',
     'hooks/hook-context-status': 'src/hooks/hook-context-status.ts',
     'hooks/hook-loop-detector': 'src/hooks/hook-loop-detector.ts',
   },


### PR DESCRIPTION
## Problem (the core of the 2026-07-09 fleet-stall class, ~3 incidents/day)
Injection has no delivery confirmation anywhere in the chain. `injectMessage()` sends Enter via fire-and-forget setTimeout with failures swallowed ("the dropped Enter is the acceptable cost"), and the fast-checker **ACKs inbox messages on PTY-write success**, not on turn start. When an Enter fails to submit, the pasted content sits in the CLI input box: the session looks idle, the daemon believes everything was delivered, every subsequent injection appends to the same unsubmitted box, and the whole backlog flushes as one batch when any later Enter lands. Boot prompts hit the same race (observed 2h boot stall).

## Fix
- **Turn-start signal**: new `UserPromptSubmit` hook (`hook-prompt-flag`) writes `last_prompt.flag` — the counterpart of the Stop hook's turn-end flag. Added to templates and to `REQUIRED_HOOKS` so the reconciler (#756) distributes it fleet-wide.
- **`injectMessageConfirmed()`**: paste once, send Enter, poll turn-start up to 9 s; no signal → re-send Enter (idempotent against a loaded input box; no content duplication) up to 3 attempts (~28 s worst case), then log `DELIVERY_FAILED` loudly. Baseline captured before the paste so a stale flag cannot false-confirm.
- **Ack-on-confirm**: fast-checker ACKs inbox messages only after turn-start confirms. Unconfirmed messages stay un-ACKed and redeliver in 5 min — closing the lost-message hole. Sessions without the hook yet (`confirmed === null`) fall back to legacy ack-on-write, so no ack deadlock during rollout.
- **Boot prompts covered**: after spawn, verify the boot prompt started a turn (flag advanced past a pre-spawn baseline); if not, re-send Enter up to 3× before logging `DELIVERY_FAILED`.
- **OpenCode PTY opts out** (different paste semantics) and keeps its own injectMessage path.

## Evidence
- 10 new unit tests: first-Enter confirm, dropped-Enter retry-then-confirm, retry exhaustion, chunked-paste path, torn-PTY safety, 30s-gate accounting, and the ack contract (ack on confirmed/legacy, never on DELIVERY_FAILED or failed inject)
- Daemon+pty suites 538/538 on the stack; independently reproduced on a fresh clone by a second agent (adversarial cross-verify pre-PR)
- 28 pre-existing non-daemon sweep failures identical to clean main @ 5a0882d (see #746)

## Honest gaps
1. The boot-prompt check (setTimeout chain) is covered by build+review, not a unit test
2. The confirmation loop is validated for the Claude Code PTY only
3. Per-agent effect begins at each agent's next session restart (hook + settings reconcile) — sequence staggered restarts on deploy

Part 4/4 — stacked on #755 + #756 + #757 (branch contains their commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)