### PR TITLE
fix(hooks): respect worktrees and custom hook paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Run unit tests
         run: npm test
 
+      - name: Test hook installer
+        run: bash tests/setup-hooks.test.sh
+
       - name: Run codex parity tests
         run: npm run test:codex
 

--- a/install.mjs
+++ b/install.mjs
@@ -11,6 +11,7 @@ import { execSync, spawnSync } from 'child_process';
 import { existsSync, mkdirSync, writeFileSync, readdirSync, statSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { homedir, platform } from 'os';
+import { pathToFileURL } from 'url';
 
 const REPO_URL = process.env.CORTEXTOS_REPO || 'https://github.com/grandamenium/cortextos.git';
 const INSTALL_DIR = process.env.CORTEXTOS_DIR || join(homedir(), 'cortextos');
@@ -475,8 +476,12 @@ ok('Build complete');
 
 if (!IS_WINDOWS && existsSync(join(INSTALL_DIR, 'scripts', 'setup-hooks.sh'))) {
   try {
-    run('bash scripts/setup-hooks.sh', { cwd: INSTALL_DIR });
-    ok('Installed git pre-push hook (build + test gate)');
+    const hookOutput = run('bash scripts/setup-hooks.sh', { cwd: INSTALL_DIR });
+    const hookStatusModule = pathToFileURL(join(INSTALL_DIR, 'scripts', 'hook-status.mjs')).href;
+    const { interpretHookInstallerOutput } = await import(hookStatusModule);
+    const hookResult = interpretHookInstallerOutput(hookOutput);
+    if (hookResult.level === 'success') ok(hookResult.message);
+    else warn(hookResult.message);
   } catch {
     warn('Could not install git pre-push hook — run manually: bash scripts/setup-hooks.sh');
   }

--- a/scripts/hook-status.d.mts
+++ b/scripts/hook-status.d.mts
@@ -1,0 +1,6 @@
+export interface HookInstallResult {
+  level: 'success' | 'warning';
+  message: string;
+}
+
+export function interpretHookInstallerOutput(output: string): HookInstallResult;

--- a/scripts/hook-status.mjs
+++ b/scripts/hook-status.mjs
@@ -1,0 +1,31 @@
+const READY_MESSAGE = 'Git pre-push hook ready (build + test gate)';
+
+/**
+ * Convert setup-hooks.sh output into the message level shared by the installer
+ * and CLI. Missing, duplicate, or unknown statuses fail closed as warnings.
+ */
+export function interpretHookInstallerOutput(output) {
+  const matches = [...output.matchAll(/^HOOK_STATUS=(\S+)$/gm)];
+  const status = matches.length === 1 ? matches[0][1] : undefined;
+
+  switch (status) {
+    case 'installed':
+    case 'ready':
+      return { level: 'success', message: READY_MESSAGE };
+    case 'preserved-existing':
+      return {
+        level: 'warning',
+        message: 'Existing pre-push hook preserved; cortextOS build + test gate was not installed',
+      };
+    case 'source-missing':
+      return {
+        level: 'warning',
+        message: 'Tracked pre-push hook source is missing; cortextOS build + test gate was not installed',
+      };
+    default:
+      return {
+        level: 'warning',
+        message: 'Git hook installer returned an unknown status; verify with: bash scripts/setup-hooks.sh',
+      };
+  }
+}

--- a/scripts/setup-hooks.sh
+++ b/scripts/setup-hooks.sh
@@ -15,7 +15,31 @@ REPO_ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
   exit 1
 }
 
-HOOKS_DIR="$REPO_ROOT/.git/hooks"
+HOOKS_PATH="$(git rev-parse --git-path hooks 2>/dev/null)" || {
+  echo "Error: could not resolve this repository's hooks directory." >&2
+  exit 1
+}
+case "$HOOKS_PATH" in
+  /*) HOOKS_DIR="$HOOKS_PATH" ;;
+  *) HOOKS_DIR="$REPO_ROOT/$HOOKS_PATH" ;;
+esac
+mkdir -p "$HOOKS_DIR"
+
+HOOK_STATUS="unavailable"
+
+report_existing_hook() {
+  local src="$1"
+  local dest="$2"
+
+  if cmp -s "$src" "$dest"; then
+    chmod +x "$dest"
+    HOOK_STATUS="ready"
+    echo "  Already installed and executable: $dest"
+  else
+    HOOK_STATUS="preserved-existing"
+    echo "  Skipped: $dest already exists (leaving your hook in place)"
+  fi
+}
 
 install_hook() {
   local name="$1"
@@ -24,6 +48,7 @@ install_hook() {
 
   if [[ ! -f "$src" ]]; then
     echo "Warning: hook source not found: $src (skipping)" >&2
+    HOOK_STATUS="source-missing"
     return
   fi
 
@@ -32,19 +57,40 @@ install_hook() {
   # when the existing hook is byte-identical to ours (already installed). The
   # -L catches a broken symlink too, which -e alone would miss (and then clobber).
   if [[ -e "$dest" || -L "$dest" ]]; then
-    if cmp -s "$src" "$dest"; then
-      echo "  Already installed: .git/hooks/$name"
-    else
-      echo "  Skipped: .git/hooks/$name already exists (leaving your hook in place)"
-    fi
+    report_existing_hook "$src" "$dest"
     return
   fi
 
-  cp "$src" "$dest"
-  chmod +x "$dest"
-  echo "  Installed: .git/hooks/$name"
+  # Build the hook beside its destination, then hard-link it into place. The
+  # link is atomic and fails rather than overwriting a hook created after the
+  # existence check above.
+  local tmp
+  tmp="$(mktemp "$HOOKS_DIR/.${name}.tmp.XXXXXX")"
+  if ! cp "$src" "$tmp" || ! chmod +x "$tmp"; then
+    rm -f "$tmp"
+    return 1
+  fi
+  if ln "$tmp" "$dest" 2>/dev/null; then
+    rm -f "$tmp"
+    HOOK_STATUS="installed"
+    echo "  Installed: $dest"
+  else
+    rm -f "$tmp"
+    if [[ -e "$dest" || -L "$dest" ]]; then
+      report_existing_hook "$src" "$dest"
+    elif (set -o noclobber; cat "$src" > "$dest") 2>/dev/null; then
+      chmod +x "$dest"
+      HOOK_STATUS="installed"
+      echo "  Installed without hard links: $dest"
+    elif [[ -e "$dest" || -L "$dest" ]]; then
+      report_existing_hook "$src" "$dest"
+    else
+      echo "Error: could not install hook at $dest" >&2
+      return 1
+    fi
+  fi
 }
 
 echo "Installing cortextOS git hooks..."
 install_hook pre-push
-echo "Done. Hooks active for this repo clone."
+echo "HOOK_STATUS=$HOOK_STATUS"

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -7,6 +7,7 @@ import { ensureDir } from '../utils/atomic.js';
 import { validateOrgName } from '../utils/validate.js';
 import { stripBom } from '../utils/strip-bom.js';
 import type { OrgContext } from '../types/index.js';
+import { interpretHookInstallerOutput } from '../../scripts/hook-status.mjs';
 
 export const initCommand = new Command('init')
   .argument('<org-name>', 'Organization name')
@@ -215,15 +216,19 @@ export const initCommand = new Command('init')
     }
 
     // Best-effort: install the tracked git pre-push hook (build + test gate) so
-    // this clone gets the gate without a manual step. Non-fatal — only runs when
-    // the project is a git repo AND ships the installer; setup-hooks.sh is
-    // non-clobbering, so this is safe to run on every init.
+    // this clone gets the gate without a manual step. Non-fatal — the installer
+    // owns repository detection and is non-clobbering, so this is safe to run
+    // on every init.
     if (process.platform !== 'win32' &&
-        existsSync(join(projectRoot, '.git')) &&
-        existsSync(join(projectRoot, 'scripts', 'setup-hooks.sh'))) {
+      existsSync(join(projectRoot, 'scripts', 'setup-hooks.sh'))) {
       try {
-        execSync('bash scripts/setup-hooks.sh', { cwd: projectRoot, stdio: 'ignore' });
-        console.log('  Installed git pre-push hook (build + test gate)');
+        const hookOutput = execSync('bash scripts/setup-hooks.sh', {
+          cwd: projectRoot,
+          encoding: 'utf8',
+          stdio: ['ignore', 'pipe', 'pipe'],
+        });
+        const hookResult = interpretHookInstallerOutput(hookOutput);
+        console.log(`  ${hookResult.message}`);
       } catch {
         console.log('  Skipped git pre-push hook install (run: bash scripts/setup-hooks.sh)');
       }

--- a/tests/setup-hooks.test.sh
+++ b/tests/setup-hooks.test.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+fails=0
+
+new_repo() {
+  local repo="$1"
+  mkdir -p "$repo/scripts/hooks"
+  cp "$ROOT/scripts/setup-hooks.sh" "$repo/scripts/setup-hooks.sh"
+  cp "$ROOT/scripts/hooks/pre-push" "$repo/scripts/hooks/pre-push"
+  git -C "$repo" init -q
+  git -C "$repo" add scripts
+  git -C "$repo" -c user.name=Test -c user.email=test@example.com commit -qm fixture
+}
+
+hooks_dir() {
+  local repo="$1"
+  git -C "$repo" rev-parse --path-format=absolute --git-path hooks
+}
+
+repo="$TMP/normal"
+new_repo "$repo"
+out="$(cd "$repo" && bash scripts/setup-hooks.sh)"
+dest="$(hooks_dir "$repo")/pre-push"
+[[ -x "$dest" && "$out" == *"HOOK_STATUS=installed"* ]] \
+  || { echo "FAIL: normal clone did not install an executable hook"; fails=1; }
+
+chmod -x "$dest"
+out="$(cd "$repo" && bash scripts/setup-hooks.sh)"
+[[ -x "$dest" && "$out" == *"HOOK_STATUS=ready"* ]] \
+  || { echo "FAIL: identical non-executable hook was not repaired"; fails=1; }
+
+printf '#!/usr/bin/env bash\necho custom\n' > "$dest"
+chmod +x "$dest"
+cp "$dest" "$TMP/custom-hook.before"
+out="$(cd "$repo" && bash scripts/setup-hooks.sh)"
+[[ "$out" == *"HOOK_STATUS=preserved-existing"* ]] && cmp -s "$dest" "$TMP/custom-hook.before" \
+  || { echo "FAIL: custom hook was not preserved"; fails=1; }
+
+rm "$dest"
+ln -s "$TMP/missing-hook-target" "$dest"
+out="$(cd "$repo" && bash scripts/setup-hooks.sh)"
+[[ -L "$dest" && "$out" == *"HOOK_STATUS=preserved-existing"* ]] \
+  || { echo "FAIL: broken-symlink hook was not preserved"; fails=1; }
+
+missing="$TMP/missing-source"
+new_repo "$missing"
+rm "$missing/scripts/hooks/pre-push"
+out="$(cd "$missing" && bash scripts/setup-hooks.sh 2>"$TMP/missing-source.err")"
+missing_dest="$(hooks_dir "$missing")/pre-push"
+missing_err="$(<"$TMP/missing-source.err")"
+[[ ! -e "$missing_dest" && "$out" == *"HOOK_STATUS=source-missing"* && "$missing_err" == *"hook source not found"* ]] \
+  || { echo "FAIL: missing hook source was not reported without installing"; fails=1; }
+
+race="$TMP/race"
+new_repo "$race"
+race_dest="$(hooks_dir "$race")/pre-push"
+fakebin="$TMP/fakebin"
+mkdir -p "$fakebin"
+real_ln="$(command -v ln)"
+printf '#!/usr/bin/env bash\nprintf "#!/usr/bin/env bash\\necho raced\\n" > "$2"\nchmod +x "$2"\nexec %q "$@"\n' "$real_ln" > "$fakebin/ln"
+chmod +x "$fakebin/ln"
+out="$(cd "$race" && PATH="$fakebin:$PATH" bash scripts/setup-hooks.sh)"
+[[ "$out" == *"HOOK_STATUS=preserved-existing"* && "$(<"$race_dest")" == *"echo raced"* ]] \
+  || { echo "FAIL: concurrently created hook was overwritten"; fails=1; }
+
+no_links="$TMP/no-hard-links"
+new_repo "$no_links"
+no_links_dest="$(hooks_dir "$no_links")/pre-push"
+no_links_bin="$TMP/no-links-bin"
+mkdir -p "$no_links_bin"
+printf '#!/usr/bin/env bash\nexit 1\n' > "$no_links_bin/ln"
+chmod +x "$no_links_bin/ln"
+out="$(cd "$no_links" && PATH="$no_links_bin:$PATH" bash scripts/setup-hooks.sh)"
+[[ -x "$no_links_dest" && "$out" == *"HOOK_STATUS=installed"* ]] \
+  || { echo "FAIL: no-clobber fallback did not install without hard links"; fails=1; }
+
+custom="$TMP/custom"
+new_repo "$custom"
+git -C "$custom" config core.hooksPath .githooks
+out="$(cd "$custom" && bash scripts/setup-hooks.sh)"
+custom_dest="$(hooks_dir "$custom")/pre-push"
+[[ -x "$custom_dest" && "$out" == *"HOOK_STATUS=installed"* ]] \
+  || { echo "FAIL: core.hooksPath was not respected"; fails=1; }
+
+parent="$TMP/parent"
+new_repo "$parent"
+git -C "$parent" branch linked
+linked="$TMP/linked"
+git -C "$parent" worktree add -q "$linked" linked
+out="$(cd "$linked" && bash scripts/setup-hooks.sh)"
+linked_dest="$(hooks_dir "$linked")/pre-push"
+[[ -x "$linked_dest" && "$out" == *"HOOK_STATUS=installed"* ]] \
+  || { echo "FAIL: linked worktree did not resolve the effective hooks directory"; fails=1; }
+
+if [[ "$fails" -eq 0 ]]; then
+  echo "setup-hooks.test: PASS"
+else
+  echo "setup-hooks.test: FAIL"
+  exit 1
+fi

--- a/tests/unit/hook-status.test.ts
+++ b/tests/unit/hook-status.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { interpretHookInstallerOutput } from '../../scripts/hook-status.mjs';
+
+describe('interpretHookInstallerOutput', () => {
+  it.each(['installed', 'ready'])('accepts %s as ready', (status) => {
+    expect(interpretHookInstallerOutput(`installer output\nHOOK_STATUS=${status}\n`)).toEqual({
+      level: 'success',
+      message: 'Git pre-push hook ready (build + test gate)',
+    });
+  });
+
+  it.each([
+    ['preserved-existing', 'Existing pre-push hook preserved; cortextOS build + test gate was not installed'],
+    ['source-missing', 'Tracked pre-push hook source is missing; cortextOS build + test gate was not installed'],
+  ])('maps %s to its warning', (status, message) => {
+    expect(interpretHookInstallerOutput(`HOOK_STATUS=${status}\n`)).toEqual({
+      level: 'warning',
+      message,
+    });
+  });
+
+  it.each([
+    ['missing', 'ordinary installer output'],
+    ['unknown', 'HOOK_STATUS=surprise'],
+    ['duplicate', 'HOOK_STATUS=ready\nHOOK_STATUS=installed'],
+  ])('fails closed for %s status output', (_case, output) => {
+    expect(interpretHookInstallerOutput(output)).toEqual({
+      level: 'warning',
+      message: 'Git hook installer returned an unknown status; verify with: bash scripts/setup-hooks.sh',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Fresh clones can now install the tracked pre-push gate without misplacing it in linked worktrees or overwriting an operator-owned hook. The installer resolves Git's effective hook directory, preserves custom and broken-symlink hooks, and reports outcomes consistently to both installation entry points.

Installation uses an atomic hard-link path with a no-clobber fallback, so a hook created concurrently wins rather than being overwritten. CI now runs the real shell installer scenarios, including custom `core.hooksPath`, worktrees, concurrent creation, missing sources, and filesystems without hard-link support.

Related: #405
Follow-up to #704.

## Validation

- `bash tests/setup-hooks.test.sh`
- `npx vitest run tests/unit/hook-status.test.ts`
- `npm run typecheck`
- `npm run build`
- Full suite serialized on macOS: 117 files passed, 1 skipped; 1,960 tests passed, 3 skipped

The default parallel local runner has a pre-existing cross-file Git-environment race; GitHub's Linux CI remains the merge gate.

## New concepts

### Atomic no-clobber installation

The hook is prepared beside its destination, then linked into place atomically. If the filesystem cannot create hard links, Bash's `noclobber` redirection provides an exclusive-create fallback. Both paths preserve a destination that appears during installation; this pattern is useful for small local installers, but not as a substitute for transactional deployment of multi-file state.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-Codex-000000)
