### PR TITLE
fix(bus/daemon): ack-path defects — reply_to send-time ack, dual-dir ackInbox, DEFERRED_CONFIRM with payload attribution

### DIFF
--- a/src/bus/message.ts
+++ b/src/bus/message.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, renameSync, statSync, existsSync } from 'fs';
+import { readdirSync, readFileSync, renameSync, statSync, existsSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { InboxMessage, Priority, BusPaths } from '../types/index.js';
@@ -84,6 +84,18 @@ export function sendMessage(
   ensureDir(inboxDir);
   atomicWriteSync(join(inboxDir, filename), JSON.stringify(message));
 
+  // A reply IS proof the replied-to message was delivered and read: ack the
+  // original in the sender's own inflight/inbox. reply_to was previously
+  // stored as metadata only, so every replied-to message redelivered after
+  // 5 minutes (D1, 2026-07-10).
+  if (replyTo) {
+    try {
+      ackInbox(paths, replyTo);
+    } catch {
+      // Best-effort: a missing or already-acked original must not fail the send.
+    }
+  }
+
   return msgId;
 }
 
@@ -164,45 +176,134 @@ export function checkInbox(paths: BusPaths): InboxMessage[] {
 }
 
 /**
- * Acknowledge a message by moving it from inflight to processed.
- * Identical to bash ack-inbox.sh behavior.
+ * Acknowledge a message by moving it to processed.
+ *
+ * Scans BOTH inflight and inbox: a message recovered by recoverStaleInflight
+ * sits back in inbox — an explicit ack while it waits there used to be a
+ * silent no-op, so the message redelivered anyway (D3, 2026-07-10).
  */
 export function ackInbox(paths: BusPaths, messageId: string): void {
-  const { inflight, processed } = paths;
+  const { inflight, inbox, processed } = paths;
   ensureDir(processed);
 
-  // Find the file in inflight that contains this message ID
-  let files: string[];
-  try {
-    files = readdirSync(inflight).filter(f => f.endsWith('.json'));
-  } catch {
-    return;
-  }
-
-  for (const file of files) {
-    const filePath = join(inflight, file);
+  for (const dir of [inflight, inbox]) {
+    let files: string[];
     try {
-      const content = readFileSync(filePath, 'utf-8');
-      const msg = JSON.parse(content);
-      if (msg.id === messageId) {
-        renameSync(filePath, join(processed, file));
-        return;
-      }
+      files = readdirSync(dir).filter(f => f.endsWith('.json') && !f.startsWith('.'));
     } catch {
-      // Skip corrupt files
+      continue;
+    }
+
+    for (const file of files) {
+      const filePath = join(dir, file);
+      try {
+        const content = readFileSync(filePath, 'utf-8');
+        const msg = JSON.parse(content);
+        if (msg.id === messageId) {
+          renameSync(filePath, join(processed, file));
+          clearDeferredMarker(inflight, file);
+          return;
+        }
+      } catch {
+        // Skip corrupt files
+      }
     }
   }
 }
 
+// ---------------------------------------------------------------------------
+// Deferred-confirmation markers (G-D2-6/G-D2-7, 2026-07-10)
+//
+// A message injected into an alive-but-mid-turn session is held in
+// DEFERRED_CONFIRM by the daemon: its content is queued in the CLI input box
+// and will flush at the next turn boundary, so it must NOT be recovered and
+// re-injected by the 300s stale-inflight sweep — that recreates the exact
+// redelivery loop the deferral exists to kill. The exemption lives HERE
+// because agent CLIs call recoverStaleInflight via every check-inbox, not
+// just the daemon.
+//
+// Markers are plain files in <inflight>/.deferred/<message-filename>.json and
+// carry the ORIGINAL hold deadline. They are a pure function of visible state
+// (rebuild-on-boot; cannot leak by construction): the daemon rederives its
+// watch list from them, and a marker whose deadline passed — or whose message
+// file is gone — is deleted on sight by the sweep itself.
+// ---------------------------------------------------------------------------
+
+export interface DeferredMarker {
+  /** ms epoch when the paste was injected (hold START — never refreshed). */
+  injectedAt: number;
+  /** ms epoch when the G-D2-5 timeout expires (original clock; a daemon
+   *  restart mid-hold must honor this, not stamp a fresh one). */
+  deadline: number;
+  /** sha256 of the injected content block, for confirm attribution. */
+  contentSha: string;
+  /** The injected content block, so a rebooted daemon can resume the
+   *  substring-attribution check for this hold. Same trust boundary as the
+   *  message file sitting next to it. */
+  content: string;
+}
+
+function deferredDir(inflightDir: string): string {
+  return join(inflightDir, '.deferred');
+}
+
+export function writeDeferredMarker(inflightDir: string, messageFile: string, marker: DeferredMarker): void {
+  const dir = deferredDir(inflightDir);
+  ensureDir(dir);
+  atomicWriteSync(join(dir, `${messageFile}.marker`), JSON.stringify(marker));
+}
+
+export function clearDeferredMarker(inflightDir: string, messageFile: string): void {
+  try {
+    unlinkSync(join(deferredDir(inflightDir), `${messageFile}.marker`));
+  } catch {
+    // Already gone — fine.
+  }
+}
+
+export function readDeferredMarker(inflightDir: string, messageFile: string): DeferredMarker | null {
+  try {
+    return JSON.parse(readFileSync(join(deferredDir(inflightDir), `${messageFile}.marker`), 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+/** List all live markers (message file still present). Orphans are deleted. */
+export function listDeferredMarkers(inflightDir: string): Array<{ messageFile: string; marker: DeferredMarker }> {
+  const dir = deferredDir(inflightDir);
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter(f => f.endsWith('.marker'));
+  } catch {
+    return [];
+  }
+  const out: Array<{ messageFile: string; marker: DeferredMarker }> = [];
+  for (const f of files) {
+    const messageFile = f.slice(0, -'.marker'.length);
+    const marker = readDeferredMarker(inflightDir, messageFile);
+    if (!marker || !existsSync(join(inflightDir, messageFile))) {
+      // Orphan (unreadable, or its message was acked/recovered without cleanup).
+      try { unlinkSync(join(dir, f)); } catch { /* ignore */ }
+      continue;
+    }
+    out.push({ messageFile, marker });
+  }
+  return out;
+}
+
 /**
  * Recover stale inflight messages (older than thresholdSeconds) back to inbox.
+ * Messages under an active deferred-confirmation hold are exempt until their
+ * ORIGINAL deadline passes (G-D2-6); expired or orphaned markers are removed.
  */
 function recoverStaleInflight(
   inflightDir: string,
   inboxDir: string,
   thresholdSeconds: number,
 ): void {
-  const now = Math.floor(Date.now() / 1000);
+  const nowMs = Date.now();
+  const now = Math.floor(nowMs / 1000);
   let files: string[];
   try {
     files = readdirSync(inflightDir).filter(f => f.endsWith('.json'));
@@ -213,6 +314,13 @@ function recoverStaleInflight(
   for (const file of files) {
     const filePath = join(inflightDir, file);
     try {
+      const marker = readDeferredMarker(inflightDir, file);
+      if (marker) {
+        if (nowMs < marker.deadline) {
+          continue; // active hold — exempt from recovery
+        }
+        clearDeferredMarker(inflightDir, file); // hold expired — normal recovery resumes
+      }
       const stat = statSync(filePath);
       const mtime = Math.floor(stat.mtimeMs / 1000);
       if (now - mtime > thresholdSeconds) {
@@ -222,4 +330,7 @@ function recoverStaleInflight(
       // Ignore stat/move errors
     }
   }
+
+  // GC markers whose message file is gone (acked or recovered elsewhere).
+  listDeferredMarkers(inflightDir);
 }

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -2471,6 +2471,11 @@ busCommand
   .action(() => runHook('hook-idle-flag'));
 
 busCommand
+  .command('hook-prompt-flag')
+  .description('UserPromptSubmit hook: writes last_prompt.flag timestamp so the daemon delivery-confirmation loop knows a turn started')
+  .action(() => runHook('hook-prompt-flag'));
+
+busCommand
   .command('hook-loop-detector')
   .description('PreToolUse hook: detects and blocks repeated tool loops (same-args repetition + ping-pong alternation)')
   .action(() => runHook('hook-loop-detector'));

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -6,6 +6,7 @@ import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { migrateCronsForAgent } from './cron-migration.js';
+import { ensureRequiredHooks } from './hook-reconciler.js';
 import type { CronDefinition } from '../types/index.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
@@ -291,6 +292,10 @@ export class AgentManager {
     if (!config) {
       config = this.loadAgentConfig(agentDir);
     }
+
+    // Reconcile required hooks into the agent's settings (agents spawned
+    // from older templates may lack them — 2026-07-09 stall diagnosis #1).
+    ensureRequiredHooks(agentDir, (msg) => console.log(`[agent-manager] ${name}: ${msg}`));
 
     const env: CtxEnv = {
       instanceId: this.instanceId,

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -976,6 +976,13 @@ export class AgentManager {
   }
 
   /**
+   * Live roster with orgs — consumed by the daemon staleness detector.
+   */
+  getAgentRoster(): Array<{ name: string; org: string }> {
+    return [...this.agents.entries()].map(([name, v]) => ({ name, org: v.process.org }));
+  }
+
+  /**
    * Return the CronScheduler for a given agent (for testing / introspection).
    * Returns undefined if no scheduler is running for that agent.
    */

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -21,6 +21,8 @@ type LogFn = (msg: string) => void;
  */
 export class AgentProcess {
   readonly name: string;
+  /** Agent's org (read-only view of env.org) — used by fast-checker heartbeat writes. */
+  get org(): string { return this.env.org; }
   private env: CtxEnv;
   private config: AgentConfig;
   private pty: AgentPTY | CodexAppServerPTY | null = null;

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -441,6 +441,9 @@ export class AgentProcess {
     const res = await loop;
     if (!res.confirmed) {
       this.log(`DELIVERY_FAILED: no turn-start after ${res.enterAttempts} Enter attempts — content may be stuck in the input box`);
+      // The un-ACKed message will redeliver with identical content; drop the
+      // dedup hash so the retry is not silently swallowed as a duplicate.
+      this.dedup.forget(content);
     }
     return { ok: true, ...res };
   }

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -1,4 +1,5 @@
 import { appendFileSync, existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'fs';
+import { createHash } from 'crypto';
 import { join, sep } from 'path';
 import { homedir } from 'os';
 import type { AgentConfig, AgentStatus, CtxEnv } from '../types/index.js';
@@ -369,6 +370,10 @@ export class AgentProcess {
     return join(this.env.ctxRoot, 'state', this.name, 'last_prompt.flag');
   }
 
+  private promptTextPath(): string {
+    return join(this.env.ctxRoot, 'state', this.name, 'last_prompt.txt');
+  }
+
   /** mtime of last_prompt.flag in ms epoch; 0 when it has never been written. */
   promptFlagMtimeMs(): number {
     try {
@@ -379,19 +384,63 @@ export class AgentProcess {
   }
 
   /**
-   * Inject with delivery confirmation (2026-07-09 dropped-Enter stall class).
+   * Read the turn-start flag with its attribution payload (G-D2-2).
+   * hashCapable=false for the legacy plain-integer flag format (older hook) —
+   * confirmation then degrades to mtime-only for this agent.
+   */
+  promptFlagInfo(): { mtimeMs: number; sha256: string | null; hashCapable: boolean } {
+    const mtimeMs = this.promptFlagMtimeMs();
+    if (mtimeMs === 0) return { mtimeMs: 0, sha256: null, hashCapable: false };
+    try {
+      const raw = readFileSync(this.promptFlagPath(), 'utf-8').trim();
+      if (raw.startsWith('{')) {
+        const parsed = JSON.parse(raw) as { sha256?: string | null };
+        return { mtimeMs, sha256: parsed.sha256 ?? null, hashCapable: true };
+      }
+    } catch {
+      // Unreadable — treat as legacy.
+    }
+    return { mtimeMs, sha256: null, hashCapable: false };
+  }
+
+  /** True when the last submitted prompt (last_prompt.txt) contains `content`.
+   *  Per-injection attribution: one turn-start can flush N queued pastes and
+   *  each injection must find ITS OWN payload in the flushed prompt (G-D2-4). */
+  submittedPromptContains(content: string): boolean {
+    try {
+      return readFileSync(this.promptTextPath(), 'utf-8').includes(content);
+    } catch {
+      return false;
+    }
+  }
+
+  /** Drop the dedup hash for a content block so its redelivery can inject.
+   *  Used by the deferred-confirmation tracker on G-D2-5 timeout. */
+  forgetDedup(content: string): void {
+    this.dedup.forget(content);
+  }
+
+  /**
+   * Inject with delivery confirmation (2026-07-09 dropped-Enter stall class;
+   * reworked 2026-07-10 for attribution + deferral — ACKFIX_REQUIREMENTS.md).
    *
    * confirmed values:
-   *   true  — turn-start signal observed (UserPromptSubmit hook fired)
-   *   false — Enter retries exhausted with no turn-start: DELIVERY FAILED,
-   *           content likely sitting in the input box; caller must NOT ack
+   *   true  — turn started AND this payload appears in the submitted prompt
+   *           (attributed confirm; mtime-only on legacy hook flag format)
+   *   false — not confirmed within the fast window. When `deferred` is set,
+   *           the session is alive with an attribution channel: the paste is
+   *           queued for the next turn boundary (DEFERRED_CONFIRM, G-D2-1) —
+   *           caller must NOT ack yet, must NOT treat as failed, and should
+   *           track the hold until `deferred.deadline` (G-D2-5). Without
+   *           `deferred`, this is a legacy-channel DELIVERY_FAILED.
    *   null  — no confirmation channel for this agent (hook never seen for
    *           this agent, or runtime opts out): legacy fire-and-forget path
    */
   async injectMessageConfirmedDetailed(
     content: string,
   ): Promise<
-    | { ok: true; confirmed: boolean | null; enterAttempts: number }
+    | { ok: true; confirmed: boolean | null; enterAttempts: number;
+        deferred?: { injectedAt: number; deadline: number; contentSha: string } }
     | { ok: false; code: 'NOT_RUNNING' | 'DEDUPED'; message: string }
   > {
     if (!this.pty || this.status !== 'running') {
@@ -422,6 +471,15 @@ export class AgentProcess {
     }
 
     const injectedAt = Date.now();
+    const contentSha = createHash('sha256').update(content, 'utf-8').digest('hex');
+    // Capability probe BEFORE injecting: hash attribution needs the JSON flag
+    // format. Legacy plain-integer flags (older hook) keep the mtime-only
+    // predicate and the fast-fail path (G-D2-3 fallback family).
+    const hashCapable = this.promptFlagInfo().hashCapable;
+    const isConfirmed = hashCapable
+      ? () => this.promptFlagMtimeMs() > injectedAt && this.submittedPromptContains(content)
+      : () => this.promptFlagMtimeMs() > injectedAt;
+
     const pty = this.pty as unknown as {
       injectMessageConfirmed: (
         c: string,
@@ -430,7 +488,7 @@ export class AgentProcess {
       injectMessage: (c: string) => void;
     };
     const loop = pty.injectMessageConfirmed(content, {
-      isConfirmed: () => this.promptFlagMtimeMs() > injectedAt,
+      isConfirmed,
       log: (m) => this.log(m),
     });
     if (loop === null) {
@@ -439,14 +497,48 @@ export class AgentProcess {
       return { ok: true, confirmed: null, enterAttempts: 1 };
     }
     const res = await loop;
-    if (!res.confirmed) {
-      this.log(`DELIVERY_FAILED: no turn-start after ${res.enterAttempts} Enter attempts — content may be stuck in the input box`);
-      // The un-ACKed message will redeliver with identical content; drop the
-      // dedup hash so the retry is not silently swallowed as a duplicate.
-      this.dedup.forget(content);
+
+    // Confirm-time instrumentation (kirk-approved scope): every verdict logs
+    // the raw predicate inputs so the next anomaly self-documents.
+    const flag = this.promptFlagInfo();
+    const instrument = (verdict: string) => this.log(
+      `[confirm] verdict=${verdict} flagMtime=${Math.round(flag.mtimeMs)} injectedAt=${injectedAt} ` +
+      `delta=${Math.round(flag.mtimeMs - injectedAt)}ms flagSha=${flag.sha256 ? flag.sha256.slice(0, 12) : 'n/a'} ` +
+      `payloadSha=${contentSha.slice(0, 12)} hashCapable=${hashCapable} enterAttempts=${res.enterAttempts}`,
+    );
+
+    if (res.confirmed) {
+      instrument('CONFIRMED');
+      return { ok: true, ...res };
     }
+
+    if (hashCapable) {
+      // Alive session, attribution channel present, payload not yet submitted:
+      // the paste is queued in the input box and will flush at the next turn
+      // boundary (kirk 14:00Z false-negative class). This is DEFERRED_CONFIRM
+      // (G-D2-1), not a failure — the dedup hash is KEPT during the hold so
+      // recovery/redelivery cannot double-inject; the tracker clears ALL dedup
+      // state if the G-D2-5 deadline expires.
+      const deferred = {
+        injectedAt,
+        deadline: injectedAt + AgentProcess.DEFERRED_CONFIRM_TIMEOUT_MS,
+        contentSha,
+      };
+      instrument('DEFERRED');
+      return { ok: true, ...res, deferred };
+    }
+
+    instrument('FAILED');
+    this.log(`DELIVERY_FAILED: no turn-start after ${res.enterAttempts} Enter attempts — content may be stuck in the input box`);
+    // The un-ACKed message will redeliver with identical content; drop the
+    // dedup hash so the retry is not silently swallowed as a duplicate.
+    this.dedup.forget(content);
     return { ok: true, ...res };
   }
+
+  /** G-D2-5: how long a DEFERRED_CONFIRM hold lasts before it times out to
+   *  DELIVERY_FAILED + dedup-forget + redelivery. */
+  static readonly DEFERRED_CONFIRM_TIMEOUT_MS = 10 * 60_000;
 
   /**
    * Boot-prompt delivery check. The startup/continue prompt is passed as a

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -171,7 +171,9 @@ export class AgentProcess {
     });
 
     try {
+      const spawnedAtMs = Date.now(); // before spawn: the boot prompt may submit while spawn() awaits bootstrap
       await this.pty.spawn(mode, prompt);
+      this.startBootDeliveryCheck(spawnedAtMs);
       // Codex exec-per-turn race: the new PTY's onExit can fire BEFORE this
       // line if `codex exec` completes its prompt quickly (CodexAppServerPTY's spawn
       // resolves once exec is launched, but the process may exit moments
@@ -361,6 +363,124 @@ export class AgentProcess {
    */
   injectMessage(content: string): boolean {
     return this.injectMessageDetailed(content).ok;
+  }
+
+  private promptFlagPath(): string {
+    return join(this.env.ctxRoot, 'state', this.name, 'last_prompt.flag');
+  }
+
+  /** mtime of last_prompt.flag in ms epoch; 0 when it has never been written. */
+  promptFlagMtimeMs(): number {
+    try {
+      return statSync(this.promptFlagPath()).mtimeMs;
+    } catch {
+      return 0;
+    }
+  }
+
+  /**
+   * Inject with delivery confirmation (2026-07-09 dropped-Enter stall class).
+   *
+   * confirmed values:
+   *   true  — turn-start signal observed (UserPromptSubmit hook fired)
+   *   false — Enter retries exhausted with no turn-start: DELIVERY FAILED,
+   *           content likely sitting in the input box; caller must NOT ack
+   *   null  — no confirmation channel for this agent (hook never seen for
+   *           this agent, or runtime opts out): legacy fire-and-forget path
+   */
+  async injectMessageConfirmedDetailed(
+    content: string,
+  ): Promise<
+    | { ok: true; confirmed: boolean | null; enterAttempts: number }
+    | { ok: false; code: 'NOT_RUNNING' | 'DEDUPED'; message: string }
+  > {
+    if (!this.pty || this.status !== 'running') {
+      return { ok: false, code: 'NOT_RUNNING', message: `agent "${this.name}" is registered but not running (status: ${this.status})` };
+    }
+    if (this.dedup.isDuplicate(content)) {
+      this.log('Dedup: skipping duplicate message');
+      return { ok: false, code: 'DEDUPED', message: `inject for "${this.name}" deduped — content matches MessageDedup hash window` };
+    }
+
+    // The confirmation channel is the UserPromptSubmit hook's flag. If it has
+    // never been written for this agent, the session predates the hook (or
+    // the settings lack it) — requiring confirmation would deadlock acks, so
+    // fall back to the legacy path.
+    const hookSeen = this.promptFlagMtimeMs() > 0;
+    const confirmable =
+      hookSeen &&
+      'injectMessageConfirmed' in this.pty &&
+      typeof (this.pty as { injectMessageConfirmed?: unknown }).injectMessageConfirmed === 'function';
+
+    if (!confirmable) {
+      if ('injectMessage' in this.pty && typeof this.pty.injectMessage === 'function') {
+        this.pty.injectMessage(content);
+      } else {
+        injectMessageIntoPty((data) => this.pty?.write(data), content);
+      }
+      return { ok: true, confirmed: null, enterAttempts: 1 };
+    }
+
+    const injectedAt = Date.now();
+    const pty = this.pty as unknown as {
+      injectMessageConfirmed: (
+        c: string,
+        o: { isConfirmed: () => boolean; log?: (m: string) => void },
+      ) => Promise<{ confirmed: boolean; enterAttempts: number }> | null;
+      injectMessage: (c: string) => void;
+    };
+    const loop = pty.injectMessageConfirmed(content, {
+      isConfirmed: () => this.promptFlagMtimeMs() > injectedAt,
+      log: (m) => this.log(m),
+    });
+    if (loop === null) {
+      // Runtime opted out (OpenCode) — use its own paste path.
+      pty.injectMessage(content);
+      return { ok: true, confirmed: null, enterAttempts: 1 };
+    }
+    const res = await loop;
+    if (!res.confirmed) {
+      this.log(`DELIVERY_FAILED: no turn-start after ${res.enterAttempts} Enter attempts — content may be stuck in the input box`);
+    }
+    return { ok: true, ...res };
+  }
+
+  /**
+   * Boot-prompt delivery check. The startup/continue prompt is passed as a
+   * CLI argument, but its submission can still be lost to the same
+   * turn-boundary race as injected messages (observed: mccoy boot stall
+   * 2026-07-10 06:05-08:08Z). After bootstrap, verify a turn actually
+   * started (last_prompt.flag advanced past spawn time); if not, re-send
+   * Enter up to 3 times, then log DELIVERY_FAILED loudly.
+   */
+  private startBootDeliveryCheck(spawnedAtMs: number): void {
+    if (this.promptFlagMtimeMs() === 0) return; // hook never seen — no signal to check
+    const pty = this.pty as unknown as { sendEnter?: () => void } | null;
+    if (!pty || typeof pty.sendEnter !== 'function') return;
+
+    const INITIAL_GRACE_MS = 30_000;
+    const RETRY_INTERVAL_MS = 10_000;
+    const MAX_RETRIES = 3;
+    let retries = 0;
+
+    const check = () => {
+      if (!this.pty || this.status !== 'running') return;
+      if (this.promptFlagMtimeMs() > spawnedAtMs) return; // boot prompt submitted
+      if (retries >= MAX_RETRIES) {
+        this.log('DELIVERY_FAILED: boot prompt never started a turn after Enter retries');
+        return;
+      }
+      retries++;
+      this.log(`Boot-prompt delivery check: no turn-start yet — sending Enter (retry ${retries}/${MAX_RETRIES})`);
+      try {
+        (this.pty as unknown as { sendEnter: () => void }).sendEnter();
+      } catch { /* pty torn down */ }
+      const timer = setTimeout(check, RETRY_INTERVAL_MS);
+      timer.unref?.();
+    };
+
+    const timer = setTimeout(check, INITIAL_GRACE_MS);
+    timer.unref?.();
   }
 
   /**

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import { hardRestart } from '../bus/system.js';
 import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
-import { checkInbox, ackInbox } from '../bus/message.js';
+import { checkInbox, ackInbox, writeDeferredMarker, clearDeferredMarker, listDeferredMarkers } from '../bus/message.js';
 import { updateApproval } from '../bus/approval.js';
 import { AgentProcess } from './agent-process.js';
 import type { TelegramAPI } from '../telegram/api.js';
@@ -58,6 +58,19 @@ export class FastChecker {
 
   // SIGUSR1 wake: resolve to immediately wake from sleep
   private wakeResolve: (() => void) | null = null;
+
+  // DEFERRED_CONFIRM holds (ACKFIX G-D2-1..7): injections paste-queued into an
+  // alive-but-mid-turn session, awaiting attribution at the next turn boundary.
+  // Mirrored on disk as inflight/.deferred markers so stale-inflight recovery
+  // exempts them and a daemon restart rebuilds this list with the ORIGINAL
+  // deadline (a restart must never extend a hold — G-D2-7 clock rule).
+  private deferredHolds: Array<{
+    ackIds: string[];
+    content: string;
+    contentSha: string;
+    injectedAt: number;
+    deadline: number;
+  }> = [];
 
   // Idle-session heartbeat watchdog
   private heartbeatTimer: NodeJS.Timeout | null = null;
@@ -124,6 +137,13 @@ export class FastChecker {
     await this.waitForBootstrap();
     this.log('Bootstrap complete. Beginning poll loop.');
 
+    // Rebuild DEFERRED_CONFIRM holds from on-disk markers (G-D2-7): the
+    // registry is a pure function of visible state, and rebuilt entries keep
+    // their ORIGINAL deadline — a daemon restart mid-hold must not reset the
+    // 10-min timeout (a crash-looping daemon would otherwise extend holds
+    // unbounded and messages would never time out to redelivery).
+    this.rebuildDeferredHolds();
+
     // Idle-session heartbeat watchdog: fires every 50 min regardless of REPL state
     const HEARTBEAT_INTERVAL_MS = 50 * 60 * 1000;
     const agentName = this.agent.name;
@@ -188,10 +208,97 @@ export class FastChecker {
     this.telegramMessages.push({ formatted, ackIds: [] });
   }
 
+  /** Find the inflight filename holding a given message id (marker key). */
+  private findInflightFileById(messageId: string): string | null {
+    try {
+      for (const file of readdirSync(this.paths.inflight).filter(f => f.endsWith('.json'))) {
+        try {
+          const msg = JSON.parse(readFileSync(join(this.paths.inflight, file), 'utf-8'));
+          if (msg.id === messageId) return file;
+        } catch { /* skip corrupt */ }
+      }
+    } catch { /* no inflight dir yet */ }
+    return null;
+  }
+
+  /** Open a DEFERRED_CONFIRM hold: in-memory entry + on-disk markers. */
+  private registerDeferredHold(
+    ackIds: string[],
+    content: string,
+    deferred: { injectedAt: number; deadline: number; contentSha: string },
+  ): void {
+    for (const id of ackIds) {
+      const file = this.findInflightFileById(id);
+      if (file) {
+        writeDeferredMarker(this.paths.inflight, file, { ...deferred, content });
+      }
+    }
+    this.deferredHolds.push({ ackIds: [...ackIds], content, ...deferred });
+    this.log(`DEFERRED_CONFIRM: hold opened for ${ackIds.length} message(s), sha=${deferred.contentSha.slice(0, 12)}, deadline=${new Date(deferred.deadline).toISOString()}`);
+  }
+
+  /** Rebuild holds from on-disk markers after a daemon restart (G-D2-7). */
+  private rebuildDeferredHolds(): void {
+    const markers = listDeferredMarkers(this.paths.inflight);
+    const bySha = new Map<string, { files: string[]; injectedAt: number; deadline: number; content: string }>();
+    for (const { messageFile, marker } of markers) {
+      const e = bySha.get(marker.contentSha) ??
+        { files: [], injectedAt: marker.injectedAt, deadline: marker.deadline, content: marker.content };
+      e.files.push(messageFile);
+      bySha.set(marker.contentSha, e);
+    }
+    for (const [contentSha, e] of bySha) {
+      const ackIds: string[] = [];
+      for (const file of e.files) {
+        try {
+          ackIds.push(JSON.parse(readFileSync(join(this.paths.inflight, file), 'utf-8')).id);
+        } catch { /* skip */ }
+      }
+      if (!ackIds.length) continue;
+      this.deferredHolds.push({ ackIds, content: e.content, contentSha, injectedAt: e.injectedAt, deadline: e.deadline });
+      this.log(`DEFERRED_CONFIRM: hold rebuilt from markers (${ackIds.length} message(s), original deadline ${new Date(e.deadline).toISOString()})`);
+    }
+  }
+
+  /** Resolve DEFERRED_CONFIRM holds: attributed confirm → ack; deadline passed
+   *  → DELIVERY_FAILED + forget ALL dedup state for the block (G-D2-5) so the
+   *  now-unblocked recovery redelivery is not swallowed as a duplicate. */
+  private checkDeferredHolds(): void {
+    if (!this.deferredHolds.length) return;
+    const now = Date.now();
+    this.deferredHolds = this.deferredHolds.filter((hold) => {
+      const flagMtime = this.agent.promptFlagMtimeMs();
+      const attributed = flagMtime > hold.injectedAt && this.agent.submittedPromptContains(hold.content);
+      if (attributed) {
+        for (const id of hold.ackIds) {
+          ackInbox(this.paths, id); // ackInbox clears the marker with the file
+        }
+        this.log(`[confirm] verdict=CONFIRMED-DEFERRED flagMtime=${Math.round(flagMtime)} injectedAt=${hold.injectedAt} ` +
+          `heldMs=${now - hold.injectedAt} payloadSha=${hold.contentSha.slice(0, 12)} acked=${hold.ackIds.length}`);
+        return false;
+      }
+      if (now >= hold.deadline) {
+        for (const id of hold.ackIds) {
+          const file = this.findInflightFileById(id);
+          if (file) clearDeferredMarker(this.paths.inflight, file);
+        }
+        this.agent.forgetDedup(hold.content);
+        this.log(`DELIVERY_FAILED: deferred-confirm timeout after ${Math.round((now - hold.injectedAt) / 1000)}s — ` +
+          `${hold.ackIds.length} message(s) released to stale-inflight recovery, payloadSha=${hold.contentSha.slice(0, 12)}`);
+        return false;
+      }
+      return true;
+    });
+  }
+
   /**
    * Single poll cycle: check inbox + queued Telegram messages.
    */
   private async pollCycle(): Promise<void> {
+    // Resolve any DEFERRED_CONFIRM holds first: a hold confirming at the turn
+    // boundary must ack before this cycle's checkInbox can re-read anything.
+    this.checkDeferredHolds();
+
     let messageBlock = '';
     const ackIds: string[] = [];
 
@@ -232,6 +339,12 @@ export class FastChecker {
           this.lastMessageInjectedAt = Date.now();
         }
         // Cooldown after injection
+        await sleep(5000);
+      } else if (result.ok && 'deferred' in result && result.deferred) {
+        // DEFERRED_CONFIRM (G-D2-1): the paste is queued in an alive-but-
+        // mid-turn session. Not acked, not failed — hold until the payload is
+        // attributed at a turn boundary or the G-D2-5 deadline passes.
+        this.registerDeferredHold(ackIds, messageBlock, result.deferred);
         await sleep(5000);
       }
     }

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -1,5 +1,5 @@
 import { readdirSync, readFileSync, existsSync, writeFileSync, unlinkSync, statSync } from 'fs';
-import { execFile } from 'child_process';
+import { updateHeartbeat } from '../bus/heartbeat.js';
 import { join } from 'path';
 import { createHash } from 'crypto';
 import { hardRestart } from '../bus/system.js';
@@ -129,9 +129,17 @@ export class FastChecker {
     const agentName = this.agent.name;
     this.heartbeatTimer = setInterval(() => {
       const ts = new Date().toISOString();
-      execFile('cortextos', ['bus', 'update-heartbeat', `[watchdog] ${agentName} alive — idle session ${ts}`], (err) => {
-        if (err) this.log(`Heartbeat watchdog error: ${err.message}`);
-      });
+      // In-process write with EXPLICIT agentName. The previous execFile
+      // shell-out inherited the daemon's env/cwd, where CTX_AGENT_NAME is
+      // unset — resolveEnv fell back to basename(cwd), so every agent's
+      // watchdog beat landed in one phantom state dir named after the
+      // framework checkout instead of the agent (2026-07-10 diagnosis,
+      // addendum 3). In-process removes the ambient-env failure class.
+      try {
+        updateHeartbeat(this.paths, agentName, `[watchdog] ${agentName} alive — idle session ${ts}`, { org: this.agent.org });
+      } catch (err) {
+        this.log(`Heartbeat watchdog error: ${err}`);
+      }
     }, HEARTBEAT_INTERVAL_MS);
 
     while (this.running) {

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -212,13 +212,19 @@ export class FastChecker {
 
     // Inject if there's anything
     if (messageBlock) {
-      const injected = this.agent.injectMessage(messageBlock);
-      if (injected) {
-        // ACK inbox messages
+      const result =
+        typeof this.agent.injectMessageConfirmedDetailed === 'function'
+          ? await this.agent.injectMessageConfirmedDetailed(messageBlock)
+          : ({ ok: this.agent.injectMessage(messageBlock), confirmed: null, enterAttempts: 1 } as const);
+      if (result.ok && result.confirmed !== false) {
+        // ACK only once delivery is confirmed (turn started) or when no
+        // confirmation channel exists (legacy sessions, confirmed === null).
+        // Ack-on-write was how messages got marked delivered while the
+        // content sat in a stuck input box (2026-07-09 stall class).
         for (const id of ackIds) {
           ackInbox(this.paths, id);
         }
-        this.log(`Injected ${messageBlock.length} bytes`);
+        this.log(`Injected ${messageBlock.length} bytes${result.confirmed === true ? ` (delivery confirmed, ${result.enterAttempts} Enter attempt${result.enterAttempts > 1 ? 's' : ''})` : ''}`);
         // Only update typing timestamp for Telegram messages, not inbox/cron.
         // Inbox messages (agent-to-agent, session continuations) must not
         // restart the typing indicator after Stop has cleared it.

--- a/src/daemon/hook-reconciler.ts
+++ b/src/daemon/hook-reconciler.ts
@@ -1,0 +1,107 @@
+/**
+ * Hook reconciler — ensures every agent's .claude/settings.json carries the
+ * cortextOS-required hooks, regardless of which template version the agent
+ * was originally spawned from.
+ *
+ * Background (2026-07-09 stall diagnosis, secondary finding #1): agents
+ * created before a template gained a hook never receive it — kirk and spock
+ * lacked the Stop → hook-idle-flag entry entirely, so last_idle.flag never
+ * wrote and the fast-checker's turn-end signal was silently absent for those
+ * agents. Settings were written once at spawn and never reconciled.
+ *
+ * Called from AgentManager.startAgent() so the guarantee holds on every
+ * agent start. Additive only: existing hook entries (including user-added
+ * ones) are never modified or removed; a required hook is appended only when
+ * no entry for that event already runs the same command. Malformed settings
+ * files are left untouched (loud log) rather than clobbered.
+ */
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { atomicWriteSync } from '../utils/atomic.js';
+
+interface RequiredHook {
+  /** Hook event name, e.g. "Stop" */
+  event: string;
+  /** Command line for the hook */
+  command: string;
+  /** Timeout in seconds */
+  timeout: number;
+}
+
+/**
+ * Hooks every cortextOS agent must have. Keep in sync with
+ * templates/agent/.claude/settings.json — this list is the enforcement for
+ * agents spawned from older template versions.
+ */
+export const REQUIRED_HOOKS: RequiredHook[] = [
+  // Turn-end signal: fast-checker liveness/typing detection and the
+  // delivery-confirmation loop both consume last_idle.flag transitions.
+  { event: 'Stop', command: 'cortextos bus hook-idle-flag', timeout: 5 },
+];
+
+interface HookCommandEntry {
+  type: string;
+  command: string;
+  timeout?: number;
+}
+interface HookGroup {
+  matcher?: string;
+  hooks: HookCommandEntry[];
+}
+
+/**
+ * Ensure required hooks exist in <agentDir>/.claude/settings.json.
+ * Returns the list of hook commands that were added (empty = no change).
+ */
+export function ensureRequiredHooks(
+  agentDir: string,
+  log: (msg: string) => void = () => {}
+): string[] {
+  const settingsPath = join(agentDir, '.claude', 'settings.json');
+  if (!existsSync(settingsPath)) {
+    // No settings file at all — an agent dir this bare is not something the
+    // reconciler should invent config for; leave it to the spawn path.
+    log(`hook-reconciler: no settings.json at ${settingsPath}, skipping`);
+    return [];
+  }
+
+  let raw: string;
+  let settings: Record<string, unknown>;
+  try {
+    raw = readFileSync(settingsPath, 'utf-8');
+    settings = JSON.parse(raw);
+  } catch (err) {
+    log(`hook-reconciler: settings.json unreadable/malformed at ${settingsPath} — leaving untouched (${err})`);
+    return [];
+  }
+  if (typeof settings !== 'object' || settings === null || Array.isArray(settings)) {
+    log(`hook-reconciler: settings.json root is not an object at ${settingsPath} — leaving untouched`);
+    return [];
+  }
+
+  const hooks = (settings.hooks ?? {}) as Record<string, HookGroup[]>;
+  if (typeof hooks !== 'object' || hooks === null || Array.isArray(hooks)) {
+    log(`hook-reconciler: settings.hooks is not an object at ${settingsPath} — leaving untouched`);
+    return [];
+  }
+
+  const added: string[] = [];
+  for (const req of REQUIRED_HOOKS) {
+    const groups: HookGroup[] = Array.isArray(hooks[req.event]) ? hooks[req.event] : [];
+    const present = groups.some(g =>
+      Array.isArray(g?.hooks) &&
+      g.hooks.some(h => typeof h?.command === 'string' && h.command.includes(req.command))
+    );
+    if (present) continue;
+    groups.push({ hooks: [{ type: 'command', command: req.command, timeout: req.timeout }] });
+    hooks[req.event] = groups;
+    added.push(`${req.event} → ${req.command}`);
+  }
+
+  if (added.length === 0) return [];
+
+  settings.hooks = hooks;
+  atomicWriteSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', true);
+  log(`hook-reconciler: added missing hook(s): ${added.join(', ')}`);
+  return added;
+}

--- a/src/daemon/hook-reconciler.ts
+++ b/src/daemon/hook-reconciler.ts
@@ -37,6 +37,9 @@ export const REQUIRED_HOOKS: RequiredHook[] = [
   // Turn-end signal: fast-checker liveness/typing detection and the
   // delivery-confirmation loop both consume last_idle.flag transitions.
   { event: 'Stop', command: 'cortextos bus hook-idle-flag', timeout: 5 },
+  // Turn-start signal: the delivery-confirmation loop watches last_prompt.flag
+  // to verify an injected message actually submitted.
+  { event: 'UserPromptSubmit', command: 'cortextos bus hook-prompt-flag', timeout: 5 },
 ];
 
 interface HookCommandEntry {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,4 +1,5 @@
 import { AgentManager } from './agent-manager.js';
+import { installTimestampedConsole } from './log-timestamps.js';
 import { IPCServer } from './ipc-server.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
@@ -230,6 +231,7 @@ class Daemon {
   }
 
   async start(): Promise<void> {
+    installTimestampedConsole();
     // Force restrictive default permissions for everything the daemon writes:
     // 0700 dirs, 0600 files. Belt-and-suspenders for explicit chmod calls.
     if (process.platform !== 'win32') {

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,6 @@
 import { AgentManager } from './agent-manager.js';
 import { installTimestampedConsole } from './log-timestamps.js';
+import { StalenessDetector } from './staleness-detector.js';
 import { IPCServer } from './ipc-server.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
@@ -224,6 +225,8 @@ class Daemon {
   private instanceId: string;
   private ctxRoot: string;
 
+  private stalenessDetector: StalenessDetector | null = null;
+
   constructor() {
     this.instanceId = process.env.CTX_INSTANCE_ID || 'default';
     // Always derive ctxRoot from instanceId to avoid inheriting a parent cortextOS's CTX_ROOT
@@ -267,6 +270,16 @@ class Daemon {
 
     // Discover and start agents
     await this.agentManager.discoverAndStart();
+
+    // Dual-source staleness detector: non-session wake trigger for the
+    // injection-stall class (flags only when heartbeat AND cron fires AND
+    // idle flag are all silent past threshold).
+    this.stalenessDetector = new StalenessDetector({
+      instanceId: this.instanceId,
+      ctxRoot: this.ctxRoot,
+      listAgents: () => this.agentManager!.getAgentRoster(),
+    });
+    this.stalenessDetector.start();
 
     console.log(`[daemon] Running (pid: ${process.pid})`);
 

--- a/src/daemon/log-timestamps.ts
+++ b/src/daemon/log-timestamps.ts
@@ -1,0 +1,30 @@
+/**
+ * Timestamped console for the daemon process.
+ *
+ * Every daemon log line (console.log/warn/error across index.ts, fast-checker,
+ * agent-manager, etc.) gets an ISO-8601 UTC prefix so stall/incident windows can
+ * be reconstructed from the out-log alone, without cross-referencing pmset or
+ * bus stores. Installed once at daemon startup; idempotent.
+ */
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+
+type ConsoleMethod = 'log' | 'warn' | 'error';
+
+/**
+ * Wrap console.log/warn/error to prefix each call with an ISO UTC timestamp.
+ * Safe to call multiple times — subsequent calls are no-ops.
+ */
+export function installTimestampedConsole(): void {
+  const g = globalThis as Record<PropertyKey, unknown>;
+  if (g[INSTALLED]) return;
+  g[INSTALLED] = true;
+
+  const methods: ConsoleMethod[] = ['log', 'warn', 'error'];
+  for (const m of methods) {
+    const original = console[m].bind(console);
+    console[m] = (...args: unknown[]) => {
+      original(`[${new Date().toISOString()}]`, ...args);
+    };
+  }
+}

--- a/src/daemon/staleness-detector.ts
+++ b/src/daemon/staleness-detector.ts
@@ -1,0 +1,178 @@
+/**
+ * Dual-source staleness detector.
+ *
+ * Heartbeat-only staleness produced a persistent false-positive class: cron
+ * prompts that lack an update-heartbeat line leave heartbeat.json untouched
+ * while cron-fire records prove continuous liveness (2026-07-10 binding
+ * amendment). And when a stall IS real, the fleet-standard peer-notify
+ * mitigation shares the failure mode — a stalled peer cannot notify anyone
+ * (stall #3 datum). This detector is the non-session trigger.
+ *
+ * Rule: an agent is flagged stale ONLY when EVERY liveness source has been
+ * silent for more than the threshold (default 45 min):
+ *   1. heartbeat.json last_heartbeat  (agent- or watchdog-written)
+ *   2. cron-state.json most recent fire (any recorded fire = liveness beat)
+ *   3. last_idle.flag mtime            (Stop hook turn-end signal)
+ *
+ * On staleness: write the .urgent-signal wake file + bus message via
+ * notifyAgent (the resubmit mechanism that recovered every observed stall),
+ * log loudly, and hold a per-agent cooldown so a genuinely wedged agent is
+ * prodded at most once per threshold window.
+ */
+import { existsSync, readFileSync, statSync } from 'fs';
+import { join } from 'path';
+import { notifyAgent } from '../bus/agents.js';
+import { readCronState } from '../bus/cron-state.js';
+import { resolvePaths } from '../utils/paths.js';
+
+export const DEFAULT_STALE_THRESHOLD_MS = 45 * 60 * 1000;
+export const DEFAULT_CHECK_INTERVAL_MS = 10 * 60 * 1000;
+
+export interface LivenessSources {
+  /** ms epoch of heartbeat.json last_heartbeat (undefined = no signal ever) */
+  heartbeatAt?: number;
+  /** ms epoch of the most recent recorded cron fire */
+  lastCronFireAt?: number;
+  /** ms epoch of last_idle.flag write (Stop hook turn-end) */
+  idleFlagAt?: number;
+}
+
+export interface StalenessVerdict {
+  stale: boolean;
+  /** ms since the freshest available signal; Infinity when no source exists */
+  ageMs: number;
+  /** which source was freshest, for the log line */
+  freshestSource: 'heartbeat' | 'cron-fire' | 'idle-flag' | 'none';
+}
+
+/**
+ * Pure staleness rule: stale iff every AVAILABLE source is older than the
+ * threshold. An agent with NO sources at all is never flagged (nothing to
+ * distinguish "new agent" from "broken state dir" — flagging would wake
+ * agents that simply have not written anything yet).
+ */
+export function assessStaleness(
+  sources: LivenessSources,
+  nowMs: number,
+  thresholdMs: number = DEFAULT_STALE_THRESHOLD_MS,
+): StalenessVerdict {
+  const entries: Array<[StalenessVerdict['freshestSource'], number]> = [];
+  if (sources.heartbeatAt !== undefined) entries.push(['heartbeat', sources.heartbeatAt]);
+  if (sources.lastCronFireAt !== undefined) entries.push(['cron-fire', sources.lastCronFireAt]);
+  if (sources.idleFlagAt !== undefined) entries.push(['idle-flag', sources.idleFlagAt]);
+
+  if (entries.length === 0) return { stale: false, ageMs: Infinity, freshestSource: 'none' };
+
+  let freshest = entries[0];
+  for (const e of entries) if (e[1] > freshest[1]) freshest = e;
+  const ageMs = nowMs - freshest[1];
+  return { stale: ageMs > thresholdMs, ageMs, freshestSource: freshest[0] };
+}
+
+/** Read the three liveness sources for one agent from its state dir. */
+export function readLivenessSources(stateDir: string): LivenessSources {
+  const out: LivenessSources = {};
+
+  const hbPath = join(stateDir, 'heartbeat.json');
+  if (existsSync(hbPath)) {
+    try {
+      const hb = JSON.parse(readFileSync(hbPath, 'utf-8'));
+      const t = Date.parse(hb.last_heartbeat);
+      out.heartbeatAt = Number.isNaN(t) ? statSync(hbPath).mtimeMs : t;
+    } catch {
+      try { out.heartbeatAt = statSync(hbPath).mtimeMs; } catch { /* gone */ }
+    }
+  }
+
+  try {
+    const cronState = readCronState(stateDir);
+    let latest: number | undefined;
+    for (const entry of cronState.crons) {
+      const t = Date.parse(entry.last_fire ?? '');
+      if (!Number.isNaN(t) && (latest === undefined || t > latest)) latest = t;
+    }
+    if (latest !== undefined) out.lastCronFireAt = latest;
+  } catch { /* no cron state */ }
+
+  const flagPath = join(stateDir, 'last_idle.flag');
+  if (existsSync(flagPath)) {
+    try { out.idleFlagAt = statSync(flagPath).mtimeMs; } catch { /* gone */ }
+  }
+
+  return out;
+}
+
+export interface StalenessDetectorOptions {
+  instanceId: string;
+  ctxRoot: string;
+  /** Live roster: agent names (with orgs) currently running under the daemon */
+  listAgents: () => Array<{ name: string; org: string }>;
+  log?: (msg: string) => void;
+  thresholdMs?: number;
+  checkIntervalMs?: number;
+  /** Injectable for tests */
+  notify?: typeof notifyAgent;
+  now?: () => number;
+}
+
+export class StalenessDetector {
+  private timer: NodeJS.Timeout | null = null;
+  private lastProddedAt: Map<string, number> = new Map();
+  private readonly opts: Required<Pick<StalenessDetectorOptions, 'thresholdMs' | 'checkIntervalMs'>> & StalenessDetectorOptions;
+
+  constructor(options: StalenessDetectorOptions) {
+    this.opts = {
+      thresholdMs: DEFAULT_STALE_THRESHOLD_MS,
+      checkIntervalMs: DEFAULT_CHECK_INTERVAL_MS,
+      ...options,
+    };
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => this.checkOnce(), this.opts.checkIntervalMs);
+    // Unref so the detector never keeps a shutting-down daemon alive
+    this.timer.unref?.();
+    (this.opts.log ?? console.log)(
+      `[staleness] detector started (threshold ${Math.round(this.opts.thresholdMs / 60000)} min, check every ${Math.round(this.opts.checkIntervalMs / 60000)} min)`
+    );
+  }
+
+  stop(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  /** One sweep over the live roster. Exposed for tests. */
+  checkOnce(): void {
+    const log = this.opts.log ?? console.log;
+    const now = (this.opts.now ?? Date.now)();
+    const notify = this.opts.notify ?? notifyAgent;
+
+    for (const { name, org } of this.opts.listAgents()) {
+      const stateDir = join(this.opts.ctxRoot, 'state', name);
+      const sources = readLivenessSources(stateDir);
+      const verdict = assessStaleness(sources, now, this.opts.thresholdMs);
+      if (!verdict.stale) continue;
+
+      const lastProd = this.lastProddedAt.get(name) ?? 0;
+      if (now - lastProd < this.opts.thresholdMs) continue; // cooldown
+
+      const ageMin = Math.round(verdict.ageMs / 60000);
+      log(`[staleness] ${name}: ALL liveness sources silent ${ageMin} min (freshest: ${verdict.freshestSource}) — sending wake signal`);
+      try {
+        const paths = resolvePaths(name, this.opts.instanceId, org);
+        notify(
+          paths,
+          'daemon',
+          name,
+          `daemon staleness detector: all liveness sources (heartbeat, cron fires, idle flag) silent ${ageMin} min. ` +
+          `If you receive this, your session likely had undelivered input — process your queue, update your heartbeat, and note the gap in your log.`,
+          this.opts.ctxRoot,
+        );
+        this.lastProddedAt.set(name, now);
+      } catch (err) {
+        log(`[staleness] ${name}: wake signal failed: ${err}`);
+      }
+    }
+  }
+}

--- a/src/hooks/hook-prompt-flag.ts
+++ b/src/hooks/hook-prompt-flag.ts
@@ -1,0 +1,27 @@
+/**
+ * UserPromptSubmit hook - writes a Unix timestamp to last_prompt.flag.
+ *
+ * This is the turn-START signal, the counterpart of hook-idle-flag's Stop
+ * (turn-end) signal. The daemon's delivery-confirmation loop watches this
+ * flag after injecting a message: flag advances past the injection time =
+ * the prompt actually submitted and a turn began; no advance = the content
+ * is sitting in the CLI input box with a dropped Enter (2026-07-09 stall
+ * class) and the injector retries Enter.
+ */
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+
+async function main(): Promise<void> {
+  const agentName = process.env.CTX_AGENT_NAME;
+  const instanceId = process.env.CTX_INSTANCE_ID || 'default';
+  if (!agentName) return;
+
+  const stateDir = join(homedir(), '.cortextos', instanceId, 'state', agentName);
+  try {
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'last_prompt.flag'), String(Math.floor(Date.now() / 1000)), 'utf-8');
+  } catch { /* ignore */ }
+}
+
+main().catch(() => process.exit(0));

--- a/src/hooks/hook-prompt-flag.ts
+++ b/src/hooks/hook-prompt-flag.ts
@@ -1,26 +1,68 @@
 /**
- * UserPromptSubmit hook - writes a Unix timestamp to last_prompt.flag.
+ * UserPromptSubmit hook - writes turn-start attribution to last_prompt.flag.
  *
  * This is the turn-START signal, the counterpart of hook-idle-flag's Stop
  * (turn-end) signal. The daemon's delivery-confirmation loop watches this
  * flag after injecting a message: flag advances past the injection time =
- * the prompt actually submitted and a turn began; no advance = the content
- * is sitting in the CLI input box with a dropped Enter (2026-07-09 stall
- * class) and the injector retries Enter.
+ * a prompt actually submitted and a turn began; no advance = the content is
+ * sitting in the CLI input box with a dropped Enter (2026-07-09 stall class)
+ * and the injector retries Enter.
+ *
+ * 2026-07-10 (G-D2-2): an mtime advance alone cannot be ATTRIBUTED — two
+ * injectors racing on one PTY both saw the same advance and one confirmed a
+ * payload that never submitted (kirk 13:00Z false confirm). The hook now also
+ * records WHAT submitted: the flag file carries JSON {ts, sha256, len} of the
+ * submitted prompt, and the raw prompt text goes to last_prompt.txt beside it
+ * (same trust boundary as the inbox files in the same state dir). The daemon
+ * confirms an injection only when the flag advances AND its payload appears
+ * in the submitted prompt. Legacy plain-integer flag content (older hook) is
+ * detected by the daemon and degrades to mtime-only confirmation.
  */
 import { writeFileSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
+import { createHash } from 'crypto';
+
+async function readStdin(): Promise<string> {
+  if (process.stdin.isTTY) return '';
+  const chunks: Buffer[] = [];
+  try {
+    for await (const chunk of process.stdin) {
+      chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+    }
+  } catch {
+    return '';
+  }
+  return Buffer.concat(chunks).toString('utf-8');
+}
 
 async function main(): Promise<void> {
   const agentName = process.env.CTX_AGENT_NAME;
   const instanceId = process.env.CTX_INSTANCE_ID || 'default';
   if (!agentName) return;
 
+  // UserPromptSubmit hooks receive JSON on stdin including the submitted prompt.
+  let prompt = '';
+  try {
+    const raw = await readStdin();
+    if (raw) {
+      const payload = JSON.parse(raw);
+      if (typeof payload.prompt === 'string') prompt = payload.prompt;
+    }
+  } catch {
+    // No/invalid stdin — flag still stamps the turn start, attribution absent.
+  }
+
   const stateDir = join(homedir(), '.cortextos', instanceId, 'state', agentName);
   try {
     mkdirSync(stateDir, { recursive: true });
-    writeFileSync(join(stateDir, 'last_prompt.flag'), String(Math.floor(Date.now() / 1000)), 'utf-8');
+    const flag = {
+      ts: Math.floor(Date.now() / 1000),
+      sha256: prompt ? createHash('sha256').update(prompt, 'utf-8').digest('hex') : null,
+      len: prompt.length,
+    };
+    writeFileSync(join(stateDir, 'last_prompt.flag'), JSON.stringify(flag), 'utf-8');
+    writeFileSync(join(stateDir, 'last_prompt.txt'), prompt, { encoding: 'utf-8', mode: 0o600 });
   } catch { /* ignore */ }
 }
 

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -3,7 +3,8 @@ import { existsSync, readFileSync, readdirSync } from 'fs';
 import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
-import { injectMessage as injectMessageIntoPty } from './inject.js';
+import { injectMessage as injectMessageIntoPty, injectMessageConfirmed as injectMessageConfirmedIntoPty, KEYS } from './inject.js';
+import type { ConfirmedInjectOptions, ConfirmedInjectResult } from './inject.js';
 
 // node-pty types
 interface IPty {
@@ -310,6 +311,27 @@ export class AgentPTY {
    */
   injectMessage(content: string): void {
     injectMessageIntoPty((data) => this.write(data), content);
+  }
+
+  /**
+   * Confirmed injection: paste + Enter with turn-start verification and
+   * Enter retries (see injectMessageConfirmed in inject.ts). Runtime
+   * subclasses whose paste semantics differ (OpenCode) return null to tell
+   * the caller to use their own injectMessage() path instead.
+   */
+  injectMessageConfirmed(
+    content: string,
+    options: ConfirmedInjectOptions,
+  ): Promise<ConfirmedInjectResult> | null {
+    return injectMessageConfirmedIntoPty((data) => this.write(data), content, options);
+  }
+
+  /**
+   * Send a bare Enter — used by the boot-prompt delivery check to re-submit
+   * a prompt stuck in the input box. No-op against an empty input box.
+   */
+  sendEnter(): void {
+    this.write(KEYS.ENTER);
   }
 
   /**

--- a/src/pty/inject.ts
+++ b/src/pty/inject.ts
@@ -179,3 +179,102 @@ export async function toggleAndSubmit(
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+/**
+ * Result of a confirmed injection attempt.
+ */
+export interface ConfirmedInjectResult {
+  /** true = turn-start confirmed; false = every Enter retry exhausted */
+  confirmed: boolean;
+  /** how many Enters were sent (1 = first attempt confirmed) */
+  enterAttempts: number;
+}
+
+export interface ConfirmedInjectOptions {
+  /** Returns true once the runtime shows the prompt actually submitted */
+  isConfirmed: () => boolean;
+  /** ms before the first Enter (mirrors injectMessage default) */
+  enterDelay?: number;
+  /** ms to poll isConfirmed() after each Enter before retrying */
+  attemptTimeoutMs?: number;
+  /** poll granularity */
+  pollMs?: number;
+  /** total Enter attempts (first + retries) */
+  maxEnterAttempts?: number;
+  log?: (msg: string) => void;
+  /** injectable for tests */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+/**
+ * Inject a message and CONFIRM it submitted, retrying Enter when it did not.
+ *
+ * The fire-and-forget injectMessage() above sends Enter 300 ms after the
+ * paste and swallows failures — "the dropped Enter is the acceptable cost."
+ * The 2026-07-09 fleet stalls showed the real cost: when the Enter fails to
+ * submit, the pasted content sits in the CLI input box, the session looks
+ * idle, every later injection appends to the same unsubmitted box, and the
+ * whole backlog flushes as one batch whenever any later Enter finally lands.
+ *
+ * This variant closes the loop: paste once, then send Enter and poll a
+ * turn-start signal (last_prompt.flag via the UserPromptSubmit hook); no
+ * signal within the window → send Enter again (idempotent against a loaded
+ * input box — an empty box treats it as a no-op) up to maxEnterAttempts.
+ * Defaults: 3 attempts × 9 s ≈ 28 s worst case, inside the 30-second
+ * delivery gate.
+ */
+export async function injectMessageConfirmed(
+  write: (data: string) => void,
+  content: string,
+  options: ConfirmedInjectOptions,
+): Promise<ConfirmedInjectResult> {
+  const {
+    isConfirmed,
+    enterDelay = 300,
+    attemptTimeoutMs = 9000,
+    pollMs = 500,
+    maxEnterAttempts = 3,
+    log = () => {},
+    sleep: doSleep = sleep,
+  } = options;
+
+  const MAX_CHUNK = 4096;
+  if (content.length <= MAX_CHUNK) {
+    write(PASTE_START + content + PASTE_END);
+  } else {
+    write(PASTE_START);
+    for (let i = 0; i < content.length; i += MAX_CHUNK) {
+      write(content.slice(i, i + MAX_CHUNK));
+    }
+    write(PASTE_END);
+  }
+  await doSleep(enterDelay);
+
+  let enterAttempts = 0;
+  while (enterAttempts < maxEnterAttempts) {
+    enterAttempts++;
+    try {
+      write(KEYS.ENTER);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      log(`[inject] Enter attempt ${enterAttempts} failed (pty likely torn down): ${msg}`);
+      return { confirmed: false, enterAttempts };
+    }
+
+    const deadline = attemptTimeoutMs;
+    let waited = 0;
+    while (waited < deadline) {
+      await doSleep(pollMs);
+      waited += pollMs;
+      if (isConfirmed()) {
+        if (enterAttempts > 1) {
+          log(`[inject] delivery confirmed after ${enterAttempts} Enter attempts`);
+        }
+        return { confirmed: true, enterAttempts };
+      }
+    }
+    log(`[inject] no turn-start signal ${deadline} ms after Enter attempt ${enterAttempts}/${maxEnterAttempts} — retrying`);
+  }
+
+  return { confirmed: false, enterAttempts };
+}

--- a/src/pty/inject.ts
+++ b/src/pty/inject.ts
@@ -43,6 +43,17 @@ export class MessageDedup {
     return false;
   }
 
+  /**
+   * Forget one content hash so the same content can inject again.
+   * Used when delivery confirmation fails: the un-ACKed message redelivers
+   * with identical content, which isDuplicate() would otherwise drop.
+   */
+  forget(content: string): void {
+    const hash = createHash('md5').update(content).digest('hex');
+    const idx = this.hashes.indexOf(hash);
+    if (idx >= 0) this.hashes.splice(idx, 1);
+  }
+
   clear(): void {
     this.hashes = [];
   }

--- a/src/pty/opencode-pty.ts
+++ b/src/pty/opencode-pty.ts
@@ -148,6 +148,13 @@ export class OpencodePTY extends AgentPTY {
     }
   }
 
+  override injectMessageConfirmed(): null {
+    // OpenCode's TUI paste path differs from Claude Code's; the Enter-retry
+    // confirmation loop is not validated there. Callers fall back to
+    // injectMessage().
+    return null;
+  }
+
   override injectMessage(content: string): void {
     // OpenCode v1.17.9's TUI does not reliably surface content delivered with
     // bracketed paste (`ESC[200~ ... ESC[201~`): sandbox validation showed the

--- a/templates/agent/.claude/settings.json
+++ b/templates/agent/.claude/settings.json
@@ -91,6 +91,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-prompt-flag",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -432,7 +432,7 @@ Photos include a `local_file:` path. Callbacks include `callback_data:` and `mes
 Reply using: cortextos bus send-message <agent> normal '<reply>' <msg_id>
 ```
 
-Always include `msg_id` as reply_to — this auto-ACKs the original. Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
+Always include `msg_id` as reply_to — `send-message` acks the original at send time (a reply IS proof of delivery; before 2026-07-10 reply_to was metadata only and every replied-to message redelivered after 5 min). Un-ACK'd messages redeliver after 5 min. For no-reply messages: `cortextos bus ack-inbox <msg_id>`
 
 ---
 

--- a/templates/analyst/.claude/settings.json
+++ b/templates/analyst/.claude/settings.json
@@ -91,6 +91,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "cortextos bus hook-prompt-flag",
+            "timeout": 5
+          }
+        ]
+      }
     ]
   }
 }

--- a/tests/unit/bus/ack-path.test.ts
+++ b/tests/unit/bus/ack-path.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readdirSync, writeFileSync, mkdirSync, utimesSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  sendMessage, checkInbox, ackInbox,
+  writeDeferredMarker, readDeferredMarker, clearDeferredMarker, listDeferredMarkers,
+} from '../../../src/bus/message';
+import type { BusPaths } from '../../../src/types';
+
+/**
+ * ACKFIX regression spec (ACKFIX_REQUIREMENTS.md, 2026-07-10) — bus half:
+ *   G-REG-1  reply acks the original at send time (D1)
+ *   G-REG-2  explicit ack works from BOTH inflight and inbox (D3)
+ *   G-REG-7  deferred messages are exempt from 300s stale-inflight recovery (G-D2-6)
+ *   G-REG-8  marker cleanup on both exit paths + ORIGINAL deadline preserved (G-D2-7)
+ */
+
+function mkPaths(root: string, agent: string): BusPaths {
+  const p = {
+    ctxRoot: root,
+    inbox: join(root, 'inbox', agent),
+    inflight: join(root, 'inflight', agent),
+    processed: join(root, 'processed', agent),
+    stateDir: join(root, 'state', agent),
+  } as unknown as BusPaths;
+  for (const d of [p.inbox, p.inflight, (p as { processed: string }).processed, (p as { stateDir: string }).stateDir]) {
+    mkdirSync(d, { recursive: true });
+  }
+  return p;
+}
+
+/** Age a file's mtime so recoverStaleInflight sees it as stale. */
+function ageFile(path: string, seconds: number): void {
+  const t = new Date(Date.now() - seconds * 1000);
+  utimesSync(path, t, t);
+}
+
+describe('ACKFIX bus regression', () => {
+  let root: string;
+  let alice: BusPaths; // original sender
+  let bob: BusPaths;   // recipient / replier
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'cortextos-ackfix-'));
+    alice = mkPaths(root, 'alice');
+    bob = mkPaths(root, 'bob');
+  });
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  it('G-REG-1: sending a reply acks the original in the REPLIER inflight at send time', () => {
+    const origId = sendMessage(alice, 'alice', 'bob', 'normal', 'ping');
+    const got = checkInbox(bob); // bob reads: message moves to bob's inflight
+    expect(got.map(m => m.id)).toEqual([origId]);
+    expect(readdirSync(bob.inflight).filter(f => f.endsWith('.json'))).toHaveLength(1);
+
+    sendMessage(bob, 'bob', 'alice', 'normal', 'pong', origId);
+
+    // Original left bob's inflight for processed — no 5-min redelivery.
+    expect(readdirSync(bob.inflight).filter(f => f.endsWith('.json'))).toHaveLength(0);
+    expect(readdirSync((bob as unknown as { processed: string }).processed)).toHaveLength(1);
+  });
+
+  it('G-REG-1: a reply_to that matches nothing does not break the send', () => {
+    const id = sendMessage(bob, 'bob', 'alice', 'normal', 'reply to ghost', 'no-such-id');
+    expect(id).toBeTruthy();
+    expect(checkInbox(alice)).toHaveLength(1);
+  });
+
+  it('G-REG-2: explicit ack succeeds while the message sits in inflight AND after recovery to inbox', () => {
+    // inflight case
+    const id1 = sendMessage(alice, 'alice', 'bob', 'normal', 'one');
+    checkInbox(bob);
+    ackInbox(bob, id1);
+    expect(readdirSync(bob.inflight).filter(f => f.endsWith('.json'))).toHaveLength(0);
+
+    // recovered-to-inbox case: deliver, move to inflight, age past 300s, let
+    // checkInbox recover it back to inbox, then ack — pre-fix this no-oped.
+    const id2 = sendMessage(alice, 'alice', 'bob', 'normal', 'two');
+    checkInbox(bob);
+    const file = readdirSync(bob.inflight).filter(f => f.endsWith('.json'))[0];
+    ageFile(join(bob.inflight, file), 400);
+    checkInbox(bob); // recovery sweep moves it to inbox (and re-reads it)
+    ackInbox(bob, id2);
+    expect(readdirSync(bob.inbox).filter(f => f.endsWith('.json') && !f.startsWith('.'))).toHaveLength(0);
+    expect(readdirSync(bob.inflight).filter(f => f.endsWith('.json'))).toHaveLength(0);
+    expect(readdirSync((bob as unknown as { processed: string }).processed)).toHaveLength(2);
+  });
+
+  it('G-REG-7: a deferred message aged past 300s is NOT recovered while its hold is active', () => {
+    const id = sendMessage(alice, 'alice', 'bob', 'normal', 'held payload');
+    checkInbox(bob);
+    const file = readdirSync(bob.inflight).filter(f => f.endsWith('.json'))[0];
+    ageFile(join(bob.inflight, file), 400); // stale by mtime
+    writeDeferredMarker(bob.inflight, file, {
+      injectedAt: Date.now() - 400_000,
+      deadline: Date.now() + 200_000, // hold still active
+      contentSha: 'a'.repeat(64),
+      content: 'held payload block',
+    });
+
+    const recovered = checkInbox(bob); // recovery sweep runs inside — must skip the held file
+    expect(recovered).toHaveLength(0);
+    expect(readdirSync(bob.inflight).filter(f => f.endsWith('.json'))).toHaveLength(1);
+    expect(readDeferredMarker(bob.inflight, file)).not.toBeNull();
+    void id;
+  });
+
+  it('G-REG-7/G-D2-5: once the hold deadline passes, recovery resumes and the message redelivers', () => {
+    const id = sendMessage(alice, 'alice', 'bob', 'normal', 'timed out payload');
+    checkInbox(bob);
+    const file = readdirSync(bob.inflight).filter(f => f.endsWith('.json'))[0];
+    ageFile(join(bob.inflight, file), 400);
+    writeDeferredMarker(bob.inflight, file, {
+      injectedAt: Date.now() - 700_000,
+      deadline: Date.now() - 100_000, // expired hold
+      contentSha: 'b'.repeat(64),
+      content: 'x',
+    });
+
+    const redelivered = checkInbox(bob); // sweep clears expired marker, recovers, re-reads
+    expect(redelivered.map(m => m.id)).toEqual([id]);
+    expect(readDeferredMarker(bob.inflight, file)).toBeNull();
+  });
+
+  it('G-REG-8: ack during a hold clears the marker (confirm exit path)', () => {
+    const id = sendMessage(alice, 'alice', 'bob', 'normal', 'confirming');
+    checkInbox(bob);
+    const file = readdirSync(bob.inflight).filter(f => f.endsWith('.json'))[0];
+    writeDeferredMarker(bob.inflight, file, {
+      injectedAt: Date.now(), deadline: Date.now() + 600_000, contentSha: 'c'.repeat(64), content: 'y',
+    });
+    ackInbox(bob, id);
+    expect(readDeferredMarker(bob.inflight, file)).toBeNull();
+    expect(existsSync(join(bob.inflight, '.deferred', `${file}.marker`))).toBe(false);
+  });
+
+  it('G-REG-8: markers survive "restart" with the ORIGINAL deadline — never refreshed', () => {
+    sendMessage(alice, 'alice', 'bob', 'normal', 'restart survivor');
+    checkInbox(bob);
+    const file = readdirSync(bob.inflight).filter(f => f.endsWith('.json'))[0];
+    const injectedAt = Date.now() - 120_000;
+    const deadline = injectedAt + 600_000;
+    writeDeferredMarker(bob.inflight, file, { injectedAt, deadline, contentSha: 'd'.repeat(64), content: 'z' });
+
+    // A rebooted daemon rederives its watch list from listDeferredMarkers:
+    const rebuilt = listDeferredMarkers(bob.inflight);
+    expect(rebuilt).toHaveLength(1);
+    expect(rebuilt[0].marker.deadline).toBe(deadline);     // original clock (G-D2-7)
+    expect(rebuilt[0].marker.injectedAt).toBe(injectedAt); // hold START preserved
+  });
+
+  it('G-REG-8: orphan markers (message file gone) are garbage-collected', () => {
+    mkdirSync(join(bob.inflight, '.deferred'), { recursive: true });
+    writeFileSync(
+      join(bob.inflight, '.deferred', 'no-such-message.json.marker'),
+      JSON.stringify({ injectedAt: 1, deadline: 2, contentSha: 'e'.repeat(64), content: 'w' }),
+    );
+    expect(listDeferredMarkers(bob.inflight)).toHaveLength(0); // orphan pruned on sight
+    expect(existsSync(join(bob.inflight, '.deferred', 'no-such-message.json.marker'))).toBe(false);
+  });
+
+  it('clearDeferredMarker is idempotent', () => {
+    clearDeferredMarker(bob.inflight, 'never-existed.json');
+  });
+});

--- a/tests/unit/daemon/deferred-confirm.test.ts
+++ b/tests/unit/daemon/deferred-confirm.test.ts
@@ -1,0 +1,242 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+vi.mock('child_process', () => ({ execFile: vi.fn() }));
+vi.mock('../../../src/bus/heartbeat.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  updateHeartbeat: vi.fn(),
+}));
+import { mkdtempSync, rmSync, writeFileSync, readdirSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { FastChecker } from '../../../src/daemon/fast-checker';
+import { AgentProcess } from '../../../src/daemon/agent-process';
+import { sendMessage, checkInbox, listDeferredMarkers, readDeferredMarker } from '../../../src/bus/message';
+import type { BusPaths, CtxEnv, AgentConfig } from '../../../src/types';
+
+/**
+ * ACKFIX regression spec (ACKFIX_REQUIREMENTS.md, 2026-07-10) — daemon half:
+ *   G-REG-3  busy-session injection → DEFERRED_CONFIRM; confirm on flag advance
+ *            + payload attribution; acked; NO redelivery
+ *   G-REG-4  dead session (no flag advance) → hold times out → dedup forgotten,
+ *            markers cleared, message released to recovery
+ *   G-REG-5  flag-less / legacy-format sessions keep the legacy path
+ *   G-REG-6  multi-injection flush: per-payload attribution; an untracked
+ *            cron-source paste neither confirms nor blocks tracked holds
+ */
+
+function createTestPaths(testDir: string, agent = 'bob'): BusPaths {
+  const paths = {
+    ctxRoot: testDir,
+    inbox: join(testDir, 'inbox', agent),
+    inflight: join(testDir, 'inflight', agent),
+    processed: join(testDir, 'processed', agent),
+    logDir: join(testDir, 'logs', agent),
+    stateDir: join(testDir, 'state', agent),
+    taskDir: join(testDir, 'tasks'),
+    approvalDir: join(testDir, 'approvals'),
+    analyticsDir: join(testDir, 'analytics'),
+    heartbeatDir: join(testDir, 'heartbeats'),
+  } as unknown as BusPaths;
+  for (const dir of Object.values(paths)) {
+    if (dir !== testDir) mkdirSync(dir as string, { recursive: true });
+  }
+  return paths;
+}
+
+/** Mock AgentProcess exposing exactly the surface the deferral tracker uses. */
+function createMockAgent(name = 'bob') {
+  return {
+    name,
+    org: 'test-org',
+    isBootstrapped: vi.fn().mockReturnValue(true),
+    injectMessage: vi.fn().mockReturnValue(true),
+    promptFlagMtimeMs: vi.fn().mockReturnValue(0),
+    submittedPromptContains: vi.fn().mockReturnValue(false),
+    forgetDedup: vi.fn(),
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('DEFERRED_CONFIRM tracker (fast-checker)', () => {
+  let testDir: string;
+  let paths: BusPaths;
+  let senderPaths: BusPaths;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-deferred-test-'));
+    paths = createTestPaths(testDir, 'bob');
+    senderPaths = createTestPaths(testDir, 'alice');
+  });
+  afterEach(() => rmSync(testDir, { recursive: true, force: true }));
+
+  function deliverToInflight(text: string): string {
+    const id = sendMessage(senderPaths, 'alice', 'bob', 'normal', text);
+    checkInbox(paths); // moves to bob's inflight
+    return id;
+  }
+
+  it('G-REG-3: deferred hold confirms on flag advance + attribution, acks, leaves nothing to redeliver', () => {
+    const agent = createMockAgent();
+    const checker = new FastChecker(agent, paths, '/tmp/framework', { log: () => {} });
+    const id = deliverToInflight('hello from alice');
+    const injectedAt = Date.now() - 30_000;
+    const block = `=== AGENT MESSAGE ... ${id} ===\nhello from alice`;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).registerDeferredHold([id], block, {
+      injectedAt, deadline: injectedAt + 600_000, contentSha: 'f'.repeat(64),
+    });
+    expect(listDeferredMarkers(paths.inflight)).toHaveLength(1);
+
+    // Turn boundary: flag advances AND the flushed prompt contains the block.
+    agent.promptFlagMtimeMs.mockReturnValue(Date.now());
+    agent.submittedPromptContains.mockImplementation((c: string) => c === block);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).checkDeferredHolds();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((checker as any).deferredHolds).toHaveLength(0);
+    expect(readdirSync(paths.inflight).filter(f => f.endsWith('.json'))).toHaveLength(0); // acked
+    expect(listDeferredMarkers(paths.inflight)).toHaveLength(0); // marker gone with ack
+    expect(checkInbox(paths)).toHaveLength(0); // nothing redelivers
+    expect(agent.forgetDedup).not.toHaveBeenCalled(); // confirm path keeps dedup state
+  });
+
+  it('G-REG-4: hold times out with no flag advance → dedup forgotten, marker cleared, recovery redelivers', () => {
+    const agent = createMockAgent(); // flag never advances (dead / wedged session)
+    const checker = new FastChecker(agent, paths, '/tmp/framework', { log: () => {} });
+    const id = deliverToInflight('doomed payload');
+    const injectedAt = Date.now() - 700_000;
+    const block = `block containing ${id}`;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).registerDeferredHold([id], block, {
+      injectedAt, deadline: injectedAt + 600_000, contentSha: '9'.repeat(64), // already expired
+    });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).checkDeferredHolds();
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((checker as any).deferredHolds).toHaveLength(0);
+    expect(agent.forgetDedup).toHaveBeenCalledWith(block); // G-D2-5: ALL dedup state for the block
+    expect(listDeferredMarkers(paths.inflight)).toHaveLength(0);
+    // File still in inflight but unmarked: after it goes stale the normal sweep redelivers it.
+    expect(readdirSync(paths.inflight).filter(f => f.endsWith('.json'))).toHaveLength(1);
+  });
+
+  it('G-REG-6: multi-injection flush — each hold confirms by ITS OWN payload; untracked cron paste neither confirms nor blocks', () => {
+    const agent = createMockAgent();
+    const checker = new FastChecker(agent, paths, '/tmp/framework', { log: () => {} });
+    const idA = deliverToInflight('payload A');
+    const idB = deliverToInflight('payload B');
+    const blockA = `block-A ${idA}`;
+    const blockB = `block-B ${idB}`;
+    const cronPaste = '[CRON FIRED] vip-scan-priority: untracked legacy-path paste';
+    const t0 = Date.now() - 10_000;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).registerDeferredHold([idA], blockA, { injectedAt: t0, deadline: t0 + 600_000, contentSha: '1'.repeat(64) });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).registerDeferredHold([idB], blockB, { injectedAt: t0, deadline: t0 + 600_000, contentSha: '2'.repeat(64) });
+
+    // Turn boundary flushes blockA + the cron paste, but NOT blockB.
+    const flushed = `${blockA}\n${cronPaste}`;
+    agent.promptFlagMtimeMs.mockReturnValue(Date.now());
+    agent.submittedPromptContains.mockImplementation((c: string) => flushed.includes(c));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).checkDeferredHolds();
+
+    // A confirmed+acked; B still held (no first-flag-wins); cron paste changed nothing.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const holds = (checker as any).deferredHolds as Array<{ ackIds: string[] }>;
+    expect(holds).toHaveLength(1);
+    expect(holds[0].ackIds).toEqual([idB]);
+    expect(listDeferredMarkers(paths.inflight)).toHaveLength(1);
+
+    // Next boundary flushes blockB — B confirms independently.
+    const flushed2 = `${blockB}`;
+    agent.submittedPromptContains.mockImplementation((c: string) => flushed2.includes(c));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker as any).checkDeferredHolds();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((checker as any).deferredHolds).toHaveLength(0);
+    expect(readdirSync(paths.inflight).filter(f => f.endsWith('.json'))).toHaveLength(0);
+  });
+
+  it('G-D2-7: rebuildDeferredHolds restores holds from markers with the ORIGINAL deadline', () => {
+    const agent = createMockAgent();
+    const id = deliverToInflight('restart survivor');
+    const injectedAt = Date.now() - 120_000;
+    const deadline = injectedAt + 600_000;
+    {
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { log: () => {} });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (checker as any).registerDeferredHold([id], 'surviving block', {
+        injectedAt, deadline, contentSha: '3'.repeat(64),
+      });
+    } // daemon "dies" — in-memory hold lost, marker remains
+
+    const checker2 = new FastChecker(createMockAgent(), paths, '/tmp/framework', { log: () => {} });
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (checker2 as any).rebuildDeferredHolds();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const holds = (checker2 as any).deferredHolds as Array<{ ackIds: string[]; deadline: number; injectedAt: number; content: string }>;
+    expect(holds).toHaveLength(1);
+    expect(holds[0].ackIds).toEqual([id]);
+    expect(holds[0].deadline).toBe(deadline);       // never refreshed on restart
+    expect(holds[0].injectedAt).toBe(injectedAt);
+    expect(holds[0].content).toBe('surviving block'); // attribution check resumes
+  });
+});
+
+describe('G-REG-5: flag-less / legacy-format fallback (AgentProcess predicate)', () => {
+  let testDir: string;
+
+  beforeEach(() => { testDir = mkdtempSync(join(tmpdir(), 'cortextos-flagless-test-')); });
+  afterEach(() => rmSync(testDir, { recursive: true, force: true }));
+
+  function makeAgent(name: string): AgentProcess {
+    const env = { ctxRoot: testDir, org: 'test-org', instanceId: 'test' } as unknown as CtxEnv;
+    const config = {} as AgentConfig;
+    return new AgentProcess(name, env, config, () => {});
+  }
+
+  it('no flag file at all → promptFlagInfo reports no channel (legacy 28s path preserved)', () => {
+    const agent = makeAgent('flagless');
+    expect(agent.promptFlagInfo()).toEqual({ mtimeMs: 0, sha256: null, hashCapable: false });
+  });
+
+  it('legacy plain-integer flag content → hashCapable=false (mtime-only confirmation)', () => {
+    const agent = makeAgent('oldhook');
+    const stateDir = join(testDir, 'state', 'oldhook');
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'last_prompt.flag'), '1783691952', 'utf-8');
+    const info = agent.promptFlagInfo();
+    expect(info.hashCapable).toBe(false);
+    expect(info.mtimeMs).toBeGreaterThan(0);
+  });
+
+  it('JSON flag content → hashCapable=true with the stamped sha', () => {
+    const agent = makeAgent('newhook');
+    const stateDir = join(testDir, 'state', 'newhook');
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'last_prompt.flag'), JSON.stringify({ ts: 1783691952, sha256: 'ab'.repeat(32), len: 10 }), 'utf-8');
+    const info = agent.promptFlagInfo();
+    expect(info.hashCapable).toBe(true);
+    expect(info.sha256).toBe('ab'.repeat(32));
+  });
+
+  it('submittedPromptContains matches per-payload against last_prompt.txt', () => {
+    const agent = makeAgent('attrib');
+    const stateDir = join(testDir, 'state', 'attrib');
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'last_prompt.txt'), 'flushed turn: block-A plus [CRON] noise', 'utf-8');
+    expect(agent.submittedPromptContains('block-A')).toBe(true);
+    expect(agent.submittedPromptContains('block-B')).toBe(false);
+  });
+
+  it('missing last_prompt.txt → attribution is simply false (no throw)', () => {
+    const agent = makeAgent('notxt');
+    expect(agent.submittedPromptContains('anything')).toBe(false);
+  });
+});

--- a/tests/unit/daemon/delivery-confirmation.test.ts
+++ b/tests/unit/daemon/delivery-confirmation.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, vi } from 'vitest';
+import { injectMessageConfirmed, KEYS } from '../../../src/pty/inject.js';
+
+// No real timers: inject a zero-delay sleep and drive confirmation state.
+const instantSleep = () => Promise.resolve();
+
+describe('injectMessageConfirmed', () => {
+  it('confirms on first Enter when the turn-start signal appears', async () => {
+    const writes: string[] = [];
+    let submitted = false;
+    const res = await injectMessageConfirmed(
+      d => {
+        writes.push(d);
+        if (d === KEYS.ENTER) submitted = true;
+      },
+      'hello',
+      { isConfirmed: () => submitted, sleep: instantSleep },
+    );
+    expect(res).toEqual({ confirmed: true, enterAttempts: 1 });
+    expect(writes[0]).toContain('hello');
+    expect(writes.filter(w => w === KEYS.ENTER)).toHaveLength(1);
+  });
+
+  it('retries Enter when the first submit is dropped, then confirms', async () => {
+    const writes: string[] = [];
+    let enters = 0;
+    let submitted = false;
+    const res = await injectMessageConfirmed(
+      d => {
+        writes.push(d);
+        if (d === KEYS.ENTER) {
+          enters++;
+          if (enters === 2) submitted = true; // first Enter dropped, second lands
+        }
+      },
+      'stall-class message',
+      { isConfirmed: () => submitted, sleep: instantSleep },
+    );
+    expect(res).toEqual({ confirmed: true, enterAttempts: 2 });
+    expect(writes.filter(w => w === KEYS.ENTER)).toHaveLength(2);
+  });
+
+  it('gives up after maxEnterAttempts and reports confirmed:false (DELIVERY_FAILED)', async () => {
+    const logs: string[] = [];
+    const res = await injectMessageConfirmed(
+      () => {},
+      'never submits',
+      { isConfirmed: () => false, sleep: instantSleep, maxEnterAttempts: 3, log: m => logs.push(m) },
+    );
+    expect(res).toEqual({ confirmed: false, enterAttempts: 3 });
+    expect(logs.join('\n')).toMatch(/no turn-start signal/);
+  });
+
+  it('chunked paste for large content still runs the confirmation loop', async () => {
+    const writes: string[] = [];
+    let submitted = false;
+    const big = 'x'.repeat(10_000);
+    const res = await injectMessageConfirmed(
+      d => {
+        writes.push(d);
+        if (d === KEYS.ENTER) submitted = true;
+      },
+      big,
+      { isConfirmed: () => submitted, sleep: instantSleep },
+    );
+    expect(res.confirmed).toBe(true);
+    expect(writes.join('').includes(big)).toBe(true);
+  });
+
+  it('a torn PTY on Enter returns confirmed:false instead of throwing', async () => {
+    let pasted = false;
+    const res = await injectMessageConfirmed(
+      d => {
+        if (d === KEYS.ENTER) throw new Error('pty torn down');
+        pasted = true;
+      },
+      'msg',
+      { isConfirmed: () => false, sleep: instantSleep, log: () => {} },
+    );
+    expect(pasted).toBe(true);
+    expect(res.confirmed).toBe(false);
+  });
+
+  it('worst-case wall clock stays within the 30s delivery gate (3 × 9s + delay)', async () => {
+    // Sum the sleeps the loop would take instead of running real timers.
+    let totalMs = 0;
+    const accountingSleep = (ms: number) => { totalMs += ms; return Promise.resolve(); };
+    await injectMessageConfirmed(() => {}, 'x', {
+      isConfirmed: () => false,
+      sleep: accountingSleep,
+    });
+    expect(totalMs).toBeLessThanOrEqual(30_000);
+  });
+});
+
+describe('fast-checker ack-on-confirm contract', () => {
+  // The pollCycle ack rule: ack when ok && confirmed !== false.
+  const shouldAck = (r: { ok: boolean; confirmed: boolean | null }) => r.ok && r.confirmed !== false;
+
+  it('acks on confirmed delivery', () => {
+    expect(shouldAck({ ok: true, confirmed: true })).toBe(true);
+  });
+  it('acks on legacy path (no confirmation channel)', () => {
+    expect(shouldAck({ ok: true, confirmed: null })).toBe(true);
+  });
+  it('does NOT ack on DELIVERY_FAILED — message must redeliver', () => {
+    expect(shouldAck({ ok: true, confirmed: false })).toBe(false);
+  });
+  it('does NOT ack when injection itself failed', () => {
+    expect(shouldAck({ ok: false, confirmed: null })).toBe(false);
+  });
+});

--- a/tests/unit/daemon/delivery-confirmation.test.ts
+++ b/tests/unit/daemon/delivery-confirmation.test.ts
@@ -110,3 +110,22 @@ describe('fast-checker ack-on-confirm contract', () => {
     expect(shouldAck({ ok: false, confirmed: null })).toBe(false);
   });
 });
+
+describe('MessageDedup.forget — redelivery after DELIVERY_FAILED', () => {
+  it('forgotten content can inject again; unforgotten stays deduped', async () => {
+    const { MessageDedup } = await import('../../../src/pty/inject.js');
+    const dedup = new MessageDedup();
+    expect(dedup.isDuplicate('msg-a')).toBe(false); // first sight records it
+    expect(dedup.isDuplicate('msg-a')).toBe(true);  // redelivery would be dropped
+    dedup.forget('msg-a');
+    expect(dedup.isDuplicate('msg-a')).toBe(false); // retry path open again
+    expect(dedup.isDuplicate('msg-a')).toBe(true);
+  });
+
+  it('forget of unseen content is a no-op', async () => {
+    const { MessageDedup } = await import('../../../src/pty/inject.js');
+    const dedup = new MessageDedup();
+    dedup.forget('never-seen');
+    expect(dedup.isDuplicate('other')).toBe(false);
+  });
+});

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('child_process', () => ({ execFile: vi.fn() }));
+vi.mock('../../../src/bus/heartbeat.js', async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  updateHeartbeat: vi.fn(),
+}));
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -804,48 +808,56 @@ describe('FastChecker', () => {
     beforeEach(() => { vi.useFakeTimers(); });
     afterEach(() => { vi.useRealTimers(); vi.clearAllMocks(); });
 
-    it('fires exec after bootstrap at 50-min interval', async () => {
-      const { execFile } = await import('child_process');
+    it('writes an in-process heartbeat for the NAMED agent at 50-min interval', async () => {
+      const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
       const agent = createMockAgent('my-agent');
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
-      expect(execFile).toHaveBeenCalledWith(
-        'cortextos',
-        expect.arrayContaining(['bus', 'update-heartbeat', expect.stringContaining('[watchdog] my-agent alive — idle session')]),
-        expect.any(Function),
+      expect(updateHeartbeat).toHaveBeenCalledWith(
+        paths,
+        'my-agent',
+        expect.stringContaining('[watchdog] my-agent alive — idle session'),
+        expect.objectContaining({}),
       );
       checker.stop();
       checker.wake();
     });
 
-    it('clears timer on stop — no further exec calls after stop', async () => {
+    it('never shells out for the watchdog beat (regression: phantom basename-cwd agent)', async () => {
       const { execFile } = await import('child_process');
-      const execMock = execFile as ReturnType<typeof vi.fn>;
       const agent = createMockAgent('my-agent');
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
-      const callsBefore = execMock.mock.calls.length;
+      expect(execFile).not.toHaveBeenCalled();
+      checker.stop();
+      checker.wake();
+    });
+
+    it('clears timer on stop — no further beats after stop', async () => {
+      const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
+      const hbMock = updateHeartbeat as ReturnType<typeof vi.fn>;
+      const agent = createMockAgent('my-agent');
+      const checker = new FastChecker(agent, paths, '/tmp/framework');
+      checker.start();
+      await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
+      const callsBefore = hbMock.mock.calls.length;
       expect(callsBefore).toBeGreaterThan(0);
       checker.stop();
       checker.wake();
       await vi.advanceTimersByTimeAsync(50 * 60 * 1000);
-      expect(execMock.mock.calls.length).toBe(callsBefore);
+      expect(hbMock.mock.calls.length).toBe(callsBefore);
     });
 
     it('does not fire before bootstrap completes', async () => {
-      const { execFile } = await import('child_process');
+      const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
       const agent = createMockAgent('my-agent');
       agent.isBootstrapped.mockReturnValue(false);
       const checker = new FastChecker(agent, paths, '/tmp/framework');
       checker.start();
       await vi.advanceTimersByTimeAsync(20 * 1000);
-      expect(execFile).not.toHaveBeenCalledWith(
-        'cortextos',
-        expect.arrayContaining([expect.stringContaining('[watchdog]')]),
-        expect.any(Function),
-      );
+      expect(updateHeartbeat).not.toHaveBeenCalled();
       checker.stop();
       checker.wake();
     });

--- a/tests/unit/daemon/hook-reconciler.test.ts
+++ b/tests/unit/daemon/hook-reconciler.test.ts
@@ -27,7 +27,8 @@ describe('ensureRequiredHooks', () => {
   it('adds the Stop hook when the event is entirely missing (kirk/spock case)', () => {
     const dir = track(agentDirWith({ hooks: { PreToolUse: [] } }));
     const added = ensureRequiredHooks(dir);
-    expect(added).toEqual([`Stop → ${STOP_CMD}`]);
+    expect(added).toContain(`Stop → ${STOP_CMD}`);
+    expect(added).toHaveLength(REQUIRED_HOOKS.length);
     const s = readSettings(dir);
     expect(s.hooks.Stop).toHaveLength(1);
     expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
@@ -44,9 +45,11 @@ describe('ensureRequiredHooks', () => {
     expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
   });
 
-  it('is idempotent — hook already present means no change', () => {
+  it('is idempotent — hooks already present mean no change', () => {
     const dir = track(agentDirWith({
-      hooks: { Stop: [{ hooks: [{ type: 'command', command: STOP_CMD, timeout: 5 }] }] },
+      hooks: Object.fromEntries(REQUIRED_HOOKS.map(r => [
+        r.event, [{ hooks: [{ type: 'command', command: r.command, timeout: r.timeout }] }],
+      ])),
     }));
     const before = readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8');
     expect(ensureRequiredHooks(dir)).toEqual([]);
@@ -55,10 +58,13 @@ describe('ensureRequiredHooks', () => {
 
   it('detects presence by command substring within existing Stop groups', () => {
     const dir = track(agentDirWith({
-      hooks: { Stop: [{ hooks: [
-        { type: 'command', command: 'some-other-hook' },
-        { type: 'command', command: `${STOP_CMD} --extra-arg` },
-      ] }] },
+      hooks: {
+        Stop: [{ hooks: [
+          { type: 'command', command: 'some-other-hook' },
+          { type: 'command', command: `${STOP_CMD} --extra-arg` },
+        ] }],
+        UserPromptSubmit: [{ hooks: [{ type: 'command', command: 'cortextos bus hook-prompt-flag' }] }],
+      },
     }));
     expect(ensureRequiredHooks(dir)).toEqual([]);
   });
@@ -68,7 +74,7 @@ describe('ensureRequiredHooks', () => {
       hooks: { Stop: [{ hooks: [{ type: 'command', command: 'user-custom-stop' }] }] },
     }));
     const added = ensureRequiredHooks(dir);
-    expect(added).toHaveLength(1);
+    expect(added).toContain(`Stop → ${STOP_CMD}`);
     const s = readSettings(dir);
     expect(s.hooks.Stop).toHaveLength(2);
     expect(s.hooks.Stop[0].hooks[0].command).toBe('user-custom-stop');

--- a/tests/unit/daemon/hook-reconciler.test.ts
+++ b/tests/unit/daemon/hook-reconciler.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { ensureRequiredHooks, REQUIRED_HOOKS } from '../../../src/daemon/hook-reconciler.js';
+
+const STOP_CMD = 'cortextos bus hook-idle-flag';
+
+function agentDirWith(settings: unknown): string {
+  const dir = mkdtempSync(join(tmpdir(), 'hook-reconciler-'));
+  mkdirSync(join(dir, '.claude'), { recursive: true });
+  writeFileSync(
+    join(dir, '.claude', 'settings.json'),
+    typeof settings === 'string' ? settings : JSON.stringify(settings, null, 2)
+  );
+  return dir;
+}
+function readSettings(dir: string): Record<string, any> {
+  return JSON.parse(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8'));
+}
+
+describe('ensureRequiredHooks', () => {
+  let dirs: string[] = [];
+  afterEach(() => { dirs.forEach(d => rmSync(d, { recursive: true, force: true })); dirs = []; });
+  const track = (d: string) => { dirs.push(d); return d; };
+
+  it('adds the Stop hook when the event is entirely missing (kirk/spock case)', () => {
+    const dir = track(agentDirWith({ hooks: { PreToolUse: [] } }));
+    const added = ensureRequiredHooks(dir);
+    expect(added).toEqual([`Stop → ${STOP_CMD}`]);
+    const s = readSettings(dir);
+    expect(s.hooks.Stop).toHaveLength(1);
+    expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
+    expect(s.hooks.Stop[0].hooks[0].timeout).toBe(5);
+    expect(s.hooks.PreToolUse).toEqual([]); // untouched
+  });
+
+  it('adds hooks key when settings has none at all', () => {
+    const dir = track(agentDirWith({ model: 'opus' }));
+    const added = ensureRequiredHooks(dir);
+    expect(added.length).toBe(REQUIRED_HOOKS.length);
+    const s = readSettings(dir);
+    expect(s.model).toBe('opus');
+    expect(s.hooks.Stop[0].hooks[0].command).toBe(STOP_CMD);
+  });
+
+  it('is idempotent — hook already present means no change', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: STOP_CMD, timeout: 5 }] }] },
+    }));
+    const before = readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8');
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8')).toBe(before);
+  });
+
+  it('detects presence by command substring within existing Stop groups', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [
+        { type: 'command', command: 'some-other-hook' },
+        { type: 'command', command: `${STOP_CMD} --extra-arg` },
+      ] }] },
+    }));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+  });
+
+  it('preserves existing user hooks when appending', () => {
+    const dir = track(agentDirWith({
+      hooks: { Stop: [{ hooks: [{ type: 'command', command: 'user-custom-stop' }] }] },
+    }));
+    const added = ensureRequiredHooks(dir);
+    expect(added).toHaveLength(1);
+    const s = readSettings(dir);
+    expect(s.hooks.Stop).toHaveLength(2);
+    expect(s.hooks.Stop[0].hooks[0].command).toBe('user-custom-stop');
+    expect(s.hooks.Stop[1].hooks[0].command).toBe(STOP_CMD);
+  });
+
+  it('leaves malformed JSON untouched and reports nothing added', () => {
+    const dir = track(agentDirWith('{ not json ]]'));
+    const logs: string[] = [];
+    expect(ensureRequiredHooks(dir, m => logs.push(m))).toEqual([]);
+    expect(readFileSync(join(dir, '.claude', 'settings.json'), 'utf-8')).toBe('{ not json ]]');
+    expect(logs.join(' ')).toMatch(/malformed|unreadable/);
+  });
+
+  it('skips when settings.json does not exist (no invention)', () => {
+    const dir = track(mkdtempSync(join(tmpdir(), 'hook-reconciler-')));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(existsSync(join(dir, '.claude', 'settings.json'))).toBe(false);
+  });
+
+  it('leaves non-object hooks value untouched', () => {
+    const dir = track(agentDirWith({ hooks: 'weird' }));
+    expect(ensureRequiredHooks(dir)).toEqual([]);
+    expect(readSettings(dir).hooks).toBe('weird');
+  });
+});

--- a/tests/unit/daemon/log-timestamps.test.ts
+++ b/tests/unit/daemon/log-timestamps.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { installTimestampedConsole } from '../../../src/daemon/log-timestamps.js';
+
+const INSTALLED = Symbol.for('cortextos.timestampedConsole');
+const ISO_PREFIX = /^\[\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\]$/;
+
+describe('installTimestampedConsole', () => {
+  const originals = { log: console.log, warn: console.warn, error: console.error };
+
+  beforeEach(() => {
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  afterEach(() => {
+    console.log = originals.log;
+    console.warn = originals.warn;
+    console.error = originals.error;
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+  });
+
+  it('prefixes console.log lines with an ISO-8601 UTC timestamp', () => {
+    installTimestampedConsole();
+    const spy = vi.fn();
+    // Capture what the wrapper forwards by re-wrapping the (already bound) sink:
+    // install() bound the ORIGINAL console.log, so intercept via a fresh install.
+    delete (globalThis as Record<PropertyKey, unknown>)[INSTALLED];
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('[daemon] hello', 42);
+    expect(spy).toHaveBeenCalledTimes(1);
+    const [ts, msg, num] = spy.mock.calls[0];
+    expect(String(ts)).toMatch(ISO_PREFIX);
+    expect(msg).toBe('[daemon] hello');
+    expect(num).toBe(42);
+  });
+
+  it('prefixes warn and error the same way', () => {
+    const warnSpy = vi.fn();
+    const errSpy = vi.fn();
+    console.warn = warnSpy;
+    console.error = errSpy;
+    installTimestampedConsole();
+    console.warn('w');
+    console.error('e');
+    expect(String(warnSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(String(errSpy.mock.calls[0][0])).toMatch(ISO_PREFIX);
+    expect(warnSpy.mock.calls[0][1]).toBe('w');
+    expect(errSpy.mock.calls[0][1]).toBe('e');
+  });
+
+  it('is idempotent — double install does not double-prefix', () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    installTimestampedConsole();
+    console.log('once');
+    expect(spy).toHaveBeenCalledTimes(1);
+    const call = spy.mock.calls[0];
+    expect(call.length).toBe(2); // [timestamp, 'once'] — not [ts, ts, 'once']
+    expect(String(call[0])).toMatch(ISO_PREFIX);
+    expect(call[1]).toBe('once');
+  });
+
+  it('timestamp advances between calls (not frozen at install time)', async () => {
+    const spy = vi.fn();
+    console.log = spy;
+    installTimestampedConsole();
+    console.log('a');
+    await new Promise(r => setTimeout(r, 5));
+    console.log('b');
+    const t1 = Date.parse(String(spy.mock.calls[0][0]).slice(1, -1));
+    const t2 = Date.parse(String(spy.mock.calls[1][0]).slice(1, -1));
+    expect(t2).toBeGreaterThanOrEqual(t1);
+    expect(Number.isNaN(t1)).toBe(false);
+  });
+});

--- a/tests/unit/daemon/staleness-detector.test.ts
+++ b/tests/unit/daemon/staleness-detector.test.ts
@@ -1,0 +1,174 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, utimesSync, existsSync, readFileSync } from 'fs';
+import { join, basename } from 'path';
+import { tmpdir } from 'os';
+import {
+  assessStaleness,
+  readLivenessSources,
+  StalenessDetector,
+  DEFAULT_STALE_THRESHOLD_MS,
+} from '../../../src/daemon/staleness-detector.js';
+
+const MIN = 60_000;
+const NOW = 1_800_000_000_000;
+
+describe('assessStaleness (pure rule)', () => {
+  it('fresh heartbeat alone = not stale', () => {
+    const v = assessStaleness({ heartbeatAt: NOW - 5 * MIN }, NOW);
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('heartbeat');
+  });
+
+  it('stale heartbeat but FRESH CRON FIRE = not stale (the 2026-07-09 false-positive class)', () => {
+    const v = assessStaleness(
+      { heartbeatAt: NOW - 165 * MIN, lastCronFireAt: NOW - 10 * MIN },
+      NOW,
+    );
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('cron-fire');
+  });
+
+  it('stale heartbeat + stale cron + fresh idle flag = not stale', () => {
+    const v = assessStaleness(
+      { heartbeatAt: NOW - 90 * MIN, lastCronFireAt: NOW - 80 * MIN, idleFlagAt: NOW - 2 * MIN },
+      NOW,
+    );
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('idle-flag');
+  });
+
+  it('ALL sources silent past threshold = stale', () => {
+    const v = assessStaleness(
+      { heartbeatAt: NOW - 90 * MIN, lastCronFireAt: NOW - 50 * MIN, idleFlagAt: NOW - 46 * MIN },
+      NOW,
+    );
+    expect(v.stale).toBe(true);
+    expect(v.ageMs).toBe(46 * MIN);
+  });
+
+  it('exactly at threshold = not stale (strictly greater)', () => {
+    const v = assessStaleness({ heartbeatAt: NOW - DEFAULT_STALE_THRESHOLD_MS }, NOW);
+    expect(v.stale).toBe(false);
+  });
+
+  it('no sources at all = never stale (new agent, nothing to judge)', () => {
+    const v = assessStaleness({}, NOW);
+    expect(v.stale).toBe(false);
+    expect(v.freshestSource).toBe('none');
+  });
+});
+
+describe('readLivenessSources', () => {
+  let dirs: string[] = [];
+  afterEach(() => { dirs.forEach(d => rmSync(d, { recursive: true, force: true })); dirs = []; });
+  const stateDir = () => { const d = mkdtempSync(join(tmpdir(), 'stale-src-')); dirs.push(d); return d; };
+
+  it('reads heartbeat.json last_heartbeat, cron-state latest fire, idle flag mtime', () => {
+    const dir = stateDir();
+    writeFileSync(join(dir, 'heartbeat.json'),
+      JSON.stringify({ agent: 'x', last_heartbeat: '2026-07-10T10:00:00Z' }));
+    writeFileSync(join(dir, 'cron-state.json'), JSON.stringify({
+      updated_at: '2026-07-10T10:22:00Z',
+      crons: [
+        { name: 'heartbeat', last_fire: '2026-07-10T09:59:00Z' },
+        { name: 'file-drop', last_fire: '2026-07-10T10:22:00Z' },
+      ],
+    }));
+    writeFileSync(join(dir, 'last_idle.flag'), '1783684800');
+    const t = new Date('2026-07-10T10:30:00Z');
+    utimesSync(join(dir, 'last_idle.flag'), t, t);
+
+    const s = readLivenessSources(dir);
+    expect(s.heartbeatAt).toBe(Date.parse('2026-07-10T10:00:00Z'));
+    expect(s.lastCronFireAt).toBe(Date.parse('2026-07-10T10:22:00Z')); // latest of the two
+    expect(Math.abs((s.idleFlagAt ?? 0) - t.getTime())).toBeLessThan(2000);
+  });
+
+  it('returns empty object for a bare state dir', () => {
+    expect(readLivenessSources(stateDir())).toEqual({});
+  });
+
+  it('malformed heartbeat.json falls back to file mtime', () => {
+    const dir = stateDir();
+    writeFileSync(join(dir, 'heartbeat.json'), '{corrupt');
+    const s = readLivenessSources(dir);
+    expect(typeof s.heartbeatAt).toBe('number');
+  });
+});
+
+describe('StalenessDetector sweep', () => {
+  let dirs: string[] = [];
+  afterEach(() => { dirs.forEach(d => rmSync(d, { recursive: true, force: true })); dirs = []; });
+
+  function ctxWithAgent(name: string, hbAgeMin: number, now: number) {
+    const ctxRoot = mkdtempSync(join(tmpdir(), 'stale-ctx-'));
+    dirs.push(ctxRoot);
+    const stateDir = join(ctxRoot, 'state', name);
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'heartbeat.json'), JSON.stringify({
+      agent: name,
+      last_heartbeat: new Date(now - hbAgeMin * MIN).toISOString().replace(/\.\d{3}Z$/, 'Z'),
+    }));
+    return ctxRoot;
+  }
+
+  it('prods a stale agent once and then respects the cooldown', () => {
+    const now = NOW;
+    const ctxRoot = ctxWithAgent('kirk', 120, now);
+    const notify = vi.fn();
+    const logs: string[] = [];
+    const det = new StalenessDetector({
+      instanceId: 'default',
+      ctxRoot,
+      listAgents: () => [{ name: 'kirk', org: '360i' }],
+      notify: notify as never,
+      now: () => now,
+      log: m => logs.push(m),
+    });
+    det.checkOnce();
+    det.checkOnce(); // same instant — cooldown must suppress
+    expect(notify).toHaveBeenCalledTimes(1);
+    const [, from, target, message] = notify.mock.calls[0];
+    expect(from).toBe('daemon');
+    expect(target).toBe('kirk');
+    expect(message).toMatch(/staleness detector/);
+    expect(logs.join('\n')).toMatch(/ALL liveness sources silent/);
+  });
+
+  it('does NOT prod when a cron fire is fresh even with stale heartbeat', () => {
+    const now = NOW;
+    const ctxRoot = ctxWithAgent('scotty', 120, now);
+    writeFileSync(join(ctxRoot, 'state', 'scotty', 'cron-state.json'), JSON.stringify({
+      updated_at: new Date(now).toISOString(),
+      crons: [{ name: 'file-drop', last_fire: new Date(now - 5 * MIN).toISOString() }],
+    }));
+    const notify = vi.fn();
+    const det = new StalenessDetector({
+      instanceId: 'default', ctxRoot,
+      listAgents: () => [{ name: 'scotty', org: '360i' }],
+      notify: notify as never, now: () => now, log: () => {},
+    });
+    det.checkOnce();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('regression (addendum 3): watchdog-class beat via updateHeartbeat writes the NAMED agent dir and no basename-cwd phantom dir appears', async () => {
+    const { updateHeartbeat } = await import('../../../src/bus/heartbeat.js');
+    const { resolvePaths } = await import('../../../src/utils/paths.js');
+    // Simulate the daemon environment: cwd basename is the framework checkout
+    const paths = resolvePaths('scotty', 'default');
+    // Write to an isolated fake state dir instead of the real one:
+    const ctxRoot = mkdtempSync(join(tmpdir(), 'stale-reg-'));
+    dirs.push(ctxRoot);
+    const fakePaths = { ...paths, stateDir: join(ctxRoot, 'state', 'scotty') };
+    const before = Date.now();
+    updateHeartbeat(fakePaths as never, 'scotty', '[watchdog] scotty alive — idle session test', { org: '360i' });
+    const hbPath = join(ctxRoot, 'state', 'scotty', 'heartbeat.json');
+    expect(existsSync(hbPath)).toBe(true);
+    const hb = JSON.parse(readFileSync(hbPath, 'utf-8'));
+    expect(hb.agent).toBe('scotty'); // named agent, not basename(cwd)
+    expect(Date.parse(hb.last_heartbeat)).toBeGreaterThanOrEqual(before - 1000);
+    // No phantom dir named after the process cwd basename:
+    expect(existsSync(join(ctxRoot, 'state', basename(process.cwd())))).toBe(false);
+  });
+});

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     'hooks/hook-compact-telegram': 'src/hooks/hook-compact-telegram.ts',
     'hooks/hook-extract-facts': 'src/hooks/hook-extract-facts.ts',
     'hooks/hook-idle-flag': 'src/hooks/hook-idle-flag.ts',
+    'hooks/hook-prompt-flag': 'src/hooks/hook-prompt-flag.ts',
     'hooks/hook-context-status': 'src/hooks/hook-context-status.ts',
     'hooks/hook-loop-detector': 'src/hooks/hook-loop-detector.ts',
   },


### PR DESCRIPTION
**STACKED ON #758** (fix/delivery-confirmation) — contains its commits until it merges; review the top 4 commits only (154bc89..0c9a992). D2 here reworks the confirmation predicate #758 introduces, so stacking is structurally necessary.

## Defects fixed (all reproduced live on our fleet 2026-07-10)

- **D1** — `send-message --reply-to` stored reply_to as metadata only; nothing ever acked the original, so every replied-to message redelivered after 5 min. Now: a reply IS proof of delivery — `sendMessage` acks the original in the sender's inflight/inbox at send time.
- **D3** — `ackInbox` scanned inflight/ only; acking a message that the 300s stale sweep had recovered back to inbox/ was a silent no-op. Now scans both.
- **D2** — the delivery-confirmation predicate (`promptFlagMtime > injectedAt`) confirmed on any flag advance it could not attribute. Live false-POSITIVE: two crons fired the same second into one idle PTY; one injection confirmed on the other's turn-start, was acked, and its kept dedup hash then swallowed every redelivery (~1/s dedup log storm, 37-min user-visible stall). Live false-NEGATIVE: a paste queued into a mid-turn session logged DELIVERY_FAILED although the content delivered at the next turn boundary.

## Design

- **Attribution (AND-gate):** the UserPromptSubmit hook now stamps `{ts, sha256, len}` into `last_prompt.flag` and writes the submitted prompt to `last_prompt.txt` (0600, same trust boundary as the inbox files beside it). A confirm requires the flag to advance past injection time AND the injected payload to appear in the submitted prompt — per-injection, so one turn-start flushing N queued pastes confirms each independently (no first-flag-wins; an unhashed cron-path paste neither confirms nor blocks). **Explicit scope flag: this extends the hook surface** (flag format + new sidecar file). Legacy plain-integer flags are auto-detected and degrade to mtime-only + fast-fail — agents converge to the JSON format at their next turn post-deploy.
- **DEFERRED_CONFIRM:** a paste queued into an alive-but-mid-turn session becomes a hold instead of a failure: not acked, not failed, exempt from the 300s stale-inflight recovery via on-disk markers (`inflight/.deferred/*.marker`), resolved at the next turn boundary or timed out at 10 min. Timeout forgets ALL dedup state for the block and releases the messages to normal redelivery. The exemption lives inside `recoverStaleInflight` because agent CLIs call it via every `check-inbox`, not just the daemon.
- **Restart safety:** markers embed the ORIGINAL injectedAt+deadline; holds rebuild from markers on daemon start and a restart never refreshes a deadline (a crash-looping daemon must not extend holds unbounded). Markers clean up on both exit paths; orphans GC on sight.
- **Instrumentation:** every confirm verdict logs flagMtime/injectedAt/delta/flagSha/payloadSha/hashCapable so the next anomaly self-documents.

## Verification

- 18 new tests (`tests/unit/bus/ack-path.test.ts`, `tests/unit/daemon/deferred-confirm.test.ts`) covering: reply-acks-original, dual-dir ack, deferred confirm/timeout, flag-less + legacy-format fallbacks, per-payload multi-flush attribution incl. inert cron paste, recovery exemption, original-deadline-under-restart, orphan GC. All pass.
- Full unit suite: 1233/1261 — the 28 failures live in 4 files whose failing set is byte-identical on the clean base (verified in a separate pinned worktree); none touch these paths. tsc clean. Integration/e2e not run.
- Spec + gate matrix + independent cross-verification (second agent, own runs + code read) maintained downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)