### PR TITLE
fix(build): refuse to deploy a live dist/ from a work-in-progress branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,10 +12,22 @@ npm test
 
 ## Before Submitting Changes
 
-1. `npm run build` — TypeScript must compile cleanly
+1. `npm run typecheck` — TypeScript must compile cleanly
 2. `npm test` — all tests must pass
 3. Match existing patterns in `src/` for new features
 4. Add unit tests in `tests/` for any new code
+
+> **Use `npm run typecheck`, not `npm run build`, to check that your code compiles.**
+>
+> `bin.cortextos` points at `dist/cli.js`. On any host where cortextOS is
+> installed from a working checkout (`npm link` / `npm i -g .`), the global
+> `cortextos` command resolves *into that checkout's `dist/`* — so **`npm run
+> build` is a DEPLOY**: every agent, cron and hook on that box immediately
+> starts executing whatever you just compiled, branch and all.
+>
+> `npm run typecheck` (`tsc --noEmit`) verifies the code and writes nothing.
+> `npm run build` is guarded on live hosts (see `scripts/guard-live-build.mjs`);
+> to deploy deliberately, use `npm run build:deploy`.
 
 ## Project Structure
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "cortextos": "dist/cli.js"
   },
   "scripts": {
+    "prebuild": "node scripts/guard-live-build.mjs",
     "build": "tsup",
+    "build:deploy": "CORTEXTOS_ALLOW_LIVE_BUILD=1 tsup",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",

--- a/scripts/guard-live-build.mjs
+++ b/scripts/guard-live-build.mjs
@@ -1,0 +1,120 @@
+#!/usr/bin/env node
+/**
+ * Refuse to overwrite a LIVE dist/ from a work-in-progress branch.
+ *
+ * WHY THIS EXISTS
+ * ---------------
+ * `bin.cortextos` points at `dist/cli.js`. When cortextOS is installed from a
+ * working checkout (`npm link`, `npm i -g .`), the global `cortextos` command
+ * resolves *into that checkout's dist/*. Every agent, cron and hook on the box
+ * executes it.
+ *
+ * So on a live fleet host, `npm run build` is not a compile step. It is a
+ * DEPLOY. And nothing said so.
+ *
+ * CONTRIBUTING.md tells you to run `npm run build` to check your code compiles
+ * before submitting — which, on such a host, ships the branch you are still
+ * writing to every agent mid-run. A held merge protects nothing when the build
+ * that "just checks it compiles" has already deployed. The gate was on `merge`;
+ * the deploy happens at `build`.
+ *
+ * This guard puts the check where the decision actually happens.
+ *
+ * To VERIFY code without deploying:      npm run typecheck   (tsc --noEmit, writes nothing)
+ * To DELIBERATELY deploy to a live host: CORTEXTOS_ALLOW_LIVE_BUILD=1 npm run build
+ */
+import { execFileSync } from 'node:child_process';
+import { existsSync, realpathSync } from 'node:fs';
+import { dirname, join, resolve, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const distDir = join(repoRoot, 'dist');
+
+const RED = '\x1b[31m';
+const YELLOW = '\x1b[33m';
+const BOLD = '\x1b[1m';
+const RESET = '\x1b[0m';
+
+/** Non-fatal: any probe failing just means "cannot prove it's live" → allow. */
+function tryExec(cmd, args) {
+  try {
+    return execFileSync(cmd, args, { cwd: repoRoot, encoding: 'utf-8', stdio: ['ignore', 'pipe', 'ignore'] }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Is THIS checkout's dist/ the binary the machine actually runs?
+ *
+ * Resolves the `cortextos` command on PATH through symlinks (npm's global bin is
+ * a symlink into the linked package) and checks whether it lands inside our dist.
+ */
+function distIsLive() {
+  const which = tryExec('sh', ['-c', 'command -v cortextos']);
+  if (!which) return false;
+  try {
+    const real = realpathSync(which);
+    return real === realpathSync(distDir) || real.startsWith(realpathSync(distDir) + sep);
+  } catch {
+    return false;
+  }
+}
+
+function gitBranch() {
+  return tryExec('git', ['rev-parse', '--abbrev-ref', 'HEAD']);
+}
+
+function gitDirty() {
+  const out = tryExec('git', ['status', '--porcelain']);
+  return out === null ? false : out.length > 0;
+}
+
+// --- escape hatches -------------------------------------------------------
+
+if (process.env.CORTEXTOS_ALLOW_LIVE_BUILD === '1') {
+  console.log(`${YELLOW}[build] CORTEXTOS_ALLOW_LIVE_BUILD=1 — deploying to dist/ deliberately.${RESET}`);
+  process.exit(0);
+}
+
+// CI builds a throwaway checkout; nothing on the box runs it.
+if (process.env.CI) process.exit(0);
+
+// A dist that nothing executes is just a build artefact — the normal case for
+// contributors who did not link the package.
+if (!existsSync(distDir) || !distIsLive()) process.exit(0);
+
+// --- dist/ is LIVE: is this a deliberate deploy, or someone verifying? -----
+
+const branch = gitBranch();
+const dirty = gitDirty();
+const onMain = branch === 'main';
+
+if (onMain && !dirty) {
+  // Clean main == the released code. Building it is a legitimate deploy, but say so.
+  console.log(`${YELLOW}[build] dist/ is LIVE on this host — this build DEPLOYS clean main to every agent.${RESET}`);
+  process.exit(0);
+}
+
+const reason = !onMain
+  ? `you are on branch "${branch}", not main`
+  : 'your working tree has uncommitted changes';
+
+console.error(`
+${RED}${BOLD}✖ REFUSING TO BUILD — this would DEPLOY, not just compile.${RESET}
+
+  ${BOLD}dist/ is the live binary on this host.${RESET}
+  The global \`cortextos\` command resolves into ${distDir},
+  so every agent, cron and hook on this box would immediately execute what
+  this build writes — and ${reason}.
+
+  ${BOLD}A build is a deploy here. That is almost certainly not what you meant.${RESET}
+
+  To CHECK YOUR CODE COMPILES (writes nothing):
+      ${BOLD}npm run typecheck${RESET}
+
+  To DELIBERATELY DEPLOY this branch to the live fleet:
+      ${BOLD}CORTEXTOS_ALLOW_LIVE_BUILD=1 npm run build${RESET}
+`);
+process.exit(1);

--- a/tests/unit/scripts/guard-live-build.test.ts
+++ b/tests/unit/scripts/guard-live-build.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, chmodSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+
+const GUARD = resolve(__dirname, '../../../scripts/guard-live-build.mjs');
+const REPO = resolve(__dirname, '../../..');
+
+/**
+ * Run the guard with a PATH in which `cortextos` may or may not resolve into
+ * this repo's dist/ — the thing that decides "is this build a deploy?".
+ */
+function runGuard(opts: { liveBin: boolean; env?: Record<string, string> }): { code: number; stderr: string; stdout: string } {
+  const shimDir = mkdtempSync(join(tmpdir(), 'cortextos-guard-path-'));
+  try {
+    if (opts.liveBin) {
+      // Reproduce npm's global bin: a symlink pointing into the checkout's dist.
+      symlinkSync(join(REPO, 'dist', 'cli.js'), join(shimDir, 'cortextos'));
+    }
+    const res = execFileSync('node', [GUARD], {
+      cwd: REPO,
+      encoding: 'utf-8',
+      env: {
+        ...process.env,
+        CI: '',
+        CORTEXTOS_ALLOW_LIVE_BUILD: '',
+        // The guard shells out to `sh` and `git`, so those must stay reachable.
+        // What varies is only whether a `cortextos` on PATH resolves into this
+        // checkout's dist/. The not-live case deliberately excludes the real
+        // npm global bin (which, on a fleet host, DOES point into this dist).
+        PATH: opts.liveBin ? `${shimDir}:/usr/bin:/bin` : '/usr/bin:/bin',
+        ...opts.env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return { code: 0, stdout: res, stderr: '' };
+  } catch (err) {
+    const e = err as { status?: number; stdout?: string; stderr?: string };
+    return { code: e.status ?? -1, stdout: e.stdout ?? '', stderr: e.stderr ?? '' };
+  } finally {
+    rmSync(shimDir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * `npm run build` writes dist/, and dist/ is what the global `cortextos`
+ * command executes on a host installed from a working checkout. So on a live
+ * fleet box, "just check it compiles" ships your half-finished branch to every
+ * running agent — which is exactly what happened, from a branch whose merge was
+ * explicitly being held for review.
+ *
+ * The gate was on `merge`. The deploy happens at `build`. This guard moves the
+ * check to where the decision actually is.
+ */
+describe('guard-live-build: a build on a live host is a deploy', () => {
+  it('REFUSES when dist/ is the live binary and we are on a WIP branch', () => {
+    // The repo is on a feature branch during test runs, so this is the real case.
+    const { code, stderr } = runGuard({ liveBin: true });
+    expect(code).toBe(1);
+    expect(stderr).toMatch(/REFUSING TO BUILD/);
+    expect(stderr).toMatch(/would DEPLOY, not just compile/);
+    // It must tell you the safe way, not just say no.
+    expect(stderr).toMatch(/npm run typecheck/);
+  });
+
+  it('ALLOWS when dist/ is not the live binary (ordinary contributor checkout)', () => {
+    const { code } = runGuard({ liveBin: false });
+    expect(code).toBe(0);
+  });
+
+  it('ALLOWS in CI — a throwaway checkout nothing executes', () => {
+    const { code } = runGuard({ liveBin: true, env: { CI: 'true' } });
+    expect(code).toBe(0);
+  });
+
+  it('ALLOWS a deliberate deploy via the explicit escape hatch', () => {
+    const { code, stdout } = runGuard({ liveBin: true, env: { CORTEXTOS_ALLOW_LIVE_BUILD: '1' } });
+    expect(code).toBe(0);
+    expect(stdout).toMatch(/deliberately/i);
+  });
+});


### PR DESCRIPTION
`bin.cortextos` points at `dist/cli.js`. On a host where cortextOS is installed from a working checkout (`npm link` / `npm i -g .`), the global `cortextos` command resolves **into that checkout's `dist/`** — so every agent, cron and hook on the box executes it.

**That makes `npm run build` a DEPLOY, not a compile step. Nothing said so.**

Worse, CONTRIBUTING told you to run it: step 1 of "Before Submitting Changes" was `npm run build` — to check your code compiles. On a live fleet host that ships the branch you are still writing to every running agent. **It happened:** a build run purely to verify a fix deployed that unreviewed fix to the fleet, from a branch whose merge was explicitly being *held for review*.

The gate was on `merge`. The deploy happens at `build`. The gate was never in the room where the decision is made.

## This puts the check where the decision actually happens

- `scripts/guard-live-build.mjs` runs as `prebuild`. If `dist/` is the live binary on this host **and** you are on a non-main branch (or main with a dirty tree), it **refuses**, explains that a build here is a deploy, and points at the safe path.
- `npm run typecheck` (`tsc --noEmit`) verifies without writing anything. Docs now tell contributors to use it.
- `npm run build:deploy` deploys deliberately; `CORTEXTOS_ALLOW_LIVE_BUILD=1` is the explicit escape hatch.
- CI and ordinary contributor checkouts (where `dist/` is just an artefact nothing executes) are unaffected.

Tests cover: refusal on a live host from a WIP branch, allowing an ordinary checkout, allowing CI, and the deliberate-deploy hatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)