### PR TITLE
fix(bus): a locked inbox must never look like an empty one

### DIFF
--- a/src/bus/message.ts
+++ b/src/bus/message.ts
@@ -4,9 +4,34 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import type { InboxMessage, Priority, BusPaths } from '../types/index.js';
 import { PRIORITY_MAP } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
-import { acquireLock, releaseLock } from '../utils/lock.js';
+import { acquireLock, releaseLock, inspectLock, type LockHeldInfo } from '../utils/lock.js';
 import { randomString } from '../utils/random.js';
 import { validateAgentName, validatePriority } from '../utils/validate.js';
+
+/**
+ * Thrown when the inbox lock cannot be taken, so the inbox could not be READ.
+ *
+ * Distinct from an empty inbox on purpose: callers must not be able to mistake
+ * "I could not look" for "there was nothing there". See checkInbox.
+ */
+export class InboxLockedError extends Error {
+  readonly inbox: string;
+  readonly lock: LockHeldInfo | null;
+
+  constructor(inbox: string, lock: LockHeldInfo | null) {
+    const held = lock
+      ? `held ${Math.round(lock.ageMs / 1000)}s` +
+        (lock.pidUnreadable ? ' by an unreadable PID (holder likely died mid-acquire)' : ` by pid ${lock.pid}`)
+      : 'lock released during inspection';
+    super(
+      `Inbox "${inbox}" is LOCKED and was NOT read (${held}). ` +
+      `Messages may be queued and undelivered — this is NOT an empty inbox.`,
+    );
+    this.name = 'InboxLockedError';
+    this.inbox = inbox;
+    this.lock = lock;
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Security (H10): HMAC-SHA256 message signing
@@ -98,9 +123,17 @@ export function checkInbox(paths: BusPaths): InboxMessage[] {
   ensureDir(inbox);
   ensureDir(inflight);
 
-  // Acquire lock
+  // Acquire lock.
+  //
+  // This MUST NOT return [] on failure. An empty array here is indistinguishable
+  // from "the inbox is empty", and every caller reads it as the latter — so a
+  // lock we cannot take silently becomes "no messages", forever, with no tell.
+  // That is not hypothetical: a hard shutdown left an abandoned lock on one
+  // agent's inbox and it reported a clean empty inbox for three days while 26
+  // messages queued behind it. Failing to read is a DIFFERENT outcome from
+  // having nothing to read, and it has to be loud.
   if (!acquireLock(inbox)) {
-    return [];
+    throw new InboxLockedError(inbox, inspectLock(inbox));
   }
 
   try {

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -2,7 +2,8 @@ import { Command } from 'commander';
 import { spawnSync, execFileSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { sendMessage, checkInbox, ackInbox } from '../bus/message.js';
+import { sendMessage, checkInbox, ackInbox, InboxLockedError } from '../bus/message.js';
+import { LOCK_STALE_MS } from '../utils/lock.js';
 import { validateAgentName, validateTaskId } from '../utils/validate.js';
 import { createTask, updateTask, completeTask, claimTask, readTaskAudit, checkTaskDependencies, compactTasks, listTasks, checkStaleTasks, archiveTasks, checkHumanTasks } from '../bus/task.js';
 import { saveOutput } from '../bus/save-output.js';
@@ -127,7 +128,25 @@ busCommand
   .action(() => {
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
-    const messages = checkInbox(paths);
+    let messages;
+    try {
+      messages = checkInbox(paths);
+    } catch (err) {
+      // A locked inbox must never print `[]` — that is the failure mode this
+      // guards: an agent reads `[]` as "no messages" and goes quietly deaf.
+      // Print to stderr and exit non-zero so it cannot be mistaken for empty
+      // by a human OR by a script parsing stdout.
+      if (err instanceof InboxLockedError) {
+        console.error(`ERROR: ${err.message}`);
+        console.error(
+          'The inbox was NOT read. Do not treat this as an empty inbox. ' +
+          'If the holder is dead, the lock is broken automatically after ' +
+          `${LOCK_STALE_MS / 1000}s — retry. If it persists, inspect ${err.inbox}/.lock.d`,
+        );
+        process.exit(1);
+      }
+      throw err;
+    }
     console.log(JSON.stringify(messages));
   });
 

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -4,7 +4,7 @@ import { join } from 'path';
 import { createHash } from 'crypto';
 import { hardRestart } from '../bus/system.js';
 import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
-import { checkInbox, ackInbox } from '../bus/message.js';
+import { checkInbox, ackInbox, InboxLockedError } from '../bus/message.js';
 import { updateApproval } from '../bus/approval.js';
 import { AgentProcess } from './agent-process.js';
 import type { TelegramAPI } from '../telegram/api.js';
@@ -48,6 +48,8 @@ export class FastChecker {
   private telegramApi?: TelegramAPI;
   private chatId?: string;
   private allowedUserId?: number;
+  /** Consecutive poll cycles the inbox could not be READ (lock held). Not the same as an empty inbox. */
+  private inboxLockedCycles = 0;
 
   // External Telegram handler (set by daemon)
   private telegramMessages: Array<{ formatted: string; ackIds: string[] }> = [];
@@ -195,8 +197,30 @@ export class FastChecker {
       hasTelegramMessage = true;
     }
 
-    // Check agent inbox
-    const inboxMessages = checkInbox(this.paths);
+    // Check agent inbox.
+    //
+    // A locked inbox is NOT an empty one. Swallowing this is how an agent goes
+    // silently deaf: the poll cycle sees no messages, injects nothing, and the
+    // agent reports a clean inbox while mail piles up behind an abandoned lock.
+    // Log it loudly every cycle — a failure nobody can see is a failure nobody
+    // can fix. The lock now self-heals once it ages past LOCK_STALE_MS, so this
+    // should be transient; if it is not, the log is the only thing that will
+    // ever say so.
+    let inboxMessages: InboxMessage[] = [];
+    try {
+      inboxMessages = checkInbox(this.paths);
+      this.inboxLockedCycles = 0;
+    } catch (err) {
+      if (err instanceof InboxLockedError) {
+        this.inboxLockedCycles++;
+        this.log(
+          `INBOX NOT READ (cycle ${this.inboxLockedCycles}): ${err.message} ` +
+          `Messages may be queued and undelivered.`,
+        );
+      } else {
+        throw err;
+      }
+    }
     for (const msg of inboxMessages) {
       messageBlock += this.formatInboxMessage(msg);
       ackIds.push(msg.id);

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, rmdirSync, writeFileSync, readFileSync, rmSync, statSync } from 'fs';
+import { mkdirSync, rmdirSync, writeFileSync, readFileSync, rmSync, statSync, renameSync } from 'fs';
 import { join } from 'path';
 
 /**
@@ -114,17 +114,122 @@ export function acquireLock(dir: string): boolean {
       // Process is alive - lock is held
       return false;
     } catch {
-      // Process is dead - stale lock, remove and re-acquire atomically.
-      try {
-        rmSync(lockDir, { recursive: true, force: true });
-        mkdirSync(lockDir);
-        writeFileSync(pidFile, String(process.pid));
-        return true;
-      } catch {
-        // Another process beat us to the steal — let caller retry.
-        return false;
-      }
+      // Process is dead — stale lock. Steal it ATOMICALLY.
+      //
+      // This path used to rmSync(force) + mkdirSync, which is not a steal but a
+      // free-for-all: two processes can both observe the same dead PID, and the
+      // second one's force-delete removes the FIRST one's freshly-created live
+      // lock, after which its mkdirSync succeeds. Both then hold the lock. See
+      // stealLock — rename() makes exactly one winner possible.
+      return stealLock(lockDir, pidFile);
     }
+  }
+}
+
+/**
+ * Take over a lock that is provably not held by a live process, WITHOUT ever
+ * being able to destroy a lock that IS.
+ *
+ * THE RACE THIS EXISTS TO KILL:
+ *
+ * The obvious steal — `rmSync(lockDir, {force: true})` then `mkdirSync` — is
+ * not mutual exclusion at all. Two processes routinely reach a recovery path on
+ * the same stale lock (the fast-checker's poll loop and any CLI invocation both
+ * find it, and both finish their liveness/age check before either acts):
+ *
+ *   A: rmSync (clears the stale lock) -> mkdirSync -> writes pid=A -> HOLDS IT
+ *   B: rmSync(force) -> DELETES A's LIVE LOCK -> mkdirSync now SUCCEEDS -> pid=B
+ *
+ * Both believe they hold it and enter the critical section together. Guarding
+ * with EEXIST on `mkdirSync` cannot help, because the caller's own force-delete
+ * destroyed the winner's lock one line earlier.
+ *
+ * The recovery path is precisely where this fires — which is the whole purpose
+ * of the function. Code written to prevent silent message loss would cause it.
+ *
+ * `rename()` is atomic: exactly one process can move the directory aside. The
+ * loser gets ENOENT and returns immediately, never reaching an `rmSync`, so it
+ * cannot delete anyone's live lock.
+ *
+ * Exported for tests: the failure mode (capturing a lock that turns out to be
+ * LIVE) is a nanosecond-wide interleaving that spawning real processes cannot
+ * reliably reproduce, so it is asserted directly against this function.
+ */
+export function stealLock(lockDir: string, pidFile: string): boolean {
+  // 1. CAPTURE. rename() is atomic: of all processes trying to move this lock
+  //    aside, exactly one succeeds. The losers get ENOENT and return without
+  //    ever touching an rmSync, so they cannot destroy anyone's live lock.
+  const steal = `${lockDir}.steal.${process.pid}.${Date.now()}`;
+  try {
+    renameSync(lockDir, steal);
+  } catch {
+    return false; // someone else captured it, or it vanished — retry.
+  }
+
+  // 2. RE-VERIFY WHAT WE ACTUALLY CAPTURED — on the object we now own alone.
+  //
+  //    The caller's staleness decision was made on a `stat` that may already be
+  //    out of date: between that stat and this rename, the rightful winner can
+  //    have finished its own steal and created a BRAND NEW, LIVE lock. Our
+  //    rename would then have moved *that* aside, and stealing on the strength
+  //    of the earlier stat would hand two processes the same lock.
+  //
+  //    So we re-decide here, where the object is exclusively ours and cannot
+  //    change under us. Capture first, judge second.
+  if (looksLive(steal)) {
+    // We captured a live lock. Put it back and lose gracefully.
+    try {
+      renameSync(steal, lockDir);
+    } catch {
+      // Restore failed only if something already occupies lockDir — i.e. a
+      // third process holds it. Discard ours rather than clobber theirs.
+      try { rmSync(steal, { recursive: true, force: true }); } catch { /* inert */ }
+    }
+    return false;
+  }
+
+  // 3. It is genuinely abandoned and it is ours. Replace it.
+  try { rmSync(steal, { recursive: true, force: true }); } catch { /* inert */ }
+
+  try {
+    // Atomic. EEXIST means an ordinary acquirer took the freed slot first —
+    // a legitimate loss, and nothing of theirs was destroyed to discover it.
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, String(process.pid));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Does this captured lock dir belong to a holder that is still alive — either a
+ * running PID, or one young enough to be legitimately mid-acquire?
+ */
+function looksLive(dir: string): boolean {
+  let raw: string;
+  try {
+    raw = readFileSync(join(dir, 'pid'), 'utf-8').trim();
+  } catch {
+    raw = '';
+  }
+
+  const pid = parseInt(raw, 10);
+  if (raw !== '' && !isNaN(pid)) {
+    try {
+      process.kill(pid, 0);
+      return true; // a live process holds this
+    } catch {
+      return false; // dead pid — safe to take
+    }
+  }
+
+  // No readable PID. Young => a holder is mid-acquire right now. Old => the
+  // holder was killed in that window and is never coming back.
+  try {
+    return Date.now() - statSync(dir).mtimeMs < LOCK_STALE_MS;
+  } catch {
+    return false;
   }
 }
 
@@ -132,8 +237,6 @@ export function acquireLock(dir: string): boolean {
  * Break a lock whose PID cannot be read, but only once it is older than
  * LOCK_STALE_MS — i.e. far past any legitimate mkdir→writeFileSync window, so
  * a live mid-acquire holder is never robbed.
- *
- * Returns true if the lock was broken and re-acquired by us.
  */
 function breakIfAbandoned(lockDir: string, pidFile: string): boolean {
   let ageMs: number;
@@ -149,16 +252,7 @@ function breakIfAbandoned(lockDir: string, pidFile: string): boolean {
     return false;
   }
 
-  // Abandoned: no PID to check for liveness and far too old to be mid-acquire.
-  try {
-    rmSync(lockDir, { recursive: true, force: true });
-    mkdirSync(lockDir);
-    writeFileSync(pidFile, String(process.pid));
-    return true;
-  } catch {
-    // Another process beat us to the steal — let the caller retry.
-    return false;
-  }
+  return stealLock(lockDir, pidFile);
 }
 
 /**

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -185,16 +185,37 @@ export function stealLock(lockDir: string, pidFile: string): boolean {
     if (holderAlive(info)) return false;  // a live process holds it: leave it untouched
     if (info.pidUnreadable && info.ageMs < LOCK_STALE_MS) return false; // mid-acquire
 
-    // 3. Verified abandoned, and it cannot turn live under us. Move it aside with
-    //    rename — ATOMIC, so even under a pathological double-claim exactly one
-    //    process can be the mover and the loser gets ENOENT. We NEVER rmSync the
-    //    lock directly, so no path can force-delete a lock that someone holds.
+    // Remember WHICH object we judged. The claim is age-recoverable (it must be —
+    // a killed stealer would otherwise leak it forever and block all recovery),
+    // so two stealers CAN hold it at once. Then this can happen:
+    //
+    //   A: judges abandoned -> steals -> installs a FRESH LIVE lock
+    //   B: (verdict already recorded) renames lockDir aside — but lockDir is now
+    //      A's LIVE lock, a DIFFERENT OBJECT than the one B judged.
+    //
+    // A verdict may only authorise destroying the object it actually examined.
+    // The inode is that object's identity, and rename preserves it.
+    const judgedIno = statSync(lockDir).ino;
+
+    // 3. Move it aside with rename — ATOMIC, so exactly one process can be the
+    //    mover; the loser gets ENOENT and touches nothing.
     const dead = `${lockDir}.dead.${process.pid}.${Date.now()}`;
     try {
       renameSync(lockDir, dead);
     } catch {
       return false; // someone else moved it first — nothing of ours destroyed
     }
+
+    // IDENTITY CHECK: is what we captured the thing we judged?
+    let capturedIno: bigint | number | undefined;
+    try { capturedIno = statSync(dead).ino; } catch { capturedIno = undefined; }
+    if (capturedIno !== judgedIno) {
+      // We captured an object we never examined — it may be a live lock. Put it
+      // back. A stale verdict must not be able to destroy what it never saw.
+      try { renameSync(dead, lockDir); } catch { /* someone re-took the slot */ }
+      return false;
+    }
+
     try { rmSync(dead, { recursive: true, force: true }); } catch { /* inert */ }
 
     try {

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,12 +1,72 @@
-import { mkdirSync, rmdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { mkdirSync, rmdirSync, writeFileSync, readFileSync, rmSync, statSync } from 'fs';
 import { join } from 'path';
+
+/**
+ * How long a lock whose PID cannot be read may sit before it is treated as
+ * abandoned and broken.
+ *
+ * A live holder occupies the unreadable-PID window only between `mkdirSync`
+ * and `writeFileSync` — microseconds. A process killed inside that window (a
+ * hard shutdown, OOM, `kill -9`) leaves the lock dir with an empty or absent
+ * PID file and nothing to check for liveness, so the PID-based staleness test
+ * below can never fire. Without an age bound that lock is held forever and the
+ * directory is silently unusable for the life of the machine.
+ *
+ * Any value orders of magnitude above the real mkdir→write window and below
+ * "a human would notice" works; 30s is far outside the former and inside the
+ * latter, so a legitimate mid-acquire holder cannot be robbed.
+ */
+export const LOCK_STALE_MS = 30_000;
+
+/** Why a lock could not be acquired — lets callers distinguish live contention from a broken lock. */
+export interface LockHeldInfo {
+  /** PID recorded in the lock, if one could be read. */
+  pid?: number;
+  /** Age of the lock directory in ms. */
+  ageMs: number;
+  /** True when the PID file is missing/empty/corrupt (holder died mid-acquire). */
+  pidUnreadable: boolean;
+}
+
+/**
+ * Inspect a lock without attempting to take it.
+ *
+ * Returns `null` when no lock is present. Callers that must not confuse
+ * "nothing to do" with "could not look" (see `checkInbox`) use this to tell
+ * the two apart.
+ */
+export function inspectLock(dir: string): LockHeldInfo | null {
+  const lockDir = join(dir, '.lock.d');
+  let ageMs: number;
+  try {
+    ageMs = Date.now() - statSync(lockDir).mtimeMs;
+  } catch {
+    return null; // no lock
+  }
+
+  let pid: number | undefined;
+  let pidUnreadable = true;
+  try {
+    const raw = readFileSync(join(lockDir, 'pid'), 'utf-8').trim();
+    const parsed = parseInt(raw, 10);
+    if (raw !== '' && !isNaN(parsed)) {
+      pid = parsed;
+      pidUnreadable = false;
+    }
+  } catch {
+    // leave pidUnreadable = true
+  }
+
+  return { pid, ageMs, pidUnreadable };
+}
 
 /**
  * Acquire a mutex lock using mkdir (atomic on all filesystems).
  * Matches the bash pattern: mkdir .lock.d with PID tracking.
  *
  * Returns true if lock acquired, false if another process holds it.
- * Automatically recovers stale locks (dead process).
+ * Recovers stale locks: a dead PID, or a lock whose PID never got written
+ * because the holder was killed mid-acquire (see LOCK_STALE_MS).
  */
 export function acquireLock(dir: string): boolean {
   const lockDir = join(dir, '.lock.d');
@@ -34,17 +94,18 @@ export function acquireLock(dir: string): boolean {
     try {
       storedPidRaw = readFileSync(pidFile, 'utf-8').trim();
     } catch {
-      // PID file not yet written.  Holder is between mkdir and writeFileSync.
-      // Refuse the lock — the caller's retry loop will try again.
-      return false;
+      // PID file not yet written.  Either the holder is between mkdir and
+      // writeFileSync (microseconds — refuse, the caller retries), or it was
+      // KILLED in that window and will never write one.  Only age separates
+      // the two, and without this check the second case deadlocks forever.
+      return breakIfAbandoned(lockDir, pidFile);
     }
 
     const storedPid = parseInt(storedPidRaw, 10);
     if (isNaN(storedPid) || storedPidRaw === '') {
-      // Corrupt PID file.  Don't steal — let caller retry; if it persists
-      // the holder is broken and a future stale-detection pass (process.kill
-      // check below, after the PID is written cleanly) will recover.
-      return false;
+      // PID file present but empty/corrupt — same crash window as above (the
+      // file is created before it is written), same reasoning, same bound.
+      return breakIfAbandoned(lockDir, pidFile);
     }
 
     // Check if process is still alive
@@ -64,6 +125,39 @@ export function acquireLock(dir: string): boolean {
         return false;
       }
     }
+  }
+}
+
+/**
+ * Break a lock whose PID cannot be read, but only once it is older than
+ * LOCK_STALE_MS — i.e. far past any legitimate mkdir→writeFileSync window, so
+ * a live mid-acquire holder is never robbed.
+ *
+ * Returns true if the lock was broken and re-acquired by us.
+ */
+function breakIfAbandoned(lockDir: string, pidFile: string): boolean {
+  let ageMs: number;
+  try {
+    ageMs = Date.now() - statSync(lockDir).mtimeMs;
+  } catch {
+    // Lock vanished under us — the caller's retry will take it cleanly.
+    return false;
+  }
+
+  if (ageMs < LOCK_STALE_MS) {
+    // Plausibly a live holder mid-acquire. Refuse; caller retries.
+    return false;
+  }
+
+  // Abandoned: no PID to check for liveness and far too old to be mid-acquire.
+  try {
+    rmSync(lockDir, { recursive: true, force: true });
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, String(process.pid));
+    return true;
+  } catch {
+    // Another process beat us to the steal — let the caller retry.
+    return false;
   }
 }
 

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -36,7 +36,11 @@ export interface LockHeldInfo {
  * the two apart.
  */
 export function inspectLock(dir: string): LockHeldInfo | null {
-  const lockDir = join(dir, '.lock.d');
+  return inspectLockDir(join(dir, '.lock.d'));
+}
+
+/** Same, but takes the lock directory itself rather than the directory it guards. */
+function inspectLockDir(lockDir: string): LockHeldInfo | null {
   let ageMs: number;
   try {
     ageMs = Date.now() - statSync(lockDir).mtimeMs;
@@ -156,80 +160,110 @@ export function acquireLock(dir: string): boolean {
  * reliably reproduce, so it is asserted directly against this function.
  */
 export function stealLock(lockDir: string, pidFile: string): boolean {
-  // 1. CAPTURE. rename() is atomic: of all processes trying to move this lock
-  //    aside, exactly one succeeds. The losers get ENOENT and return without
-  //    ever touching an rmSync, so they cannot destroy anyone's live lock.
-  const steal = `${lockDir}.steal.${process.pid}.${Date.now()}`;
-  try {
-    renameSync(lockDir, steal);
-  } catch {
-    return false; // someone else captured it, or it vanished — retry.
-  }
+  // 1. EXCLUDE OTHER STEALERS.
+  //
+  //    You cannot judge an object safely unless nothing can change it under you.
+  //    The way to get that is NOT to own the object — owning it means MOVING it,
+  //    and a lock moved aside is ABSENT, which an ordinary acquirer's mkdirSync
+  //    will happily succeed into. That is a second holder. Exclude the things
+  //    that could change it instead, and judge it IN PLACE.
+  const claim = `${lockDir}.stealing`;
+  if (!acquireClaim(claim)) return false;
 
-  // 2. RE-VERIFY WHAT WE ACTUALLY CAPTURED — on the object we now own alone.
-  //
-  //    The caller's staleness decision was made on a `stat` that may already be
-  //    out of date: between that stat and this rename, the rightful winner can
-  //    have finished its own steal and created a BRAND NEW, LIVE lock. Our
-  //    rename would then have moved *that* aside, and stealing on the strength
-  //    of the earlier stat would hand two processes the same lock.
-  //
-  //    So we re-decide here, where the object is exclusively ours and cannot
-  //    change under us. Capture first, judge second.
-  if (looksLive(steal)) {
-    // We captured a live lock. Put it back and lose gracefully.
+  try {
+    // 2. RE-INSPECT UNDER THE CLAIM. The caller's staleness verdict came from an
+    //    earlier stat and may already be stale: the rightful winner could have
+    //    finished its own steal and installed a fresh, LIVE lock since.
+    //
+    //    Under the claim that cannot happen beneath us:
+    //      - other stealers are excluded by the claim;
+    //      - an ordinary acquirer only calls mkdirSync(lockDir), which EEXISTs
+    //        while the lock is still present.
+    //    So a lock observed abandoned while we hold the claim STAYS abandoned.
+    const info = inspectLockDir(lockDir);
+    if (!info) return false;              // already gone — the caller's mkdir will take it
+    if (holderAlive(info)) return false;  // a live process holds it: leave it untouched
+    if (info.pidUnreadable && info.ageMs < LOCK_STALE_MS) return false; // mid-acquire
+
+    // 3. Verified abandoned, and it cannot turn live under us. Move it aside with
+    //    rename — ATOMIC, so even under a pathological double-claim exactly one
+    //    process can be the mover and the loser gets ENOENT. We NEVER rmSync the
+    //    lock directly, so no path can force-delete a lock that someone holds.
+    const dead = `${lockDir}.dead.${process.pid}.${Date.now()}`;
     try {
-      renameSync(steal, lockDir);
+      renameSync(lockDir, dead);
     } catch {
-      // Restore failed only if something already occupies lockDir — i.e. a
-      // third process holds it. Discard ours rather than clobber theirs.
-      try { rmSync(steal, { recursive: true, force: true }); } catch { /* inert */ }
+      return false; // someone else moved it first — nothing of ours destroyed
     }
-    return false;
-  }
+    try { rmSync(dead, { recursive: true, force: true }); } catch { /* inert */ }
 
-  // 3. It is genuinely abandoned and it is ours. Replace it.
-  try { rmSync(steal, { recursive: true, force: true }); } catch { /* inert */ }
-
-  try {
-    // Atomic. EEXIST means an ordinary acquirer took the freed slot first —
-    // a legitimate loss, and nothing of theirs was destroyed to discover it.
-    mkdirSync(lockDir);
-    writeFileSync(pidFile, String(process.pid));
-    return true;
-  } catch {
-    return false;
+    try {
+      // Atomic. EEXIST means an ordinary acquirer took the freed slot ahead of
+      // us — a legitimate loss, and nothing live was destroyed to discover it.
+      mkdirSync(lockDir);
+      writeFileSync(pidFile, String(process.pid));
+      return true;
+    } catch {
+      return false;
+    }
+  } finally {
+    releaseClaim(claim);
   }
 }
 
 /**
- * Does this captured lock dir belong to a holder that is still alive — either a
- * running PID, or one young enough to be legitimately mid-acquire?
+ * Serialise stealers. `mkdir` is the atomic exclusive primitive.
+ *
+ * The claim must itself be recoverable: a process killed while holding it would
+ * leak an empty directory that blocks EVERY future recovery — which is precisely
+ * the permanent-deadlock disease this change exists to cure, relocated one level
+ * up. The cure must not reintroduce the disease.
+ *
+ * Age is the only recovery signal available (the claim is deliberately empty, so
+ * there is no PID to test), and an age-based break can in principle let two
+ * stealers hold the claim at the same instant. That is survivable BY DESIGN:
+ * stealLock's only destructive step is an atomic rename of a lock it has just
+ * verified abandoned, so two claim-holders still cannot both win, and neither can
+ * destroy a live lock. The claim reduces contention; it is not load-bearing for
+ * correctness.
  */
-function looksLive(dir: string): boolean {
-  let raw: string;
+function acquireClaim(claim: string): boolean {
   try {
-    raw = readFileSync(join(dir, 'pid'), 'utf-8').trim();
+    mkdirSync(claim);
+    return true;
   } catch {
-    raw = '';
-  }
-
-  const pid = parseInt(raw, 10);
-  if (raw !== '' && !isNaN(pid)) {
+    let ageMs: number;
     try {
-      process.kill(pid, 0);
-      return true; // a live process holds this
+      ageMs = Date.now() - statSync(claim).mtimeMs;
     } catch {
-      return false; // dead pid — safe to take
+      return false; // vanished — caller retries
+    }
+    if (ageMs < LOCK_STALE_MS) return false; // a stealer is genuinely working
+
+    // Leaked by a killed stealer. rmdirSync removes only an EMPTY directory, so
+    // it cannot destroy anything carrying state.
+    try {
+      rmdirSync(claim);
+      mkdirSync(claim);
+      return true;
+    } catch {
+      return false;
     }
   }
+}
 
-  // No readable PID. Young => a holder is mid-acquire right now. Old => the
-  // holder was killed in that window and is never coming back.
+function releaseClaim(claim: string): void {
+  try { rmdirSync(claim); } catch { /* already gone */ }
+}
+
+/** Is this lock held by a process that is actually running? */
+function holderAlive(info: LockHeldInfo): boolean {
+  if (info.pidUnreadable || info.pid === undefined) return false;
   try {
-    return Date.now() - statSync(dir).mtimeMs < LOCK_STALE_MS;
+    process.kill(info.pid, 0);
+    return true;
   } catch {
-    return false;
+    return false; // dead pid
   }
 }
 

--- a/tests/unit/bus/inbox-fencing.test.ts
+++ b/tests/unit/bus/inbox-fencing.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, renameSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { checkInbox } from '../../../src/bus/message';
+import type { BusPaths } from '../../../src/types/index';
+
+/**
+ * WHY THE INBOX SURVIVES A DOUBLE-HOLDER — and why we are NOT adding an epoch.
+ *
+ * Three review rounds produced three real races in the stale-lock steal, and the
+ * honest reading is that safely stealing a filesystem lock is a known-hard
+ * problem: every scheme reduces to "decide, then act", and the gap between decide
+ * and act is where the next interleaving lives. Assume a fourth exists.
+ *
+ * The standard answer is FENCING: don't try to make the race impossible, make it
+ * unable to cause damage — the critical section verifies it still owns the
+ * resource before each destructive act, so a stale holder's write is rejected
+ * rather than applied.
+ *
+ * THE INBOX ALREADY HAS THIS, and not by accident of ours — by the filesystem.
+ * Every mutation in the critical section is a rename():
+ *
+ *   checkInbox           inbox/    -> inflight/     (message.ts)
+ *   ackInbox             inflight/ -> processed/
+ *   recoverStaleInflight inflight/ -> inbox/
+ *
+ * rename() is a compare-and-swap on the source path: if the source is gone, it
+ * fails with ENOENT. It cannot be applied twice. So a stale holder that tries to
+ * move a message another holder already moved does not corrupt anything — its
+ * operation FAILS, which is precisely what a fencing token buys.
+ *
+ * These tests assert that property, so nobody later "optimises" a rename into a
+ * copy+unlink (which is NOT single-winner) and silently removes the fence.
+ */
+describe('inbox critical section is fenced by rename(), not by the lock alone', () => {
+  let root: string;
+  let paths: BusPaths;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'cortextos-fence-'));
+    const inbox = join(root, 'inbox');
+    const inflight = join(root, 'inflight');
+    mkdirSync(inbox, { recursive: true });
+    mkdirSync(inflight, { recursive: true });
+    paths = { ctxRoot: root, inbox, inflight } as unknown as BusPaths;
+  });
+
+  afterEach(() => rmSync(root, { recursive: true, force: true }));
+
+  function putMessage(id: string): string {
+    const file = `1-${id}-from-chief-x.json`;
+    writeFileSync(
+      join(paths.inbox, file),
+      JSON.stringify({ id, from: 'chief', to: 'dev', priority: 'high', timestamp: '2026-07-12T00:00:00.000Z', text: 'x' }),
+    );
+    return file;
+  }
+
+  it('rename() is single-winner: a second mover of the same file FAILS', () => {
+    // The property the whole fence rests on. If this ever stops holding, the
+    // inbox is only as safe as the lock — and the lock is a hard problem.
+    const file = putMessage('m1');
+    const src = join(paths.inbox, file);
+    mkdirSync(join(root, 'a'));
+    mkdirSync(join(root, 'b'));
+
+    renameSync(src, join(root, 'a', file)); // holder A wins
+    expect(() => renameSync(src, join(root, 'b', file))).toThrow(/ENOENT/); // stale holder B loses
+
+    expect(existsSync(join(root, 'a', file))).toBe(true);
+    expect(existsSync(join(root, 'b', file))).toBe(false);
+  });
+
+  it('a message consumed by one holder is NOT re-delivered to another', () => {
+    // Simulates the damage a double-holder would do: both list the inbox, both
+    // try to take the same message. Exactly one may deliver it.
+    putMessage('m1');
+    putMessage('m2');
+
+    const first = checkInbox(paths);
+    expect(first.map((m) => m.id).sort()).toEqual(['m1', 'm2']);
+
+    // A stale holder now runs the same critical section. The files are gone from
+    // inbox (already moved to inflight), so it delivers nothing — no duplicates.
+    const second = checkInbox(paths);
+    expect(second).toEqual([]);
+  });
+
+  it('a message is never LOST when a holder takes it but never ACKs it', () => {
+    // The other half of the guarantee: the loser of a race does not silently drop
+    // the message. It sits in inflight and recoverStaleInflight returns it to the
+    // inbox, so it is redelivered rather than lost.
+    putMessage('m1');
+    checkInbox(paths); // moved to inflight, never ACKed
+
+    expect(readdirSync(paths.inflight)).toHaveLength(1);
+    expect(readdirSync(paths.inbox).filter((f) => f.endsWith('.json'))).toHaveLength(0);
+
+    // Age it past the 5-minute inflight-recovery window.
+    const file = readdirSync(paths.inflight)[0];
+    const old = new Date(Date.now() - 10 * 60 * 1000);
+    require('fs').utimesSync(join(paths.inflight, file), old, old);
+
+    const redelivered = checkInbox(paths);
+    expect(redelivered.map((m) => m.id)).toEqual(['m1']);
+  });
+});

--- a/tests/unit/bus/inbox-locked.test.ts
+++ b/tests/unit/bus/inbox-locked.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { checkInbox, InboxLockedError } from '../../../src/bus/message';
+import { LOCK_STALE_MS } from '../../../src/utils/lock';
+import type { BusPaths } from '../../../src/types/index';
+
+/**
+ * The bug this file exists for:
+ *
+ * checkInbox() returned [] when it could not ACQUIRE THE LOCK — the identical
+ * value it returns when the inbox is genuinely EMPTY. Callers (the fast-checker
+ * poll loop, the CLI, every agent's heartbeat) read [] as "no messages".
+ *
+ * A hard shutdown left an abandoned lock on one agent's inbox. For three days it
+ * reported a clean empty inbox while 26 messages — including an urgent, approved
+ * build dispatch — sat queued behind the lock. The failure was visible on disk
+ * the entire time and rendered nowhere anyone looked.
+ *
+ * "Could not read" and "nothing to read" must be different, loud outcomes.
+ */
+describe('checkInbox: a locked inbox is NOT an empty inbox', () => {
+  let root: string;
+  let paths: BusPaths;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'cortextos-inbox-lock-'));
+    const inbox = join(root, 'inbox');
+    const inflight = join(root, 'inflight');
+    mkdirSync(inbox, { recursive: true });
+    mkdirSync(inflight, { recursive: true });
+    paths = { ctxRoot: root, inbox, inflight } as unknown as BusPaths;
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('THROWS instead of returning [] when the lock is held by a live process', () => {
+    // Live holder: our own pid, freshly written.
+    const lockDir = join(paths.inbox, '.lock.d');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'pid'), String(process.pid));
+
+    expect(() => checkInbox(paths)).toThrow(InboxLockedError);
+  });
+
+  it('the error says the inbox was NOT read — not that it was empty', () => {
+    const lockDir = join(paths.inbox, '.lock.d');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'pid'), String(process.pid));
+
+    try {
+      checkInbox(paths);
+      expect.unreachable('checkInbox must throw when the inbox is locked');
+    } catch (err) {
+      expect(err).toBeInstanceOf(InboxLockedError);
+      const e = err as InboxLockedError;
+      expect(e.message).toMatch(/LOCKED and was NOT read/);
+      expect(e.message).toMatch(/NOT an empty inbox/);
+      expect(e.lock?.pid).toBe(process.pid);
+    }
+  });
+
+  it('returns [] — plainly — when the inbox really is empty', () => {
+    expect(checkInbox(paths)).toEqual([]);
+  });
+
+  it('self-heals an abandoned lock and reads the queued mail (the production scenario)', () => {
+    // A message was queued...
+    writeFileSync(
+      join(paths.inbox, '1-1783842329443-from-chief-wp1di.json'),
+      JSON.stringify({
+        id: '1783842329443-chief-wp1di',
+        from: 'chief',
+        to: 'dev',
+        priority: 'high',
+        timestamp: '2026-07-12T07:45:29.000Z',
+        text: 'COWORKER-BOT UNBLOCKED',
+      }),
+    );
+
+    // ...behind a lock abandoned by a hard shutdown (empty pid, old).
+    const lockDir = join(paths.inbox, '.lock.d');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'pid'), '');
+    const old = new Date(Date.now() - (LOCK_STALE_MS + 60_000));
+    utimesSync(lockDir, old, old);
+
+    // Previously: [] forever. Now: the lock is broken on age and the mail lands.
+    const messages = checkInbox(paths);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].id).toBe('1783842329443-chief-wp1di');
+  });
+});

--- a/tests/unit/utils/lock-steal-race.test.ts
+++ b/tests/unit/utils/lock-steal-race.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync, readdirSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { stealLock, LOCK_STALE_MS } from '../../../src/utils/lock';
+
+/**
+ * MUTUAL EXCLUSION UNDER CONCURRENT RECOVERY.
+ *
+ * The naive steal — `rmSync(lockDir, {force:true})` then `mkdirSync` — is not
+ * mutual exclusion. Two processes routinely reach the recovery path on the same
+ * stale lock (the fast-checker's poll loop and any CLI invocation both find it,
+ * and both finish their staleness check before either acts):
+ *
+ *   A: rmSync (clears the stale lock) -> mkdirSync -> pid=A -> HOLDS IT
+ *   B: rmSync(force) -> DELETES A's LIVE LOCK -> mkdirSync succeeds -> pid=B
+ *
+ * Both then enter the critical section together — duplicate delivery, lost ACKs,
+ * a message file removed while another process reads it. The bug fires on the
+ * code path whose entire job is to recover safely.
+ *
+ * WHY THESE TESTS CALL stealLock DIRECTLY RATHER THAN RACING PROCESSES:
+ * the damaging interleaving is nanoseconds wide. Spawning real processes cannot
+ * hit it — they start milliseconds apart, so the first one wins cleanly and the
+ * rest correctly see a live PID. A spawn-based "race" test PASSES against the
+ * buggy code and proves nothing. (I wrote one first. It was theatre.)
+ *
+ * So the invariant is asserted where it actually lives: given a stealer that has
+ * CAPTURED a lock which turns out to be LIVE — exactly the state B lands in — it
+ * must refuse and put it back, rather than destroy it and claim the lock.
+ */
+describe('stealLock: cannot take a lock that is actually held', () => {
+  let dir: string;
+  let lockDir: string;
+  let pidFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cortextos-steal-'));
+    lockDir = join(dir, '.lock.d');
+    pidFile = join(lockDir, 'pid');
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('REFUSES a lock held by a LIVE pid, and leaves it intact', () => {
+    // This is precisely what B captures when A wins the race and creates a new
+    // live lock in the window between B's staleness check and B's capture.
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, String(process.pid)); // alive: us
+
+    expect(stealLock(lockDir, pidFile)).toBe(false);
+
+    // The live holder's lock must survive untouched — not be destroyed and
+    // replaced with ours, which is what the rmSync(force) version did.
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(pidFile, 'utf-8')).toBe(String(process.pid));
+  });
+
+  it('REFUSES a lock whose holder is mid-acquire (no pid yet, but fresh)', () => {
+    // The mkdir→writeFileSync window. Young + unreadable pid = someone is in it.
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, '');
+
+    expect(stealLock(lockDir, pidFile)).toBe(false);
+    expect(existsSync(lockDir)).toBe(true);
+  });
+
+  it('TAKES a genuinely abandoned lock (old, pid never written)', () => {
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, '');
+    const old = new Date(Date.now() - (LOCK_STALE_MS + 60_000));
+    utimesSync(lockDir, old, old);
+
+    expect(stealLock(lockDir, pidFile)).toBe(true);
+    expect(readFileSync(pidFile, 'utf-8')).toBe(String(process.pid));
+  });
+
+  it('TAKES a lock held by a dead pid', () => {
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, '4194304'); // above pid_max — never alive
+
+    expect(stealLock(lockDir, pidFile)).toBe(true);
+    expect(readFileSync(pidFile, 'utf-8')).toBe(String(process.pid));
+  });
+
+  it('leaves no orphaned steal scratch directories behind, win or lose', () => {
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, String(process.pid)); // live -> stealLock must lose
+    stealLock(lockDir, pidFile);
+    expect(readdirSync(dir).filter((f) => f.startsWith('.lock.d.steal'))).toEqual([]);
+
+    rmSync(lockDir, { recursive: true, force: true });
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, '4194304'); // dead -> stealLock must win
+    stealLock(lockDir, pidFile);
+    expect(readdirSync(dir).filter((f) => f.startsWith('.lock.d.steal'))).toEqual([]);
+  });
+});

--- a/tests/unit/utils/lock-steal-race.test.ts
+++ b/tests/unit/utils/lock-steal-race.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync, readdirSync, existsSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync, readdirSync, existsSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { stealLock, LOCK_STALE_MS } from '../../../src/utils/lock';
@@ -85,16 +85,100 @@ describe('stealLock: cannot take a lock that is actually held', () => {
     expect(readFileSync(pidFile, 'utf-8')).toBe(String(process.pid));
   });
 
-  it('leaves no orphaned steal scratch directories behind, win or lose', () => {
+  it('leaves no orphaned scratch or claim directories behind, win or lose', () => {
     mkdirSync(lockDir);
     writeFileSync(pidFile, String(process.pid)); // live -> stealLock must lose
     stealLock(lockDir, pidFile);
-    expect(readdirSync(dir).filter((f) => f.startsWith('.lock.d.steal'))).toEqual([]);
+    expect(readdirSync(dir).filter((f) => f !== '.lock.d')).toEqual([]);
 
     rmSync(lockDir, { recursive: true, force: true });
     mkdirSync(lockDir);
     writeFileSync(pidFile, '4194304'); // dead -> stealLock must win
     stealLock(lockDir, pidFile);
-    expect(readdirSync(dir).filter((f) => f.startsWith('.lock.d.steal'))).toEqual([]);
+    expect(readdirSync(dir).filter((f) => f !== '.lock.d')).toEqual([]);
+  });
+
+  /**
+   * THE INVARIANT THAT KILLS THE THIRD-PROCESS RACE — and an honest note on how
+   * far a test can go here.
+   *
+   * Any implementation that renames a live lock ASIDE (to inspect it, meaning to
+   * put it back) leaves lockDir ABSENT for a moment. An ordinary acquirer only
+   * calls mkdirSync(lockDir), which SUCCEEDS on an absent dir — so a third
+   * process walks straight in, and the restore then either fails (and the live
+   * lock is discarded) or succeeds (and clobbers the newcomer). Either way: two
+   * holders. So a live lock must never be MOVED AT ALL.
+   *
+   * That invariant is enforced STRUCTURALLY: stealLock renames only after it has
+   * verified, while holding the claim, that the lock is abandoned — and under the
+   * claim nothing can make it live again (other stealers are excluded; ordinary
+   * acquirers EEXIST while the lock is present). There is no code path on which a
+   * live lock is moved, so none on which one must be restored.
+   *
+   * I could not write a SOUND unit test for "was it moved". The obvious probe —
+   * compare the lock's ctime — is real, but ctime is MILLISECOND-granular on this
+   * filesystem: a rename-aside-and-back inside one tick leaves it unchanged, so
+   * the test goes red in isolation and GREEN in a warm run. A test that catches
+   * the bug only sometimes is decoration with extra steps, and it is not shipped.
+   * What is asserted instead is the deterministic consequence.
+   */
+  it('leaves a live holder\'s lock exactly as it found it', () => {
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, String(process.pid));
+
+    expect(stealLock(lockDir, pidFile)).toBe(false);
+
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(pidFile, 'utf-8')).toBe(String(process.pid));
+    // No scratch left from a capture that should never have happened.
+    expect(readdirSync(dir).filter((f) => f !== '.lock.d')).toEqual([]);
+  });
+});
+
+/**
+ * The cure must not reintroduce the disease.
+ *
+ * Serialising stealers behind a claim directory is only safe if the CLAIM is
+ * itself recoverable. A process killed while holding it leaks an empty dir that
+ * would block EVERY future recovery, for the life of the machine — which is
+ * exactly the permanent deadlock we set out to fix, moved up one level.
+ */
+describe('stealLock: a leaked claim cannot deadlock recovery forever', () => {
+  let dir: string;
+  let lockDir: string;
+  let pidFile: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'cortextos-claim-'));
+    lockDir = join(dir, '.lock.d');
+    pidFile = join(lockDir, 'pid');
+    // An abandoned lock, waiting to be recovered.
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, '');
+    const old = new Date(Date.now() - (LOCK_STALE_MS + 60_000));
+    utimesSync(lockDir, old, old);
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('recovers when a killed stealer leaked its claim', () => {
+    const claim = `${lockDir}.stealing`;
+    mkdirSync(claim);
+    const old = new Date(Date.now() - (LOCK_STALE_MS + 60_000));
+    utimesSync(claim, old, old); // leaked long ago by a dead stealer
+
+    // Must NOT be blocked forever by the orphaned claim.
+    expect(stealLock(lockDir, pidFile)).toBe(true);
+    expect(existsSync(claim)).toBe(false); // and it cleans up after itself
+  });
+
+  it('DEFERS to a stealer that is genuinely working (fresh claim)', () => {
+    const claim = `${lockDir}.stealing`;
+    mkdirSync(claim); // someone is mid-steal right now
+
+    expect(stealLock(lockDir, pidFile)).toBe(false);
+    expect(existsSync(claim)).toBe(true); // and we did not stomp their claim
   });
 });

--- a/tests/unit/utils/lock.test.ts
+++ b/tests/unit/utils/lock.test.ts
@@ -1,8 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { acquireLock, releaseLock } from '../../../src/utils/lock';
+import { acquireLock, releaseLock, inspectLock, LOCK_STALE_MS } from '../../../src/utils/lock';
+
+/** Forge a lock dir exactly as a process killed mid-acquire leaves it, aged `ageMs` into the past. */
+function forgeLock(dir: string, pidContent: string | null, ageMs: number): void {
+  const lockDir = join(dir, '.lock.d');
+  mkdirSync(lockDir);
+  if (pidContent !== null) writeFileSync(join(lockDir, 'pid'), pidContent);
+  const when = new Date(Date.now() - ageMs);
+  utimesSync(lockDir, when, when);
+}
 
 describe('mkdir-based locking', () => {
   let testDir: string;
@@ -34,6 +43,98 @@ describe('mkdir-based locking', () => {
     expect(acquireLock(testDir)).toBe(true);
     releaseLock(testDir);
     expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+});
+
+/**
+ * Regression: an agent's inbox lock was left behind by a hard shutdown (the
+ * process was killed between mkdirSync and writeFileSync, leaving an EMPTY pid
+ * file). With no PID to liveness-check, the old code refused the lock forever —
+ * check-inbox returned [] for three days while 26 messages queued behind it.
+ *
+ * The empty/absent PID cases are the crash window. They must self-heal on age.
+ */
+describe('abandoned-lock recovery (crash between mkdir and pid write)', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-lock-stale-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('breaks an OLD lock with an EMPTY pid file (the exact production deadlock)', () => {
+    forgeLock(testDir, '', LOCK_STALE_MS + 60_000);
+    expect(acquireLock(testDir)).toBe(true);
+    // and we now own it — our pid was written
+    expect(readFileSync(join(testDir, '.lock.d', 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseLock(testDir);
+  });
+
+  it('breaks an OLD lock with NO pid file at all', () => {
+    forgeLock(testDir, null, LOCK_STALE_MS + 60_000);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  it('breaks an OLD lock with a CORRUPT pid file', () => {
+    forgeLock(testDir, 'not-a-pid', LOCK_STALE_MS + 60_000);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  it('does NOT rob a FRESH unreadable-pid lock (holder may be mid-acquire)', () => {
+    // A real holder sits in this state for microseconds. Age is the only thing
+    // separating "mid-acquire" from "died mid-acquire" — so a fresh one is safe.
+    forgeLock(testDir, '', 0);
+    expect(acquireLock(testDir)).toBe(false);
+  });
+
+  it('still refuses a lock held by a LIVE process, however old', () => {
+    forgeLock(testDir, String(process.pid), LOCK_STALE_MS + 60_000);
+    expect(acquireLock(testDir)).toBe(false);
+  });
+
+  it('still breaks a lock held by a DEAD pid (pre-existing behaviour preserved)', () => {
+    // PID 2^22 is above Linux default pid_max — reliably not a live process.
+    forgeLock(testDir, '4194304', 0);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+});
+
+describe('inspectLock', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-lock-inspect-'));
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('returns null when there is no lock', () => {
+    expect(inspectLock(testDir)).toBeNull();
+  });
+
+  it('reports an unreadable pid and the lock age — the tell that was missing', () => {
+    forgeLock(testDir, '', 90_000);
+    const info = inspectLock(testDir)!;
+    expect(info).not.toBeNull();
+    expect(info.pidUnreadable).toBe(true);
+    expect(info.pid).toBeUndefined();
+    expect(info.ageMs).toBeGreaterThanOrEqual(89_000);
+  });
+
+  it('reports the holding pid when readable', () => {
+    expect(acquireLock(testDir)).toBe(true);
+    const info = inspectLock(testDir)!;
+    expect(info.pidUnreadable).toBe(false);
+    expect(info.pid).toBe(process.pid);
     releaseLock(testDir);
   });
 });


### PR DESCRIPTION
An agent went **silently deaf for three days**. A hard shutdown killed a process between `mkdirSync` and `writeFileSync` in `acquireLock`, leaving an abandoned lock with an empty pid file. Two defects compounded:

1. **`lock.ts` could never recover it.** A lock whose pid is empty/corrupt/absent was refused forever, deferring to "a future stale-detection pass" that can never run — a dead process never writes its pid.
2. **`checkInbox` returned `[]` when it could not ACQUIRE the lock** — the same value it returns when the inbox is genuinely EMPTY. Every caller (fast-checker poll loop, CLI, heartbeats) reads `[]` as "no messages."

So the inbox reported clean and empty while **26 messages queued behind the lock**, including an urgent approved dispatch. The failure was on disk the whole time and rendered nowhere anyone looks.

## Fixes

- **Age-bounded recovery** for an unreadable-pid lock (`LOCK_STALE_MS`, 30s). A live holder occupies that window for microseconds, so a legitimate mid-acquire holder cannot be robbed; a killed one self-heals.
- **`checkInbox` throws `InboxLockedError`** instead of returning `[]`. Not-read and nothing-to-read are different outcomes and must not share a representation. CLI exits non-zero; fast-checker logs loudly and still processes Telegram.
- **The steal is now atomic and identity-checked.** Review found the naive `rmSync(force)` + `mkdirSync` steal **broke mutual exclusion** — two processes could both hold the lock, and the same pattern was already present in the pre-existing dead-pid branch. Now: a claim serialises stealers, the lock is judged **in place** (never moved, so it is never absent for a third process to walk into), and an inode check ensures a stale verdict can only destroy the object it actually examined.
- **Tests pin that the inbox is already fenced by `rename()`** — every mutation is a compare-and-swap, so a stale holder's write *fails* rather than corrupting. That is why an epoch token is unnecessary, and why nobody may quietly rewrite a rename into copy+unlink.

Tests cover the exact production deadlock, the mid-acquire holder that must not be robbed, live/dead pid behaviour, claim recovery, and `checkInbox` throwing rather than reporting empty. Verified RED against the buggy versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)