### PR TITLE
fix(bus): persist agent messages to message-history.jsonl (dashboard Comms shows empty agent history)

### DIFF
--- a/src/bus/message.ts
+++ b/src/bus/message.ts
@@ -1,4 +1,4 @@
-import { readdirSync, readFileSync, renameSync, statSync, existsSync } from 'fs';
+import { readdirSync, readFileSync, renameSync, statSync, existsSync, appendFileSync } from 'fs';
 import { join } from 'path';
 import { createHmac, timingSafeEqual } from 'crypto';
 import type { InboxMessage, Priority, BusPaths } from '../types/index.js';
@@ -83,6 +83,33 @@ export function sendMessage(
   const inboxDir = join(paths.ctxRoot, 'inbox', to);
   ensureDir(inboxDir);
   atomicWriteSync(join(inboxDir, filename), JSON.stringify(message));
+
+  // Persist to the durable message-history log so agent-to-agent conversations
+  // survive inbox cleanup. The inbox copy is transient — it is moved to
+  // inflight on check and deleted/processed after ACK — so without this append
+  // the dashboard's Comms view has no source for agent chat history and renders
+  // channels as empty. The dashboard (dashboard/src/app/api/comms/*) already
+  // reads this file as its primary source; nothing wrote it until now.
+  //
+  // Best-effort and non-fatal: message delivery already succeeded above, so a
+  // logging failure must never break sends. Signature is intentionally omitted
+  // from the history record — it is a delivery-integrity field, not chat data.
+  try {
+    const historyDir = join(paths.ctxRoot, 'logs');
+    ensureDir(historyDir);
+    const historyLine = JSON.stringify({
+      id: msgId,
+      from,
+      to,
+      priority,
+      timestamp: message.timestamp,
+      text,
+      reply_to: replyTo || null,
+    });
+    appendFileSync(join(historyDir, 'message-history.jsonl'), historyLine + '\n', 'utf-8');
+  } catch {
+    /* history logging is best-effort — never fail a delivered message */
+  }
 
   return msgId;
 }


### PR DESCRIPTION
## Problem

The dashboard Comms view reads `${CTX_ROOT}/logs/message-history.jsonl` as its **primary persistent source** for agent-to-agent chat history (see `dashboard/src/app/api/comms/channels/route.ts` and `channel/[pair]/route.ts`, which both iterate that file first). But **nothing in the framework ever writes it** — `git grep message-history src/` returns no writer.

As a result, agent↔agent messages only ever live transiently in the recipient's `inbox/<to>/` directory and are removed once ACK'd, so the dashboard has no durable source for them. Agent↔agent channels render **"No messages in this channel"** even though the conversation happened, while user↔agent Telegram channels (which have their own `logs/<agent>/{inbound,outbound}-messages.jsonl`) display full history — making the bug look selective.

## Fix

`sendMessage()` now appends each delivered message to `logs/message-history.jsonl` using the exact schema the dashboard routes already expect (`id`/`from`/`to`/`priority`/`timestamp`/`text`/`reply_to`), matching the existing `appendFileSync` JSONL convention in `event.ts`.

- **Best-effort and non-fatal:** the append is wrapped in try/catch and runs *after* delivery already succeeded, so a logging failure can never break a message that was sent.
- **Signature omitted** from the history record — the HMAC `sig` is a delivery-integrity field, not chat content.
- **Forward-only:** history that was already lost before this change cannot be recovered; channels populate from the next message onward.

## Verification

- `npm run build` clean; the bus `message` unit tests and the dashboard comms route tests pass.
- Verified end-to-end on a live fleet: `message-history.jsonl` went from absent to capturing every agent message, and the dashboard Comms view populates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)