### PR TITLE
fix(security): isolate Codex fleet credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,89 @@ Every agent's `config.json` carries an explicit `runtime` field that the daemon 
 
 Pass `--runtime <kind>` on `add-agent` to set it at scaffold time, or edit the field in `config.json` and restart the agent. The default is `claude-code`. Today only `--template agent` (and the alias `--template agent-codex`) supports `--runtime codex-app-server` — pairing the codex runtime with `--template orchestrator`/`analyst`/`m2c1-worker`/`hermes` errors with a clean message until codex variants of those templates ship.
 
+### Codex role-capability profile
+
+Unattended `codex-app-server` agents require an explicit capability profile in
+their `config.json`. The runtime starts from Codex's `:read-only` profile, then
+adds broad role-work roots while keeping nested policy files immutable. This is
+intended to give an agent freedom inside its job while denying an enumerated,
+reviewed set of credential files and avoiding ambient connectors or writable
+directories from the host account. Because `:read-only` remains the base, this
+is not a general host-read allowlist: files omitted from the deny inventory can
+remain readable and must not be represented as proven credential isolation.
+
+```json
+{
+  "codex_credential_deny_paths": [
+    "/absolute/path/to/agent/.env",
+    "/absolute/path/to/.codex/auth.json",
+    "/absolute/path/to/.codex/config.toml"
+  ],
+  "codex_writable_paths": [
+    "/absolute/path/to/role-work",
+    "/absolute/path/to/shared-deliverables"
+  ],
+  "codex_readonly_paths": [
+    "/absolute/path/to/role-work/AGENTS.md"
+  ],
+  "codex_network_allow_domains": [],
+  "codex_env_allowlist": ["ROLE_SCOPED_TOKEN"],
+  "codex_mcp_allowlist": ["role-specific-server"]
+}
+```
+
+All six arrays are required, though the last four may be empty. Paths must be
+normalized and absolute. `codex_writable_paths` should name useful directories,
+not individual output files; the agent may create arbitrary descendants there.
+Use more-specific `codex_readonly_paths` for instruction, identity, and routing
+files that are direct children of a writable root. A protected path below a
+writable intermediate directory is rejected because renaming that intermediate
+directory can relocate the file outside a path-based rule. Existing credential
+files and read-only control files must have exactly one hard-link name before
+launch; symbolic links and pre-existing hard-link aliases fail closed. The
+adapter adds one private
+`state/<agent>/model-tmp` write root for normal scratch-file use, removes it on
+exit, and keeps the rest of the daemon state directory outside model writes.
+For Codex 0.144.2, `codex_network_allow_domains` must remain empty: the runtime
+exposes only an effective network-access boolean, and a live contract probe
+showed that an unlisted loopback port remained reachable when network was
+enabled. Model-executed shell network therefore stays off; reviewed MCP and
+built-in tools are the capability seam until exact-domain enforcement is both
+available and readable back. Only allowlisted environment variables are loaded from org/agent env
+files, and only allowlisted, already-enabled MCP servers may start. Host apps,
+plugins, browser/computer-control, and image-generation integrations are not
+implicitly inherited.
+
+The adapter verifies the returned profile parent, exact writable-root set,
+network state, and active MCP inventory on every thread start/resume and full
+settings update. Run the optional real-parser/sandbox check
+after changing this contract:
+
+```bash
+CODEX_PERMISSION_PROFILE_LIVE=1 npx vitest run \
+  tests/integration/codex-permission-profile-live.test.ts
+```
+
+Fresh Codex agents receive a concrete baseline profile from `add-agent`. For an
+existing agent, the migration command is dry-run by default and prints hashes
+over the exact proposed profile and complete source config. It writes only when
+the seat is absent from an explicit daemon-status response and both reviewed
+hashes are supplied; ambiguous IPC failures fail closed. A dedicated durable
+migration hold and the daemon's per-seat start claim share one barrier, blocking
+concurrent starts without changing the ordinary enabled/autostart state:
+
+```bash
+cortextos migrate-codex-permissions <agent> --org <org>
+cortextos migrate-codex-permissions <agent> --org <org> \
+  --apply --expect <profile-sha256> --expect-config <config-sha256>
+```
+
+Stop a running seat through its normal reviewed control path before applying,
+and keep the daemon available for the exact status read-back. Applying the
+profile never starts, enables, restarts, or changes the autostart state of the
+seat. A concurrent config edit invalidates the full-config compare-and-swap
+hash and fails closed.
+
 `opencode` agents run OpenCode's terminal UI as a persistent PTY and are provider-agnostic — set any `provider/model` in `config.json` (default `openai/gpt-4.1-nano`). Scaffold with `--template agent --runtime opencode` (auto-maps to the `agent-opencode` bootstrap) or `--template agent-opencode` directly. OpenCode agents also ship the **context-handoff lifecycle**: the daemon watches each session's context-window usage and, at a configurable threshold (`ctx_handoff_threshold`, default 60%), prompts the agent to write a handoff document under `memory/handoffs/` and hard-restart into a fresh session that resumes from that doc — so long-running agents never lose state to a context overflow. Tune it with `ctx_warning_threshold` (default 30%) and `ctx_handoff_threshold` in `config.json`.
 
 ---

--- a/README.md
+++ b/README.md
@@ -166,12 +166,14 @@ remain readable and must not be represented as proven credential isolation.
     "/absolute/path/to/role-work/AGENTS.md"
   ],
   "codex_network_allow_domains": [],
+  "codex_web_search_enabled": true,
   "codex_env_allowlist": ["ROLE_SCOPED_TOKEN"],
   "codex_mcp_allowlist": ["role-specific-server"]
 }
 ```
 
-All six arrays are required, though the last four may be empty. Paths must be
+All six arrays and the web-search boolean are required, though the final three
+arrays may be empty. Paths must be
 normalized and absolute. `codex_writable_paths` should name useful directories,
 not individual output files; the agent may create arbitrary descendants there.
 Use more-specific `codex_readonly_paths` for instruction, identity, and routing
@@ -188,7 +190,11 @@ exposes only an effective network-access boolean, and a live contract probe
 showed that an unlisted loopback port remained reachable when network was
 enabled. Model-executed shell network therefore stays off; reviewed MCP and
 built-in tools are the capability seam until exact-domain enforcement is both
-available and readable back. Only allowlisted environment variables are loaded from org/agent env
+available and readable back. A seat may separately set
+`codex_web_search_enabled: true` to receive Codex's native read-only Responses
+web-search tool. This does not enable model-executed shell networking, browser
+control, apps, plugins, MCP servers, or arbitrary HTTP requests. Only
+allowlisted environment variables are loaded from org/agent env
 files, and only allowlisted, already-enabled MCP servers may start. Host apps,
 plugins, browser/computer-control, and image-generation integrations are not
 implicitly inherited.

--- a/dashboard/src/app/api/agents/[name]/lifecycle/route.ts
+++ b/dashboard/src/app/api/agents/[name]/lifecycle/route.ts
@@ -3,6 +3,10 @@ import fs from 'fs/promises';
 import path from 'path';
 import { getFrameworkRoot, getCTXRoot } from '@/lib/config';
 import { IPCClient } from '@/lib/ipc-client';
+import {
+  mutateEnabledAgentsRegistry,
+  readEnabledAgentsRegistry,
+} from '@/lib/enabled-agents-registry';
 
 export const dynamic = 'force-dynamic';
 
@@ -89,21 +93,13 @@ export async function POST(
     switch (action) {
       case 'enable': {
         const ctxRoot = getCTXRoot();
-        const enabledAgentsPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
-        let enabledAgents: Record<string, unknown> = {};
-        try {
-          const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-          enabledAgents = JSON.parse(raw);
-        } catch { /* file may not exist yet */ }
-        enabledAgents[decoded] = {
-          ...(typeof enabledAgents[decoded] === 'object' && enabledAgents[decoded] !== null
-            ? (enabledAgents[decoded] as object)
-            : {}),
-          enabled: true,
-          ...(safeOrg ? { org: safeOrg } : {}),
-        };
-        await fs.mkdir(path.dirname(enabledAgentsPath), { recursive: true });
-        await fs.writeFile(enabledAgentsPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+        mutateEnabledAgentsRegistry(ctxRoot, (enabledAgents) => {
+          enabledAgents[decoded] = {
+            ...(enabledAgents[decoded] ?? {}),
+            enabled: true,
+            ...(safeOrg ? { org: safeOrg } : {}),
+          };
+        });
         registryMessage = 'enabled in registry';
         ipcResult = await ipc.send({ type: 'start-agent', agent: decoded });
         break;
@@ -112,14 +108,10 @@ export async function POST(
       case 'disable': {
         ipcResult = await ipc.send({ type: 'stop-agent', agent: decoded });
         const ctxRoot = getCTXRoot();
-        const enabledAgentsPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
         try {
-          const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-          const enabledAgents = JSON.parse(raw) as Record<string, unknown>;
-          if (enabledAgents[decoded] && typeof enabledAgents[decoded] === 'object') {
-            (enabledAgents[decoded] as Record<string, unknown>).enabled = false;
-          }
-          await fs.writeFile(enabledAgentsPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+          mutateEnabledAgentsRegistry(ctxRoot, (enabledAgents) => {
+            if (enabledAgents[decoded]) enabledAgents[decoded].enabled = false;
+          });
           registryMessage = 'disabled in registry';
         } catch {
           registryMessage = 'registry update failed (non-fatal)';
@@ -185,15 +177,13 @@ export async function DELETE(
   }
 
   const ctxRoot = getCTXRoot();
-  const enabledAgentsPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
   const deleteFiles = request.nextUrl.searchParams.get('deleteFiles') === 'true';
 
   // Look up org from enabled-agents.json
   let org = '';
   let enabledAgents: Record<string, { org?: string; enabled?: boolean }> = {};
   try {
-    const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-    enabledAgents = JSON.parse(raw);
+    enabledAgents = readEnabledAgentsRegistry(ctxRoot);
     if (enabledAgents[decoded]) {
       org = enabledAgents[decoded].org ?? '';
     }
@@ -224,12 +214,9 @@ export async function DELETE(
 
   // 2. Remove from enabled-agents.json
   try {
-    delete enabledAgents[decoded];
-    await fs.writeFile(
-      enabledAgentsPath,
-      JSON.stringify(enabledAgents, null, 2) + '\n',
-      'utf-8',
-    );
+    mutateEnabledAgentsRegistry(ctxRoot, (registry) => {
+      delete registry[decoded];
+    });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[api/agents/${decoded}/lifecycle] failed to update enabled-agents.json:`, message);

--- a/dashboard/src/app/api/agents/route.ts
+++ b/dashboard/src/app/api/agents/route.ts
@@ -4,6 +4,10 @@ import path from 'path';
 import { getFrameworkRoot, getCTXRoot, getAllAgents } from '@/lib/config';
 import { IPCClient } from '@/lib/ipc-client';
 import { getHeartbeat, getHealthStatus } from '@/lib/data/heartbeats';
+import {
+  mutateEnabledAgentsRegistry,
+  readEnabledAgentsRegistry,
+} from '@/lib/enabled-agents-registry';
 
 export const dynamic = 'force-dynamic';
 
@@ -101,20 +105,19 @@ export async function POST(request: NextRequest) {
 
   const frameworkRoot = getFrameworkRoot();
   const ctxRoot = getCTXRoot();
-  const enabledAgentsPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
 
   // Check for duplicate name in enabled-agents.json
+  let existing: Record<string, Record<string, unknown>>;
   try {
-    const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-    const existing = JSON.parse(raw);
-    if (existing[name]) {
-      return Response.json(
-        { error: `Agent "${name}" already exists` },
-        { status: 409 },
-      );
-    }
+    existing = readEnabledAgentsRegistry(ctxRoot);
   } catch {
-    // File doesn't exist yet - that's fine, we'll create it
+    return Response.json({ error: 'Agent registry is unreadable or malformed' }, { status: 500 });
+  }
+  if (existing[name]) {
+    return Response.json(
+      { error: `Agent "${name}" already exists` },
+      { status: 409 },
+    );
   }
 
   try {
@@ -159,27 +162,17 @@ export async function POST(request: NextRequest) {
     }
 
     // 5. Update enabled-agents.json
-    let enabledAgents: Record<string, unknown> = {};
-    try {
-      const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-      enabledAgents = JSON.parse(raw);
-    } catch {
-      // Start fresh
-    }
-
-    enabledAgents[name] = {
-      enabled: true,
-      org,
-      template,
-      createdAt: new Date().toISOString(),
-    };
-
-    await fs.mkdir(path.dirname(enabledAgentsPath), { recursive: true });
-    await fs.writeFile(
-      enabledAgentsPath,
-      JSON.stringify(enabledAgents, null, 2) + '\n',
-      'utf-8',
-    );
+    mutateEnabledAgentsRegistry(ctxRoot, (enabledAgents) => {
+      if (enabledAgents[name]) {
+        throw new Error(`Agent "${name}" was registered concurrently`);
+      }
+      enabledAgents[name] = {
+        enabled: true,
+        org,
+        template,
+        createdAt: new Date().toISOString(),
+      };
+    });
 
     return Response.json({ success: true, agent: { name, org } }, { status: 201 });
   } catch (err: unknown) {

--- a/dashboard/src/lib/enabled-agents-registry.ts
+++ b/dashboard/src/lib/enabled-agents-registry.ts
@@ -1,0 +1,5 @@
+export {
+  mutateEnabledAgentsRegistry,
+  readEnabledAgentsRegistry,
+  type EnabledAgentsRegistry,
+} from '../../../src/utils/enabled-agents-registry';

--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -2,8 +2,14 @@ import { Command } from 'commander';
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, copyFileSync, chmodSync, symlinkSync, lstatSync, unlinkSync } from 'fs';
 import { join, resolve } from 'path';
 import { homedir } from 'os';
-import { OrgContext } from '../types';
+import { AgentConfig, OrgContext } from '../types';
 import { validateAgentName, validateOrgName } from '../utils/validate';
+import {
+  applyCodexCapabilityProfile,
+  buildDefaultCodexCapabilityProfile,
+} from '../utils/codex-capability-profile';
+import { compileCodexCapabilityPolicy } from '../pty/codex-app-server-pty';
+import { mutateEnabledAgentsRegistry } from '../utils/enabled-agents-registry';
 
 const VALID_RUNTIMES = ['claude-code', 'hermes', 'codex-app-server', 'opencode'] as const;
 type RuntimeKind = typeof VALID_RUNTIMES[number];
@@ -316,29 +322,36 @@ export const addAgentCommand = new Command('add-agent')
       }
     }
 
+    // A new Codex seat must be startable without inheriting host-wide powers.
+    // add-agent knows the concrete role directory and credential locations, so
+    // it can write a fully explicit, reviewable profile rather than leaving the
+    // runtime to infer authority later. The role directory remains broadly
+    // writable; only identity/config controls and credential files are nested
+    // exceptions. Network, env, and MCP capabilities begin empty by design.
+    if (isCodexAppServer) {
+      seedCodexCapabilityProfile(
+        configPath,
+        agentDir,
+        projectRoot,
+        org,
+        options.instance,
+        name,
+      );
+    }
+
     // Register in enabled-agents.json
     const instanceId = options.instance;
     const ctxRoot = join(homedir(), '.cortextos', instanceId);
-    const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-    const configDir = join(ctxRoot, 'config');
-    mkdirSync(configDir, { recursive: true });
-
-    let enabledAgents: Record<string, any> = {};
-    try {
-      if (existsSync(enabledPath)) {
-        enabledAgents = JSON.parse(readFileSync(enabledPath, 'utf-8'));
-      }
-    } catch { /* start fresh */ }
-
-    if (!enabledAgents[name]) {
+    const registered = mutateEnabledAgentsRegistry(ctxRoot, (enabledAgents) => {
+      if (enabledAgents[name]) return false;
       enabledAgents[name] = {
         enabled: true,
         status: 'configured',
         ...(org ? { org } : {}),
       };
-      writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
-      console.log(`  Registered in enabled-agents.json`);
-    }
+      return true;
+    });
+    if (registered) console.log(`  Registered in enabled-agents.json`);
 
     console.log(`\n  Agent "${name}" created.`);
     console.log(`\n  Next steps:`);
@@ -346,6 +359,35 @@ export const addAgentCommand = new Command('add-agent')
     console.log(`    2. Customize identity files (IDENTITY.md, SOUL.md, GOALS.md)`);
     console.log(`    3. Start: cortextos start ${name}\n`);
   });
+
+function seedCodexCapabilityProfile(
+  configPath: string,
+  agentDir: string,
+  projectRoot: string,
+  org: string,
+  instance: string,
+  agentName: string,
+): void {
+  const absoluteAgentDir = resolve(agentDir);
+  const config = JSON.parse(readFileSync(configPath, 'utf-8')) as Record<string, unknown>;
+  const profile = buildDefaultCodexCapabilityProfile(
+    absoluteAgentDir,
+    projectRoot,
+    org,
+  );
+  const updated = applyCodexCapabilityProfile(config, profile);
+  const stateDir = join(homedir(), '.cortextos', instance, 'state', agentName);
+  compileCodexCapabilityPolicy(
+    updated as AgentConfig,
+    join(stateDir, 'model-tmp'),
+    join(stateDir, 'codex.sock'),
+  );
+  writeFileSync(
+    configPath,
+    JSON.stringify(updated, null, 2) + '\n',
+    'utf-8',
+  );
+}
 
 /**
  * Walk an agent's plugins/cortextos-agent-skills/skills tree and create one

--- a/src/cli/enable-agent.ts
+++ b/src/cli/enable-agent.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { TelegramAPI, formatValidateError } from '../telegram/api.js';
+import { mutateEnabledAgentsRegistry } from '../utils/enabled-agents-registry.js';
 
 /**
  * BUG-035 fix: discover the cortextOS framework root without depending on
@@ -112,13 +113,6 @@ export function writeDisableMarker(instanceId: string, agent: string, reason: st
   } catch { /* don't block disable on marker-write failure */ }
 }
 
-function writeEnabledAgents(instanceId: string, agents: Record<string, any>): void {
-  const path = getEnabledAgentsPath(instanceId);
-  const dir = join(homedir(), '.cortextos', instanceId, 'config');
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(agents, null, 2) + '\n', 'utf-8');
-}
-
 export const enableAgentCommand = new Command('enable')
   .argument('<agent>', 'Agent name to enable')
   .option('--instance <id>', 'Instance ID', 'default')
@@ -220,16 +214,16 @@ export const enableAgentCommand = new Command('enable')
       console.error('  Continuing enable. Investigate the validator if this recurs.');
     }
 
-    const agents = readEnabledAgents(options.instance);
-    agents[agent] = {
-      enabled: true,
-      status: 'configured',
-      ...(options.org ? { org: options.org } : {}),
-    };
-    writeEnabledAgents(options.instance, agents);
+    const ctxRoot = join(homedir(), '.cortextos', options.instance);
+    mutateEnabledAgentsRegistry(ctxRoot, (agents) => {
+      agents[agent] = {
+        enabled: true,
+        status: 'configured',
+        ...(options.org ? { org: options.org } : {}),
+      };
+    });
 
     // Create per-agent state directories
-    const ctxRoot = join(homedir(), '.cortextos', options.instance);
     const agentDirs = [
       join(ctxRoot, 'inbox', agent),
       join(ctxRoot, 'inflight', agent),
@@ -262,11 +256,12 @@ export const disableAgentCommand = new Command('disable')
   .option('--instance <id>', 'Instance ID', 'default')
   .description('Disable an agent (stop and deregister)')
   .action(async (agent: string, options: { instance: string }) => {
-    const agents = readEnabledAgents(options.instance);
-    if (agents[agent]) {
-      agents[agent].enabled = false;
-    }
-    writeEnabledAgents(options.instance, agents);
+    mutateEnabledAgentsRegistry(
+      join(homedir(), '.cortextos', options.instance),
+      (agents) => {
+        if (agents[agent]) agents[agent].enabled = false;
+      },
+    );
 
     // Try to stop via daemon IPC
     const ipc = new IPCClient(options.instance);

--- a/src/cli/import-agent.ts
+++ b/src/cli/import-agent.ts
@@ -6,6 +6,7 @@ import { spawnSync } from 'child_process';
 import { validateAgentName } from '../utils/validate.js';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { resolvePaths } from '../utils/paths.js';
+import { mutateEnabledAgentsRegistry } from '../utils/enabled-agents-registry.js';
 
 interface ExportManifest {
   version: string;
@@ -156,16 +157,9 @@ export const importAgentCommand = new Command('import-agent')
 
     // Register in enabled-agents.json
     const ctxRoot = join(homedir(), '.cortextos', options.instance);
-    const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-    let enabledAgents: Record<string, any> = {};
-    try {
-      if (existsSync(enabledPath)) {
-        enabledAgents = JSON.parse(readFileSync(enabledPath, 'utf-8'));
-      }
-    } catch { /* start fresh */ }
-    enabledAgents[agentName] = { enabled: true, status: 'configured', org };
-    mkdirSync(join(ctxRoot, 'config'), { recursive: true });
-    writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+    mutateEnabledAgentsRegistry(ctxRoot, (enabledAgents) => {
+      enabledAgents[agentName] = { enabled: true, status: 'configured', org };
+    });
     console.log(`  Registered in enabled-agents.json`);
 
     cleanup(tmpDir);

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -25,6 +25,7 @@ import { setupCommand } from './setup.js';
 import { spawnWorkerCommand, terminateWorkerCommand, listWorkersCommand, injectWorkerCommand } from './workers.js';
 import { importAgentCommand } from './import-agent.js';
 import { updateCommand } from './update.js';
+import { migrateCodexPermissionsCommand } from './migrate-codex-permissions.js';
 
 const program = new Command();
 
@@ -60,6 +61,7 @@ program.addCommand(listWorkersCommand);
 program.addCommand(injectWorkerCommand);
 program.addCommand(importAgentCommand);
 program.addCommand(updateCommand);
+program.addCommand(migrateCodexPermissionsCommand);
 
 // crash-alert: SessionEnd hook — cross-platform replacement for crash-alert.sh
 const crashAlertCommand = new Command('crash-alert')

--- a/src/cli/migrate-codex-permissions.ts
+++ b/src/cli/migrate-codex-permissions.ts
@@ -1,0 +1,379 @@
+import { createHash, randomBytes } from 'crypto';
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join, resolve } from 'path';
+import { homedir } from 'os';
+import { Command } from 'commander';
+import { IPCClient } from '../daemon/ipc-server.js';
+import { atomicWriteSync } from '../utils/atomic.js';
+import { withFileLockSync } from '../utils/lock.js';
+import {
+  codexPermissionBarrierRoot,
+  codexPermissionMigrationHoldPath,
+  codexPermissionStartClaimPath,
+  recoverDeadCodexPermissionStartClaimWhileBarrierHeld,
+} from '../utils/codex-permission-migration.js';
+import {
+  applyCodexCapabilityProfile,
+  buildDefaultCodexCapabilityProfile,
+  mergeCodexCapabilityProfile,
+  type CodexCapabilityProfile,
+} from '../utils/codex-capability-profile.js';
+import { validateAgentName, validateInstanceId, validateOrgName } from '../utils/validate.js';
+import { compileCodexCapabilityPolicy } from '../pty/codex-app-server-pty.js';
+import type { AgentConfig } from '../types/index.js';
+
+const MIGRATION_HOLD_SCHEMA = 'cortextos-codex-permission-migration-hold/v1';
+const SHA256 = /^[a-f0-9]{64}$/;
+
+interface MigrationHold {
+  schemaVersion: typeof MIGRATION_HOLD_SCHEMA;
+  agent: string;
+  sourceConfigSha256: string;
+  targetConfigSha256: string;
+  profileSha256: string;
+  nonce: string;
+}
+
+interface MigrationHoldLease {
+  path: string;
+  barrierRoot: string;
+  raw: string;
+  value: MigrationHold;
+  created: boolean;
+}
+
+export function codexCapabilityProfileHash(profile: CodexCapabilityProfile): string {
+  return createHash('sha256').update(JSON.stringify(profile, null, 2) + '\n').digest('hex');
+}
+
+export function codexConfigHash(rawConfig: string): string {
+  return createHash('sha256').update(rawConfig).digest('hex');
+}
+
+export const migrateCodexPermissionsCommand = new Command('migrate-codex-permissions')
+  .argument('<agent>', 'Existing codex-app-server agent name')
+  .option('--org <org>', 'Organization name when it cannot be resolved uniquely')
+  .option('--instance <id>', 'Instance ID (defaults to CTX_INSTANCE_ID, then default)')
+  .option('--apply', 'Atomically write the reviewed profile (default is dry-run)')
+  .option('--expect <sha256>', 'Exact profile hash printed by the dry-run')
+  .option('--expect-config <sha256>', 'Exact full config hash printed by the dry-run')
+  .description('Prepare or apply an explicit fail-closed Codex capability profile')
+  .action(async (
+    agent: string,
+    options: {
+      org?: string;
+      instance?: string;
+      apply?: boolean;
+      expect?: string;
+      expectConfig?: string;
+    },
+  ) => {
+    try {
+      validateAgentName(agent);
+      if (options.instance && process.env.CTX_INSTANCE_ID
+          && options.instance !== process.env.CTX_INSTANCE_ID) {
+        throw new Error(
+          `--instance ${options.instance} conflicts with CTX_INSTANCE_ID=${process.env.CTX_INSTANCE_ID}`,
+        );
+      }
+      const instance = options.instance || process.env.CTX_INSTANCE_ID || 'default';
+      validateInstanceId(instance);
+      const projectRoot = process.env.CTX_FRAMEWORK_ROOT
+        || process.env.CTX_PROJECT_ROOT
+        || process.cwd();
+      const org = resolveAgentOrg(projectRoot, agent, options.org);
+      const agentDir = join(projectRoot, 'orgs', org, 'agents', agent);
+      const configPath = join(agentDir, 'config.json');
+      if (!existsSync(configPath)) throw new Error(`No config.json found for ${agent}`);
+
+      const originalConfig = readFileSync(configPath, 'utf-8');
+      const config = JSON.parse(originalConfig) as Record<string, unknown>;
+      if (config.runtime !== 'codex-app-server') {
+        throw new Error(`${agent} is not configured for runtime=codex-app-server`);
+      }
+      const defaults = buildDefaultCodexCapabilityProfile(agentDir, projectRoot, org);
+      const profile = mergeCodexCapabilityProfile(config, defaults);
+      const updated = applyCodexCapabilityProfile(config, profile);
+      const ctxRoot = resolveMigrationCtxRoot(instance);
+      const stateDir = join(ctxRoot, 'state', agent);
+      compileCodexCapabilityPolicy(
+        updated as AgentConfig,
+        join(stateDir, 'model-tmp'),
+        join(stateDir, 'codex.sock'),
+      );
+      const profileSha256 = codexCapabilityProfileHash(profile);
+      const configSha256 = codexConfigHash(originalConfig);
+      const review = {
+        agent, org, instance, configPath, configSha256, profileSha256, profile,
+      };
+
+      if (!options.apply) {
+        console.log(JSON.stringify(review, null, 2));
+        console.log(
+          `\nStop the seat if it is running, review the profile, then apply with --apply --expect ${profileSha256} --expect-config ${configSha256}`,
+        );
+        return;
+      }
+      if (!options.expect || options.expect !== profileSha256) {
+        throw new Error('Refusing to apply without the exact current dry-run profile hash');
+      }
+      if (!options.expectConfig || !SHA256.test(options.expectConfig)) {
+        throw new Error('Refusing to apply without the exact current full-config hash');
+      }
+      const targetConfigBody = JSON.stringify(updated, null, 2);
+      const targetConfig = `${targetConfigBody}\n`;
+      const targetConfigSha256 = codexConfigHash(targetConfig);
+      const migrationLockRoot = join(stateDir, 'permission-migration-lock');
+      mkdirSync(migrationLockRoot, { recursive: true });
+      const lease = acquireMigrationHold({
+        ctxRoot,
+        agent,
+        sourceConfigSha256: options.expectConfig,
+        targetConfigSha256,
+        profileSha256,
+      });
+      let committed = false;
+      try {
+        // The dedicated hold is visible to AgentManager before the status
+        // request. It blocks new starts without repurposing the autostart bit
+        // used by approval-gated Command Center workers.
+        await assertSeatAbsent(agent, instance);
+        const currentConfig = readFileSync(configPath, 'utf-8');
+        const currentConfigSha256 = codexConfigHash(currentConfig);
+        if (!lease.created && currentConfigSha256 === lease.value.targetConfigSha256) {
+          clearMigrationHold(lease);
+          console.log(`Recovered completed Codex capability migration ${profileSha256} at ${configPath}`);
+          console.log(`Seat ${agent} was not started or enabled by migration.`);
+          return;
+        }
+        if (currentConfigSha256 !== lease.value.sourceConfigSha256
+            || currentConfig !== originalConfig) {
+          throw new Error('Refusing to apply because config.json changed after review');
+        }
+        withFileLockSync(migrationLockRoot, () => {
+          const lockedConfig = readFileSync(configPath, 'utf-8');
+          if (codexConfigHash(lockedConfig) !== lease.value.sourceConfigSha256
+              || lockedConfig !== originalConfig) {
+            throw new Error('Refusing to apply because config.json changed after review');
+          }
+          atomicWriteSync(configPath, targetConfigBody);
+        });
+        committed = true;
+        if (readFileSync(configPath, 'utf-8') !== targetConfig) {
+          throw new Error('Codex capability migration write could not be verified');
+        }
+        clearMigrationHold(lease);
+      } catch (err) {
+        // A post-write failure deliberately leaves the hold in place so no
+        // seat can start from an uncertain revision. A newly created pre-write
+        // hold can be removed exactly; a recovered hold remains for retry.
+        if (!committed && lease.created) clearMigrationHold(lease);
+        throw err;
+      }
+      console.log(`Applied Codex capability profile ${profileSha256} to ${configPath}`);
+      console.log(`Seat ${agent} was not started or enabled by migration.`);
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exitCode = 1;
+    }
+  });
+
+function resolveAgentOrg(projectRoot: string, agent: string, requested?: string): string {
+  if (requested) {
+    validateOrgName(requested);
+    const requestedDir = join(projectRoot, 'orgs', requested, 'agents', agent);
+    if (!existsSync(requestedDir)) throw new Error(`Agent ${agent} was not found in org ${requested}`);
+    return requested;
+  }
+  const orgsRoot = join(projectRoot, 'orgs');
+  if (!existsSync(orgsRoot)) throw new Error('No orgs directory was found');
+  const matches = readdirSync(orgsRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name)
+    .filter((org) => existsSync(join(orgsRoot, org, 'agents', agent)));
+  if (matches.length !== 1) {
+    throw new Error(
+      matches.length === 0
+        ? `Agent ${agent} was not found`
+        : `Agent ${agent} exists in multiple orgs; pass --org explicitly`,
+    );
+  }
+  validateOrgName(matches[0]);
+  return matches[0];
+}
+
+async function assertSeatAbsent(agent: string, instance: string): Promise<void> {
+  const ipc = new IPCClient(instance);
+  let response;
+  try {
+    response = await ipc.send({
+      type: 'status',
+      source: 'cortextos migrate-codex-permissions',
+    });
+  } catch (err) {
+    throw new Error(
+      `Could not prove the target seat is absent from daemon status: ${(err as Error).message}`,
+    );
+  }
+  if (!response.success) {
+    throw new Error(
+      `Could not prove the target seat is absent from daemon status: ${response.error || 'unknown IPC failure'}`,
+    );
+  }
+  if (!Array.isArray(response.data)) {
+    throw new Error('Could not prove the target seat is absent from daemon status');
+  }
+  const target = (response.data as Array<{ name?: string; status?: string }>)
+    .find((status) => status.name === agent);
+  if (target) {
+    throw new Error(
+      `Seat ${agent} must be absent from daemon status before migration (current: ${target.status})`,
+    );
+  }
+}
+
+function resolveMigrationCtxRoot(instance: string): string {
+  validateInstanceId(instance);
+  const canonical = resolve(join(homedir(), '.cortextos', instance));
+  if (process.env.CTX_ROOT && resolve(process.env.CTX_ROOT) !== canonical) {
+    throw new Error(
+      `CTX_ROOT does not match --instance ${instance}; refusing to prove state against different instances`,
+    );
+  }
+  return canonical;
+}
+
+function acquireMigrationHold(input: {
+  ctxRoot: string;
+  agent: string;
+  sourceConfigSha256: string;
+  targetConfigSha256: string;
+  profileSha256: string;
+}): MigrationHoldLease {
+  const barrierRoot = codexPermissionBarrierRoot(input.ctxRoot, input.agent);
+  mkdirSync(barrierRoot, { recursive: true, mode: 0o700 });
+  return withFileLockSync(barrierRoot, () => {
+    if (existsSync(codexPermissionStartClaimPath(input.ctxRoot, input.agent))) {
+      if (!recoverDeadCodexPermissionStartClaimWhileBarrierHeld(input.ctxRoot, input.agent)) {
+        throw new Error(`Seat ${input.agent} has a start preparation in progress`);
+      }
+    }
+    return acquireMigrationHoldUnlocked(input, barrierRoot);
+  });
+}
+
+function acquireMigrationHoldUnlocked(input: {
+  ctxRoot: string;
+  agent: string;
+  sourceConfigSha256: string;
+  targetConfigSha256: string;
+  profileSha256: string;
+}, barrierRoot: string): MigrationHoldLease {
+  const path = codexPermissionMigrationHoldPath(input.ctxRoot, input.agent);
+  mkdirSync(dirname(path), { recursive: true, mode: 0o700 });
+  const value: MigrationHold = {
+    schemaVersion: MIGRATION_HOLD_SCHEMA,
+    agent: input.agent,
+    sourceConfigSha256: input.sourceConfigSha256,
+    targetConfigSha256: input.targetConfigSha256,
+    profileSha256: input.profileSha256,
+    nonce: randomBytes(16).toString('hex'),
+  };
+  const raw = `${JSON.stringify(value, null, 2)}\n`;
+  let fd: number | null = null;
+  try {
+    fd = openSync(
+      path,
+      constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+      0o600,
+    );
+    chmodSync(path, 0o600);
+    writeFileSync(fd, raw, 'utf-8');
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
+    fsyncDirectory(dirname(path));
+    return { path, barrierRoot, raw, value, created: true };
+  } catch (err) {
+    if (fd !== null) closeSync(fd);
+    if ((err as NodeJS.ErrnoException).code !== 'EEXIST') throw err;
+    const existing = readMigrationHold(path);
+    for (const key of ['agent', 'sourceConfigSha256', 'targetConfigSha256', 'profileSha256'] as const) {
+      if (existing.value[key] !== value[key]) {
+        throw new Error(`A different Codex permission migration hold already exists for ${input.agent}`);
+      }
+    }
+    return { ...existing, barrierRoot, created: false };
+  }
+}
+
+function readMigrationHold(
+  path: string,
+): Omit<MigrationHoldLease, 'created' | 'barrierRoot'> {
+  const stat = lstatSync(path);
+  const currentUid = typeof process.getuid === 'function' ? process.getuid() : null;
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1 || (stat.mode & 0o077) !== 0) {
+    throw new Error('Codex permission migration hold has unsafe inode or mode');
+  }
+  if (currentUid !== null && stat.uid !== currentUid) {
+    throw new Error('Codex permission migration hold has unsafe ownership');
+  }
+  const raw = readFileSync(path, 'utf-8');
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error('Codex permission migration hold is malformed');
+  }
+  const expectedKeys = [
+    'agent', 'nonce', 'profileSha256', 'schemaVersion',
+    'sourceConfigSha256', 'targetConfigSha256',
+  ];
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+      || Object.keys(value).sort().join('\n') !== expectedKeys.sort().join('\n')) {
+    throw new Error('Codex permission migration hold is malformed');
+  }
+  const hold = value as MigrationHold;
+  if (hold.schemaVersion !== MIGRATION_HOLD_SCHEMA
+      || typeof hold.agent !== 'string' || !hold.agent
+      || !SHA256.test(hold.sourceConfigSha256)
+      || !SHA256.test(hold.targetConfigSha256)
+      || !SHA256.test(hold.profileSha256)
+      || !/^[a-f0-9]{32}$/.test(hold.nonce)) {
+    throw new Error('Codex permission migration hold is malformed');
+  }
+  return { path, raw, value: hold };
+}
+
+function clearMigrationHold(lease: MigrationHoldLease): void {
+  withFileLockSync(lease.barrierRoot, () => {
+    const current = readMigrationHold(lease.path);
+    if (current.raw !== lease.raw) {
+      throw new Error('Codex permission migration hold changed before release');
+    }
+    unlinkSync(lease.path);
+    fsyncDirectory(dirname(lease.path));
+  });
+}
+
+function fsyncDirectory(path: string): void {
+  const fd = openSync(path, constants.O_RDONLY);
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { homedir, platform } from 'os';
 import { execSync, spawn, spawnSync } from 'child_process';
 import { IPCClient } from '../daemon/ipc-server.js';
+import { mutateEnabledAgentsRegistry } from '../utils/enabled-agents-registry.js';
 
 const IS_WINDOWS = platform() === 'win32';
 const SAFE_CMD = /^[@a-z0-9._/-]+$/i;
@@ -165,26 +166,20 @@ export const startCommand = new Command('start')
     if (agent) {
       // Auto-register in enabled-agents.json if not already present
       const ctxRoot = join(homedir(), '.cortextos', options.instance);
-      const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-      let enabledAgents: Record<string, any> = {};
-      try {
-        if (existsSync(enabledPath)) {
-          enabledAgents = JSON.parse(readFileSync(enabledPath, 'utf-8'));
-        }
-      } catch { /* ignore */ }
-
-      if (!enabledAgents[agent]) {
+      const registered = mutateEnabledAgentsRegistry(ctxRoot, (enabledAgents) => {
+        if (enabledAgents[agent]) return false;
         // Try to detect org from existing entries or project structure
-        const existingOrg = Object.values(enabledAgents as Record<string, any>).find((e: any) => e.org)?.org;
+        const existingOrg = Object.values(enabledAgents).find((entry) => (
+          typeof entry.org === 'string' && entry.org
+        ))?.org;
         enabledAgents[agent] = {
           enabled: true,
           status: 'configured',
           ...(existingOrg ? { org: existingOrg } : {}),
         };
-        mkdirSync(join(ctxRoot, 'config'), { recursive: true });
-        writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
-        console.log(`  Registered ${agent} in enabled-agents.json`);
-      }
+        return true;
+      });
+      if (registered) console.log(`  Registered ${agent} in enabled-agents.json`);
 
       console.log(`Starting agent: ${agent}`);
       const response = await ipc.send({ type: 'start-agent', agent, source: 'cortextos start' });

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -16,6 +16,12 @@ import { collectTelegramCommands, registerTelegramCommands } from '../bus/metric
 import { stripControlChars } from '../utils/validate.js';
 import { processMediaMessage } from '../telegram/media.js';
 import { stripBom } from '../utils/strip-bom.js';
+import {
+  acquireCodexPermissionStartClaim,
+  releaseCodexPermissionStartClaim,
+  type CodexPermissionStartClaim,
+} from '../utils/codex-permission-migration.js';
+import { readEnabledAgentsRegistry } from '../utils/enabled-agents-registry.js';
 
 type LogFn = (msg: string) => void;
 
@@ -120,6 +126,10 @@ export class AgentManager {
     // commands have no effect across daemon restarts — the daemon would
     // re-discover and re-start any agent dir on disk regardless of user intent.
     const instanceEnabled = this.readInstanceEnableList();
+    if (instanceEnabled === null) {
+      console.error('[agent-manager] Refusing automatic discovery: enabled-agents.json exists but is unreadable or malformed');
+      return;
+    }
 
     for (const { name, dir, org, config } of agentDirs) {
       // Per-agent config.json `enabled: false` (existing behavior, unchanged)
@@ -135,7 +145,14 @@ export class AgentManager {
       }
       // BUG-043 fix: pass the per-agent org so startAgent can use it instead
       // of falling back to `this.org` (the daemon's startup org).
-      await this.startAgent(name, dir, config, org);
+      try {
+        await this.startAgent(name, dir, config, org);
+      } catch (err) {
+        // One malformed or unavailable seat must not take the shared daemon or
+        // unrelated agents down. startAgent normally records its own crashed
+        // status; this boundary catches unexpected construction/setup errors.
+        console.error(`[agent-manager] Failed to start ${name}: ${String(err)}`);
+      }
     }
 
     // Successful startup pass — clear .daemon-crashed markers from disk
@@ -152,13 +169,14 @@ export class AgentManager {
    * agents not present in the file default to enabled, matching the existing
    * default-on behavior of `discoverAndStart`.
    */
-  private readInstanceEnableList(): Record<string, { enabled?: boolean; org?: string; status?: string }> {
+  private readInstanceEnableList(): Record<string, { enabled?: boolean; org?: string; status?: string }> | null {
     const enabledFile = join(this.ctxRoot, 'config', 'enabled-agents.json');
     if (!existsSync(enabledFile)) return {};
     try {
-      return JSON.parse(readFileSync(enabledFile, 'utf-8'));
-    } catch {
-      return {}; // corrupt or unreadable — fall through to default-enabled
+      return readEnabledAgentsRegistry(this.ctxRoot);
+    } catch (err) {
+      console.error(`[agent-manager] Failed to read ${enabledFile}: ${String(err)}`);
+      return null;
     }
   }
 
@@ -184,7 +202,7 @@ export class AgentManager {
     if (explicitOrg) return explicitOrg;
 
     const enabledAgents = this.readInstanceEnableList();
-    const entry = enabledAgents[name];
+    const entry = enabledAgents?.[name];
     if (entry?.org) return entry.org;
 
     // Legacy fallback: scan all orgs on disk for a dir named `name`.
@@ -291,29 +309,61 @@ export class AgentManager {
     if (!config) {
       config = this.loadAgentConfig(agentDir);
     }
+    let permissionStartClaim: CodexPermissionStartClaim | null = null;
+    if (config.runtime === 'codex-app-server') {
+      try {
+        permissionStartClaim = acquireCodexPermissionStartClaim(this.ctxRoot, name);
+      } catch (err) {
+        console.error(`[agent-manager] Refusing to start ${name}: could not acquire Codex permission start claim: ${String(err)}`);
+        return;
+      }
+      if (!permissionStartClaim) {
+        console.log(`[agent-manager] Refusing to start ${name}: Codex permission migration hold is active`);
+        return;
+      }
 
-    const env: CtxEnv = {
-      instanceId: this.instanceId,
-      ctxRoot: this.ctxRoot,
-      frameworkRoot: this.frameworkRoot,
-      agentName: name,
-      agentDir,
-      org: resolvedOrg,
-      projectRoot: this.frameworkRoot,
-    };
-
-    const paths = resolvePaths(name, this.instanceId, resolvedOrg);
+      // Bind the runtime to the config revision read inside the shared start /
+      // migration barrier. A migration that completed between discovery and
+      // start cannot leave this process using the stale pre-migration object.
+      const refreshedConfig = this.loadAgentConfig(agentDir);
+      if (refreshedConfig.runtime !== 'codex-app-server') {
+        try {
+          releaseCodexPermissionStartClaim(this.ctxRoot, name, permissionStartClaim);
+        } catch (err) {
+          console.error(`[agent-manager] Codex permission start claim could not be released for ${name}: ${String(err)}`);
+        }
+        console.error(`[agent-manager] Refusing to start ${name}: runtime changed while acquiring the Codex permission barrier`);
+        return;
+      }
+      config = refreshedConfig;
+    }
 
     const log = (msg: string) => {
       console.log(`[${name}] ${msg}`);
     };
-
-    // Read agent .env for Telegram credentials
-    const agentEnvFile = join(agentDir, '.env');
+    let agentProcess!: AgentProcess;
+    let checker!: FastChecker;
+    let paths!: BusPaths;
     let telegramApi: TelegramAPI | undefined;
     let chatId: string | undefined;
     let allowedUserId: string | undefined;
     let botToken: string | undefined;
+
+    try {
+      const env: CtxEnv = {
+        instanceId: this.instanceId,
+        ctxRoot: this.ctxRoot,
+        frameworkRoot: this.frameworkRoot,
+        agentName: name,
+        agentDir,
+        org: resolvedOrg,
+        projectRoot: this.frameworkRoot,
+      };
+
+      paths = resolvePaths(name, this.instanceId, resolvedOrg);
+
+      // Read agent .env for Telegram credentials
+      const agentEnvFile = join(agentDir, '.env');
 
     if (existsSync(agentEnvFile)) {
       // stripBom: Windows tooling writes .env with a UTF-8 BOM that breaks
@@ -369,14 +419,14 @@ export class AgentManager {
       }
     }
 
-    const agentProcess = new AgentProcess(name, env, config, log);
+    agentProcess = new AgentProcess(name, env, config, log);
     // Issue #330: pass the Telegram handle into AgentProcess so CodexAppServerPTY
     // can emit sendChatAction directly from the JSONL stream. Has no effect for
     // claude-code / hermes runtimes — those still use fast-checker.
     if (telegramApi && chatId) {
       agentProcess.setTelegramHandle(telegramApi, chatId);
     }
-    const checker = new FastChecker(agentProcess, paths, this.frameworkRoot, {
+    checker = new FastChecker(agentProcess, paths, this.frameworkRoot, {
       log,
       telegramApi,
       chatId,
@@ -393,7 +443,10 @@ export class AgentManager {
       agentProcess.onStatusChanged((status) => {
         if (status.status === 'crashed') {
           const crashNum = status.crashCount ?? '?';
-          tgApi.sendMessage(tgChatId, `Agent ${name} crashed (crash #${crashNum}) — auto-restarting`).catch(() => {});
+          const suffix = status.restartScheduled
+            ? ' — auto-restarting'
+            : ' — no restart scheduled; review configuration and start manually';
+          tgApi.sendMessage(tgChatId, `Agent ${name} crashed (crash #${crashNum})${suffix}`).catch(() => {});
         } else if (status.status === 'halted') {
           tgApi.sendMessage(tgChatId, `Agent ${name} HALTED — exceeded crash limit. Restart manually with: cortextos start ${name}`).catch(() => {});
         } else if (status.status === 'running' && prevStatus === 'crashed') {
@@ -403,10 +456,41 @@ export class AgentManager {
       });
     }
 
-    this.agents.set(name, { process: agentProcess, checker });
+      this.agents.set(name, { process: agentProcess, checker });
+    } catch (err) {
+      if (permissionStartClaim) {
+        try {
+          releaseCodexPermissionStartClaim(this.ctxRoot, name, permissionStartClaim);
+          permissionStartClaim = null;
+        } catch (releaseErr) {
+          console.error(`[agent-manager] Codex permission start claim could not be released after setup failure for ${name}: ${String(releaseErr)}`);
+        }
+      }
+      console.error(`[agent-manager] Refusing to start ${name}: synchronous setup failed: ${String(err)}`);
+      return;
+    }
+    if (permissionStartClaim) {
+      try {
+        releaseCodexPermissionStartClaim(this.ctxRoot, name, permissionStartClaim);
+        permissionStartClaim = null;
+      } catch (err) {
+        // The retained claim keeps future migration fail-closed. The seat is
+        // already visible in daemon status, so starting it cannot race an
+        // authorized migration even if cleanup itself failed.
+        console.error(`[agent-manager] Codex permission start claim could not be released for ${name}; migration remains blocked: ${String(err)}`);
+      }
+    }
 
     // Start agent
-    await agentProcess.start();
+    const startOutcome = await agentProcess.start();
+    if (startOutcome.kind === 'configuration-error') {
+      log('Runtime configuration failed; cron, checker, and Telegram services remain disabled');
+      return;
+    }
+    if (startOutcome.kind === 'cancelled' || startOutcome.kind === 'runtime-error') {
+      log(`Runtime startup did not complete (${startOutcome.kind}); ancillary services remain disabled`);
+      return;
+    }
 
     // Subtask 2.2: Auto-migrate crons from config.json → crons.json before
     // starting the scheduler, so the scheduler always has a populated crons.json

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -15,6 +15,10 @@ import { resolvePaths } from '../utils/paths.js';
 
 type LogFn = (msg: string) => void;
 
+export type AgentStartOutcome =
+  | { kind: 'started' | 'already-running' | 'recovery-pending' }
+  | { kind: 'cancelled' | 'configuration-error' | 'runtime-error'; error?: string };
+
 /**
  * Manages a single agent's lifecycle.
  * Replaces agent-wrapper.sh for one agent.
@@ -36,6 +40,10 @@ export class AgentProcess {
   private sessionStart: Date | null = null;
   private status: AgentStatus['status'] = 'stopped';
   private stopping: boolean = false;
+  /** Invalidates an in-flight delayed/spawning start when stop() wins the race. */
+  private startAttemptGeneration: number = 0;
+  /** Status evidence for callers that must not claim an unscheduled restart. */
+  private restartScheduled: boolean = false;
   // BUG-040 fix: persists across stop() return until handleExit clears it.
   // Required because BUG-032's CRLF + 5s wait can cause graceful shutdown to
   // exceed the 5s Promise.race timeout in stop(), which would otherwise reset
@@ -88,17 +96,32 @@ export class AgentProcess {
   /**
    * Start the agent. Spawns Claude Code in a PTY.
    */
-  async start(): Promise<void> {
+  async start(): Promise<AgentStartOutcome> {
     if (this.status === 'running') {
       this.log('Already running');
-      return;
+      return { kind: 'already-running' };
     }
+
+    const startAttempt = ++this.startAttemptGeneration;
+    // A new explicit/recovery start supersedes a completed prior stop. A stop
+    // that races this attempt increments startAttemptGeneration and therefore
+    // cannot be cleared after the startup delay.
+    this.stopRequested = false;
+    this.restartScheduled = false;
+    this.status = 'starting';
+    this.notifyStatusChange();
 
     // Apply startup delay
     const delay = this.config.startup_delay || 0;
     if (delay > 0) {
       this.log(`Startup delay: ${delay}s`);
       await sleep(delay * 1000);
+    }
+    if (startAttempt !== this.startAttemptGeneration || this.stopRequested) {
+      this.log('Startup cancelled before runtime configuration');
+      this.status = 'stopped';
+      this.notifyStatusChange();
+      return { kind: 'cancelled' };
     }
 
     // Write .cortextos-env for backward compat (D6)
@@ -113,12 +136,6 @@ export class AgentProcess {
       : this.buildContinuePrompt();
 
     this.log(`Starting in ${mode} mode`);
-    this.status = 'starting';
-
-    // BUG-040 fix: clear any stale stop request from a previous lifecycle
-    // (e.g. if the previous stop() timed out before the PTY actually exited).
-    // We're starting fresh — the new PTY has no pending stop.
-    this.stopRequested = false;
     // BUG-040 fix: bump generation. The onExit closure below captures THIS
     // value and uses it to detect "I'm an old PTY whose exit fired after a
     // new lifecycle began" — in which case it bails out without touching
@@ -129,13 +146,25 @@ export class AgentProcess {
     const logPath = join(this.env.ctxRoot, 'logs', this.name, 'stdout.log');
     ensureDir(join(this.env.ctxRoot, 'logs', this.name));
     this.log(`Log path: ${logPath}`);
-    this.pty = this.config.runtime === 'hermes'
-      ? new HermesPTY(this.env, this.config, logPath)
-      : this.config.runtime === 'opencode'
-        ? new OpencodePTY(this.env, this.config, logPath)
-        : this.config.runtime === 'codex-app-server'
-          ? new CodexAppServerPTY(this.env, this.config, logPath)
-          : new AgentPTY(this.env, this.config, logPath);
+    try {
+      this.pty = this.config.runtime === 'hermes'
+        ? new HermesPTY(this.env, this.config, logPath)
+        : this.config.runtime === 'opencode'
+          ? new OpencodePTY(this.env, this.config, logPath)
+          : this.config.runtime === 'codex-app-server'
+            ? new CodexAppServerPTY(this.env, this.config, logPath)
+            : new AgentPTY(this.env, this.config, logPath);
+    } catch (err) {
+      const error = String(err);
+      const hint = this.config.runtime === 'codex-app-server'
+        ? ' Review the explicit codex_* capability arrays in config.json before restarting this seat.'
+        : '';
+      this.log(`Failed to configure runtime: ${error}.${hint}`);
+      this.status = 'crashed';
+      this.restartScheduled = false;
+      this.notifyStatusChange();
+      return { kind: 'configuration-error', error };
+    }
 
     // Issue #330: re-wire the Telegram handle on every start() (session refresh
     // creates a fresh CodexAppServerPTY). Only CodexAppServerPTY uses this — Claude / Hermes
@@ -167,22 +196,31 @@ export class AgentProcess {
       this.resolveExit?.();
       this.resolveExit = null;
     });
+    const startingPty = this.pty;
 
     try {
-      await this.pty.spawn(mode, prompt);
+      await startingPty.spawn(mode, prompt);
+      if (startAttempt !== this.startAttemptGeneration || this.stopRequested || this.stopping) {
+        this.disposeCancelledStartupPty(startingPty);
+        this.status = 'stopped';
+        this.restartScheduled = false;
+        this.notifyStatusChange();
+        return { kind: 'cancelled' };
+      }
       // Codex exec-per-turn race: the new PTY's onExit can fire BEFORE this
       // line if `codex exec` completes its prompt quickly (CodexAppServerPTY's spawn
       // resolves once exec is launched, but the process may exit moments
       // later as it finishes the bootstrap turn). handleExit() nulls
       // this.pty and schedules crash recovery — we must not claim 'running'
       // or call getPid() on null in that window.
-      if (!this.pty) {
+      if (this.pty !== startingPty) {
         this.log('PTY exited during spawn — handleExit will recover');
-        return;
+        return { kind: 'recovery-pending' };
       }
       this.status = 'running';
+      this.restartScheduled = false;
       this.sessionStart = new Date();
-      this.log(`Running (pid: ${this.pty.getPid()})`);
+      this.log(`Running (pid: ${startingPty.getPid()})`);
 
       this.maybeSendRuntimeLifecycleNotification();
 
@@ -190,10 +228,36 @@ export class AgentProcess {
       this.startSessionTimer();
 
       this.notifyStatusChange();
+      return { kind: 'started' };
     } catch (err) {
+      if (startAttempt !== this.startAttemptGeneration || this.stopRequested || this.stopping) {
+        this.disposeCancelledStartupPty(startingPty);
+        this.status = 'stopped';
+        this.restartScheduled = false;
+        this.notifyStatusChange();
+        return { kind: 'cancelled' };
+      }
+      if (this.restartScheduled) {
+        this.log(`Runtime exited during startup; scheduled recovery remains authoritative: ${err}`);
+        return { kind: 'recovery-pending' };
+      }
       this.log(`Failed to start: ${err}`);
       this.status = 'crashed';
+      this.restartScheduled = false;
       this.notifyStatusChange();
+      return { kind: 'runtime-error', error: String(err) };
+    }
+  }
+
+  private disposeCancelledStartupPty(
+    pty: AgentPTY | CodexAppServerPTY,
+  ): void {
+    if (this.pty === pty) this.pty = null;
+    try {
+      if (pty.isAlive()) pty.kill();
+    } catch {
+      // Cancellation remains authoritative even if adapter teardown races an
+      // already-exited child.
     }
   }
 
@@ -203,6 +267,10 @@ export class AgentProcess {
   async stop(): Promise<void> {
     if (this.stopping) return;
     this.stopping = true;
+    // Cancel a startup_delay or in-flight spawn before it can clear the stop
+    // request and create an untracked process after AgentManager removes it.
+    this.startAttemptGeneration++;
+    this.restartScheduled = false;
     // BUG-040 fix: stopRequested persists ACROSS stop()'s return until
     // handleExit clears it. This is the safety net for the case where the
     // PTY exits later than the Promise.race timeout below.
@@ -382,6 +450,7 @@ export class AgentProcess {
       sessionStart: this.sessionStart?.toISOString(),
       crashCount: this.crashCount,
       model: this.config.model,
+      restartScheduled: this.restartScheduled,
     };
   }
 
@@ -583,6 +652,7 @@ export class AgentProcess {
       this.armForceFresh('image-poison auto-recovery');
       this.appendCrashToRestartsLog(exitCode, 5000, 'IMAGE_POISON_RECOVERY');
       this.status = 'crashed';
+      this.restartScheduled = true;
       this.notifyStatusChange();
       setTimeout(() => {
         if (this.status === 'crashed') {
@@ -610,6 +680,7 @@ export class AgentProcess {
         );
         this.appendCrashToRestartsLog(exitCode, 0, 'CRASH_LOOP');
         this.status = 'halted';
+        this.restartScheduled = false;
         this.notifyStatusChange();
         return;
       }
@@ -625,6 +696,7 @@ export class AgentProcess {
       this.log(`HALTED: exceeded ${this.maxCrashesPerDay} crashes today`);
       this.appendCrashToRestartsLog(exitCode, 0, 'HALTED');
       this.status = 'halted';
+      this.restartScheduled = false;
       this.notifyStatusChange();
       return;
     }
@@ -638,6 +710,7 @@ export class AgentProcess {
     // invisible outside the rotating PM2 daemon stdout log.
     this.appendCrashToRestartsLog(exitCode, backoff, 'CRASH');
     this.status = 'crashed';
+    this.restartScheduled = true;
     this.notifyStatusChange();
 
     setTimeout(() => {

--- a/src/pty/codex-app-server-pty.ts
+++ b/src/pty/codex-app-server-pty.ts
@@ -1,5 +1,5 @@
 import { appendFileSync, existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join, normalize } from 'path';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
@@ -46,6 +46,18 @@ interface ThreadResponse {
     id: string;
     status?: unknown;
   };
+  activePermissionProfile: {
+    id: string;
+    extends?: string | null;
+  } | null;
+}
+
+interface PermissionProfileListResponse {
+  data: Array<{
+    id: string;
+    allowed: boolean;
+  }>;
+  nextCursor?: string | null;
 }
 
 interface SkillsListResponse {
@@ -67,19 +79,17 @@ interface GoalResponse {
   } | null;
 }
 
-const THREAD_PERMISSION_OVERRIDES = {
-  approvalPolicy: 'never',
-  sandbox: 'danger-full-access',
-} as const;
-
-const TURN_PERMISSION_OVERRIDES = {
-  approvalPolicy: 'never',
-  sandboxPolicy: { type: 'dangerFullAccess' },
-} as const;
+class PermissionProfileError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PermissionProfileError';
+  }
+}
 
 const SOCKET_BASENAME = 'codex.sock';
 const SOCKET_PATH_WARN_BYTES = 100;
 const BOOTSTRAP_PATTERN = '[codex-app-server] ready';
+const PERMISSION_PROFILE_PREFIX = 'cortextos-fleet';
 
 const SLASH_REWRITE_RE = /^\/([a-z][a-z0-9_-]*)(?:\s+([\s\S]*))?$/i;
 const LOCAL_SLASH_COMMANDS = new Set(['goal']);
@@ -118,6 +128,8 @@ export class CodexAppServerPTY {
   private _socketCwd: string;
   private _threadStatePath: string;
   private _socketPointerPath: string;
+  private readonly _permissionProfileId: string;
+  private readonly _permissionProfileConfigArgs: string[];
   private _threadId: string | null = null;
   private _telegramApi: TelegramAPI | null = null;
   private _chatId: string | null = null;
@@ -130,10 +142,14 @@ export class CodexAppServerPTY {
     this._stateDir = join(env.ctxRoot, 'state', env.agentName);
     this._threadStatePath = join(this._stateDir, 'codex-app-server-thread.json');
     this._socketPointerPath = join(this._stateDir, 'codex-app-server-socket.json');
+    const credentialDenyPaths = validateCredentialDenyPaths(config.codex_credential_deny_paths);
     const socket = this.resolveSocketPath();
     this._socketPath = socket.path;
     this._socketListenArg = socket.listenArg;
     this._socketCwd = socket.cwd;
+    const profile = buildPermissionProfile(credentialDenyPaths, this._socketPath);
+    this._permissionProfileId = profile.id;
+    this._permissionProfileConfigArgs = profile.configArgs;
     this._outputBuffer = new OutputBuffer(1000, logPath, BOOTSTRAP_PATTERN);
   }
 
@@ -423,7 +439,9 @@ export class CodexAppServerPTY {
       const spawnFn = this._spawnFn!;
       const pty = spawnFn('codex', [
         'app-server',
+        '--strict-config',
         '--enable', 'goals',
+        ...this._permissionProfileConfigArgs,
         '--listen', this._socketListenArg,
       ], {
         name: 'xterm-256color',
@@ -477,6 +495,24 @@ export class CodexAppServerPTY {
       capabilities: { experimentalApi: true },
     });
     this._rpc?.notify('initialized');
+    await this.verifyPermissionProfileAvailable();
+  }
+
+  private async verifyPermissionProfileAvailable(): Promise<void> {
+    const response = await this.request<PermissionProfileListResponse>('permissionProfile/list', {
+      cwd: this._cwd,
+    });
+    const profile = response.result?.data?.find((entry) => entry.id === this._permissionProfileId);
+    if (!profile) {
+      throw new PermissionProfileError(
+        `Required Codex permission profile ${this._permissionProfileId} is not available`,
+      );
+    }
+    if (profile.allowed !== true) {
+      throw new PermissionProfileError(
+        `Required Codex permission profile ${this._permissionProfileId} is not allowed`,
+      );
+    }
   }
 
   private async startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> {
@@ -487,14 +523,17 @@ export class CodexAppServerPTY {
           const resumed = await this.request<ThreadResponse>('thread/resume', {
             threadId: persisted.threadId,
             cwd: this._cwd,
-            ...THREAD_PERMISSION_OVERRIDES,
+            approvalPolicy: 'never',
+            permissions: this._permissionProfileId,
             config: { features: { goals: true } },
             excludeTurns: true,
             persistExtendedHistory: true,
           });
+          this.verifyActivePermissionProfile(resumed, 'thread/resume');
           this.setThreadId(resumed.result?.thread.id || persisted.threadId);
           return;
         } catch (err) {
+          if (err instanceof PermissionProfileError) throw err;
           this._outputBuffer.push(`[codex-app-server] persisted resume failed: ${err}\n`);
         }
       }
@@ -504,11 +543,13 @@ export class CodexAppServerPTY {
         const resumed = await this.request<ThreadResponse>('thread/resume', {
           threadId: latest,
           cwd: this._cwd,
-          ...THREAD_PERMISSION_OVERRIDES,
+          approvalPolicy: 'never',
+          permissions: this._permissionProfileId,
           config: { features: { goals: true } },
           excludeTurns: true,
           persistExtendedHistory: true,
         });
+        this.verifyActivePermissionProfile(resumed, 'thread/resume');
         this.setThreadId(resumed.result?.thread.id || latest);
         return;
       }
@@ -516,13 +557,24 @@ export class CodexAppServerPTY {
 
     const started = await this.request<ThreadResponse>('thread/start', {
       cwd: this._cwd,
-      ...THREAD_PERMISSION_OVERRIDES,
+      approvalPolicy: 'never',
+      permissions: this._permissionProfileId,
       config: { features: { goals: true } },
       sessionStartSource: 'startup',
       experimentalRawEvents: false,
       persistExtendedHistory: true,
     });
+    this.verifyActivePermissionProfile(started, 'thread/start');
     this.setThreadId(started.result!.thread.id);
+  }
+
+  private verifyActivePermissionProfile(response: JsonRpcResponse<ThreadResponse>, method: string): void {
+    const actual = response.result?.activePermissionProfile?.id ?? null;
+    if (actual !== this._permissionProfileId) {
+      throw new PermissionProfileError(
+        `${method} active permission profile mismatch: expected ${this._permissionProfileId}, got ${actual ?? 'none'}`,
+      );
+    }
   }
 
   private async findLatestThreadForCwd(): Promise<string | null> {
@@ -599,7 +651,12 @@ export class CodexAppServerPTY {
   private async startTurn(input: unknown[]): Promise<void> {
     if (!this._threadId) throw new Error('No Codex app-server thread is active');
     const completion = this.createTurnCompletion();
-    await this.request('turn/start', { threadId: this._threadId, input, ...TURN_PERMISSION_OVERRIDES });
+    await this.request('turn/start', {
+      threadId: this._threadId,
+      input,
+      approvalPolicy: 'never',
+      permissions: this._permissionProfileId,
+    });
     await completion;
   }
 
@@ -736,6 +793,26 @@ export class CodexAppServerPTY {
       case 'thread/goal/cleared':
         this._outputBuffer.push('[goal] cleared\n');
         break;
+      case 'thread/settings/updated': {
+        const threadId = typeof params.threadId === 'string' ? params.threadId : null;
+        if (threadId === this._threadId) {
+          const settings = isRecord(params.threadSettings) ? params.threadSettings : null;
+          const active = settings && isRecord(settings.activePermissionProfile)
+            ? settings.activePermissionProfile.id
+            : null;
+          if (active !== this._permissionProfileId) {
+            const error = new PermissionProfileError(
+              `thread/settings/updated active permission profile mismatch: expected ${this._permissionProfileId}, got ${typeof active === 'string' ? active : 'none'}`,
+            );
+            this._outputBuffer.push(`[codex-app-server] degraded: ${error.message}\n`);
+            this.rejectTurnCompletion(error);
+            this.kill();
+            return;
+          }
+        }
+        this._outputBuffer.push('[codex-app-server:event] thread/settings/updated\n');
+        break;
+      }
       case 'error':
         this._activeTurnId = null;
         this._outputBuffer.push(`[codex-app-server] error: ${JSON.stringify(params)}\n`);
@@ -1037,6 +1114,58 @@ export class CodexAppServerPTY {
       return '0.0.0';
     }
   }
+}
+
+function validateCredentialDenyPaths(paths: string[] | undefined): string[] {
+  if (!Array.isArray(paths) || paths.length === 0) {
+    throw new Error('codex_credential_deny_paths must contain at least one normalized absolute path');
+  }
+
+  const normalized = paths.map((path, index) => validateAbsolutePolicyPath(
+    path,
+    `codex_credential_deny_paths[${index}]`,
+  ));
+  return [...new Set(normalized)];
+}
+
+function validateAbsolutePolicyPath(path: unknown, label: string): string {
+  if (
+    typeof path !== 'string'
+    || path.length === 0
+    || path.trim() !== path
+    || path.includes('\0')
+    || !isAbsolute(path)
+    || normalize(path) !== path
+  ) {
+    throw new Error(`${label} must be a normalized absolute path`);
+  }
+  return path;
+}
+
+function buildPermissionProfile(
+  credentialDenyPaths: string[],
+  socketPath: string,
+): { id: string; configArgs: string[] } {
+  const exactSocketPath = validateAbsolutePolicyPath(socketPath, 'Codex app-server control socket');
+  const denyPaths = [...new Set([...credentialDenyPaths, exactSocketPath])].sort();
+  const id = `${PERMISSION_PROFILE_PREFIX}-${randomBytes(8).toString('hex')}`;
+  const prefix = `permissions.${id}`;
+  const overrides = [
+    `${prefix}.description=${tomlString('cortextOS fleet workspace with credential isolation')}`,
+    `${prefix}.extends=${tomlString(':workspace')}`,
+    `${prefix}.network.enabled=true`,
+    `${prefix}.network.domains.${tomlString('*')}=${tomlString('allow')}`,
+    `${prefix}.network.unix_sockets.${tomlString(exactSocketPath)}=${tomlString('deny')}`,
+    ...denyPaths.map((path) => `${prefix}.filesystem.${tomlString(path)}=${tomlString('deny')}`),
+  ];
+  return {
+    id,
+    configArgs: overrides.flatMap((override) => ['-c', override]),
+  };
+}
+
+function tomlString(value: string): string {
+  return JSON.stringify(value);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/src/pty/codex-app-server-pty.ts
+++ b/src/pty/codex-app-server-pty.ts
@@ -208,6 +208,7 @@ export class CodexAppServerPTY {
   private readonly _writablePaths: string[];
   private readonly _readonlyPaths: string[];
   private readonly _networkAllowDomains: string[];
+  private readonly _webSearchEnabled: boolean;
   private readonly _envAllowlist: Set<string>;
   private readonly _mcpAllowlist: Set<string>;
   private readonly _mcpStartupStates = new Map<string, McpServerStartupState>();
@@ -237,6 +238,7 @@ export class CodexAppServerPTY {
     this._writablePaths = compiled.writablePaths;
     this._readonlyPaths = compiled.readonlyPaths;
     this._networkAllowDomains = compiled.networkAllowDomains;
+    this._webSearchEnabled = compiled.webSearchEnabled;
     this._envAllowlist = new Set(compiled.envAllowlist);
     this._mcpAllowlist = new Set(compiled.mcpAllowlist);
     this._permissionProfileId = compiled.profile.id;
@@ -573,6 +575,7 @@ export class CodexAppServerPTY {
       const spawnFn = this._spawnFn!;
       const mcpConfigArgs = this.buildMcpConfigArgs();
       const pty = spawnFn('codex', [
+        ...(this._webSearchEnabled ? ['--search'] : []),
         'app-server',
         '--strict-config',
         '--enable', 'goals',
@@ -1625,6 +1628,7 @@ export function compileCodexCapabilityPolicy(
   writablePaths: string[];
   readonlyPaths: string[];
   networkAllowDomains: string[];
+  webSearchEnabled: boolean;
   envAllowlist: string[];
   mcpAllowlist: string[];
   profile: { id: string; configArgs: string[] };
@@ -1638,6 +1642,7 @@ export function compileCodexCapabilityPolicy(
   const readonlyPaths = validateReadonlyPaths(config.codex_readonly_paths);
   assertSensitivePathsHaveNoAliases(readonlyPaths, 'codex_readonly_paths');
   const networkAllowDomains = validateNetworkAllowDomains(config.codex_network_allow_domains);
+  const webSearchEnabled = validateWebSearchEnabled(config.codex_web_search_enabled);
   const envAllowlist = validateEnvAllowlist(config.codex_env_allowlist);
   const mcpAllowlist = validateMcpAllowlist(config.codex_mcp_allowlist);
   const profile = buildPermissionProfile(
@@ -1652,6 +1657,7 @@ export function compileCodexCapabilityPolicy(
     writablePaths,
     readonlyPaths,
     networkAllowDomains,
+    webSearchEnabled,
     envAllowlist,
     mcpAllowlist,
     profile,
@@ -1721,6 +1727,13 @@ function validateNetworkAllowDomains(domains: string[] | undefined): string[] {
     );
   }
   return [];
+}
+
+function validateWebSearchEnabled(enabled: boolean | undefined): boolean {
+  if (typeof enabled !== 'boolean') {
+    throw new Error('codex_web_search_enabled must be an explicit boolean');
+  }
+  return enabled;
 }
 
 function validateEnvAllowlist(names: string[] | undefined): string[] {

--- a/src/pty/codex-app-server-pty.ts
+++ b/src/pty/codex-app-server-pty.ts
@@ -1,7 +1,20 @@
-import { appendFileSync, existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
-import { isAbsolute, join, normalize } from 'path';
+import {
+  appendFileSync,
+  chmodSync,
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { basename, dirname, isAbsolute, join, normalize, relative, sep } from 'path';
 import { homedir } from 'os';
 import { randomBytes } from 'crypto';
+import { spawnSync } from 'child_process';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
 import type { TelegramAPI } from '../telegram/api.js';
@@ -50,6 +63,13 @@ interface ThreadResponse {
     id: string;
     extends?: string | null;
   } | null;
+  sandbox?: {
+    type?: unknown;
+    writableRoots?: unknown;
+    networkAccess?: unknown;
+    excludeTmpdirEnvVar?: unknown;
+    excludeSlashTmp?: unknown;
+  };
 }
 
 interface PermissionProfileListResponse {
@@ -58,6 +78,25 @@ interface PermissionProfileListResponse {
     allowed: boolean;
   }>;
   nextCursor?: string | null;
+}
+
+interface McpServerStatusListResponse {
+  data: Array<{
+    name: string;
+    serverInfo: unknown;
+    tools: unknown;
+    resources: unknown;
+    resourceTemplates: unknown;
+    authStatus: unknown;
+  }>;
+  nextCursor: string | null;
+}
+
+type McpServerStartupState = 'starting' | 'ready' | 'failed' | 'cancelled';
+
+interface McpReadinessWaiter {
+  resolve: () => void;
+  reject: (error: Error) => void;
 }
 
 interface SkillsListResponse {
@@ -90,6 +129,39 @@ const SOCKET_BASENAME = 'codex.sock';
 const SOCKET_PATH_WARN_BYTES = 100;
 const BOOTSTRAP_PATTERN = '[codex-app-server] ready';
 const PERMISSION_PROFILE_PREFIX = 'cortextos-fleet';
+const MCP_STARTUP_TIMEOUT_MS = 10_000;
+const EXTERNAL_FEATURES_DISABLED_FOR_FLEET = [
+  'apps',
+  'plugins',
+  'browser_use',
+  'computer_use',
+  'in_app_browser',
+  'image_generation',
+  'remote_plugin',
+  'plugin_sharing',
+] as const;
+const BASE_ENV_VARS = ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL', 'TMPDIR'] as const;
+const RESERVED_ENV_VARS = new Set([
+  ...BASE_ENV_VARS,
+  'ALL_PROXY',
+  'BASH_ENV',
+  'CODEX_HOME',
+  'CURL_CA_BUNDLE',
+  'ENV',
+  'HTTPS_PROXY',
+  'HTTP_PROXY',
+  'NODE_OPTIONS',
+  'NODE_PATH',
+  'NO_PROXY',
+  'PERL5OPT',
+  'PYTHONHOME',
+  'PYTHONPATH',
+  'RUBYOPT',
+  'SSL_CERT_FILE',
+  'TEMP',
+  'TMP',
+  'ZDOTDIR',
+]);
 
 const SLASH_REWRITE_RE = /^\/([a-z][a-z0-9_-]*)(?:\s+([\s\S]*))?$/i;
 const LOCAL_SLASH_COMMANDS = new Set(['goal']);
@@ -105,6 +177,8 @@ const LOCAL_SLASH_COMMANDS = new Set(['goal']);
  */
 export class CodexAppServerPTY {
   private _alive = false;
+  private _startupCancelled = false;
+  private _startupComplete = false;
   private _executing = false;
   private _activeTurnId: string | null = null;
   private _writeBuffer = '';
@@ -122,6 +196,7 @@ export class CodexAppServerPTY {
   private _env: CtxEnv;
   private _config: AgentConfig;
   private _stateDir: string;
+  private readonly _modelTempDir: string;
   private _cwd: string;
   private _socketPath: string;
   private _socketListenArg: string;
@@ -130,6 +205,13 @@ export class CodexAppServerPTY {
   private _socketPointerPath: string;
   private readonly _permissionProfileId: string;
   private readonly _permissionProfileConfigArgs: string[];
+  private readonly _writablePaths: string[];
+  private readonly _readonlyPaths: string[];
+  private readonly _networkAllowDomains: string[];
+  private readonly _envAllowlist: Set<string>;
+  private readonly _mcpAllowlist: Set<string>;
+  private readonly _mcpStartupStates = new Map<string, McpServerStartupState>();
+  private _mcpReadinessWaiter: McpReadinessWaiter | null = null;
   private _threadId: string | null = null;
   private _telegramApi: TelegramAPI | null = null;
   private _chatId: string | null = null;
@@ -140,16 +222,25 @@ export class CodexAppServerPTY {
     this._config = config;
     this._cwd = config.working_directory || env.agentDir || process.cwd();
     this._stateDir = join(env.ctxRoot, 'state', env.agentName);
+    this._modelTempDir = join(this._stateDir, 'model-tmp');
     this._threadStatePath = join(this._stateDir, 'codex-app-server-thread.json');
     this._socketPointerPath = join(this._stateDir, 'codex-app-server-socket.json');
-    const credentialDenyPaths = validateCredentialDenyPaths(config.codex_credential_deny_paths);
     const socket = this.resolveSocketPath();
     this._socketPath = socket.path;
     this._socketListenArg = socket.listenArg;
     this._socketCwd = socket.cwd;
-    const profile = buildPermissionProfile(credentialDenyPaths, this._socketPath);
-    this._permissionProfileId = profile.id;
-    this._permissionProfileConfigArgs = profile.configArgs;
+    const compiled = compileCodexCapabilityPolicy(
+      config,
+      this._modelTempDir,
+      this._socketPath,
+    );
+    this._writablePaths = compiled.writablePaths;
+    this._readonlyPaths = compiled.readonlyPaths;
+    this._networkAllowDomains = compiled.networkAllowDomains;
+    this._envAllowlist = new Set(compiled.envAllowlist);
+    this._mcpAllowlist = new Set(compiled.mcpAllowlist);
+    this._permissionProfileId = compiled.profile.id;
+    this._permissionProfileConfigArgs = compiled.profile.configArgs;
     this._outputBuffer = new OutputBuffer(1000, logPath, BOOTSTRAP_PATTERN);
   }
 
@@ -158,7 +249,17 @@ export class CodexAppServerPTY {
       throw new Error('CodexAppServerPTY already spawned. Kill first.');
     }
 
-    ensureDir(this._stateDir);
+    assertSensitivePathsHaveNoAliases(
+      validateCredentialDenyPaths(this._config.codex_credential_deny_paths),
+      'codex_credential_deny_paths',
+    );
+    assertSensitivePathsHaveNoAliases(
+      validateReadonlyPaths(this._config.codex_readonly_paths),
+      'codex_readonly_paths',
+    );
+    this._mcpStartupStates.clear();
+    this._startupCancelled = false;
+    this._startupComplete = false;
     this._alive = true;
 
     try {
@@ -167,12 +268,18 @@ export class CodexAppServerPTY {
       await this.initializeRpc();
       await this.startOrResumeThread(mode);
       this._outputBuffer.push(`${BOOTSTRAP_PATTERN} thread=${this._threadId}\n`);
+      this._startupComplete = true;
       if (prompt.trim()) {
         this.queueTurn([{ type: 'text', text: prompt, text_elements: [] }]);
       }
     } catch (err) {
       this._alive = false;
+      this._startupComplete = false;
       this._outputBuffer.push(`[codex-app-server] degraded: ${err}\n`);
+      // This adapter never became a running AgentProcess. Suppress the normal
+      // runtime-exit callback while cleaning up so AgentProcess does not queue
+      // a phantom recovery timer for a synchronous setup failure.
+      this._onExitHandler = null;
       this.kill();
       throw err;
     }
@@ -198,7 +305,11 @@ export class CodexAppServerPTY {
   }
 
   kill(): void {
+    this._startupCancelled = true;
+    this._startupComplete = false;
     this._alive = false;
+    this.rejectMcpReadiness(new PermissionProfileError('Codex app-server stopped before MCP startup completed'));
+    this._mcpStartupStates.clear();
     this._activeTurnId = null;
     this._turnQueue = [];
     this.rejectTurnCompletion(new Error('Codex app-server stopped'));
@@ -215,6 +326,7 @@ export class CodexAppServerPTY {
       this._appServerPty = null;
     }
     this.removeSocket();
+    this.cleanupPrivateModelTempDir();
     this._onExitHandler?.(0, undefined);
     this._onExitHandler = null;
   }
@@ -412,16 +524,38 @@ export class CodexAppServerPTY {
     let lastErr: unknown;
 
     for (let attempt = 0; attempt < delays.length; attempt += 1) {
+      if (this._startupCancelled) {
+        throw new Error('Codex app-server startup was cancelled');
+      }
+      // An app-server may have exited during the prior attempt. A new retry is
+      // live again unless kill() explicitly cancelled the startup generation.
+      // Unexpected exit cleanup removes model-tmp, so every attempt recreates
+      // and revalidates the private TMPDIR before constructing the child env.
+      this.preparePrivateModelTempDir();
+      this._alive = true;
       try {
         this.removeSocket();
         await this.startAppServer();
+        if (this._startupCancelled) {
+          this.cleanupSpawnAttempt();
+          throw new Error('Codex app-server startup was cancelled');
+        }
+        if (!this._alive) {
+          throw new Error('Codex app-server exited during startup');
+        }
         return;
       } catch (err) {
         lastErr = err;
         this.cleanupSpawnAttempt();
         this._outputBuffer.push(`[codex-app-server] spawn attempt ${attempt + 1} failed: ${err}\n`);
+        if (this._startupCancelled) {
+          throw new Error('Codex app-server startup was cancelled');
+        }
         if (attempt < delays.length - 1) {
           await sleep(delays[attempt]);
+          if (this._startupCancelled) {
+            throw new Error('Codex app-server startup was cancelled');
+          }
         }
       }
     }
@@ -437,10 +571,13 @@ export class CodexAppServerPTY {
       }
 
       const spawnFn = this._spawnFn!;
+      const mcpConfigArgs = this.buildMcpConfigArgs();
       const pty = spawnFn('codex', [
         'app-server',
         '--strict-config',
         '--enable', 'goals',
+        ...EXTERNAL_FEATURES_DISABLED_FOR_FLEET.flatMap((feature) => ['--disable', feature]),
+        ...mcpConfigArgs,
         ...this._permissionProfileConfigArgs,
         '--listen', this._socketListenArg,
       ], {
@@ -460,10 +597,25 @@ export class CodexAppServerPTY {
       });
       pty.onExit(({ exitCode, signal }) => {
         if (this._appServerPty !== pty) return;
+        const publishRuntimeExit = this._startupComplete;
         this._appServerPty = null;
         this._alive = false;
+        this._startupComplete = false;
+        this.rejectMcpReadiness(new PermissionProfileError(
+          'Codex app-server exited before MCP startup completed',
+        ));
+        this._mcpStartupStates.clear();
         this.rejectTurnCompletion(new Error('Codex app-server exited'));
-        this._onExitHandler?.(exitCode, signal);
+        if (this._rpc) {
+          this._rpc.close();
+          this._rpc = null;
+        }
+        this.removeSocket();
+        this.cleanupPrivateModelTempDir();
+        // A failed internal launch attempt belongs to the bounded adapter
+        // retry loop. AgentProcess only receives exits after this adapter has
+        // completed its profile/MCP/thread read-back and declared startup.
+        if (publishRuntimeExit) this._onExitHandler?.(exitCode, signal);
       });
 
       this.waitForSocket().then(resolve, reject);
@@ -473,6 +625,8 @@ export class CodexAppServerPTY {
   private async waitForSocket(timeoutMs = 10000): Promise<void> {
     const start = Date.now();
     while (Date.now() - start < timeoutMs) {
+      if (this._startupCancelled) throw new Error('Codex app-server startup was cancelled');
+      if (!this._alive) throw new Error('Codex app-server exited during startup');
       if (existsSync(this._socketPath)) return;
       await sleep(100);
     }
@@ -496,6 +650,7 @@ export class CodexAppServerPTY {
     });
     this._rpc?.notify('initialized');
     await this.verifyPermissionProfileAvailable();
+    await this.verifyMcpStatusReadback();
   }
 
   private async verifyPermissionProfileAvailable(): Promise<void> {
@@ -515,6 +670,134 @@ export class CodexAppServerPTY {
     }
   }
 
+  private async verifyMcpStatusReadback(
+    readinessTimeoutMs = MCP_STARTUP_TIMEOUT_MS,
+  ): Promise<void> {
+    await this.waitForMcpReadiness(readinessTimeoutMs);
+    await this.verifyMcpInventoryReadback();
+  }
+
+  private async waitForMcpReadiness(timeoutMs: number): Promise<void> {
+    if (this._mcpAllowlist.size === 0) return;
+    if (!this._alive) {
+      throw new PermissionProfileError('Codex app-server stopped before MCP startup completed');
+    }
+    if (this.allApprovedMcpServersReady()) return;
+    if (!Number.isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new PermissionProfileError('MCP startup timeout must be a positive finite duration');
+    }
+    if (this._mcpReadinessWaiter) {
+      throw new PermissionProfileError('MCP startup readiness is already being awaited');
+    }
+
+    await new Promise<void>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this._mcpReadinessWaiter = null;
+        const pending = [...this._mcpAllowlist]
+          .filter((name) => this._mcpStartupStates.get(name) !== 'ready')
+          .sort()
+          .map((name) => `${name}=${this._mcpStartupStates.get(name) ?? 'pending'}`)
+          .join(', ');
+        reject(new PermissionProfileError(
+          `Timed out waiting for approved MCP servers to become ready: ${pending}`,
+        ));
+      }, timeoutMs);
+      this._mcpReadinessWaiter = {
+        resolve: () => {
+          clearTimeout(timer);
+          this._mcpReadinessWaiter = null;
+          resolve();
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          this._mcpReadinessWaiter = null;
+          reject(error);
+        },
+      };
+      this.settleMcpReadinessWaiter();
+    });
+  }
+
+  private allApprovedMcpServersReady(): boolean {
+    return [...this._mcpAllowlist]
+      .every((name) => this._mcpStartupStates.get(name) === 'ready');
+  }
+
+  private settleMcpReadinessWaiter(): void {
+    const waiter = this._mcpReadinessWaiter;
+    if (!waiter) return;
+    const failed = [...this._mcpAllowlist]
+      .find((name) => {
+        const status = this._mcpStartupStates.get(name);
+        return status === 'failed' || status === 'cancelled';
+      });
+    if (failed) {
+      waiter.reject(new PermissionProfileError(
+        `Approved MCP server ${failed} did not become available`,
+      ));
+    } else if (this.allApprovedMcpServersReady()) {
+      waiter.resolve();
+    }
+  }
+
+  private rejectMcpReadiness(error: Error): void {
+    this._mcpReadinessWaiter?.reject(error);
+  }
+
+  private async verifyMcpInventoryReadback(): Promise<void> {
+    const seen = new Set<string>();
+    let cursor: string | null = null;
+    let pages = 0;
+    do {
+      pages += 1;
+      if (pages > 100) throw new PermissionProfileError('MCP status pagination exceeded its bound');
+      const response: JsonRpcResponse<McpServerStatusListResponse> =
+        await this.request<McpServerStatusListResponse>('mcpServerStatus/list', {
+        cursor,
+        limit: 100,
+        detail: 'toolsAndAuthOnly',
+      });
+      const result: McpServerStatusListResponse | undefined = response.result;
+      if (!result || !Array.isArray(result.data)) {
+        throw new PermissionProfileError('MCP status read-back had an invalid shape');
+      }
+      for (const entry of result.data) {
+        if (!isRecord(entry) || typeof entry.name !== 'string' || seen.has(entry.name)) {
+          throw new PermissionProfileError('MCP status read-back contained an invalid or duplicate name');
+        }
+        seen.add(entry.name);
+        const tools = isRecord(entry.tools) ? Object.keys(entry.tools) : null;
+        const resources = Array.isArray(entry.resources) ? entry.resources : null;
+        const templates = Array.isArray(entry.resourceTemplates) ? entry.resourceTemplates : null;
+        if (!tools || !resources || !templates || typeof entry.authStatus !== 'string') {
+          throw new PermissionProfileError(`MCP status read-back for ${entry.name} was malformed`);
+        }
+        if (this._mcpAllowlist.has(entry.name)) {
+          if (!isRecord(entry.serverInfo)) {
+            throw new PermissionProfileError(`Approved MCP server ${entry.name} is not active`);
+          }
+        } else if (
+          entry.serverInfo !== null
+          || tools.length !== 0
+          || resources.length !== 0
+          || templates.length !== 0
+        ) {
+          throw new PermissionProfileError(`Unapproved MCP server ${entry.name} is not inert`);
+        }
+      }
+      if (result.nextCursor !== null && typeof result.nextCursor !== 'string') {
+        throw new PermissionProfileError('MCP status read-back returned an invalid cursor');
+      }
+      cursor = result.nextCursor;
+    } while (cursor !== null);
+
+    for (const name of this._mcpAllowlist) {
+      if (!seen.has(name)) {
+        throw new PermissionProfileError(`Approved MCP server ${name} was absent from active read-back`);
+      }
+    }
+  }
+
   private async startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> {
     if (mode === 'continue') {
       const persisted = this.readThreadState();
@@ -525,11 +808,10 @@ export class CodexAppServerPTY {
             cwd: this._cwd,
             approvalPolicy: 'never',
             permissions: this._permissionProfileId,
-            config: { features: { goals: true } },
             excludeTurns: true,
             persistExtendedHistory: true,
           });
-          this.verifyActivePermissionProfile(resumed, 'thread/resume');
+          this.verifyEffectivePermissionProfile(resumed, 'thread/resume');
           this.setThreadId(resumed.result?.thread.id || persisted.threadId);
           return;
         } catch (err) {
@@ -545,11 +827,10 @@ export class CodexAppServerPTY {
           cwd: this._cwd,
           approvalPolicy: 'never',
           permissions: this._permissionProfileId,
-          config: { features: { goals: true } },
           excludeTurns: true,
           persistExtendedHistory: true,
         });
-        this.verifyActivePermissionProfile(resumed, 'thread/resume');
+        this.verifyEffectivePermissionProfile(resumed, 'thread/resume');
         this.setThreadId(resumed.result?.thread.id || latest);
         return;
       }
@@ -559,20 +840,79 @@ export class CodexAppServerPTY {
       cwd: this._cwd,
       approvalPolicy: 'never',
       permissions: this._permissionProfileId,
-      config: { features: { goals: true } },
       sessionStartSource: 'startup',
       experimentalRawEvents: false,
       persistExtendedHistory: true,
     });
-    this.verifyActivePermissionProfile(started, 'thread/start');
+    this.verifyEffectivePermissionProfile(started, 'thread/start');
     this.setThreadId(started.result!.thread.id);
   }
 
-  private verifyActivePermissionProfile(response: JsonRpcResponse<ThreadResponse>, method: string): void {
-    const actual = response.result?.activePermissionProfile?.id ?? null;
+  private verifyEffectivePermissionProfile(response: JsonRpcResponse<ThreadResponse>, method: string): void {
+    this.verifyEffectivePermissionState(
+      response.result?.activePermissionProfile,
+      response.result?.sandbox,
+      method,
+    );
+  }
+
+  private verifyEffectivePermissionState(
+    activeProfile: unknown,
+    sandboxValue: unknown,
+    method: string,
+  ): void {
+    const profile = isRecord(activeProfile) ? activeProfile : null;
+    const actual = typeof profile?.id === 'string' ? profile.id : null;
     if (actual !== this._permissionProfileId) {
       throw new PermissionProfileError(
         `${method} active permission profile mismatch: expected ${this._permissionProfileId}, got ${actual ?? 'none'}`,
+      );
+    }
+    const parent = typeof profile?.extends === 'string' ? profile.extends : null;
+    if (parent !== ':read-only') {
+      throw new PermissionProfileError(
+        `${method} active permission profile parent mismatch: expected :read-only, got ${parent ?? 'none'}`,
+      );
+    }
+
+    const sandbox = isRecord(sandboxValue) ? sandboxValue : null;
+    const expectedSandboxType = this._writablePaths.length > 0 ? 'workspaceWrite' : 'readOnly';
+    if (sandbox?.type !== expectedSandboxType) {
+      throw new PermissionProfileError(
+        `${method} sandbox type mismatch: expected ${expectedSandboxType}`,
+      );
+    }
+    const rawRoots = sandbox?.writableRoots;
+    if (expectedSandboxType === 'readOnly') {
+      if (rawRoots !== undefined && (!Array.isArray(rawRoots) || rawRoots.length !== 0)) {
+        throw new PermissionProfileError(`${method} returned writable roots for a read-only profile`);
+      }
+    } else if (!Array.isArray(rawRoots) || !rawRoots.every((path) => typeof path === 'string')) {
+      throw new PermissionProfileError(`${method} returned malformed writable roots`);
+    }
+    if (expectedSandboxType === 'workspaceWrite'
+      && (typeof sandbox?.excludeTmpdirEnvVar !== 'boolean' || sandbox?.excludeSlashTmp !== true)) {
+      throw new PermissionProfileError(`${method} ambient /tmp exclusion is not fail-closed`);
+    }
+    const cwd = canonicalizeExistingPath(this._cwd);
+    const configuredRoots = this._writablePaths.map(canonicalizeExistingPath);
+    const cwdIsDeclaredWritable = configuredRoots.includes(cwd);
+    const actualRoots = (Array.isArray(rawRoots) ? rawRoots : [])
+      .map(canonicalizeExistingPath)
+      .filter((path) => !(cwdIsDeclaredWritable && path === cwd));
+    // Codex represents a writable cwd as the implicit workspace root and omits
+    // it from writableRoots. Other declared roots remain explicit.
+    const expectedRoots = configuredRoots
+      .filter((path) => !(cwdIsDeclaredWritable && path === cwd));
+    if (!sameStringSet(actualRoots, expectedRoots)) {
+      throw new PermissionProfileError(
+        `${method} writable roots mismatch for ${this._permissionProfileId}`,
+      );
+    }
+    const expectedNetworkAccess = this._networkAllowDomains.length > 0;
+    if (sandbox?.networkAccess !== expectedNetworkAccess) {
+      throw new PermissionProfileError(
+        `${method} network access mismatch: expected ${expectedNetworkAccess}`,
       );
     }
   }
@@ -797,13 +1137,16 @@ export class CodexAppServerPTY {
         const threadId = typeof params.threadId === 'string' ? params.threadId : null;
         if (threadId === this._threadId) {
           const settings = isRecord(params.threadSettings) ? params.threadSettings : null;
-          const active = settings && isRecord(settings.activePermissionProfile)
-            ? settings.activePermissionProfile.id
-            : null;
-          if (active !== this._permissionProfileId) {
-            const error = new PermissionProfileError(
-              `thread/settings/updated active permission profile mismatch: expected ${this._permissionProfileId}, got ${typeof active === 'string' ? active : 'none'}`,
+          try {
+            this.verifyEffectivePermissionState(
+              settings?.activePermissionProfile,
+              settings?.sandboxPolicy,
+              'thread/settings/updated',
             );
+          } catch (cause) {
+            const error = cause instanceof Error
+              ? cause
+              : new PermissionProfileError('thread/settings/updated permission state is invalid');
             this._outputBuffer.push(`[codex-app-server] degraded: ${error.message}\n`);
             this.rejectTurnCompletion(error);
             this.kill();
@@ -823,8 +1166,54 @@ export class CodexAppServerPTY {
         this.appendCodexTokenLog(params);
         this._outputBuffer.push(`[codex-app-server:event] ${method}\n`);
         break;
+      case 'mcpServer/startupStatus/updated': {
+        const name = typeof params.name === 'string' ? params.name : null;
+        const status = typeof params.status === 'string' ? params.status : null;
+        if (!name || !this._mcpAllowlist.has(name)) {
+          const error = new PermissionProfileError(
+            `Unapproved MCP server ${name ?? '<missing>'} reported ${status ?? 'unknown'} startup state`,
+          );
+          this._outputBuffer.push(`[codex-app-server] degraded: ${error.message}\n`);
+          this.rejectTurnCompletion(error);
+          this.kill();
+          return;
+        }
+        if (status !== 'starting' && status !== 'ready' && status !== 'failed' && status !== 'cancelled') {
+          const error = new PermissionProfileError(
+            `Approved MCP server ${name} reported an invalid startup state`,
+          );
+          this._outputBuffer.push(`[codex-app-server] degraded: ${error.message}\n`);
+          this.rejectMcpReadiness(error);
+          this.rejectTurnCompletion(error);
+          this.kill();
+          return;
+        }
+        this._mcpStartupStates.set(name, status);
+        if (status === 'failed' || status === 'cancelled') {
+          const error = new PermissionProfileError(`Approved MCP server ${name} did not become available`);
+          this._outputBuffer.push(`[codex-app-server] degraded: ${error.message}\n`);
+          this.rejectMcpReadiness(error);
+          this.rejectTurnCompletion(error);
+          this.kill();
+          return;
+        }
+        this.settleMcpReadinessWaiter();
+        this._outputBuffer.push(`[codex-app-server:event] ${method} ${name} ${status ?? 'unknown'}\n`);
+        break;
+      }
+      case 'mcpServer/oauthLogin/completed': {
+        const name = typeof params.name === 'string' ? params.name : null;
+        if (!name || !this._mcpAllowlist.has(name)) {
+          const error = new PermissionProfileError('Unapproved MCP server attempted OAuth completion');
+          this._outputBuffer.push(`[codex-app-server] degraded: ${error.message}\n`);
+          this.rejectTurnCompletion(error);
+          this.kill();
+          return;
+        }
+        this._outputBuffer.push(`[codex-app-server:event] ${method} ${name}\n`);
+        break;
+      }
       case 'warning':
-      case 'mcpServer/startupStatus/updated':
       case 'account/rateLimits/updated':
       case 'skills/changed':
       case 'item/started':
@@ -1061,12 +1450,15 @@ export class CodexAppServerPTY {
   }
 
   private buildEnv(): Record<string, string> {
-    const env: Record<string, string> = {};
+    const env = this.buildBaseEnv();
 
-    const keepVars = ['PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL', 'TMPDIR'];
-    for (const key of keepVars) {
-      if (process.env[key]) env[key] = process.env[key]!;
-    }
+    // Codex workspaceWrite deliberately excludes the ambient TMPDIR and /tmp.
+    // Rebind all conventional temp variables to one explicit, private write
+    // root so ordinary tools retain scratch space without opening the agent's
+    // broader state/control directory.
+    env['TMPDIR'] = this._modelTempDir;
+    env['TMP'] = this._modelTempDir;
+    env['TEMP'] = this._modelTempDir;
 
     env['CTX_INSTANCE_ID'] = this._env.instanceId;
     env['CTX_ROOT'] = this._env.ctxRoot;
@@ -1090,6 +1482,47 @@ export class CodexAppServerPTY {
     return env;
   }
 
+  private preparePrivateModelTempDir(): void {
+    ensureDir(this._stateDir);
+    const stateStat = lstatSync(this._stateDir);
+    if (stateStat.isSymbolicLink() || !stateStat.isDirectory()) {
+      throw new PermissionProfileError('Codex agent state directory must be a real directory');
+    }
+    chmodSync(this._stateDir, 0o700);
+
+    if (existsSync(this._modelTempDir)) {
+      const tempStat = lstatSync(this._modelTempDir);
+      if (tempStat.isSymbolicLink() || !tempStat.isDirectory()) {
+        throw new PermissionProfileError('Codex model temporary path must be a real directory');
+      }
+      // A prior unclean exit may leave model-created scratch data behind.
+      // The seat is single-process; clear it before granting the new process.
+      rmSync(this._modelTempDir, { recursive: true, force: false });
+    }
+    mkdirSync(this._modelTempDir, { recursive: false, mode: 0o700 });
+    chmodSync(this._modelTempDir, 0o700);
+  }
+
+  private cleanupPrivateModelTempDir(): void {
+    try {
+      if (!existsSync(this._modelTempDir)) return;
+      const stat = lstatSync(this._modelTempDir);
+      if (stat.isSymbolicLink() || !stat.isDirectory()) return;
+      rmSync(this._modelTempDir, { recursive: true, force: true });
+    } catch {
+      // Best-effort on process shutdown. The next spawn rejects unsafe path
+      // types and clears a valid stale directory before reuse.
+    }
+  }
+
+  private buildBaseEnv(): Record<string, string> {
+    const env: Record<string, string> = {};
+    for (const key of BASE_ENV_VARS) {
+      if (process.env[key]) env[key] = process.env[key]!;
+    }
+    return env;
+  }
+
   private loadEnvFile(path: string, env: Record<string, string>): void {
     if (!existsSync(path)) return;
     try {
@@ -1098,12 +1531,67 @@ export class CodexAppServerPTY {
         if (!trimmed || trimmed.startsWith('#')) continue;
         const eqIdx = trimmed.indexOf('=');
         if (eqIdx > 0) {
-          env[trimmed.slice(0, eqIdx).trim()] = trimmed.slice(eqIdx + 1).trim();
+          const name = trimmed.slice(0, eqIdx).trim();
+          if (this._envAllowlist.has(name)) {
+            env[name] = trimmed.slice(eqIdx + 1).trim();
+          }
         }
       }
     } catch {
       // Ignore env file read errors.
     }
+  }
+
+  private buildMcpConfigArgs(): string[] {
+    const result = spawnSync('codex', [
+      ...EXTERNAL_FEATURES_DISABLED_FOR_FLEET.flatMap((feature) => ['--disable', feature]),
+      'mcp',
+      'list',
+      '--json',
+    ], {
+      env: this.buildBaseEnv(),
+      cwd: this._cwd,
+      encoding: 'utf-8',
+      maxBuffer: 1024 * 1024,
+      timeout: 10_000,
+    });
+    if (result.error || result.status !== 0 || typeof result.stdout !== 'string') {
+      throw new PermissionProfileError('Unable to enumerate configured Codex MCP servers safely');
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(result.stdout);
+    } catch {
+      throw new PermissionProfileError('Configured Codex MCP inventory was not valid JSON');
+    }
+    if (!Array.isArray(parsed)) {
+      throw new PermissionProfileError('Configured Codex MCP inventory had an invalid shape');
+    }
+
+    const configured = new Map<string, boolean>();
+    for (const entry of parsed) {
+      if (!isRecord(entry) || typeof entry.name !== 'string' || typeof entry.enabled !== 'boolean') {
+        throw new PermissionProfileError('Configured Codex MCP inventory had an invalid entry');
+      }
+      const name = validateMcpName(entry.name, 'configured MCP server name');
+      if (configured.has(name)) {
+        throw new PermissionProfileError('Configured Codex MCP inventory contained a duplicate name');
+      }
+      configured.set(name, entry.enabled);
+    }
+
+    for (const name of this._mcpAllowlist) {
+      if (configured.get(name) !== true) {
+        throw new PermissionProfileError(`Approved MCP server ${name} is not configured and enabled`);
+      }
+    }
+    const disabled = [...configured.keys()].filter((name) => !this._mcpAllowlist.has(name)).sort();
+    if (disabled.length === 0) return [];
+    const inlineServers = disabled
+      .map((name) => `${tomlString(name)}={enabled=false}`)
+      .join(',');
+    return ['-c', `mcp_servers={${inlineServers}}`];
   }
 
   private getPackageVersion(): string {
@@ -1128,6 +1616,156 @@ function validateCredentialDenyPaths(paths: string[] | undefined): string[] {
   return [...new Set(normalized)];
 }
 
+export function compileCodexCapabilityPolicy(
+  config: AgentConfig,
+  modelTempDir: string,
+  socketPath: string,
+): {
+  credentialDenyPaths: string[];
+  writablePaths: string[];
+  readonlyPaths: string[];
+  networkAllowDomains: string[];
+  envAllowlist: string[];
+  mcpAllowlist: string[];
+  profile: { id: string; configArgs: string[] };
+} {
+  const credentialDenyPaths = validateCredentialDenyPaths(config.codex_credential_deny_paths);
+  assertSensitivePathsHaveNoAliases(credentialDenyPaths, 'codex_credential_deny_paths');
+  const writablePaths = [...new Set([
+    ...validateWritablePaths(config.codex_writable_paths),
+    validateAbsolutePolicyPath(modelTempDir, 'Codex model temporary directory'),
+  ])].sort();
+  const readonlyPaths = validateReadonlyPaths(config.codex_readonly_paths);
+  assertSensitivePathsHaveNoAliases(readonlyPaths, 'codex_readonly_paths');
+  const networkAllowDomains = validateNetworkAllowDomains(config.codex_network_allow_domains);
+  const envAllowlist = validateEnvAllowlist(config.codex_env_allowlist);
+  const mcpAllowlist = validateMcpAllowlist(config.codex_mcp_allowlist);
+  const profile = buildPermissionProfile(
+    credentialDenyPaths,
+    writablePaths,
+    readonlyPaths,
+    networkAllowDomains,
+    socketPath,
+  );
+  return {
+    credentialDenyPaths,
+    writablePaths,
+    readonlyPaths,
+    networkAllowDomains,
+    envAllowlist,
+    mcpAllowlist,
+    profile,
+  };
+}
+
+function assertSensitivePathsHaveNoAliases(
+  paths: string[],
+  policyField: 'codex_credential_deny_paths' | 'codex_readonly_paths',
+): void {
+  const maximumEntries = 10_000;
+  let entries = 0;
+  const inspect = (path: string): void => {
+    if (!existsSync(path)) return;
+    entries += 1;
+    if (entries > maximumEntries) {
+      throw new Error(`${policyField} exceeded the bounded inode audit`);
+    }
+    const stat = lstatSync(path);
+    if (stat.isSymbolicLink()) {
+      throw new Error(`${policyField} must not contain symbolic links`);
+    }
+    if (stat.isFile()) {
+      if (stat.nlink !== 1) {
+        throw new Error(
+          `${policyField} contains a hard-linked file; every protected inode must have exactly one name before launch`,
+        );
+      }
+      return;
+    }
+    if (stat.isDirectory()) {
+      for (const name of readdirSync(path)) inspect(join(path, name));
+      return;
+    }
+    throw new Error(`${policyField} must contain only regular files or directories`);
+  };
+  for (const path of paths) inspect(path);
+}
+
+function validateWritablePaths(paths: string[] | undefined): string[] {
+  if (!Array.isArray(paths)) {
+    throw new Error('codex_writable_paths must be an explicit array of normalized absolute paths');
+  }
+  return [...new Set(paths.map((path, index) => validateAbsolutePolicyPath(
+    path,
+    `codex_writable_paths[${index}]`,
+  )))].sort();
+}
+
+function validateReadonlyPaths(paths: string[] | undefined): string[] {
+  if (!Array.isArray(paths)) {
+    throw new Error('codex_readonly_paths must be an explicit array of normalized absolute paths');
+  }
+  return [...new Set(paths.map((path, index) => validateAbsolutePolicyPath(
+    path,
+    `codex_readonly_paths[${index}]`,
+  )))].sort();
+}
+
+function validateNetworkAllowDomains(domains: string[] | undefined): string[] {
+  if (!Array.isArray(domains)) {
+    throw new Error('codex_network_allow_domains must be an explicit array');
+  }
+  if (domains.length > 0) {
+    throw new Error(
+      'codex_network_allow_domains must remain empty: Codex 0.144.2 exposes only a networkAccess boolean and does not provide enforcement-grade exact-domain read-back',
+    );
+  }
+  return [];
+}
+
+function validateEnvAllowlist(names: string[] | undefined): string[] {
+  if (!Array.isArray(names)) {
+    throw new Error('codex_env_allowlist must be an explicit array');
+  }
+  const validated = names.map((name, index) => {
+    if (
+      typeof name !== 'string'
+      || !/^[A-Z_][A-Z0-9_]*$/.test(name)
+      || name.startsWith('CTX_')
+      || name.startsWith('DYLD_')
+      || name.startsWith('LD_')
+      || RESERVED_ENV_VARS.has(name)
+    ) {
+      throw new Error(`codex_env_allowlist[${index}] is not an allowed environment-variable name`);
+    }
+    return name;
+  });
+  return [...new Set(validated)].sort();
+}
+
+function validateMcpAllowlist(names: string[] | undefined): string[] {
+  if (!Array.isArray(names)) {
+    throw new Error('codex_mcp_allowlist must be an explicit array');
+  }
+  return [...new Set(names.map((name, index) => validateMcpName(
+    name,
+    `codex_mcp_allowlist[${index}]`,
+  )))].sort();
+}
+
+function validateMcpName(name: unknown, label: string): string {
+  if (
+    typeof name !== 'string'
+    || name.length === 0
+    || name.length > 128
+    || name.trim() !== name
+    || /[\0-\x1f\x7f]/.test(name)
+  ) {
+    throw new Error(`${label} must be a non-empty normalized MCP server name`);
+  }
+  return name;
+}
+
 function validateAbsolutePolicyPath(path: unknown, label: string): string {
   if (
     typeof path !== 'string'
@@ -1144,24 +1782,122 @@ function validateAbsolutePolicyPath(path: unknown, label: string): string {
 
 function buildPermissionProfile(
   credentialDenyPaths: string[],
+  writablePaths: string[],
+  readonlyPaths: string[],
+  networkAllowDomains: string[],
   socketPath: string,
 ): { id: string; configArgs: string[] } {
   const exactSocketPath = validateAbsolutePolicyPath(socketPath, 'Codex app-server control socket');
   const denyPaths = [...new Set([...credentialDenyPaths, exactSocketPath])].sort();
+  assertFilesystemPrivilegeLattice(denyPaths, readonlyPaths, writablePaths);
+  assertSensitivePathsCannotBeRelocated(denyPaths, readonlyPaths, writablePaths);
   const id = `${PERMISSION_PROFILE_PREFIX}-${randomBytes(8).toString('hex')}`;
   const prefix = `permissions.${id}`;
+  const filesystemPolicy = [
+    ...writablePaths.map((path) => [path, 'write'] as const),
+    ...readonlyPaths.map((path) => [path, 'read'] as const),
+    ...denyPaths.map((path) => [path, 'deny'] as const),
+  ].sort(([left], [right]) => left.localeCompare(right));
+  const domainPolicy = networkAllowDomains.map((domain) => [domain, 'allow'] as const);
   const overrides = [
-    `${prefix}.description=${tomlString('cortextOS fleet workspace with credential isolation')}`,
-    `${prefix}.extends=${tomlString(':workspace')}`,
-    `${prefix}.network.enabled=true`,
-    `${prefix}.network.domains.${tomlString('*')}=${tomlString('allow')}`,
-    `${prefix}.network.unix_sockets.${tomlString(exactSocketPath)}=${tomlString('deny')}`,
-    ...denyPaths.map((path) => `${prefix}.filesystem.${tomlString(path)}=${tomlString('deny')}`),
+    `${prefix}.description=${tomlString('cortextOS fleet role workspace with isolated control plane')}`,
+    `${prefix}.extends=${tomlString(':read-only')}`,
+    `${prefix}.filesystem=${tomlStringMap(filesystemPolicy)}`,
+    `${prefix}.network.enabled=${networkAllowDomains.length > 0}`,
+    ...(domainPolicy.length > 0 ? [`${prefix}.network.domains=${tomlStringMap(domainPolicy)}`] : []),
+    `${prefix}.network.unix_sockets=${tomlStringMap([[exactSocketPath, 'deny']])}`,
   ];
   return {
     id,
     configArgs: overrides.flatMap((override) => ['-c', override]),
   };
+}
+
+function canonicalizePolicyPath(path: string): string {
+  let cursor = path;
+  const suffix: string[] = [];
+  while (true) {
+    try {
+      return normalize(join(realpathSync(cursor), ...suffix.reverse()));
+    } catch {
+      const parent = dirname(cursor);
+      if (parent === cursor) return path;
+      suffix.push(basename(cursor));
+      cursor = parent;
+    }
+  }
+}
+
+function isSameOrDescendant(candidate: string, ancestor: string): boolean {
+  const rel = relative(ancestor, candidate);
+  return rel === '' || (!isAbsolute(rel) && rel !== '..' && !rel.startsWith(`..${sep}`));
+}
+
+function privilegeReopensPath(candidate: string, stronger: string): boolean {
+  return isSameOrDescendant(candidate, stronger)
+    || isSameOrDescendant(canonicalizePolicyPath(candidate), canonicalizePolicyPath(stronger));
+}
+
+function assertFilesystemPrivilegeLattice(
+  denyPaths: string[],
+  readonlyPaths: string[],
+  writablePaths: string[],
+): void {
+  for (const path of [...readonlyPaths, ...writablePaths]) {
+    if (denyPaths.some((denied) => privilegeReopensPath(path, denied))) {
+      throw new Error(
+        'Codex readable or writable capability paths must not equal or descend from a credential or control-socket deny path',
+      );
+    }
+  }
+  for (const writable of writablePaths) {
+    if (readonlyPaths.some((readonly) => privilegeReopensPath(writable, readonly))) {
+      throw new Error(
+        'codex_writable_paths must not equal or descend from codex_readonly_paths',
+      );
+    }
+  }
+}
+
+function assertSensitivePathsCannotBeRelocated(
+  denyPaths: string[],
+  readonlyPaths: string[],
+  writablePaths: string[],
+): void {
+  for (const sensitive of [...denyPaths, ...readonlyPaths]) {
+    for (const writable of writablePaths) {
+      for (const [candidate, root] of [
+        [sensitive, writable],
+        [canonicalizePolicyPath(sensitive), canonicalizePolicyPath(writable)],
+      ] as const) {
+        if (!isSameOrDescendant(candidate, root) || candidate === root) continue;
+        const segments = relative(root, candidate).split(sep).filter(Boolean);
+        if (segments.length > 1) {
+          throw new Error(
+            'Codex deny/read-only paths may be direct children of a writable root but must not sit below a renameable writable intermediate directory',
+          );
+        }
+      }
+    }
+  }
+}
+
+function tomlStringMap(entries: ReadonlyArray<readonly [string, string]>): string {
+  return `{${entries.map(([key, value]) => `${tomlString(key)}=${tomlString(value)}`).join(',')}}`;
+}
+
+function canonicalizeExistingPath(path: string): string {
+  try {
+    return require('fs').realpathSync(path) as string;
+  } catch {
+    return path;
+  }
+}
+
+function sameStringSet(left: string[], right: string[]): boolean {
+  const a = [...new Set(left)].sort();
+  const b = [...new Set(right)].sort();
+  return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
 function tomlString(value: string): string {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -228,6 +228,12 @@ export interface AgentConfig {
    */
   codex_network_allow_domains?: string[];
   /**
+   * Enables the native, read-only Responses web-search tool without enabling
+   * model-executed shell networking. This is explicit per seat and does not
+   * grant browser, app, plugin, MCP, or arbitrary HTTP capabilities.
+   */
+  codex_web_search_enabled?: boolean;
+  /**
    * Exact environment-variable names that may be loaded from the org and
    * agent env files into the Codex process. Runtime context variables are
    * supplied separately by cortextOS.

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,13 +195,49 @@ export interface AgentConfig {
    */
   codex_context_cap?: number;
   /**
-   * Absolute credential-bearing file or directory paths that the
+   * Absolute, enumerated credential-bearing file or directory paths that the
    * codex-app-server runtime must deny to model-executed commands. At least
    * one normalized absolute path is required; relative, empty, or ambiguous
    * paths fail closed before the app-server is started. The adapter also adds
-   * its active app-server control socket to the same deny policy.
+   * its active app-server control socket to the same deny policy. This is not
+   * a host-wide read allowlist: omitted readable credentials are out of proof.
    */
   codex_credential_deny_paths?: string[];
+  /**
+   * Absolute role-work paths that a codex-app-server agent may write. The
+   * generated profile is read-only everywhere else, so these roots should be
+   * broad enough for the role to create and revise its work without per-file
+   * policy edits while excluding the agent's immutable control surface. The
+   * adapter adds a separate private model-temp root automatically.
+   */
+  codex_writable_paths?: string[];
+  /**
+   * Absolute immutable policy paths that must remain readable but not writable
+   * even when they sit inside a broader role-work root. More-specific `read`
+   * entries override an ancestor `write` entry in the generated profile.
+   * Protected paths may be direct children of a writable root but are rejected
+   * below writable intermediate directories whose rename could bypass policy.
+   */
+  codex_readonly_paths?: string[];
+  /**
+   * Reserved exact-domain policy input for model-executed commands. Codex
+   * 0.144.2 exposes only an effective networkAccess boolean and did not enforce
+   * a configured loopback port boundary in the live contract test, so this
+   * array is required but must remain empty. Use reviewed MCP/built-in tools
+   * for external capabilities until exact-domain enforcement is observable.
+   */
+  codex_network_allow_domains?: string[];
+  /**
+   * Exact environment-variable names that may be loaded from the org and
+   * agent env files into the Codex process. Runtime context variables are
+   * supplied separately by cortextOS.
+   */
+  codex_env_allowlist?: string[];
+  /**
+   * Exact configured MCP server names this role may inherit. Every other
+   * host-configured MCP server is disabled before app-server startup.
+   */
+  codex_mcp_allowlist?: string[];
   /**
    * Fallback context window cap (tokens) for opencode agents when the OpenCode
    * model cache does not expose a context limit. Only applies to runtime:
@@ -816,4 +852,6 @@ export interface AgentStatus {
   sessionStart?: string;
   crashCount?: number;
   model?: string;
+  /** True only when AgentProcess has actually scheduled an automatic restart. */
+  restartScheduled?: boolean;
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -195,6 +195,14 @@ export interface AgentConfig {
    */
   codex_context_cap?: number;
   /**
+   * Absolute credential-bearing file or directory paths that the
+   * codex-app-server runtime must deny to model-executed commands. At least
+   * one normalized absolute path is required; relative, empty, or ambiguous
+   * paths fail closed before the app-server is started. The adapter also adds
+   * its active app-server control socket to the same deny policy.
+   */
+  codex_credential_deny_paths?: string[];
+  /**
    * Fallback context window cap (tokens) for opencode agents when the OpenCode
    * model cache does not expose a context limit. Only applies to runtime:
    * 'opencode'.

--- a/src/utils/codex-capability-profile.ts
+++ b/src/utils/codex-capability-profile.ts
@@ -1,0 +1,78 @@
+import { homedir } from 'os';
+import { join, resolve } from 'path';
+
+export const CODEX_CAPABILITY_KEYS = [
+  'codex_credential_deny_paths',
+  'codex_writable_paths',
+  'codex_readonly_paths',
+  'codex_network_allow_domains',
+  'codex_env_allowlist',
+  'codex_mcp_allowlist',
+] as const;
+
+export type CodexCapabilityKey = typeof CODEX_CAPABILITY_KEYS[number];
+export type CodexCapabilityProfile = Record<CodexCapabilityKey, string[]>;
+
+const IMMUTABLE_AGENT_FILES = [
+  '.gitignore',
+  'AGENTS.md',
+  'GOALS.md',
+  'GUARDRAILS.md',
+  'IDENTITY.md',
+  'SOUL.md',
+  'SYSTEM.md',
+  'TOOLS.md',
+  'USER.md',
+  'config.json',
+  'goals.json',
+] as const;
+
+export function buildDefaultCodexCapabilityProfile(
+  agentDir: string,
+  projectRoot: string,
+  org: string,
+): CodexCapabilityProfile {
+  const absoluteAgentDir = resolve(agentDir);
+  const absoluteProjectRoot = resolve(projectRoot);
+  return {
+    codex_credential_deny_paths: [
+      join(absoluteAgentDir, '.env'),
+      join(absoluteProjectRoot, 'orgs', org, 'secrets.env'),
+      join(homedir(), '.codex', 'auth.json'),
+      join(homedir(), '.codex', 'config.toml'),
+    ],
+    codex_writable_paths: [absoluteAgentDir],
+    codex_readonly_paths: IMMUTABLE_AGENT_FILES.map((name) => join(absoluteAgentDir, name)),
+    codex_network_allow_domains: [],
+    codex_env_allowlist: [],
+    codex_mcp_allowlist: [],
+  };
+}
+
+export function mergeCodexCapabilityProfile(
+  config: Record<string, unknown>,
+  defaults: CodexCapabilityProfile,
+): CodexCapabilityProfile {
+  const merged = {} as CodexCapabilityProfile;
+  for (const key of CODEX_CAPABILITY_KEYS) {
+    const current = config[key];
+    if (current === undefined) {
+      merged[key] = [...defaults[key]];
+      continue;
+    }
+    if (!Array.isArray(current) || !current.every((value) => typeof value === 'string')) {
+      throw new Error(`${key} is present but malformed; refusing to infer a replacement`);
+    }
+    merged[key] = (key === 'codex_credential_deny_paths' || key === 'codex_readonly_paths')
+      ? [...new Set([...defaults[key], ...current])]
+      : [...new Set(current)];
+  }
+  return merged;
+}
+
+export function applyCodexCapabilityProfile(
+  config: Record<string, unknown>,
+  profile: CodexCapabilityProfile,
+): Record<string, unknown> {
+  return { ...config, ...profile };
+}

--- a/src/utils/codex-capability-profile.ts
+++ b/src/utils/codex-capability-profile.ts
@@ -11,7 +11,9 @@ export const CODEX_CAPABILITY_KEYS = [
 ] as const;
 
 export type CodexCapabilityKey = typeof CODEX_CAPABILITY_KEYS[number];
-export type CodexCapabilityProfile = Record<CodexCapabilityKey, string[]>;
+export type CodexCapabilityProfile = Record<CodexCapabilityKey, string[]> & {
+  codex_web_search_enabled: boolean;
+};
 
 const IMMUTABLE_AGENT_FILES = [
   '.gitignore',
@@ -46,6 +48,7 @@ export function buildDefaultCodexCapabilityProfile(
     codex_network_allow_domains: [],
     codex_env_allowlist: [],
     codex_mcp_allowlist: [],
+    codex_web_search_enabled: false,
   };
 }
 
@@ -67,6 +70,11 @@ export function mergeCodexCapabilityProfile(
       ? [...new Set([...defaults[key], ...current])]
       : [...new Set(current)];
   }
+  const webSearch = config.codex_web_search_enabled;
+  if (webSearch !== undefined && typeof webSearch !== 'boolean') {
+    throw new Error('codex_web_search_enabled is present but malformed; refusing to infer a replacement');
+  }
+  merged.codex_web_search_enabled = webSearch ?? defaults.codex_web_search_enabled;
   return merged;
 }
 

--- a/src/utils/codex-permission-migration.ts
+++ b/src/utils/codex-permission-migration.ts
@@ -1,0 +1,206 @@
+import { randomBytes } from 'crypto';
+import {
+  chmodSync,
+  closeSync,
+  constants,
+  existsSync,
+  fsyncSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, join } from 'path';
+import { withFileLockSync } from './lock.js';
+
+export const CODEX_PERMISSION_MIGRATION_HOLD = 'codex-permission-migration.hold.json';
+export const CODEX_PERMISSION_START_CLAIM = 'codex-permission-start.claim.json';
+export const CODEX_PERMISSION_BARRIER = 'codex-permission-barrier';
+
+export interface CodexPermissionStartClaim {
+  path: string;
+  raw: string;
+}
+
+interface CodexPermissionStartClaimValue {
+  schemaVersion: 'cortextos-codex-permission-start-claim/v1';
+  agent: string;
+  pid: number;
+  nonce: string;
+}
+
+export function codexPermissionMigrationHoldPath(
+  ctxRoot: string,
+  agent: string,
+): string {
+  return join(ctxRoot, 'state', agent, CODEX_PERMISSION_MIGRATION_HOLD);
+}
+
+export function codexPermissionStartClaimPath(
+  ctxRoot: string,
+  agent: string,
+): string {
+  return join(ctxRoot, 'state', agent, CODEX_PERMISSION_START_CLAIM);
+}
+
+export function codexPermissionBarrierRoot(
+  ctxRoot: string,
+  agent: string,
+): string {
+  return join(ctxRoot, 'state', agent, CODEX_PERMISSION_BARRIER);
+}
+
+/**
+ * A malformed or attacker-created hold still blocks startup. The migration
+ * command performs the stricter shape, inode, and ownership checks before it
+ * may consume or clear one.
+ */
+export function hasCodexPermissionMigrationHold(
+  ctxRoot: string,
+  agent: string,
+): boolean {
+  return existsSync(codexPermissionMigrationHoldPath(ctxRoot, agent));
+}
+
+/**
+ * Claim the synchronous start-preparation window shared with permission
+ * migration. The daemon publishes the agent in its in-memory status registry
+ * before releasing this claim. Migration therefore sees exactly one of:
+ * an active claim, a durable hold, or the registered seat.
+ */
+export function acquireCodexPermissionStartClaim(
+  ctxRoot: string,
+  agent: string,
+): CodexPermissionStartClaim | null {
+  const stateDir = join(ctxRoot, 'state', agent);
+  const barrierRoot = codexPermissionBarrierRoot(ctxRoot, agent);
+  const path = codexPermissionStartClaimPath(ctxRoot, agent);
+  mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+  mkdirSync(barrierRoot, { recursive: true, mode: 0o700 });
+
+  return withFileLockSync(barrierRoot, () => {
+    if (hasCodexPermissionMigrationHold(ctxRoot, agent)) return null;
+    if (existsSync(path)) {
+      if (!recoverDeadCodexPermissionStartClaimWhileBarrierHeld(ctxRoot, agent)) {
+        throw new Error(`A live Codex permission start claim already exists for ${agent}`);
+      }
+    }
+    const value: CodexPermissionStartClaimValue = {
+      schemaVersion: 'cortextos-codex-permission-start-claim/v1',
+      agent,
+      pid: process.pid,
+      nonce: randomBytes(16).toString('hex'),
+    };
+    const raw = `${JSON.stringify(value, null, 2)}\n`;
+    let fd: number | null = null;
+    try {
+      fd = openSync(
+        path,
+        constants.O_WRONLY | constants.O_CREAT | constants.O_EXCL | constants.O_NOFOLLOW,
+        0o600,
+      );
+      chmodSync(path, 0o600);
+      writeFileSync(fd, raw, 'utf-8');
+      fsyncSync(fd);
+      closeSync(fd);
+      fd = null;
+      fsyncDirectory(stateDir);
+      return { path, raw };
+    } catch (err) {
+      if (fd !== null) closeSync(fd);
+      throw err;
+    }
+  });
+}
+
+/**
+ * Recover a strict same-agent claim only when its recorded owner is dead.
+ * The caller must already hold codexPermissionBarrierRoot(ctxRoot, agent), so
+ * start and migration can both use the same parser without a nested lock.
+ * Returns false when the owner is still live; malformed/unsafe claims throw.
+ */
+export function recoverDeadCodexPermissionStartClaimWhileBarrierHeld(
+  ctxRoot: string,
+  agent: string,
+): boolean {
+  const path = codexPermissionStartClaimPath(ctxRoot, agent);
+  if (!existsSync(path)) return true;
+  const existing = readStartClaim(path, agent);
+  if (isProcessAlive(existing.value.pid)) return false;
+  unlinkSync(path);
+  fsyncDirectory(dirname(path));
+  return true;
+}
+
+function readStartClaim(
+  path: string,
+  expectedAgent: string,
+): { raw: string; value: CodexPermissionStartClaimValue } {
+  const stat = lstatSync(path);
+  const currentUid = typeof process.getuid === 'function' ? process.getuid() : null;
+  if (!stat.isFile() || stat.isSymbolicLink() || stat.nlink !== 1
+      || (stat.mode & 0o077) !== 0
+      || (currentUid !== null && stat.uid !== currentUid)) {
+    throw new Error(`Codex permission start claim is unsafe for ${expectedAgent}`);
+  }
+  const raw = readFileSync(path, 'utf-8');
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    throw new Error(`Codex permission start claim is malformed for ${expectedAgent}`);
+  }
+  const keys = ['agent', 'nonce', 'pid', 'schemaVersion'];
+  if (!value || typeof value !== 'object' || Array.isArray(value)
+      || Object.keys(value).sort().join('\n') !== keys.join('\n')) {
+    throw new Error(`Codex permission start claim is malformed for ${expectedAgent}`);
+  }
+  const claim = value as CodexPermissionStartClaimValue;
+  if (claim.schemaVersion !== 'cortextos-codex-permission-start-claim/v1'
+      || claim.agent !== expectedAgent
+      || !Number.isSafeInteger(claim.pid) || claim.pid <= 0
+      || !/^[a-f0-9]{32}$/.test(claim.nonce)) {
+    throw new Error(`Codex permission start claim is malformed for ${expectedAgent}`);
+  }
+  return { raw, value: claim };
+}
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code !== 'ESRCH';
+  }
+}
+
+/**
+ * Release only the exact claim created by this start attempt. A replaced or
+ * malformed claim stays in place and keeps migration fail-closed.
+ */
+export function releaseCodexPermissionStartClaim(
+  ctxRoot: string,
+  agent: string,
+  claim: CodexPermissionStartClaim,
+): void {
+  const barrierRoot = codexPermissionBarrierRoot(ctxRoot, agent);
+  withFileLockSync(barrierRoot, () => {
+    if (claim.path !== codexPermissionStartClaimPath(ctxRoot, agent)
+        || readFileSync(claim.path, 'utf-8') !== claim.raw) {
+      throw new Error(`Codex permission start claim changed before release for ${agent}`);
+    }
+    unlinkSync(claim.path);
+    fsyncDirectory(dirname(claim.path));
+  });
+}
+
+function fsyncDirectory(path: string): void {
+  const fd = openSync(path, constants.O_RDONLY);
+  try {
+    fsyncSync(fd);
+  } finally {
+    closeSync(fd);
+  }
+}

--- a/src/utils/enabled-agents-registry.ts
+++ b/src/utils/enabled-agents-registry.ts
@@ -1,0 +1,45 @@
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { atomicWriteSync } from './atomic.js';
+import { withFileLockSync } from './lock.js';
+
+export type EnabledAgentsRegistry = Record<string, Record<string, unknown>>;
+
+export function enabledAgentsRegistryPath(ctxRoot: string): string {
+  return join(ctxRoot, 'config', 'enabled-agents.json');
+}
+
+export function readEnabledAgentsRegistry(ctxRoot: string): EnabledAgentsRegistry {
+  const path = enabledAgentsRegistryPath(ctxRoot);
+  if (!existsSync(path)) return {};
+  const raw = readFileSync(path, 'utf-8');
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error(`${path} must contain a JSON object`);
+  }
+  return parsed as EnabledAgentsRegistry;
+}
+
+/**
+ * Serialize every registry read-modify-write across CLI and dashboard writers,
+ * then replace the file atomically. Existing malformed state is never treated
+ * as an empty registry and overwritten.
+ */
+export function mutateEnabledAgentsRegistry<T>(
+  ctxRoot: string,
+  mutate: (registry: EnabledAgentsRegistry) => T,
+): T {
+  const configDir = join(ctxRoot, 'config');
+  const lockRoot = join(configDir, 'enabled-agents-registry-lock');
+  mkdirSync(configDir, { recursive: true, mode: 0o700 });
+  mkdirSync(lockRoot, { recursive: true, mode: 0o700 });
+  return withFileLockSync(lockRoot, () => {
+    const registry = readEnabledAgentsRegistry(ctxRoot);
+    const result = mutate(registry);
+    atomicWriteSync(
+      enabledAgentsRegistryPath(ctxRoot),
+      JSON.stringify(registry, null, 2),
+    );
+    return result;
+  });
+}

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -122,12 +122,12 @@ export function withFileLockSync<T>(
   // Use process.hrtime.bigint() instead of Date.now() so the timeout works
   // under vi.useFakeTimers() (which freezes Date.now).  hrtime reads the
   // monotonic clock via syscall and is not stubbed by fake-timer libraries.
-  const start = process.hrtime.bigint();
-  const timeoutNs = BigInt(timeoutMs) * 1_000_000n;
+  const start = process.hrtime();
   let backoff = initBackoff;
 
   while (!acquireLock(dir)) {
-    if (process.hrtime.bigint() - start > timeoutNs) {
+    const [elapsedSeconds, elapsedNanos] = process.hrtime(start);
+    if ((elapsedSeconds * 1000) + (elapsedNanos / 1_000_000) > timeoutMs) {
       throw new Error(
         `withFileLockSync: failed to acquire lock on "${dir}" within ${timeoutMs}ms`,
       );

--- a/tests/integration/codex-permission-profile-live.test.ts
+++ b/tests/integration/codex-permission-profile-live.test.ts
@@ -78,6 +78,7 @@ const LIVE = process.env.CODEX_PERMISSION_PROFILE_LIVE === '1';
       codex_writable_paths: [roleWorkDir],
       codex_readonly_paths: [nestedControlPath],
       codex_network_allow_domains: [],
+      codex_web_search_enabled: true,
       codex_env_allowlist: [],
       codex_mcp_allowlist: [],
     });
@@ -198,7 +199,8 @@ const LIVE = process.env.CODEX_PERMISSION_PROFILE_LIVE === '1';
         runtime: 'codex-app-server', working_directory: policyDir,
         codex_credential_deny_paths: [secretPath],
         codex_writable_paths: [roleWorkDir], codex_readonly_paths: [],
-        codex_network_allow_domains: [], codex_env_allowlist: [],
+        codex_network_allow_domains: [], codex_web_search_enabled: false,
+        codex_env_allowlist: [],
         codex_mcp_allowlist: [],
       })).toThrow(/hard-linked file/);
     } finally {
@@ -218,7 +220,8 @@ const LIVE = process.env.CODEX_PERMISSION_PROFILE_LIVE === '1';
         runtime: 'codex-app-server', working_directory: policyDir,
         codex_credential_deny_paths: [secretPath],
         codex_writable_paths: [roleWorkDir], codex_readonly_paths: [nestedControlPath],
-        codex_network_allow_domains: [], codex_env_allowlist: [],
+        codex_network_allow_domains: [], codex_web_search_enabled: false,
+        codex_env_allowlist: [],
         codex_mcp_allowlist: [],
       })).toThrow(/codex_readonly_paths contains a hard-linked file/);
     } finally {
@@ -270,6 +273,7 @@ const LIVE = process.env.CODEX_PERMISSION_PROFILE_LIVE === '1';
       codex_writable_paths: [roleWorkDir],
       codex_readonly_paths: [nestedControlPath],
       codex_network_allow_domains: [],
+      codex_web_search_enabled: false,
       codex_env_allowlist: [],
       codex_mcp_allowlist: [],
     };
@@ -335,7 +339,8 @@ const LIVE = process.env.CODEX_PERMISSION_PROFILE_LIVE === '1';
       runtime: 'codex-app-server', working_directory: implicitCwd,
       codex_credential_deny_paths: [secretPath],
       codex_writable_paths: [implicitCwd], codex_readonly_paths: [],
-      codex_network_allow_domains: [], codex_env_allowlist: [],
+      codex_network_allow_domains: [], codex_web_search_enabled: false,
+      codex_env_allowlist: [],
       codex_mcp_allowlist: [],
     });
     try {
@@ -358,7 +363,8 @@ const LIVE = process.env.CODEX_PERMISSION_PROFILE_LIVE === '1';
       runtime: 'codex-app-server', working_directory: policyDir,
       codex_credential_deny_paths: [secretPath], codex_writable_paths: [],
       codex_readonly_paths: [], codex_network_allow_domains: [],
-      codex_env_allowlist: [], codex_mcp_allowlist: [],
+      codex_web_search_enabled: false, codex_env_allowlist: [],
+      codex_mcp_allowlist: [],
     });
     try {
       await readonly.spawn('fresh', '');

--- a/tests/integration/codex-permission-profile-live.test.ts
+++ b/tests/integration/codex-permission-profile-live.test.ts
@@ -1,0 +1,387 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { existsSync, linkSync, mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'fs';
+import { createServer, type Server } from 'http';
+import { join } from 'path';
+import { CodexAppServerPTY } from '../../src/pty/codex-app-server-pty.js';
+
+/**
+ * Source-only live contract test for the real Codex permission-profile parser
+ * and sandbox. It starts an isolated temporary app-server but does not run a
+ * model turn, install anything, or touch a cortextOS/Fleet service.
+ *
+ *   CODEX_PERMISSION_PROFILE_LIVE=1 npx vitest run \
+ *     tests/integration/codex-permission-profile-live.test.ts
+ */
+const LIVE = process.env.CODEX_PERMISSION_PROFILE_LIVE === '1';
+
+(LIVE ? describe : describe.skip)('Codex app-server role capability profile (live)', () => {
+  let root: string;
+  let policyDir: string;
+  let roleWorkDir: string;
+  let immutablePath: string;
+  let nestedControlPath: string;
+  let secretPath: string;
+  let nodeSurfaceServer: Server;
+  let brainSurfaceServer: Server;
+  let nodeSurfacePort: number;
+  let brainSurfacePort: number;
+  let pty: CodexAppServerPTY;
+
+  async function listen(server: Server): Promise<number> {
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => resolve());
+    });
+    const address = server.address();
+    if (!address || typeof address === 'string') throw new Error('test server did not bind a TCP port');
+    return address.port;
+  }
+
+  beforeAll(async () => {
+    // Keep the test's control socket under the adapter's normal state-dir
+    // threshold. The legacy long-path fallback is a separate adapter contract.
+    root = mkdtempSync('/tmp/cpl-');
+    policyDir = join(root, 'agent-policy');
+    roleWorkDir = join(root, 'role-work');
+    immutablePath = join(policyDir, 'SYSTEM.md');
+    nestedControlPath = join(roleWorkDir, 'AGENTS.md');
+    secretPath = join(policyDir, 'secret.env');
+    mkdirSync(policyDir, { recursive: true });
+    mkdirSync(roleWorkDir, { recursive: true });
+    writeFileSync(immutablePath, 'immutable\n', 'utf-8');
+    writeFileSync(nestedControlPath, 'immutable role control\n', 'utf-8');
+    writeFileSync(secretPath, 'private\n', 'utf-8');
+
+    nodeSurfaceServer = createServer((_request, response) => {
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+      response.end('node-surface-target\n');
+    });
+    brainSurfaceServer = createServer((_request, response) => {
+      response.writeHead(200, { 'Content-Type': 'text/plain' });
+      response.end('brain-surface-target\n');
+    });
+    nodeSurfacePort = await listen(nodeSurfaceServer);
+    brainSurfacePort = await listen(brainSurfaceServer);
+
+    pty = new CodexAppServerPTY({
+      instanceId: 'permission-profile-live',
+      ctxRoot: join(root, 'ctx'),
+      frameworkRoot: root,
+      agentName: 'codex-profile-live',
+      agentDir: policyDir,
+      org: 'audit',
+      projectRoot: root,
+    }, {
+      runtime: 'codex-app-server',
+      working_directory: policyDir,
+      codex_credential_deny_paths: [secretPath],
+      codex_writable_paths: [roleWorkDir],
+      codex_readonly_paths: [nestedControlPath],
+      codex_network_allow_domains: [],
+      codex_env_allowlist: [],
+      codex_mcp_allowlist: [],
+    });
+
+    try {
+      await pty.spawn('fresh', '');
+    } catch (error) {
+      throw new Error(`${String(error)}\n${pty.getOutputBuffer().getRecent()}`);
+    }
+  }, 30_000);
+
+  afterAll(async () => {
+    try {
+      pty?.kill();
+    } catch {
+      // Best-effort cleanup for a test-only process.
+    }
+    await Promise.all([
+      new Promise<void>((resolve) => nodeSurfaceServer?.close(() => resolve())),
+      new Promise<void>((resolve) => brainSurfaceServer?.close(() => resolve())),
+    ]);
+    if (root) rmSync(root, { recursive: true, force: true });
+  });
+
+  async function commandFor(
+    targetPty: CodexAppServerPTY,
+    commandCwd: string,
+    command: string,
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    const profileId = (targetPty as unknown as { _permissionProfileId: string })._permissionProfileId;
+    let response: { result?: { exitCode: number; stdout: string; stderr: string } };
+    try {
+      response = await (targetPty as unknown as {
+        request<T>(method: string, params: unknown): Promise<{ result?: T }>;
+      }).request<{ exitCode: number; stdout: string; stderr: string }>('command/exec', {
+        command: ['/bin/sh', '-c', command],
+        cwd: commandCwd,
+        permissionProfile: profileId,
+        timeoutMs: 5_000,
+      });
+    } catch (error) {
+      throw new Error(`${String(error)}\n${targetPty.getOutputBuffer().getRecent()}`);
+    }
+    if (!response.result) throw new Error('command/exec returned no result');
+    return response.result;
+  }
+
+  async function command(commandText: string) {
+    return commandFor(pty, policyDir, commandText);
+  }
+
+  it('allows arbitrary creation inside the broad role work root', async () => {
+    const nested = join(roleWorkDir, 'new', 'artifact.txt');
+    const result = await command(`mkdir -p '${join(roleWorkDir, 'new')}' && printf work > '${nested}'`);
+    expect(result.exitCode).toBe(0);
+    expect(existsSync(nested)).toBe(true);
+  });
+
+  it('keeps the policy directory read-only', async () => {
+    const result = await command(`printf changed >> '${immutablePath}'`);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('keeps nested control files read-only inside a broad writable work root', async () => {
+    const result = await command(`printf changed >> '${nestedControlPath}'`);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('allows normal private temp use while ambient /tmp remains unavailable', async () => {
+    const modelTempDir = (pty as unknown as { _modelTempDir: string })._modelTempDir;
+    const result = await command(
+      'created=$(mktemp) && printf scratch > "$created" '
+      + '&& printf "%s\\n%s\\n%s\\n%s\\n" "$TMPDIR" "$TMP" "$TEMP" "$created"',
+    );
+    expect(result.exitCode).toBe(0);
+    const [tmpdirEnv, tmpEnv, tempEnv, created] = result.stdout.trim().split('\n');
+    expect(tmpdirEnv).toBe(modelTempDir);
+    expect(tmpEnv).toBe(modelTempDir);
+    expect(tempEnv).toBe(modelTempDir);
+    expect(created).toMatch(new RegExp(`^${modelTempDir.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/`));
+
+    const ambient = join('/tmp', `codex-ambient-${process.pid}`);
+    const blocked = await command(`printf blocked > '${ambient}'`);
+    expect(blocked.exitCode).not.toBe(0);
+    expect(existsSync(ambient)).toBe(false);
+  });
+
+  it('cannot use private-temp staging to delete, replace, or symlink through control policy', async () => {
+    const modelTempDir = (pty as unknown as { _modelTempDir: string })._modelTempDir;
+    const remove = await command(`rm -f '${nestedControlPath}'`);
+    expect(remove.exitCode).not.toBe(0);
+    expect(existsSync(nestedControlPath)).toBe(true);
+
+    const staged = join(modelTempDir, 'staged-control');
+    const replace = await command(`printf replacement > '${staged}' && mv -f '${staged}' '${nestedControlPath}'`);
+    expect(replace.exitCode).not.toBe(0);
+    expect(existsSync(nestedControlPath)).toBe(true);
+
+    const alias = join(modelTempDir, 'control-alias');
+    const symlinkEscape = await command(`ln -s '${nestedControlPath}' '${alias}' && printf changed >> '${alias}'`);
+    expect(symlinkEscape.exitCode).not.toBe(0);
+  });
+
+  it('denies reads of an exact credential path', async () => {
+    const result = await command(`test -r '${secretPath}'`);
+    expect(result.exitCode).not.toBe(0);
+  });
+
+  it('fails pre-launch when a credential inode already has another readable name', () => {
+    const alias = join(roleWorkDir, 'preexisting-secret-hardlink');
+    linkSync(secretPath, alias);
+    try {
+      expect(() => new CodexAppServerPTY({
+        instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-hardlink'),
+        frameworkRoot: root, agentName: 'hardlink-test', agentDir: policyDir,
+        org: 'audit', projectRoot: root,
+      }, {
+        runtime: 'codex-app-server', working_directory: policyDir,
+        codex_credential_deny_paths: [secretPath],
+        codex_writable_paths: [roleWorkDir], codex_readonly_paths: [],
+        codex_network_allow_domains: [], codex_env_allowlist: [],
+        codex_mcp_allowlist: [],
+      })).toThrow(/hard-linked file/);
+    } finally {
+      rmSync(alias, { force: true });
+    }
+  });
+
+  it('fails pre-launch when a read-only control inode has a writable alias', () => {
+    const alias = join(roleWorkDir, 'preexisting-control-hardlink');
+    linkSync(nestedControlPath, alias);
+    try {
+      expect(() => new CodexAppServerPTY({
+        instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-control-hardlink'),
+        frameworkRoot: root, agentName: 'control-hardlink-test', agentDir: policyDir,
+        org: 'audit', projectRoot: root,
+      }, {
+        runtime: 'codex-app-server', working_directory: policyDir,
+        codex_credential_deny_paths: [secretPath],
+        codex_writable_paths: [roleWorkDir], codex_readonly_paths: [nestedControlPath],
+        codex_network_allow_domains: [], codex_env_allowlist: [],
+        codex_mcp_allowlist: [],
+      })).toThrow(/codex_readonly_paths contains a hard-linked file/);
+    } finally {
+      rmSync(alias, { force: true });
+    }
+  });
+
+  it('blocks creation of a new credential hard-link after launch', async () => {
+    const alias = join(roleWorkDir, 'runtime-secret-hardlink');
+    const result = await command(`ln '${secretPath}' '${alias}'`);
+    expect(result.exitCode).not.toBe(0);
+    expect(existsSync(alias)).toBe(false);
+  });
+
+  it('denies model access to the app-server control socket', async () => {
+    const socketPath = (pty as unknown as { _socketPath: string })._socketPath;
+    const script = [
+      "const net=require('net')",
+      `const socket=net.createConnection(${JSON.stringify(socketPath)})`,
+      "socket.on('connect',()=>process.exit(0))",
+      "socket.on('error',()=>process.exit(7))",
+      "setTimeout(()=>process.exit(8),1000)",
+    ].join(';');
+    const result = await command(`${JSON.stringify(process.execPath)} -e ${JSON.stringify(script)}`);
+    expect(result.exitCode).not.toBe(0);
+
+    const modelTempDir = (pty as unknown as { _modelTempDir: string })._modelTempDir;
+    const alias = join(modelTempDir, 'socket-alias');
+    const aliasScript = [
+      "const net=require('net')",
+      `const socket=net.createConnection(${JSON.stringify(alias)})`,
+      "socket.on('connect',()=>process.exit(0))",
+      "socket.on('error',()=>process.exit(7))",
+      "setTimeout(()=>process.exit(8),1000)",
+    ].join(';');
+    const aliased = await command(
+      `ln -s '${socketPath}' '${alias}' && ${JSON.stringify(process.execPath)} -e ${JSON.stringify(aliasScript)}`,
+    );
+    expect(aliased.exitCode).not.toBe(0);
+  });
+
+  it('rejects descendant and symlink capability entries that would reopen stronger policy', () => {
+    const alias = join(root, 'secret-alias');
+    symlinkSync(secretPath, alias);
+    const base = {
+      runtime: 'codex-app-server' as const,
+      working_directory: policyDir,
+      codex_credential_deny_paths: [secretPath],
+      codex_writable_paths: [roleWorkDir],
+      codex_readonly_paths: [nestedControlPath],
+      codex_network_allow_domains: [],
+      codex_env_allowlist: [],
+      codex_mcp_allowlist: [],
+    };
+
+    expect(() => new CodexAppServerPTY({
+      instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-alias'),
+      frameworkRoot: root, agentName: 'alias-test', agentDir: policyDir,
+      org: 'audit', projectRoot: root,
+    }, { ...base, codex_readonly_paths: [alias] })).toThrow(/must not contain symbolic links/);
+    expect(() => new CodexAppServerPTY({
+      instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-denied-child'),
+      frameworkRoot: root, agentName: 'denied-child-test', agentDir: policyDir,
+      org: 'audit', projectRoot: root,
+    }, {
+      ...base,
+      codex_credential_deny_paths: [policyDir],
+      codex_writable_paths: [roleWorkDir],
+      codex_readonly_paths: [immutablePath],
+    })).toThrow(/must not equal or descend/);
+    expect(() => new CodexAppServerPTY({
+      instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-read-child'),
+      frameworkRoot: root, agentName: 'read-child-test', agentDir: policyDir,
+      org: 'audit', projectRoot: root,
+    }, {
+      ...base,
+      codex_readonly_paths: [roleWorkDir],
+      codex_writable_paths: [join(roleWorkDir, 'output')],
+    })).toThrow(/must not equal or descend/);
+
+    const nested = join(roleWorkDir, 'renameable', 'controls');
+    mkdirSync(nested, { recursive: true });
+    const nestedPolicy = join(nested, 'AGENTS.md');
+    const nestedCredential = join(nested, 'secret.env');
+    writeFileSync(nestedPolicy, 'control\n');
+    writeFileSync(nestedCredential, 'private\n');
+    expect(() => new CodexAppServerPTY({
+      instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-nested-readonly'),
+      frameworkRoot: root, agentName: 'nested-readonly-test', agentDir: policyDir,
+      org: 'audit', projectRoot: root,
+    }, {
+      ...base,
+      codex_readonly_paths: [nestedPolicy],
+    })).toThrow(/renameable writable intermediate/);
+    expect(() => new CodexAppServerPTY({
+      instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-nested-deny'),
+      frameworkRoot: root, agentName: 'nested-deny-test', agentDir: policyDir,
+      org: 'audit', projectRoot: root,
+    }, {
+      ...base,
+      codex_credential_deny_paths: [nestedCredential],
+      codex_readonly_paths: [],
+    })).toThrow(/renameable writable intermediate/);
+  });
+
+  it('accepts the role cwd as an implicit writable root', async () => {
+    const implicitCwd = join(root, 'implicit-role-work');
+    mkdirSync(implicitCwd);
+    const implicit = new CodexAppServerPTY({
+      instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-implicit'),
+      frameworkRoot: root, agentName: 'implicit-cwd-test', agentDir: implicitCwd,
+      org: 'audit', projectRoot: root,
+    }, {
+      runtime: 'codex-app-server', working_directory: implicitCwd,
+      codex_credential_deny_paths: [secretPath],
+      codex_writable_paths: [implicitCwd], codex_readonly_paths: [],
+      codex_network_allow_domains: [], codex_env_allowlist: [],
+      codex_mcp_allowlist: [],
+    });
+    try {
+      await implicit.spawn('fresh', '');
+      const output = join(implicitCwd, 'created.txt');
+      const result = await commandFor(implicit, implicitCwd, `printf work > '${output}'`);
+      expect(result.exitCode).toBe(0);
+      expect(existsSync(output)).toBe(true);
+    } finally {
+      implicit.kill();
+    }
+  }, 30_000);
+
+  it('accepts a fully read-only profile with no writableRoots member', async () => {
+    const readonly = new CodexAppServerPTY({
+      instanceId: 'permission-profile-live', ctxRoot: join(root, 'ctx-readonly'),
+      frameworkRoot: root, agentName: 'readonly-test', agentDir: policyDir,
+      org: 'audit', projectRoot: root,
+    }, {
+      runtime: 'codex-app-server', working_directory: policyDir,
+      codex_credential_deny_paths: [secretPath], codex_writable_paths: [],
+      codex_readonly_paths: [], codex_network_allow_domains: [],
+      codex_env_allowlist: [], codex_mcp_allowlist: [],
+    });
+    try {
+      await readonly.spawn('fresh', '');
+      const result = await commandFor(
+        readonly, policyDir, `printf changed >> '${immutablePath}'`,
+      );
+      expect(result.exitCode).not.toBe(0);
+    } finally {
+      readonly.kill();
+    }
+  }, 30_000);
+
+  it('denies both canonical loopback surfaces when raw network is disabled', async () => {
+    const nodeSurface = await command(
+      `/usr/bin/curl --silent --show-error --fail --max-time 3 http://127.0.0.1:${nodeSurfacePort}/`,
+    );
+    expect(nodeSurface.exitCode).not.toBe(0);
+    expect(nodeSurface.stdout).not.toContain('node-surface-target');
+
+    const brainSurface = await command(
+      `/usr/bin/curl --silent --show-error --fail --max-time 3 http://127.0.0.1:${brainSurfacePort}/`,
+    );
+    expect(brainSurface.exitCode).not.toBe(0);
+    expect(brainSurface.stdout).not.toContain('brain-surface-target');
+  });
+});

--- a/tests/unit/cli/add-agent-codex.test.ts
+++ b/tests/unit/cli/add-agent-codex.test.ts
@@ -109,6 +109,24 @@ describe('PR-02: add-agent --runtime codex-app-server', () => {
     expect(cfg.runtime).toBe('codex-app-server');
     expect(cfg.model).toBe('gpt-5-codex');
     expect(cfg.agent_name).toBe('codex-cfg');
+    const agentDir = join(tempRoot, 'orgs', 'testorg', 'agents', 'codex-cfg');
+    expect(cfg.codex_credential_deny_paths).toEqual([
+      join(agentDir, '.env'),
+      join(tempRoot, 'orgs', 'testorg', 'secrets.env'),
+      join(tempHome, '.codex', 'auth.json'),
+      join(tempHome, '.codex', 'config.toml'),
+    ]);
+    expect(cfg.codex_writable_paths).toEqual([agentDir]);
+    expect(cfg.codex_readonly_paths).toEqual(expect.arrayContaining([
+      join(agentDir, 'AGENTS.md'),
+      join(agentDir, 'IDENTITY.md'),
+      join(agentDir, 'SYSTEM.md'),
+      join(agentDir, 'config.json'),
+      join(agentDir, 'goals.json'),
+    ]));
+    expect(cfg.codex_network_allow_domains).toEqual([]);
+    expect(cfg.codex_env_allowlist).toEqual([]);
+    expect(cfg.codex_mcp_allowlist).toEqual([]);
   });
 
   it('copies the 23 codex skills into plugins/cortextos-agent-skills/skills', async () => {

--- a/tests/unit/cli/add-agent-codex.test.ts
+++ b/tests/unit/cli/add-agent-codex.test.ts
@@ -125,6 +125,7 @@ describe('PR-02: add-agent --runtime codex-app-server', () => {
       join(agentDir, 'goals.json'),
     ]));
     expect(cfg.codex_network_allow_domains).toEqual([]);
+    expect(cfg.codex_web_search_enabled).toBe(false);
     expect(cfg.codex_env_allowlist).toEqual([]);
     expect(cfg.codex_mcp_allowlist).toEqual([]);
   });

--- a/tests/unit/cli/migrate-codex-permissions.test.ts
+++ b/tests/unit/cli/migrate-codex-permissions.test.ts
@@ -1,0 +1,375 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const ipcState = vi.hoisted(() => ({
+  running: false,
+  statuses: [] as Array<{ name: string; status: string }>,
+  error: null as Error | null,
+  malformed: false,
+  instances: [] as string[],
+}));
+const osState = vi.hoisted(() => ({ home: '' }));
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  return { ...actual, homedir: () => osState.home || actual.homedir() };
+});
+
+vi.mock('../../../src/daemon/ipc-server.js', () => ({
+  IPCClient: class {
+    constructor(instance: string) { ipcState.instances.push(instance); }
+    async isDaemonRunning() { return ipcState.running; }
+    async send() {
+      if (ipcState.error) throw ipcState.error;
+      if (!ipcState.running) {
+        return {
+          success: false,
+          error: 'Daemon is not running. Start it with: cortextos start',
+        };
+      }
+      if (ipcState.malformed) return { success: true, data: {} };
+      return { success: true, data: ipcState.statuses };
+    }
+  },
+}));
+
+const {
+  codexCapabilityProfileHash,
+  codexConfigHash,
+  migrateCodexPermissionsCommand,
+} = await import('../../../src/cli/migrate-codex-permissions.js');
+const { buildDefaultCodexCapabilityProfile } = await import(
+  '../../../src/utils/codex-capability-profile.js'
+);
+const { codexPermissionMigrationHoldPath, codexPermissionStartClaimPath } = await import(
+  '../../../src/utils/codex-permission-migration.js'
+);
+
+describe('migrate-codex-permissions', () => {
+  let root: string;
+  let agentDir: string;
+  let configPath: string;
+  let ctxRoot: string;
+  let oldFrameworkRoot: string | undefined;
+  let oldCtxRoot: string | undefined;
+  let oldInstanceId: string | undefined;
+  let oldExitCode: string | number | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'codex-profile-migrate-'));
+    osState.home = join(root, 'home');
+    agentDir = join(root, 'orgs', 'acme', 'agents', 'legacy-codex');
+    configPath = join(agentDir, 'config.json');
+    ctxRoot = join(osState.home, '.cortextos', 'test');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(configPath, JSON.stringify({
+      agent_name: 'legacy-codex',
+      runtime: 'codex-app-server',
+      enabled: true,
+    }, null, 2) + '\n');
+    mkdirSync(join(ctxRoot, 'config'), { recursive: true });
+    writeFileSync(
+      join(ctxRoot, 'config', 'enabled-agents.json'),
+      JSON.stringify({
+        'legacy-codex': { enabled: false, org: 'acme' },
+      }, null, 2) + '\n',
+    );
+    oldFrameworkRoot = process.env.CTX_FRAMEWORK_ROOT;
+    oldCtxRoot = process.env.CTX_ROOT;
+    oldInstanceId = process.env.CTX_INSTANCE_ID;
+    oldExitCode = process.exitCode;
+    process.env.CTX_FRAMEWORK_ROOT = root;
+    delete process.env.CTX_ROOT;
+    delete process.env.CTX_INSTANCE_ID;
+    process.exitCode = undefined;
+    ipcState.running = true;
+    ipcState.statuses = [];
+    ipcState.error = null;
+    ipcState.malformed = false;
+    ipcState.instances = [];
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    if (oldFrameworkRoot === undefined) delete process.env.CTX_FRAMEWORK_ROOT;
+    else process.env.CTX_FRAMEWORK_ROOT = oldFrameworkRoot;
+    if (oldCtxRoot === undefined) delete process.env.CTX_ROOT;
+    else process.env.CTX_ROOT = oldCtxRoot;
+    if (oldInstanceId === undefined) delete process.env.CTX_INSTANCE_ID;
+    else process.env.CTX_INSTANCE_ID = oldInstanceId;
+    process.exitCode = oldExitCode;
+    vi.restoreAllMocks();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('dry-runs a concrete profile without mutating config', async () => {
+    const before = readFileSync(configPath, 'utf-8');
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+    ]);
+
+    expect(readFileSync(configPath, 'utf-8')).toBe(before);
+    const firstLog = vi.mocked(console.log).mock.calls[0][0] as string;
+    const review = JSON.parse(firstLog);
+    expect(review.agent).toBe('legacy-codex');
+    expect(review.profile.codex_writable_paths).toEqual([agentDir]);
+    expect(review.configSha256).toBe(codexConfigHash(before));
+    expect(review.profileSha256).toMatch(/^[a-f0-9]{64}$/);
+  });
+
+  it('requires both reviewed hashes and applies atomically while absent', async () => {
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+    const hash = codexCapabilityProfileHash(profile);
+    const configHash = codexConfigHash(readFileSync(configPath, 'utf-8'));
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', hash, '--expect-config', configHash,
+    ]);
+
+    expect(
+      process.exitCode,
+      vi.mocked(console.error).mock.calls.flat().join('\n'),
+    ).toBeUndefined();
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.codex_credential_deny_paths).toEqual(profile.codex_credential_deny_paths);
+    expect(config.codex_writable_paths).toEqual([agentDir]);
+    expect(config.codex_network_allow_domains).toEqual([]);
+    expect(existsSync(codexPermissionMigrationHoldPath(ctxRoot, 'legacy-codex')))
+      .toBe(false);
+  });
+
+  it('unions mandatory baseline guards into a partial legacy profile', async () => {
+    const customDeny = join(root, 'custom-secret');
+    writeFileSync(configPath, JSON.stringify({
+      agent_name: 'legacy-codex',
+      runtime: 'codex-app-server',
+      codex_credential_deny_paths: [customDeny],
+      codex_readonly_paths: [],
+    }, null, 2) + '\n');
+
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+    ]);
+    const review = JSON.parse(vi.mocked(console.log).mock.calls[0][0] as string);
+    expect(review.profile.codex_credential_deny_paths).toEqual(expect.arrayContaining([
+      customDeny,
+      join(agentDir, '.env'),
+    ]));
+    expect(review.profile.codex_readonly_paths).toEqual(expect.arrayContaining([
+      join(agentDir, 'AGENTS.md'),
+      join(agentDir, 'config.json'),
+    ]));
+    expect(review.profile.codex_writable_paths).toEqual([agentDir]);
+  });
+
+  it('uses the runtime compiler and rejects a profile the adapter would reject', async () => {
+    const defaults = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+    writeFileSync(configPath, JSON.stringify({
+      agent_name: 'legacy-codex',
+      runtime: 'codex-app-server',
+      ...defaults,
+      codex_env_allowlist: ['PATH'],
+    }, null, 2) + '\n');
+
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+    ]);
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/codex_env_allowlist/);
+  });
+
+  it('refuses a stale profile hash, stale full-config hash, or registered seat', async () => {
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', '0'.repeat(64), '--expect-config', '0'.repeat(64),
+    ]);
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths).toBeUndefined();
+
+    process.exitCode = undefined;
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', '0'.repeat(64),
+    ]);
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/changed after review/);
+
+    process.exitCode = undefined;
+    ipcState.running = true;
+    ipcState.statuses = [{ name: 'legacy-codex', status: 'running' }];
+    const configHash = codexConfigHash(readFileSync(configPath, 'utf-8'));
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', configHash,
+    ]);
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths).toBeUndefined();
+    expect(existsSync(codexPermissionMigrationHoldPath(ctxRoot, 'legacy-codex')))
+      .toBe(false);
+  });
+
+  it('accepts absence from a running daemon without changing autostart state', async () => {
+    ipcState.running = true;
+    ipcState.statuses = [];
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+    const configHash = codexConfigHash(readFileSync(configPath, 'utf-8'));
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', configHash,
+    ]);
+    expect(process.exitCode).toBeUndefined();
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths)
+      .toEqual([agentDir]);
+  });
+
+  it('rejects every registered status, including stopped, halted, and crashed', async () => {
+    ipcState.running = true;
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+    const configHash = codexConfigHash(readFileSync(configPath, 'utf-8'));
+    for (const status of ['stopped', 'halted', 'crashed']) {
+      process.exitCode = undefined;
+      ipcState.statuses = [{ name: 'legacy-codex', status }];
+      await migrateCodexPermissionsCommand.parseAsync([
+        'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+        '--apply', '--expect', codexCapabilityProfileHash(profile),
+        '--expect-config', configHash,
+      ]);
+      expect(process.exitCode).toBe(1);
+      expect(vi.mocked(console.error).mock.calls.flat().join('\n'))
+        .toMatch(new RegExp(`current: ${status}`));
+      expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths)
+        .toBeUndefined();
+    }
+  });
+
+  it('fails closed on IPC errors, malformed status, or a mismatched CTX_ROOT', async () => {
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+    const args = [
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', codexConfigHash(readFileSync(configPath, 'utf-8')),
+    ];
+
+    ipcState.error = new Error('IPC request timed out');
+    await migrateCodexPermissionsCommand.parseAsync(args);
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/could not prove/i);
+
+    process.exitCode = undefined;
+    ipcState.error = null;
+    ipcState.running = false;
+    await migrateCodexPermissionsCommand.parseAsync(args);
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/daemon is not running/i);
+
+    process.exitCode = undefined;
+    ipcState.running = true;
+    ipcState.malformed = true;
+    await migrateCodexPermissionsCommand.parseAsync(args);
+    expect(process.exitCode).toBe(1);
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths)
+      .toBeUndefined();
+
+    process.exitCode = undefined;
+    ipcState.malformed = false;
+    process.env.CTX_ROOT = join(root, 'different-instance');
+    await migrateCodexPermissionsCommand.parseAsync(args);
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/different instances/);
+  });
+
+  it('refuses to acquire a migration hold while start preparation is claimed', async () => {
+    const claimPath = join(ctxRoot, 'state', 'legacy-codex', 'codex-permission-start.claim.json');
+    mkdirSync(join(ctxRoot, 'state', 'legacy-codex'), { recursive: true });
+    writeFileSync(claimPath, '{}', { mode: 0o600 });
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', codexConfigHash(readFileSync(configPath, 'utf-8')),
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/start claim is malformed/);
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths)
+      .toBeUndefined();
+  });
+
+  it('recovers a strict dead-owner start claim before acquiring the migration hold', async () => {
+    const claimPath = codexPermissionStartClaimPath(ctxRoot, 'legacy-codex');
+    mkdirSync(join(ctxRoot, 'state', 'legacy-codex'), { recursive: true });
+    writeFileSync(claimPath, `${JSON.stringify({
+      schemaVersion: 'cortextos-codex-permission-start-claim/v1',
+      agent: 'legacy-codex',
+      pid: 2_147_483_647,
+      nonce: 'a'.repeat(32),
+    }, null, 2)}\n`, { mode: 0o600 });
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', codexConfigHash(readFileSync(configPath, 'utf-8')),
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(existsSync(claimPath)).toBe(false);
+    expect(existsSync(codexPermissionMigrationHoldPath(ctxRoot, 'legacy-codex')))
+      .toBe(false);
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths)
+      .toEqual([agentDir]);
+  });
+
+  it('does not repurpose the instance registry autostart bit as migration authority', async () => {
+    writeFileSync(
+      join(ctxRoot, 'config', 'enabled-agents.json'),
+      JSON.stringify({ 'legacy-codex': { enabled: true, org: 'acme' } }),
+    );
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', codexConfigHash(readFileSync(configPath, 'utf-8')),
+    ]);
+    expect(process.exitCode).toBeUndefined();
+    expect(JSON.parse(readFileSync(configPath, 'utf-8')).codex_writable_paths)
+      .toEqual([agentDir]);
+  });
+
+  it('inherits CTX_INSTANCE_ID when --instance is omitted', async () => {
+    process.env.CTX_INSTANCE_ID = 'fleet';
+    const profile = buildDefaultCodexCapabilityProfile(agentDir, root, 'acme');
+
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme',
+      '--apply', '--expect', codexCapabilityProfileHash(profile),
+      '--expect-config', codexConfigHash(readFileSync(configPath, 'utf-8')),
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+    expect(ipcState.instances).toEqual(['fleet']);
+    expect(existsSync(codexPermissionMigrationHoldPath(
+      join(osState.home, '.cortextos', 'fleet'),
+      'legacy-codex',
+    ))).toBe(false);
+  });
+
+  it('rejects disagreement between --instance and CTX_INSTANCE_ID', async () => {
+    process.env.CTX_INSTANCE_ID = 'fleet';
+
+    await migrateCodexPermissionsCommand.parseAsync([
+      'node', 'cli', 'legacy-codex', '--org', 'acme', '--instance', 'test',
+    ]);
+
+    expect(process.exitCode).toBe(1);
+    expect(vi.mocked(console.error).mock.calls.flat().join('\n')).toMatch(/conflicts with CTX_INSTANCE_ID/);
+  });
+});

--- a/tests/unit/daemon/agent-manager-codex-startup.test.ts
+++ b/tests/unit/daemon/agent-manager-codex-startup.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const lifecycle = vi.hoisted(() => ({
+  checkerStarts: 0,
+  cronMigrations: 0,
+  genericPtyConstructions: 0,
+}));
+
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class {
+    start() { lifecycle.checkerStarts += 1; return Promise.resolve(); }
+    stop() {}
+    wake() {}
+  },
+}));
+
+vi.mock('../../../src/daemon/cron-migration.js', () => ({
+  migrateCronsForAgent() { lifecycle.cronMigrations += 1; },
+}));
+
+vi.mock('../../../src/pty/agent-pty.js', () => ({
+  AgentPTY: class {
+    constructor() { lifecycle.genericPtyConstructions += 1; }
+    onExit() {}
+    async spawn() {}
+    getPid() { return 1234; }
+    isAlive() { return true; }
+    kill() {}
+    write() {}
+    getOutputBuffer() { return { isBootstrapped: () => false }; }
+  },
+}));
+
+vi.mock('../../../src/telegram/api.js', () => ({
+  TelegramAPI: class {
+    sendMessage() { return Promise.resolve(); }
+  },
+}));
+
+vi.mock('../../../src/telegram/poller.js', () => ({
+  TelegramPoller: class {
+    start() {}
+    stop() {}
+  },
+}));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+
+describe('AgentManager Codex fail-closed startup', () => {
+  let root: string;
+  let ctxRoot: string;
+  let frameworkRoot: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'cortextos-codex-startup-'));
+    ctxRoot = join(root, 'instance');
+    frameworkRoot = join(root, 'framework');
+    mkdirSync(join(ctxRoot, 'config'), { recursive: true });
+    lifecycle.checkerStarts = 0;
+    lifecycle.cronMigrations = 0;
+    lifecycle.genericPtyConstructions = 0;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function agentDir(name: string): string {
+    const dir = join(frameworkRoot, 'orgs', 'acme', 'agents', name);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  it('keeps every ancillary service off after a real malformed Codex profile', async () => {
+    const dir = agentDir('bad-codex');
+    const config = {
+      agent_name: 'bad-codex',
+      runtime: 'codex-app-server' as const,
+      enabled: true,
+    };
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config));
+    const logs: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args) => logs.push(args.join(' ')));
+
+    const manager = new AgentManager('test', ctxRoot, frameworkRoot, 'acme');
+    await manager.startAgent('bad-codex', dir, config, 'acme');
+
+    const entry = (manager as any).agents.get('bad-codex');
+    expect(entry.process.getStatus()).toMatchObject({
+      status: 'crashed',
+      restartScheduled: false,
+    });
+    expect(lifecycle.checkerStarts).toBe(0);
+    expect(lifecycle.cronMigrations).toBe(0);
+    expect((manager as any).cronSchedulers.size).toBe(0);
+    expect(logs.join('\n')).toMatch(/services remain disabled/);
+    expect(existsSync(join(
+      ctxRoot,
+      'state',
+      'bad-codex',
+      'codex-permission-start.claim.json',
+    ))).toBe(false);
+  });
+
+  it('removes a stopped startup-delay seat without allowing a late spawn', async () => {
+    vi.useFakeTimers();
+    const dir = agentDir('slow-agent');
+    const config = {
+      agent_name: 'slow-agent',
+      enabled: true,
+      startup_delay: 30,
+    };
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config));
+    const manager = new AgentManager('test', ctxRoot, frameworkRoot, 'acme');
+
+    const startPromise = manager.startAgent('slow-agent', dir, config, 'acme');
+    await Promise.resolve();
+    expect((manager as any).agents.get('slow-agent').process.getStatus().status)
+      .toBe('starting');
+
+    await manager.stopAgent('slow-agent');
+    expect((manager as any).agents.has('slow-agent')).toBe(false);
+    await vi.advanceTimersByTimeAsync(30_000);
+    await startPromise;
+
+    expect(lifecycle.genericPtyConstructions).toBe(0);
+    expect(lifecycle.checkerStarts).toBe(0);
+    expect(lifecycle.cronMigrations).toBe(0);
+    expect((manager as any).agents.has('slow-agent')).toBe(false);
+  });
+
+  it('preserves approval-gated starts for registry-disabled workers', async () => {
+    vi.useFakeTimers();
+    const dir = agentDir('disabled-agent');
+    const config = { agent_name: 'disabled-agent', enabled: true, startup_delay: 30 };
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config));
+    writeFileSync(
+      join(ctxRoot, 'config', 'enabled-agents.json'),
+      JSON.stringify({ 'disabled-agent': { enabled: false, org: 'acme' } }),
+    );
+    const manager = new AgentManager('test', ctxRoot, frameworkRoot, 'acme');
+
+    const startPromise = manager.startAgent('disabled-agent', dir, config, 'acme');
+    await Promise.resolve();
+
+    expect((manager as any).agents.has('disabled-agent')).toBe(true);
+    expect((manager as any).agents.get('disabled-agent').process.getStatus().status)
+      .toBe('starting');
+    await manager.stopAgent('disabled-agent');
+    await vi.advanceTimersByTimeAsync(30_000);
+    await startPromise;
+    expect(lifecycle.genericPtyConstructions).toBe(0);
+  });
+
+  it('blocks a start only while the dedicated permission-migration hold exists', async () => {
+    const dir = agentDir('held-agent');
+    const config = {
+      agent_name: 'held-agent',
+      runtime: 'codex-app-server' as const,
+      enabled: true,
+    };
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config));
+    const stateDir = join(ctxRoot, 'state', 'held-agent');
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(join(stateDir, 'codex-permission-migration.hold.json'), '{}');
+    const manager = new AgentManager('test', ctxRoot, frameworkRoot, 'acme');
+
+    await manager.startAgent('held-agent', dir, config, 'acme');
+
+    expect((manager as any).agents.has('held-agent')).toBe(false);
+    expect(lifecycle.genericPtyConstructions).toBe(0);
+  });
+
+  it('releases the start claim when synchronous seat setup fails', async () => {
+    const dir = agentDir('setup-failure');
+    const config = {
+      agent_name: 'setup-failure',
+      runtime: 'codex-app-server' as const,
+      enabled: true,
+    };
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config));
+    mkdirSync(join(dir, '.env'));
+    const manager = new AgentManager('test', ctxRoot, frameworkRoot, 'acme');
+
+    await manager.startAgent('setup-failure', dir, config, 'acme');
+
+    expect((manager as any).agents.has('setup-failure')).toBe(false);
+    expect(existsSync(join(
+      ctxRoot,
+      'state',
+      'setup-failure',
+      'codex-permission-start.claim.json',
+    ))).toBe(false);
+  });
+
+  it('recovers a strictly valid start claim owned by a dead daemon', async () => {
+    const dir = agentDir('dead-claim');
+    const config = {
+      agent_name: 'dead-claim',
+      runtime: 'codex-app-server' as const,
+      enabled: true,
+    };
+    writeFileSync(join(dir, 'config.json'), JSON.stringify(config));
+    const stateDir = join(ctxRoot, 'state', 'dead-claim');
+    mkdirSync(stateDir, { recursive: true });
+    writeFileSync(
+      join(stateDir, 'codex-permission-start.claim.json'),
+      `${JSON.stringify({
+        schemaVersion: 'cortextos-codex-permission-start-claim/v1',
+        agent: 'dead-claim',
+        pid: 2_147_483_647,
+        nonce: 'a'.repeat(32),
+      }, null, 2)}\n`,
+      { mode: 0o600 },
+    );
+    const manager = new AgentManager('test', ctxRoot, frameworkRoot, 'acme');
+
+    await manager.startAgent('dead-claim', dir, config, 'acme');
+
+    expect((manager as any).agents.has('dead-claim')).toBe(true);
+    expect(existsSync(join(stateDir, 'codex-permission-start.claim.json'))).toBe(false);
+  });
+});

--- a/tests/unit/daemon/agent-manager-inspect-op.test.ts
+++ b/tests/unit/daemon/agent-manager-inspect-op.test.ts
@@ -12,7 +12,7 @@ vi.mock('../../../src/daemon/agent-process.js', () => ({
     name: string;
     dir: string;
     constructor(name: string, dir: string) { this.name = name; this.dir = dir; }
-    async start() { /* no-op */ }
+    async start() { return { kind: 'started' }; }
     async stop() { /* no-op */ }
     getStatus() { return { name: this.name, status: 'stopped' }; }
     onExit() { /* no-op */ }

--- a/tests/unit/daemon/agent-manager.test.ts
+++ b/tests/unit/daemon/agent-manager.test.ts
@@ -14,7 +14,7 @@ vi.mock('../../../src/daemon/agent-process.js', () => ({
       this.name = name;
       this.dir = dir;
     }
-    async start() { /* no-op */ }
+    async start() { return { kind: 'started' }; }
     async stop() { /* no-op */ }
     getStatus() { return { name: this.name, status: 'stopped' }; }
     onExit() { /* no-op */ }
@@ -105,6 +105,23 @@ describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
     expect(startSpy).toHaveBeenCalledTimes(2);
   });
 
+  it('isolates one malformed seat instead of aborting unrelated agent startup', async () => {
+    const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const startSpy = vi.spyOn(am, 'startAgent').mockImplementation(async (name) => {
+      if (name === 'alice') throw new Error('missing explicit Codex capability profile');
+    });
+
+    await expect(am.discoverAndStart()).resolves.toBeUndefined();
+
+    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(startSpy.mock.calls.map((call) => call[0]).sort()).toEqual(['alice', 'bob']);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Failed to start alice'),
+    );
+    errorSpy.mockRestore();
+  });
+
   it('still respects per-agent config.json enabled: false (existing behavior)', async () => {
     // Per-agent config.json takes precedence — this is the legacy behavior we
     // explicitly preserved in the BUG-028 fix
@@ -123,7 +140,7 @@ describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
     expect(startSpy).toHaveBeenCalledWith('bob', expect.any(String), expect.any(Object), 'acme');
   });
 
-  it('handles corrupt enabled-agents.json by defaulting to enabled-all', async () => {
+  it('fails closed instead of auto-starting when enabled-agents.json is corrupt', async () => {
     writeFileSync(
       join(ctxRoot, 'config', 'enabled-agents.json'),
       'this is not valid json',
@@ -131,11 +148,15 @@ describe('AgentManager.discoverAndStart - BUG-028 fix', () => {
 
     const am = new AgentManager('test-instance', ctxRoot, frameworkRoot, 'acme');
     const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue();
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await am.discoverAndStart();
 
-    // Corrupt file is treated as missing — all discovered agents start
-    expect(startSpy).toHaveBeenCalledTimes(2);
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Refusing automatic discovery'),
+    );
+    errorSpy.mockRestore();
   });
 });
 

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -93,7 +93,7 @@ const mockEnv = {
 
 beforeEach(() => {
   capturedOnExit = null;
-  mockPty.spawn.mockClear();
+  mockPty.spawn.mockReset().mockResolvedValue(undefined);
   mockPty.kill.mockClear();
   mockPty.write.mockClear();
   mockPty.isAlive.mockClear();
@@ -108,6 +108,62 @@ beforeEach(() => {
 });
 
 describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
+  it('tears down the exact retained adapter when a startup attempt is cancelled', async () => {
+    let finishSpawn: (() => void) | null = null;
+    mockPty.spawn.mockImplementationOnce(() => new Promise<void>((resolve) => {
+      finishSpawn = resolve;
+    }));
+    const ap = new AgentProcess('alice', mockEnv, {});
+    const startPromise = ap.start();
+    await Promise.resolve();
+
+    (ap as unknown as { startAttemptGeneration: number }).startAttemptGeneration += 1;
+    finishSpawn!();
+
+    await expect(startPromise).resolves.toEqual({ kind: 'cancelled' });
+    expect(mockPty.kill).toHaveBeenCalledOnce();
+    expect(ap.getStatus().status).toBe('stopped');
+  });
+
+  it('keeps an exit-scheduled recovery authoritative when spawn then rejects', async () => {
+    vi.useFakeTimers();
+    try {
+      mockPty.spawn.mockImplementationOnce(async () => {
+        capturedOnExit!(1, 0);
+        throw new Error('spawn failed after child exit');
+      });
+      const ap = new AgentProcess('alice', mockEnv, {});
+
+      await expect(ap.start()).resolves.toEqual({ kind: 'recovery-pending' });
+      expect(ap.getStatus()).toMatchObject({
+        status: 'crashed',
+        restartScheduled: true,
+      });
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('stop cancels a startup-delay attempt before any PTY can be created', async () => {
+    vi.useFakeTimers();
+    try {
+      const ap = new AgentProcess('alice', mockEnv, { startup_delay: 30 });
+      const startPromise = ap.start();
+      expect(ap.getStatus().status).toBe('starting');
+
+      await ap.stop();
+      expect(ap.getStatus().status).toBe('stopped');
+
+      await vi.advanceTimersByTimeAsync(30_000);
+      await expect(startPromise).resolves.toEqual({ kind: 'cancelled' });
+      expect(mockPty.spawn).not.toHaveBeenCalled();
+      expect(ap.getStatus().status).toBe('stopped');
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('stop() awaits the PTY exit handler before resolving', async () => {
     const ap = new AgentProcess('alice', mockEnv, {});
     await ap.start();

--- a/tests/unit/pty/codex-app-server-pty.test.ts
+++ b/tests/unit/pty/codex-app-server-pty.test.ts
@@ -76,6 +76,15 @@ const mockEnv = {
   projectRoot: '/tmp/fw',
 };
 
+const credentialSecretPath = '/tmp/command-center/brain/.env';
+const secureConfig = {
+  codex_credential_deny_paths: [credentialSecretPath],
+};
+
+function permissionProfileId(pty: InstanceType<typeof CodexAppServerPTY>): string {
+  return (pty as unknown as { _permissionProfileId: string })._permissionProfileId;
+}
+
 beforeEach(() => {
   fsMocks.existsSync.mockReset().mockReturnValue(false);
   fsMocks.readFileSync.mockReset();
@@ -93,7 +102,7 @@ beforeEach(() => {
 
 describe('CodexAppServerPTY socket path policy', () => {
   it('uses codex.sock in the agent state dir by default', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     expect((pty as unknown as { _socketPath: string })._socketPath).toBe('/tmp/ctx/state/codex-app-agent/codex.sock');
     expect((pty as unknown as { _socketListenArg: string })._socketListenArg).toBe('unix://./codex.sock');
   });
@@ -103,8 +112,11 @@ describe('CodexAppServerPTY socket path policy', () => {
       ...mockEnv,
       ctxRoot: `/tmp/${'x'.repeat(120)}`,
     };
-    const pty = new CodexAppServerPTY(longEnv, {});
+    const pty = new CodexAppServerPTY(longEnv, secureConfig);
     const socketPath = (pty as unknown as { _socketPath: string })._socketPath;
+    const profileId = permissionProfileId(pty);
+    const args = (pty as unknown as { _permissionProfileConfigArgs: string[] })._permissionProfileConfigArgs;
+    const overrides = args.filter((_, index) => index % 2 === 1);
     expect(socketPath).toMatch(/\/cas-[a-f0-9]{8}\.sock$/);
     expect((pty as unknown as { _socketListenArg: string })._socketListenArg).toMatch(/^unix:\/\/\.\/cas-[a-f0-9]{8}\.sock$/);
     expect((pty as unknown as { _socketCwd: string })._socketCwd).toBe('/tmp');
@@ -113,12 +125,99 @@ describe('CodexAppServerPTY socket path policy', () => {
       expect.stringContaining('"fallback": true'),
       'utf-8',
     );
+    expect(overrides).toContain(
+      `permissions.${profileId}.filesystem.${JSON.stringify(socketPath)}=\"deny\"`,
+    );
+    expect(overrides).toContain(
+      `permissions.${profileId}.network.unix_sockets.${JSON.stringify(socketPath)}=\"deny\"`,
+    );
+  });
+});
+
+describe('CodexAppServerPTY permission profile policy', () => {
+  it.each([
+    undefined,
+    [],
+    ['relative/brain/.env'],
+    ['/tmp/../brain/.env'],
+    [''],
+    [' /tmp/brain/.env'],
+    ['/tmp/brain/.env\0suffix'],
+    [42],
+  ])('rejects a missing or malformed absolute credential deny list before RPC setup: %j', (paths) => {
+    expect(() => new CodexAppServerPTY(mockEnv, {
+      codex_credential_deny_paths: paths,
+    })).toThrow(/codex_credential_deny_paths/);
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it('compiles a unique named workspace profile with exact secret and control-socket denies', () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const secondPty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const profileId = permissionProfileId(pty);
+    const socketPath = '/tmp/ctx/state/codex-app-agent/codex.sock';
+    const args = (pty as unknown as { _permissionProfileConfigArgs: string[] })._permissionProfileConfigArgs;
+    const overrides = args.filter((_, index) => index % 2 === 1);
+
+    expect(profileId).toMatch(/^cortextos-fleet-[a-f0-9]{16}$/);
+    expect(permissionProfileId(secondPty)).not.toBe(profileId);
+    expect(overrides).toContain(`permissions.${profileId}.extends=\":workspace\"`);
+    expect(overrides).toContain(`permissions.${profileId}.filesystem.${JSON.stringify(credentialSecretPath)}=\"deny\"`);
+    expect(overrides).toContain(`permissions.${profileId}.filesystem.${JSON.stringify(socketPath)}=\"deny\"`);
+    expect(overrides).toContain(`permissions.${profileId}.network.unix_sockets.${JSON.stringify(socketPath)}=\"deny\"`);
+    expect(overrides).toContain(`permissions.${profileId}.network.enabled=true`);
+    expect(overrides).toContain(`permissions.${profileId}.network.domains.\"*\"=\"allow\"`);
+    expect(JSON.stringify(args)).not.toMatch(/danger-full-access|dangerFullAccess|sandbox_mode/);
+  });
+
+  it.each([
+    { entries: [], expected: /not available/ },
+    { entries: [{ id: 'PROFILE_ID', allowed: false }], expected: /not allowed/ },
+  ])('fails closed when the provisioned named profile is missing or disallowed', async ({ entries, expected }) => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const profileId = permissionProfileId(pty);
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+    requestMock.mockResolvedValue({
+      result: {
+        data: entries.map((entry) => ({
+          ...entry,
+          id: entry.id === 'PROFILE_ID' ? profileId : entry.id,
+        })),
+        nextCursor: null,
+      },
+    });
+
+    await expect((pty as unknown as { verifyPermissionProfileAvailable(): Promise<void> })
+      .verifyPermissionProfileAvailable()).rejects.toThrow(expected);
+    expect(requestMock).toHaveBeenCalledWith('permissionProfile/list', {
+      cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
+    });
+  });
+
+  it('spawns app-server with strict generated config and no danger override', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const spawn = vi.fn().mockReturnValue({
+      pid: 88,
+      write: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      kill: vi.fn(),
+    });
+    (pty as unknown as { _spawnFn: typeof spawn })._spawnFn = spawn;
+    fsMocks.existsSync.mockReturnValue(true);
+
+    await (pty as unknown as { startAppServer(): Promise<void> }).startAppServer();
+
+    const args = spawn.mock.calls[0][1] as string[];
+    expect(args).toContain('--strict-config');
+    expect(args.some((arg) => arg.includes(permissionProfileId(pty)))).toBe(true);
+    expect(JSON.stringify(args)).not.toMatch(/danger-full-access|dangerFullAccess|sandbox_mode/);
   });
 });
 
 describe('CodexAppServerPTY command mapping', () => {
   function makeReadyPty() {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _alive: boolean })._alive = true;
     (pty as unknown as { _threadId: string })._threadId = 'thread-1';
     (pty as unknown as { _rpc: { request: typeof requestMock; respondError: typeof respondErrorMock } })._rpc = {
@@ -286,7 +385,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
         { type: 'text', text: 'make a logo', text_elements: [] },
       ],
       approvalPolicy: 'never',
-      sandboxPolicy: { type: 'dangerFullAccess' },
+      permissions: permissionProfileId(pty),
     });
   });
 
@@ -316,7 +415,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
         { type: 'text', text: 'make a logo', text_elements: [] },
       ],
       approvalPolicy: 'never',
-      sandboxPolicy: { type: 'dangerFullAccess' },
+      permissions: permissionProfileId(pty),
     });
 
     (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
@@ -348,7 +447,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
       threadId: 'thread-1',
       input: [{ type: 'skill', name: 'heartbeat', path: '/h.md' }],
       approvalPolicy: 'never',
-      sandboxPolicy: { type: 'dangerFullAccess' },
+      permissions: permissionProfileId(pty),
     });
   });
 
@@ -404,7 +503,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
         { type: 'text', text: 'extra context here', text_elements: [] },
       ],
       approvalPolicy: 'never',
-      sandboxPolicy: { type: 'dangerFullAccess' },
+      permissions: permissionProfileId(pty),
     });
   });
 
@@ -453,7 +552,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
       threadId: 'thread-1',
       input: [{ type: 'skill', name: 'heartbeat', path: '/h.md' }],
       approvalPolicy: 'never',
-      sandboxPolicy: { type: 'dangerFullAccess' },
+      permissions: permissionProfileId(pty),
     });
   });
 
@@ -471,7 +570,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
       threadId: 'thread-1',
       input: [{ type: 'text', text: 'first', text_elements: [] }],
       approvalPolicy: 'never',
-      sandboxPolicy: { type: 'dangerFullAccess' },
+      permissions: permissionProfileId(pty),
     });
 
     pty.write('second');
@@ -488,7 +587,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
       threadId: 'thread-1',
       input: [{ type: 'text', text: 'second', text_elements: [] }],
       approvalPolicy: 'never',
-      sandboxPolicy: { type: 'dangerFullAccess' },
+      permissions: permissionProfileId(pty),
     });
 
     internals.handleRpcMessage({ method: 'turn/completed', params: {} });
@@ -497,7 +596,7 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
 
 describe('CodexAppServerPTY mid-turn steer', () => {
   function makeReadyPty() {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _alive: boolean })._alive = true;
     (pty as unknown as { _threadId: string })._threadId = 'thread-1';
     (pty as unknown as { _rpc: { request: typeof requestMock; respondError: typeof respondErrorMock } })._rpc = {
@@ -684,14 +783,14 @@ describe('CodexAppServerPTY extractTelegramPayload media types', () => {
   function extract(content: string, options?: { existsSync?: boolean; readFileSync?: string }): string | null {
     if (options?.existsSync !== undefined) fsMocks.existsSync.mockReturnValue(options.existsSync);
     if (options?.readFileSync !== undefined) fsMocks.readFileSync.mockReturnValue(options.readFileSync);
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const result = (pty as unknown as {
       extractTelegramPayload(c: string): { payload: string; replyDirective: string | null } | null;
     }).extractTelegramPayload(content);
     return result?.payload ?? null;
   }
   function extractWithDirective(content: string): { payload: string; replyDirective: string | null } | null {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     return (pty as unknown as {
       extractTelegramPayload(c: string): { payload: string; replyDirective: string | null } | null;
     }).extractTelegramPayload(content);
@@ -971,8 +1070,11 @@ Reply using: cortextos bus send-telegram 7940429114 '<your reply>'
 
 describe('CodexAppServerPTY thread lifecycle', () => {
   it('starts a new thread in fresh mode', async () => {
-    requestMock.mockResolvedValue({ result: { thread: { id: 'fresh-thread' } } });
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const profileId = permissionProfileId(pty);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'fresh-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
+    });
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('fresh');
@@ -980,7 +1082,7 @@ describe('CodexAppServerPTY thread lifecycle', () => {
     expect(requestMock).toHaveBeenCalledWith('thread/start', {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       approvalPolicy: 'never',
-      sandbox: 'danger-full-access',
+      permissions: profileId,
       config: { features: { goals: true } },
       sessionStartSource: 'startup',
       experimentalRawEvents: false,
@@ -1000,8 +1102,11 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       updatedAt: '2026-05-07T00:00:00Z',
     }));
-    requestMock.mockResolvedValue({ result: { thread: { id: 'persisted-thread' } } });
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const profileId = permissionProfileId(pty);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'persisted-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
+    });
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('continue');
@@ -1010,7 +1115,7 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       threadId: 'persisted-thread',
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       approvalPolicy: 'never',
-      sandbox: 'danger-full-access',
+      permissions: profileId,
       config: { features: { goals: true } },
       excludeTurns: true,
       persistExtendedHistory: true,
@@ -1024,8 +1129,11 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       updatedAt: '2026-05-07T00:00:00Z',
     }));
-    requestMock.mockResolvedValue({ result: { thread: { id: 'new-fresh-thread' } } });
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const profileId = permissionProfileId(pty);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'new-fresh-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
+    });
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('fresh');
@@ -1034,7 +1142,7 @@ describe('CodexAppServerPTY thread lifecycle', () => {
     expect(requestMock).toHaveBeenCalledWith('thread/start', {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       approvalPolicy: 'never',
-      sandbox: 'danger-full-access',
+      permissions: profileId,
       config: { features: { goals: true } },
       sessionStartSource: 'startup',
       experimentalRawEvents: false,
@@ -1050,17 +1158,115 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       'utf-8',
     );
   });
+
+  it('rejects a start response whose returned active profile does not match', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'unsafe-thread' }, activePermissionProfile: { id: ':danger-full-access', extends: null } },
+    });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/active permission profile mismatch/);
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('codex-app-server-thread.json'),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('rejects a start response that omits the returned active profile', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'profileless-thread' } },
+    });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/active permission profile mismatch.*none/);
+    expect(requestMock.mock.calls.map(([method]) => method)).toEqual(['thread/start']);
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalledWith(
+      expect.stringContaining('codex-app-server-thread.json'),
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+
+  it('does not downgrade or fall back when a persisted resume returns the wrong profile', async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readFileSync.mockReturnValue(JSON.stringify({
+      threadId: 'persisted-thread',
+      cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
+      updatedAt: '2026-05-07T00:00:00Z',
+    }));
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'persisted-thread' }, activePermissionProfile: { id: ':workspace', extends: null } },
+    });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'continue'): Promise<void> })
+      .startOrResumeThread('continue')).rejects.toThrow(/active permission profile mismatch/);
+    expect(requestMock.mock.calls.map(([method]) => method)).toEqual(['thread/resume']);
+  });
+
+  it('does not downgrade or fall back when a persisted resume omits the returned active profile', async () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readFileSync.mockReturnValue(JSON.stringify({
+      threadId: 'persisted-thread',
+      cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
+      updatedAt: '2026-05-07T00:00:00Z',
+    }));
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'persisted-thread' } },
+    });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'continue'): Promise<void> })
+      .startOrResumeThread('continue')).rejects.toThrow(/active permission profile mismatch.*none/);
+    expect(requestMock.mock.calls.map(([method]) => method)).toEqual(['thread/resume']);
+  });
+
+  it('never emits legacy sandbox payloads on thread or turn RPCs', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const profileId = permissionProfileId(pty);
+    requestMock.mockResolvedValue({
+      result: { thread: { id: 'safe-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
+    });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await (pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> }).startOrResumeThread('fresh');
+    const turn = (pty as unknown as { startTurn(input: unknown[]): Promise<void> })
+      .startTurn([{ type: 'text', text: 'safe', text_elements: [] }]);
+    await Promise.resolve();
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'turn/completed',
+      params: { threadId: 'safe-thread', turn: { id: 'turn-1' } },
+    });
+    await turn;
+
+    expect(requestMock).toHaveBeenCalledWith('turn/start', {
+      threadId: 'safe-thread',
+      input: [{ type: 'text', text: 'safe', text_elements: [] }],
+      approvalPolicy: 'never',
+      permissions: profileId,
+    });
+    expect(JSON.stringify(requestMock.mock.calls)).not.toMatch(
+      /danger-full-access|dangerFullAccess|sandboxPolicy|\"sandbox\"/,
+    );
+  });
 });
 
 describe('CodexAppServerPTY event handling', () => {
   it('bootstraps on the app-server ready marker', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     pty.getOutputBuffer().push('[codex-app-server] ready thread=abc\n');
     expect(pty.getOutputBuffer().isBootstrapped()).toBe(true);
   });
 
   it('responds with an error for unsupported server requests', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _rpc: { respondError: typeof respondErrorMock } })._rpc = { respondError: respondErrorMock };
     (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
       id: 7,
@@ -1085,7 +1291,7 @@ describe('CodexAppServerPTY event handling', () => {
   });
 
   it('fires Telegram typing from streamed assistant deltas', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const api = { sendChatAction: vi.fn().mockResolvedValue(undefined) };
     pty.setTelegramHandle(api as unknown as Parameters<typeof pty.setTelegramHandle>[0], '12345');
     (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
@@ -1097,9 +1303,45 @@ describe('CodexAppServerPTY event handling', () => {
   });
 
   it('registers a message handler when connecting RPC', async () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     await (pty as unknown as { connectRpc(): Promise<void> }).connectRpc();
     expect(messageHandler).not.toBeNull();
+  });
+
+  it('fails closed if a settings update reports a different active profile', () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    (pty as unknown as { _alive: boolean; _threadId: string })._alive = true;
+    (pty as unknown as { _threadId: string })._threadId = 'thread-1';
+
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'thread/settings/updated',
+      params: {
+        threadId: 'thread-1',
+        threadSettings: { activePermissionProfile: { id: ':workspace', extends: null } },
+      },
+    });
+
+    expect(pty.isAlive()).toBe(false);
+    expect(pty.getOutputBuffer().getRecent()).toContain('active permission profile mismatch');
+  });
+
+  it('fails closed with no fallback if a settings update omits the active profile', () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    (pty as unknown as { _alive: boolean; _threadId: string })._alive = true;
+    (pty as unknown as { _threadId: string })._threadId = 'thread-1';
+
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'thread/settings/updated',
+      params: {
+        threadId: 'thread-1',
+        threadSettings: {},
+      },
+    });
+
+    expect(pty.isAlive()).toBe(false);
+    expect(pty.getOutputBuffer().getRecent()).toContain('active permission profile mismatch');
+    expect(pty.getOutputBuffer().getRecent()).toContain('got none');
+    expect(requestMock).not.toHaveBeenCalled();
   });
 });
 
@@ -1118,7 +1360,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   }
 
   it('writes context_status.json atomically with computed used_percentage', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 5000, inputTokens: 60000, outputTokens: 4000, reasoningOutputTokens: 1000, totalTokens: 70000 },
@@ -1144,7 +1386,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('falls back to default 256000 cap when modelContextWindow is null', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 64000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 64000 },
@@ -1158,7 +1400,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('honours codex_context_cap config override when modelContextWindow is null', () => {
-    const pty = new CodexAppServerPTY(mockEnv, { codex_context_cap: 100000 });
+    const pty = new CodexAppServerPTY(mockEnv, { ...secureConfig, codex_context_cap: 100000 });
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 50000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 50000 },
@@ -1172,7 +1414,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('flags exceeds_200k_tokens once total > 200k', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 210000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 210000 },
@@ -1185,7 +1427,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('clamps used_percentage to 100 when totals exceed cap', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 300000, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 300000 },
@@ -1198,7 +1440,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('uses current-window last tokens instead of lifetime total tokens', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 30000, inputTokens: 80000, outputTokens: 2000, reasoningOutputTokens: 0, totalTokens: 82000 },
@@ -1218,7 +1460,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('writes null used_percentage instead of false-100 when current-window data is missing', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       total: { cachedInputTokens: 312000000, inputTokens: 323000000, outputTokens: 880000, reasoningOutputTokens: 0, totalTokens: 324000000 },
@@ -1237,7 +1479,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('skips the write when params.tokenUsage is missing', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
       method: 'thread/tokenUsage/updated',
@@ -1247,7 +1489,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('writes null used_percentage when total.totalTokens is missing', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1258,7 +1500,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
   });
 
   it('still emits the event log line even on a successful context write', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1270,7 +1512,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → context_status.json', 
 
   it('does not throw when atomicWriteSync rejects (write failure is non-fatal)', () => {
     atomicWriteSyncMock.mockImplementationOnce(() => { throw new Error('disk full'); });
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     expect(() => feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1300,7 +1542,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
   }
 
   it('appends a JSONL line to <ctxRoot>/logs/<agent>/codex-tokens.jsonl on tokenUsage', () => {
-    const pty = new CodexAppServerPTY(mockEnv, { model: 'gpt-5-codex' });
+    const pty = new CodexAppServerPTY(mockEnv, { ...secureConfig, model: 'gpt-5-codex' });
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1325,7 +1567,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
   });
 
   it('defaults model to gpt-5-codex when config.model is unset', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1338,7 +1580,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
   });
 
   it('preserves config.model override when set', () => {
-    const pty = new CodexAppServerPTY(mockEnv, { model: 'gpt-5-codex-preview' });
+    const pty = new CodexAppServerPTY(mockEnv, { ...secureConfig, model: 'gpt-5-codex-preview' });
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1351,7 +1593,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
   });
 
   it('skips append when turnId is missing', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1363,7 +1605,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
   });
 
   it('skips append when threadId has not been set', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
       total: { cachedInputTokens: 0, inputTokens: 100, outputTokens: 50, reasoningOutputTokens: 0, totalTokens: 150 },
@@ -1374,7 +1616,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
   });
 
   it('skips append when params.tokenUsage is missing', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
       method: 'thread/tokenUsage/updated',
@@ -1384,7 +1626,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
   });
 
   it('produces a separate JSONL line per turn (no implicit dedup at writer)', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1407,7 +1649,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
 
   it('does not throw when appendFileSync rejects (cost logging is non-fatal)', () => {
     fsMocks.appendFileSync.mockImplementationOnce(() => { throw new Error('disk full'); });
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _threadId: string })._threadId = 'thread-9';
     expect(() => feedTokenUsage(pty, {
       last: { cachedInputTokens: 0, inputTokens: 0, outputTokens: 0, reasoningOutputTokens: 0, totalTokens: 0 },
@@ -1419,7 +1661,7 @@ describe('CodexAppServerPTY thread/tokenUsage/updated → codex-tokens.jsonl', (
 
 describe('CodexAppServerPTY buildMediaPayload — dynamic fence parsing', () => {
   it('extracts a caption wrapped in a dynamically-sized (4-backtick) fence', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     // wrapFenceSafe grows the fence to 4 backticks when the caption contains ```;
     // the consumer must match the same fence length, not a hard-coded ```.
     const beforeReply = [
@@ -1436,7 +1678,7 @@ describe('CodexAppServerPTY buildMediaPayload — dynamic fence parsing', () => 
   });
 
   it('still extracts a caption in a plain 3-backtick fence', () => {
-    const pty = new CodexAppServerPTY(mockEnv, {});
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const beforeReply = '=== TELEGRAM PHOTO from Bob (chat_id:2) ===\ncaption:\n```\nhello\n```\nlocal_file: /tmp/x.jpg';
     const payload = (pty as unknown as { buildMediaPayload(t: string, b: string): string | null })
       .buildMediaPayload('PHOTO', beforeReply);

--- a/tests/unit/pty/codex-app-server-pty.test.ts
+++ b/tests/unit/pty/codex-app-server-pty.test.ts
@@ -97,6 +97,7 @@ const secureConfig = {
   codex_writable_paths: ['/tmp/fw/role-work'],
   codex_readonly_paths: ['/tmp/fw/role-work/AGENTS.md'],
   codex_network_allow_domains: [],
+  codex_web_search_enabled: false,
   codex_env_allowlist: ['CC_AGENT_ACTION_TOKEN'],
   codex_mcp_allowlist: [],
 };
@@ -323,6 +324,8 @@ describe('CodexAppServerPTY permission profile policy', () => {
     [{ ...secureConfig, codex_network_allow_domains: undefined }, /codex_network_allow_domains/],
     [{ ...secureConfig, codex_network_allow_domains: ['*'] }, /codex_network_allow_domains/],
     [{ ...secureConfig, codex_network_allow_domains: ['127.0.0.1:8091'] }, /must remain empty/],
+    [{ ...secureConfig, codex_web_search_enabled: undefined }, /codex_web_search_enabled/],
+    [{ ...secureConfig, codex_web_search_enabled: 'yes' }, /codex_web_search_enabled/],
     [{ ...secureConfig, codex_env_allowlist: undefined }, /codex_env_allowlist/],
     [{ ...secureConfig, codex_env_allowlist: ['PATH'] }, /codex_env_allowlist/],
     [{ ...secureConfig, codex_env_allowlist: ['CTX_ROOT'] }, /codex_env_allowlist/],
@@ -556,12 +559,43 @@ describe('CodexAppServerPTY permission profile policy', () => {
 
     const args = spawn.mock.calls[0][1] as string[];
     expect(args).toContain('--strict-config');
+    expect(args).not.toContain('--search');
     for (const feature of ['apps', 'plugins', 'browser_use', 'computer_use', 'in_app_browser', 'image_generation']) {
       expect(args).toContain(feature);
     }
     expect(args).toContain('mcp_servers={\"ambient-host-server\"={enabled=false}}');
     expect(args.some((arg) => arg.includes(permissionProfileId(pty)))).toBe(true);
     expect(JSON.stringify(args)).not.toMatch(/danger-full-access|dangerFullAccess|sandbox_mode/);
+  });
+
+  it('enables native read-only web search without enabling raw profile network', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: '[]',
+      stderr: '',
+      error: undefined,
+    });
+    const pty = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_web_search_enabled: true,
+    });
+    const spawn = vi.fn().mockReturnValue({
+      pid: 88,
+      write: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+      kill: vi.fn(),
+    });
+    (pty as unknown as { _spawnFn: typeof spawn; _alive: boolean })._spawnFn = spawn;
+    (pty as unknown as { _alive: boolean })._alive = true;
+    fsMocks.existsSync.mockReturnValue(true);
+
+    await (pty as unknown as { startAppServer(): Promise<void> }).startAppServer();
+
+    const args = spawn.mock.calls[0][1] as string[];
+    expect(args.slice(0, 2)).toEqual(['--search', 'app-server']);
+    const overrides = args.filter((arg) => arg.startsWith('permissions.'));
+    expect(overrides.some((arg) => /\.network\.enabled=false$/.test(arg))).toBe(true);
   });
 
   it('cleans private temp and socket state on an unexpected app-server exit', async () => {

--- a/tests/unit/pty/codex-app-server-pty.test.ts
+++ b/tests/unit/pty/codex-app-server-pty.test.ts
@@ -6,6 +6,11 @@ const fsMocks = {
   writeFileSync: vi.fn(),
   unlinkSync: vi.fn(),
   appendFileSync: vi.fn(),
+  chmodSync: vi.fn(),
+  lstatSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  rmSync: vi.fn(),
 };
 
 vi.mock('fs', async () => {
@@ -17,14 +22,24 @@ vi.mock('fs', async () => {
     get writeFileSync() { return fsMocks.writeFileSync; },
     get unlinkSync() { return fsMocks.unlinkSync; },
     get appendFileSync() { return fsMocks.appendFileSync; },
+    get chmodSync() { return fsMocks.chmodSync; },
+    get lstatSync() { return fsMocks.lstatSync; },
+    get mkdirSync() { return fsMocks.mkdirSync; },
+    get readdirSync() { return fsMocks.readdirSync; },
+    get rmSync() { return fsMocks.rmSync; },
   };
 });
 
 const atomicWriteSyncMock = vi.fn();
+const spawnSyncMock = vi.fn();
 
 vi.mock('../../../src/utils/atomic.js', () => ({
   ensureDir: vi.fn(),
   atomicWriteSync: atomicWriteSyncMock,
+}));
+
+vi.mock('child_process', () => ({
+  spawnSync: spawnSyncMock,
 }));
 
 vi.mock('node-pty', () => ({
@@ -79,10 +94,36 @@ const mockEnv = {
 const credentialSecretPath = '/tmp/command-center/brain/.env';
 const secureConfig = {
   codex_credential_deny_paths: [credentialSecretPath],
+  codex_writable_paths: ['/tmp/fw/role-work'],
+  codex_readonly_paths: ['/tmp/fw/role-work/AGENTS.md'],
+  codex_network_allow_domains: [],
+  codex_env_allowlist: ['CC_AGENT_ACTION_TOKEN'],
+  codex_mcp_allowlist: [],
 };
 
 function permissionProfileId(pty: InstanceType<typeof CodexAppServerPTY>): string {
   return (pty as unknown as { _permissionProfileId: string })._permissionProfileId;
+}
+
+function effectiveWritablePaths(pty: InstanceType<typeof CodexAppServerPTY>): string[] {
+  return (pty as unknown as { _writablePaths: string[] })._writablePaths;
+}
+
+function safeThreadResult(
+  pty: InstanceType<typeof CodexAppServerPTY>,
+  threadId: string,
+) {
+  return {
+    thread: { id: threadId },
+    activePermissionProfile: { id: permissionProfileId(pty), extends: ':read-only' },
+    sandbox: {
+      type: 'workspaceWrite',
+      writableRoots: effectiveWritablePaths(pty),
+      networkAccess: false,
+      excludeTmpdirEnvVar: false,
+      excludeSlashTmp: true,
+    },
+  };
 }
 
 beforeEach(() => {
@@ -91,16 +132,99 @@ beforeEach(() => {
   fsMocks.writeFileSync.mockReset();
   fsMocks.unlinkSync.mockReset();
   fsMocks.appendFileSync.mockReset();
+  fsMocks.chmodSync.mockReset();
+  fsMocks.lstatSync.mockReset().mockReturnValue({
+    isSymbolicLink: () => false,
+    isDirectory: () => true,
+    isFile: () => false,
+    nlink: 1,
+  });
+  fsMocks.mkdirSync.mockReset();
+  fsMocks.readdirSync.mockReset().mockReturnValue([]);
+  fsMocks.rmSync.mockReset();
   requestMock.mockReset();
   notifyMock.mockReset();
   closeMock.mockReset();
   respondErrorMock.mockReset();
   logEventMock.mockReset();
   atomicWriteSyncMock.mockReset();
+  spawnSyncMock.mockReset().mockReturnValue({
+    status: 0,
+    stdout: '[]',
+    stderr: '',
+    error: undefined,
+  });
   messageHandler = null;
 });
 
 describe('CodexAppServerPTY socket path policy', () => {
+  it('does not launch a replacement app-server after kill cancels retry backoff', async () => {
+    vi.useFakeTimers();
+    let start: ReturnType<typeof vi.spyOn> | null = null;
+    try {
+      const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+      const internals = pty as unknown as {
+        _alive: boolean;
+        startAppServer(): Promise<void>;
+        startAppServerWithRetry(): Promise<void>;
+      };
+      internals._alive = true;
+      start = vi.spyOn(internals, 'startAppServer')
+        .mockRejectedValueOnce(new Error('first attempt failed'))
+        .mockResolvedValue(undefined);
+
+      const retry = internals.startAppServerWithRetry();
+      const result = retry.then(
+        () => null,
+        (err: unknown) => err as Error,
+      );
+      await Promise.resolve();
+      pty.kill();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      expect((await result)?.message).toMatch(/startup was cancelled/);
+      expect(start).toHaveBeenCalledOnce();
+    } finally {
+      start?.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
+  it('still retries an unexpected app-server exit that was not an operator cancellation', async () => {
+    vi.useFakeTimers();
+    let start: ReturnType<typeof vi.spyOn> | null = null;
+    let prepareTemp: ReturnType<typeof vi.spyOn> | null = null;
+    try {
+      const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+      const internals = pty as unknown as {
+        _alive: boolean;
+        preparePrivateModelTempDir(): void;
+        startAppServer(): Promise<void>;
+        startAppServerWithRetry(): Promise<void>;
+      };
+      internals._alive = true;
+      prepareTemp = vi.spyOn(internals, 'preparePrivateModelTempDir');
+      start = vi.spyOn(internals, 'startAppServer')
+        .mockImplementationOnce(async () => {
+          internals._alive = false;
+          throw new Error('child exited');
+        })
+        .mockResolvedValue(undefined);
+
+      const retry = internals.startAppServerWithRetry();
+      await Promise.resolve();
+      await vi.advanceTimersByTimeAsync(1_000);
+
+      await expect(retry).resolves.toBeUndefined();
+      expect(start).toHaveBeenCalledTimes(2);
+      expect(prepareTemp).toHaveBeenCalledTimes(2);
+    } finally {
+      prepareTemp?.mockRestore();
+      start?.mockRestore();
+      vi.useRealTimers();
+    }
+  });
+
   it('uses codex.sock in the agent state dir by default', () => {
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     expect((pty as unknown as { _socketPath: string })._socketPath).toBe('/tmp/ctx/state/codex-app-agent/codex.sock');
@@ -125,16 +249,30 @@ describe('CodexAppServerPTY socket path policy', () => {
       expect.stringContaining('"fallback": true'),
       'utf-8',
     );
+    expect(overrides.find((value) => value.startsWith(`permissions.${profileId}.filesystem=`)))
+      .toContain(`${JSON.stringify(socketPath)}=\"deny\"`);
     expect(overrides).toContain(
-      `permissions.${profileId}.filesystem.${JSON.stringify(socketPath)}=\"deny\"`,
-    );
-    expect(overrides).toContain(
-      `permissions.${profileId}.network.unix_sockets.${JSON.stringify(socketPath)}=\"deny\"`,
+      `permissions.${profileId}.network.unix_sockets={${JSON.stringify(socketPath)}=\"deny\"}`,
     );
   });
 });
 
 describe('CodexAppServerPTY permission profile policy', () => {
+  it('rejects a hard-linked read-only control file before RPC setup', () => {
+    const readonlyPath = secureConfig.codex_readonly_paths[0];
+    fsMocks.existsSync.mockImplementation((path) => path === readonlyPath);
+    fsMocks.lstatSync.mockReturnValue({
+      isSymbolicLink: () => false,
+      isDirectory: () => false,
+      isFile: () => true,
+      nlink: 2,
+    });
+
+    expect(() => new CodexAppServerPTY(mockEnv, secureConfig))
+      .toThrow(/codex_readonly_paths contains a hard-linked file/);
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
   it.each([
     undefined,
     [],
@@ -151,7 +289,53 @@ describe('CodexAppServerPTY permission profile policy', () => {
     expect(requestMock).not.toHaveBeenCalled();
   });
 
-  it('compiles a unique named workspace profile with exact secret and control-socket denies', () => {
+  it.each([
+    [{ ...secureConfig, codex_writable_paths: undefined }, /codex_writable_paths/],
+    [{ ...secureConfig, codex_writable_paths: ['relative'] }, /codex_writable_paths/],
+    [{
+      ...secureConfig,
+      codex_credential_deny_paths: ['/tmp/denied'],
+      codex_writable_paths: ['/tmp/denied/child'],
+    }, /must not equal or descend/],
+    [{ ...secureConfig, codex_readonly_paths: undefined }, /codex_readonly_paths/],
+    [{ ...secureConfig, codex_readonly_paths: ['relative'] }, /codex_readonly_paths/],
+    [{
+      ...secureConfig,
+      codex_credential_deny_paths: ['/tmp/denied'],
+      codex_readonly_paths: ['/tmp/denied/child'],
+    }, /must not equal or descend/],
+    [{
+      ...secureConfig,
+      codex_readonly_paths: ['/tmp/role-policy'],
+      codex_writable_paths: ['/tmp/role-policy/output'],
+    }, /must not equal or descend/],
+    [{
+      ...secureConfig,
+      codex_writable_paths: ['/tmp/role-work'],
+      codex_readonly_paths: ['/tmp/role-work/nested/AGENTS.md'],
+    }, /renameable writable intermediate/],
+    [{
+      ...secureConfig,
+      codex_credential_deny_paths: ['/tmp/role-work/nested/secret.env'],
+      codex_writable_paths: ['/tmp/role-work'],
+      codex_readonly_paths: [],
+    }, /renameable writable intermediate/],
+    [{ ...secureConfig, codex_network_allow_domains: undefined }, /codex_network_allow_domains/],
+    [{ ...secureConfig, codex_network_allow_domains: ['*'] }, /codex_network_allow_domains/],
+    [{ ...secureConfig, codex_network_allow_domains: ['127.0.0.1:8091'] }, /must remain empty/],
+    [{ ...secureConfig, codex_env_allowlist: undefined }, /codex_env_allowlist/],
+    [{ ...secureConfig, codex_env_allowlist: ['PATH'] }, /codex_env_allowlist/],
+    [{ ...secureConfig, codex_env_allowlist: ['CTX_ROOT'] }, /codex_env_allowlist/],
+    [{ ...secureConfig, codex_env_allowlist: ['DYLD_INSERT_LIBRARIES'] }, /codex_env_allowlist/],
+    [{ ...secureConfig, codex_env_allowlist: ['NODE_OPTIONS'] }, /codex_env_allowlist/],
+    [{ ...secureConfig, codex_env_allowlist: ['HTTPS_PROXY'] }, /codex_env_allowlist/],
+    [{ ...secureConfig, codex_mcp_allowlist: undefined }, /codex_mcp_allowlist/],
+    [{ ...secureConfig, codex_mcp_allowlist: [' bad '] }, /codex_mcp_allowlist/],
+  ])('rejects malformed explicit role capability policy: %j', (config, expected) => {
+    expect(() => new CodexAppServerPTY(mockEnv, config)).toThrow(expected);
+  });
+
+  it('compiles a unique read-only-base profile with broad role-work writes and exact control-plane denies', () => {
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const secondPty = new CodexAppServerPTY(mockEnv, secureConfig);
     const profileId = permissionProfileId(pty);
@@ -161,12 +345,21 @@ describe('CodexAppServerPTY permission profile policy', () => {
 
     expect(profileId).toMatch(/^cortextos-fleet-[a-f0-9]{16}$/);
     expect(permissionProfileId(secondPty)).not.toBe(profileId);
-    expect(overrides).toContain(`permissions.${profileId}.extends=\":workspace\"`);
-    expect(overrides).toContain(`permissions.${profileId}.filesystem.${JSON.stringify(credentialSecretPath)}=\"deny\"`);
-    expect(overrides).toContain(`permissions.${profileId}.filesystem.${JSON.stringify(socketPath)}=\"deny\"`);
-    expect(overrides).toContain(`permissions.${profileId}.network.unix_sockets.${JSON.stringify(socketPath)}=\"deny\"`);
-    expect(overrides).toContain(`permissions.${profileId}.network.enabled=true`);
-    expect(overrides).toContain(`permissions.${profileId}.network.domains.\"*\"=\"allow\"`);
+    expect(overrides).toContain(`permissions.${profileId}.extends=\":read-only\"`);
+    const filesystem = overrides.find((value) => value.startsWith(`permissions.${profileId}.filesystem=`));
+    expect(filesystem).toContain(`${JSON.stringify(credentialSecretPath)}=\"deny\"`);
+    expect(filesystem).toContain(`${JSON.stringify(socketPath)}=\"deny\"`);
+    expect(filesystem).toContain(`${JSON.stringify('/tmp/fw/role-work')}=\"write\"`);
+    expect(filesystem).toContain(`${JSON.stringify('/tmp/ctx/state/codex-app-agent/model-tmp')}=\"write\"`);
+    expect(filesystem).toContain(`${JSON.stringify('/tmp/fw/role-work/AGENTS.md')}=\"read\"`);
+    expect(overrides).toContain(
+      `permissions.${profileId}.network.unix_sockets={${JSON.stringify(socketPath)}=\"deny\"}`,
+    );
+    expect(overrides).toContain(`permissions.${profileId}.network.enabled=false`);
+    expect(overrides.some((value) => value.startsWith(
+      `permissions.${profileId}.network.domains=`,
+    ))).toBe(false);
+    expect(JSON.stringify(args)).not.toContain('*');
     expect(JSON.stringify(args)).not.toMatch(/danger-full-access|dangerFullAccess|sandbox_mode/);
   });
 
@@ -194,7 +387,159 @@ describe('CodexAppServerPTY permission profile policy', () => {
     });
   });
 
+  it('verifies paginated active MCP status and accepts only inert unapproved placeholders', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+    requestMock
+      .mockResolvedValueOnce({ result: {
+        data: [{
+          name: 'ambient-one', serverInfo: null, tools: {}, resources: [],
+          resourceTemplates: [], authStatus: 'unsupported',
+        }],
+        nextCursor: 'page-2',
+      } })
+      .mockResolvedValueOnce({ result: {
+        data: [{
+          name: 'ambient-two', serverInfo: null, tools: {}, resources: [],
+          resourceTemplates: [], authStatus: 'unsupported',
+        }],
+        nextCursor: null,
+      } });
+
+    await expect((pty as unknown as { verifyMcpStatusReadback(): Promise<void> })
+      .verifyMcpStatusReadback()).resolves.toBeUndefined();
+    expect(requestMock).toHaveBeenNthCalledWith(2, 'mcpServerStatus/list', {
+      cursor: 'page-2', limit: 100, detail: 'toolsAndAuthOnly',
+    });
+  });
+
+  it('waits for an approved MCP to move from starting to ready before paginated inventory read-back', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_mcp_allowlist: ['approved-role-server'],
+    });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+    requestMock
+      .mockResolvedValueOnce({ result: {
+        data: [{
+          name: 'ambient', serverInfo: null, tools: {}, resources: [],
+          resourceTemplates: [], authStatus: 'unsupported',
+        }],
+        nextCursor: 'page-2',
+      } })
+      .mockResolvedValueOnce({ result: {
+        data: [{
+          name: 'approved-role-server', serverInfo: { name: 'approved-role-server' },
+          tools: { read: {} }, resources: [], resourceTemplates: [], authStatus: 'notRequired',
+        }],
+        nextCursor: null,
+      } });
+    const internals = pty as unknown as {
+      _alive: boolean;
+      verifyMcpStatusReadback(timeoutMs?: number): Promise<void>;
+      handleRpcMessage(message: unknown): void;
+    };
+    internals._alive = true;
+
+    const verification = internals.verifyMcpStatusReadback(1_000);
+    internals.handleRpcMessage({
+      method: 'mcpServer/startupStatus/updated',
+      params: { name: 'approved-role-server', status: 'starting' },
+    });
+    await Promise.resolve();
+    expect(requestMock).not.toHaveBeenCalled();
+
+    internals.handleRpcMessage({
+      method: 'mcpServer/startupStatus/updated',
+      params: { name: 'approved-role-server', status: 'ready' },
+    });
+    await expect(verification).resolves.toBeUndefined();
+    expect(requestMock).toHaveBeenNthCalledWith(2, 'mcpServerStatus/list', {
+      cursor: 'page-2', limit: 100, detail: 'toolsAndAuthOnly',
+    });
+  });
+
+  it.each(['failed', 'cancelled'] as const)(
+    'fails readiness immediately when an approved MCP reports %s',
+    async (status) => {
+      const pty = new CodexAppServerPTY(mockEnv, {
+        ...secureConfig,
+        codex_mcp_allowlist: ['approved-role-server'],
+      });
+      const internals = pty as unknown as {
+        _alive: boolean;
+        verifyMcpStatusReadback(timeoutMs?: number): Promise<void>;
+        handleRpcMessage(message: unknown): void;
+      };
+      internals._alive = true;
+
+      const verification = internals.verifyMcpStatusReadback(10_000);
+      internals.handleRpcMessage({
+        method: 'mcpServer/startupStatus/updated',
+        params: { name: 'approved-role-server', status },
+      });
+
+      await expect(verification).rejects.toThrow(/did not become available/);
+      expect(requestMock).not.toHaveBeenCalled();
+    },
+  );
+
+  it('fails readiness on a bounded timeout without reading a premature inventory', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_mcp_allowlist: ['approved-role-server'],
+    });
+    (pty as unknown as { _alive: boolean })._alive = true;
+
+    await expect((pty as unknown as {
+      verifyMcpStatusReadback(timeoutMs?: number): Promise<void>;
+    }).verifyMcpStatusReadback(5)).rejects.toThrow(
+      /Timed out waiting for approved MCP servers to become ready: approved-role-server=pending/,
+    );
+    expect(requestMock).not.toHaveBeenCalled();
+  });
+
+  it('fails active read-back for a capable ambient MCP or an inactive approved MCP', async () => {
+    const ambient = new CodexAppServerPTY(mockEnv, secureConfig);
+    (ambient as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+    requestMock.mockResolvedValue({ result: {
+      data: [{
+        name: 'ambient', serverInfo: { name: 'ambient' }, tools: { send: {} },
+        resources: [], resourceTemplates: [], authStatus: 'bearerToken',
+      }],
+      nextCursor: null,
+    } });
+    await expect((ambient as unknown as { verifyMcpStatusReadback(): Promise<void> })
+      .verifyMcpStatusReadback()).rejects.toThrow(/not inert/);
+
+    requestMock.mockReset().mockResolvedValue({ result: {
+      data: [{
+        name: 'approved-role-server', serverInfo: null, tools: {},
+        resources: [], resourceTemplates: [], authStatus: 'unsupported',
+      }],
+      nextCursor: null,
+    } });
+    const approved = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_mcp_allowlist: ['approved-role-server'],
+    });
+    (approved as unknown as { _alive: boolean })._alive = true;
+    (approved as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+    (approved as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'mcpServer/startupStatus/updated',
+      params: { name: 'approved-role-server', status: 'ready' },
+    });
+    await expect((approved as unknown as { verifyMcpStatusReadback(): Promise<void> })
+      .verifyMcpStatusReadback()).rejects.toThrow(/not active/);
+  });
+
   it('spawns app-server with strict generated config and no danger override', async () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([{ name: 'ambient-host-server', enabled: true }]),
+      stderr: '',
+      error: undefined,
+    });
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const spawn = vi.fn().mockReturnValue({
       pid: 88,
@@ -204,14 +549,161 @@ describe('CodexAppServerPTY permission profile policy', () => {
       kill: vi.fn(),
     });
     (pty as unknown as { _spawnFn: typeof spawn })._spawnFn = spawn;
+    (pty as unknown as { _alive: boolean })._alive = true;
     fsMocks.existsSync.mockReturnValue(true);
 
     await (pty as unknown as { startAppServer(): Promise<void> }).startAppServer();
 
     const args = spawn.mock.calls[0][1] as string[];
     expect(args).toContain('--strict-config');
+    for (const feature of ['apps', 'plugins', 'browser_use', 'computer_use', 'in_app_browser', 'image_generation']) {
+      expect(args).toContain(feature);
+    }
+    expect(args).toContain('mcp_servers={\"ambient-host-server\"={enabled=false}}');
     expect(args.some((arg) => arg.includes(permissionProfileId(pty)))).toBe(true);
     expect(JSON.stringify(args)).not.toMatch(/danger-full-access|dangerFullAccess|sandbox_mode/);
+  });
+
+  it('cleans private temp and socket state on an unexpected app-server exit', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const publishedExit = vi.fn();
+    pty.onExit(publishedExit);
+    let exitHandler: ((event: { exitCode: number; signal?: number }) => void) | null = null;
+    const spawn = vi.fn().mockReturnValue({
+      pid: 88,
+      write: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn((handler) => { exitHandler = handler; }),
+      kill: vi.fn(),
+    });
+    (pty as unknown as { _spawnFn: typeof spawn; _alive: boolean })._spawnFn = spawn;
+    (pty as unknown as { _alive: boolean })._alive = true;
+    (pty as unknown as { _startupComplete: boolean })._startupComplete = true;
+    fsMocks.existsSync.mockReturnValue(true);
+
+    await (pty as unknown as { startAppServer(): Promise<void> }).startAppServer();
+    expect(exitHandler).not.toBeNull();
+    (exitHandler as unknown as (event: { exitCode: number }) => void)({ exitCode: 1 });
+
+    expect(fsMocks.rmSync).toHaveBeenCalledWith(
+      '/tmp/ctx/state/codex-app-agent/model-tmp',
+      { recursive: true, force: true },
+    );
+    expect(fsMocks.unlinkSync).toHaveBeenCalledWith(
+      '/tmp/ctx/state/codex-app-agent/codex.sock',
+    );
+    expect(publishedExit).toHaveBeenCalledWith(1, undefined);
+  });
+
+  it('keeps a failed internal app-server attempt inside the adapter retry boundary', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const publishedExit = vi.fn();
+    pty.onExit(publishedExit);
+    let exitHandler: ((event: { exitCode: number; signal?: number }) => void) | null = null;
+    const spawn = vi.fn().mockReturnValue({
+      pid: 88,
+      write: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn((handler) => { exitHandler = handler; }),
+      kill: vi.fn(),
+    });
+    (pty as unknown as { _spawnFn: typeof spawn; _alive: boolean })._spawnFn = spawn;
+    (pty as unknown as { _alive: boolean })._alive = true;
+    fsMocks.existsSync.mockReturnValue(true);
+
+    await (pty as unknown as { startAppServer(): Promise<void> }).startAppServer();
+    (exitHandler as unknown as (event: { exitCode: number }) => void)({ exitCode: 1 });
+
+    expect(publishedExit).not.toHaveBeenCalled();
+  });
+
+  it('discovers host MCP configuration privately and disables every server outside the role allowlist', () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([
+        { name: 'approved-role-server', enabled: true, transport: { authorization: 'must-not-log' } },
+        { name: 'ambient-host-server', enabled: true, transport: { authorization: 'must-not-log' } },
+      ]),
+      stderr: '',
+      error: undefined,
+    });
+    const pty = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_mcp_allowlist: ['approved-role-server'],
+    });
+
+    const args = (pty as unknown as { buildMcpConfigArgs(): string[] }).buildMcpConfigArgs();
+
+    expect(args).toEqual(['-c', 'mcp_servers={"ambient-host-server"={enabled=false}}']);
+    expect(JSON.stringify(args)).not.toContain('must-not-log');
+    expect(spawnSyncMock).toHaveBeenCalledWith(
+      'codex',
+      expect.arrayContaining(['--disable', 'apps', '--disable', 'plugins', 'mcp', 'list', '--json']),
+      expect.objectContaining({
+        cwd: mockEnv.agentDir,
+        encoding: 'utf-8',
+        maxBuffer: 1024 * 1024,
+      }),
+    );
+  });
+
+  it('fails closed when an allowlisted MCP server is absent or disabled', () => {
+    spawnSyncMock.mockReturnValue({
+      status: 0,
+      stdout: JSON.stringify([{ name: 'approved-role-server', enabled: false }]),
+      stderr: '',
+      error: undefined,
+    });
+    const pty = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_mcp_allowlist: ['approved-role-server'],
+    });
+
+    expect(() => (pty as unknown as { buildMcpConfigArgs(): string[] }).buildMcpConfigArgs())
+      .toThrow(/not configured and enabled/);
+  });
+
+  it('loads only explicitly allowlisted role secrets from inherited env files', () => {
+    fsMocks.existsSync.mockReturnValue(true);
+    fsMocks.readFileSync.mockReturnValue([
+      'CC_AGENT_ACTION_TOKEN=scoped-test-token',
+      'ANTHROPIC_API_KEY=must-not-inherit',
+      'PATH=/hostile/path',
+      '',
+    ].join('\n'));
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+
+    const env = (pty as unknown as { buildEnv(): Record<string, string> }).buildEnv();
+
+    expect(env.CC_AGENT_ACTION_TOKEN).toBe('scoped-test-token');
+    expect(env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(env.PATH).not.toBe('/hostile/path');
+    expect(env.CTX_AGENT_NAME).toBe('codex-app-agent');
+    expect(env.TMPDIR).toBe('/tmp/ctx/state/codex-app-agent/model-tmp');
+    expect(env.TMP).toBe(env.TMPDIR);
+    expect(env.TEMP).toBe(env.TMPDIR);
+  });
+
+  it('prepares only a private model temp child and rejects a symlinked state directory', () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    (pty as unknown as { preparePrivateModelTempDir(): void }).preparePrivateModelTempDir();
+
+    expect(fsMocks.chmodSync).toHaveBeenCalledWith('/tmp/ctx/state/codex-app-agent', 0o700);
+    expect(fsMocks.mkdirSync).toHaveBeenCalledWith(
+      '/tmp/ctx/state/codex-app-agent/model-tmp',
+      { recursive: false, mode: 0o700 },
+    );
+    expect(fsMocks.chmodSync).toHaveBeenCalledWith(
+      '/tmp/ctx/state/codex-app-agent/model-tmp',
+      0o700,
+    );
+
+    fsMocks.lstatSync.mockReturnValueOnce({
+      isSymbolicLink: () => true,
+      isDirectory: () => false,
+    });
+    expect(() => (pty as unknown as { preparePrivateModelTempDir(): void })
+      .preparePrivateModelTempDir()).toThrow(/state directory must be a real directory/);
   });
 });
 
@@ -1072,9 +1564,7 @@ describe('CodexAppServerPTY thread lifecycle', () => {
   it('starts a new thread in fresh mode', async () => {
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const profileId = permissionProfileId(pty);
-    requestMock.mockResolvedValue({
-      result: { thread: { id: 'fresh-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
-    });
+    requestMock.mockResolvedValue({ result: safeThreadResult(pty, 'fresh-thread') });
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('fresh');
@@ -1083,7 +1573,6 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       approvalPolicy: 'never',
       permissions: profileId,
-      config: { features: { goals: true } },
       sessionStartSource: 'startup',
       experimentalRawEvents: false,
       persistExtendedHistory: true,
@@ -1104,9 +1593,7 @@ describe('CodexAppServerPTY thread lifecycle', () => {
     }));
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const profileId = permissionProfileId(pty);
-    requestMock.mockResolvedValue({
-      result: { thread: { id: 'persisted-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
-    });
+    requestMock.mockResolvedValue({ result: safeThreadResult(pty, 'persisted-thread') });
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('continue');
@@ -1116,7 +1603,6 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       approvalPolicy: 'never',
       permissions: profileId,
-      config: { features: { goals: true } },
       excludeTurns: true,
       persistExtendedHistory: true,
     });
@@ -1131,9 +1617,7 @@ describe('CodexAppServerPTY thread lifecycle', () => {
     }));
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const profileId = permissionProfileId(pty);
-    requestMock.mockResolvedValue({
-      result: { thread: { id: 'new-fresh-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
-    });
+    requestMock.mockResolvedValue({ result: safeThreadResult(pty, 'new-fresh-thread') });
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh' | 'continue'): Promise<void> }).startOrResumeThread('fresh');
@@ -1143,7 +1627,6 @@ describe('CodexAppServerPTY thread lifecycle', () => {
       cwd: '/tmp/fw/orgs/acme/agents/codex-app-agent',
       approvalPolicy: 'never',
       permissions: profileId,
-      config: { features: { goals: true } },
       sessionStartSource: 'startup',
       experimentalRawEvents: false,
       persistExtendedHistory: true,
@@ -1228,12 +1711,131 @@ describe('CodexAppServerPTY thread lifecycle', () => {
     expect(requestMock.mock.calls.map(([method]) => method)).toEqual(['thread/resume']);
   });
 
+  it('rejects a matching profile id whose parent is not the read-only base', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const result = safeThreadResult(pty, 'unsafe-parent');
+    result.activePermissionProfile.extends = ':workspace';
+    requestMock.mockResolvedValue({ result });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/profile parent mismatch/);
+  });
+
+  it('rejects extra writable roots not declared by the role policy', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const result = safeThreadResult(pty, 'extra-root');
+    result.sandbox.writableRoots = [...result.sandbox.writableRoots, '/tmp/unapproved'];
+    requestMock.mockResolvedValue({ result });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/writable roots mismatch/);
+  });
+
+  it('does not hide an unexpected writable cwd when the role declared other roots', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const result = safeThreadResult(pty, 'cwd-leak');
+    result.sandbox.writableRoots = [
+      ...result.sandbox.writableRoots,
+      mockEnv.agentDir,
+    ];
+    requestMock.mockResolvedValue({ result });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/writable roots mismatch/);
+  });
+
+  it('rejects malformed writable-root entries instead of filtering them out', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const result = safeThreadResult(pty, 'malformed-roots');
+    (result.sandbox as { writableRoots: unknown[] }).writableRoots = [
+      ...result.sandbox.writableRoots,
+      42,
+    ];
+    requestMock.mockResolvedValue({ result });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/malformed writable roots/);
+  });
+
+  it('accepts a declared writable cwd as the implicit workspace root while retaining private temp', async () => {
+    const config = {
+      ...secureConfig,
+      working_directory: mockEnv.agentDir,
+      codex_writable_paths: [mockEnv.agentDir],
+      codex_readonly_paths: [],
+    };
+    const pty = new CodexAppServerPTY(mockEnv, config);
+    const result = {
+      thread: { id: 'implicit-cwd' },
+      activePermissionProfile: { id: permissionProfileId(pty), extends: ':read-only' },
+      sandbox: {
+        type: 'workspaceWrite',
+        writableRoots: ['/tmp/ctx/state/codex-app-agent/model-tmp'],
+        networkAccess: false,
+        excludeTmpdirEnvVar: true, excludeSlashTmp: true,
+      },
+    };
+    requestMock.mockResolvedValue({ result });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).resolves.toBeUndefined();
+  });
+
+  it('keeps a no-role-write profile limited to the adapter-owned private temp root', async () => {
+    const config = {
+      ...secureConfig,
+      codex_writable_paths: [],
+      codex_readonly_paths: [],
+    };
+    const pty = new CodexAppServerPTY(mockEnv, config);
+    const base = {
+      thread: { id: 'read-only' },
+      activePermissionProfile: { id: permissionProfileId(pty), extends: ':read-only' },
+      sandbox: {
+        type: 'workspaceWrite',
+        writableRoots: ['/tmp/ctx/state/codex-app-agent/model-tmp'],
+        networkAccess: false,
+        excludeTmpdirEnvVar: false,
+        excludeSlashTmp: true,
+      } as {
+        type: string; networkAccess: boolean; writableRoots?: string[];
+        excludeTmpdirEnvVar?: boolean; excludeSlashTmp?: boolean;
+      },
+    };
+    requestMock.mockResolvedValue({ result: base });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).resolves.toBeUndefined();
+
+    base.sandbox.writableRoots = [
+      '/tmp/ctx/state/codex-app-agent/model-tmp',
+      '/tmp/leaked',
+    ];
+    requestMock.mockResolvedValue({ result: base });
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/writable roots mismatch/);
+  });
+
+  it('rejects effective network access for an offline model process', async () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    const result = safeThreadResult(pty, 'network-drift');
+    result.sandbox.networkAccess = true;
+    requestMock.mockResolvedValue({ result });
+    (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
+
+    await expect((pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> })
+      .startOrResumeThread('fresh')).rejects.toThrow(/network access mismatch/);
+  });
+
   it('never emits legacy sandbox payloads on thread or turn RPCs', async () => {
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     const profileId = permissionProfileId(pty);
-    requestMock.mockResolvedValue({
-      result: { thread: { id: 'safe-thread' }, activePermissionProfile: { id: profileId, extends: ':workspace' } },
-    });
+    requestMock.mockResolvedValue({ result: safeThreadResult(pty, 'safe-thread') });
     (pty as unknown as { _rpc: { request: typeof requestMock } })._rpc = { request: requestMock };
 
     await (pty as unknown as { startOrResumeThread(mode: 'fresh'): Promise<void> }).startOrResumeThread('fresh');
@@ -1308,6 +1910,52 @@ describe('CodexAppServerPTY event handling', () => {
     expect(messageHandler).not.toBeNull();
   });
 
+  it('keeps an explicitly allowlisted role MCP available', () => {
+    const pty = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_mcp_allowlist: ['approved-role-server'],
+    });
+    (pty as unknown as { _alive: boolean })._alive = true;
+
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'mcpServer/startupStatus/updated',
+      params: { name: 'approved-role-server', status: 'ready' },
+    });
+
+    expect(pty.isAlive()).toBe(true);
+    expect(pty.getOutputBuffer().getRecent()).toContain('approved-role-server ready');
+  });
+
+  it('fails closed if any ambient host MCP server attempts startup', () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    (pty as unknown as { _alive: boolean })._alive = true;
+
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'mcpServer/startupStatus/updated',
+      params: { name: 'ambient-host-server', status: 'starting' },
+    });
+
+    expect(pty.isAlive()).toBe(false);
+    expect(pty.getOutputBuffer().getRecent()).toContain('Unapproved MCP server ambient-host-server reported starting');
+  });
+
+  it('fails closed when an allowlisted role MCP cannot start', () => {
+    const pty = new CodexAppServerPTY(mockEnv, {
+      ...secureConfig,
+      codex_mcp_allowlist: ['approved-role-server'],
+    });
+    (pty as unknown as { _alive: boolean })._alive = true;
+
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'mcpServer/startupStatus/updated',
+      params: { name: 'approved-role-server', status: 'failed', error: 'sensitive detail' },
+    });
+
+    expect(pty.isAlive()).toBe(false);
+    expect(pty.getOutputBuffer().getRecent()).toContain('did not become available');
+    expect(pty.getOutputBuffer().getRecent()).not.toContain('sensitive detail');
+  });
+
   it('fails closed if a settings update reports a different active profile', () => {
     const pty = new CodexAppServerPTY(mockEnv, secureConfig);
     (pty as unknown as { _alive: boolean; _threadId: string })._alive = true;
@@ -1323,6 +1971,71 @@ describe('CodexAppServerPTY event handling', () => {
 
     expect(pty.isAlive()).toBe(false);
     expect(pty.getOutputBuffer().getRecent()).toContain('active permission profile mismatch');
+  });
+
+  it('keeps a matching full settings update alive', () => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    (pty as unknown as { _alive: boolean; _threadId: string })._alive = true;
+    (pty as unknown as { _threadId: string })._threadId = 'thread-1';
+    const safe = safeThreadResult(pty, 'thread-1');
+
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'thread/settings/updated',
+      params: {
+        threadId: 'thread-1',
+        threadSettings: {
+          activePermissionProfile: safe.activePermissionProfile,
+          sandboxPolicy: safe.sandbox,
+        },
+      },
+    });
+
+    expect(pty.isAlive()).toBe(true);
+  });
+
+  it.each([
+    {
+      label: 'same id with wrong parent',
+      mutate: (settings: { activePermissionProfile: { extends: string | null } }) => {
+        settings.activePermissionProfile.extends = ':workspace';
+      },
+      expected: /profile parent mismatch/,
+    },
+    {
+      label: 'same id with network expansion',
+      mutate: (settings: { sandboxPolicy: { networkAccess: boolean } }) => {
+        settings.sandboxPolicy.networkAccess = true;
+      },
+      expected: /network access mismatch/,
+    },
+    {
+      label: 'same id with writable-root expansion',
+      mutate: (settings: { sandboxPolicy: { writableRoots: string[] } }) => {
+        settings.sandboxPolicy.writableRoots.push('/tmp/unapproved');
+      },
+      expected: /writable roots mismatch/,
+    },
+  ])('fails closed on $label in a settings update', ({ mutate, expected }) => {
+    const pty = new CodexAppServerPTY(mockEnv, secureConfig);
+    (pty as unknown as { _alive: boolean; _threadId: string })._alive = true;
+    (pty as unknown as { _threadId: string })._threadId = 'thread-1';
+    const safe = safeThreadResult(pty, 'thread-1');
+    const settings = {
+      activePermissionProfile: { ...safe.activePermissionProfile },
+      sandboxPolicy: {
+        ...safe.sandbox,
+        writableRoots: [...safe.sandbox.writableRoots],
+      },
+    };
+    mutate(settings as never);
+
+    (pty as unknown as { handleRpcMessage(message: unknown): void }).handleRpcMessage({
+      method: 'thread/settings/updated',
+      params: { threadId: 'thread-1', threadSettings: settings },
+    });
+
+    expect(pty.isAlive()).toBe(false);
+    expect(pty.getOutputBuffer().getRecent()).toMatch(expected);
   });
 
   it('fails closed with no fallback if a settings update omits the active profile', () => {

--- a/tests/unit/utils/enabled-agents-registry.test.ts
+++ b/tests/unit/utils/enabled-agents-registry.test.ts
@@ -1,0 +1,47 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  mutateEnabledAgentsRegistry,
+  readEnabledAgentsRegistry,
+} from '../../../src/utils/enabled-agents-registry.js';
+
+describe('enabled-agents registry transaction', () => {
+  let root: string;
+  let registryPath: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'enabled-agents-registry-'));
+    registryPath = join(root, 'config', 'enabled-agents.json');
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('serializes a read-modify-write through atomic replacement', () => {
+    mutateEnabledAgentsRegistry(root, (registry) => {
+      registry.alice = { enabled: false, org: 'acme' };
+    });
+    mutateEnabledAgentsRegistry(root, (registry) => {
+      registry.bob = { enabled: true, org: 'acme' };
+    });
+
+    expect(readEnabledAgentsRegistry(root)).toEqual({
+      alice: { enabled: false, org: 'acme' },
+      bob: { enabled: true, org: 'acme' },
+    });
+    expect(readFileSync(registryPath, 'utf-8').endsWith('\n')).toBe(true);
+  });
+
+  it('refuses to overwrite an existing malformed registry', () => {
+    mkdirSync(join(root, 'config'), { recursive: true });
+    writeFileSync(registryPath, 'not json');
+
+    expect(() => mutateEnabledAgentsRegistry(root, (registry) => {
+      registry.alice = { enabled: true };
+    })).toThrow();
+    expect(readFileSync(registryPath, 'utf-8')).toBe('not json');
+  });
+});


### PR DESCRIPTION
## Summary

- replace forced danger-full-access with a read-only base and explicit per-seat writable, read-only, credential-deny, socket-deny, environment, MCP, network, and native-search capabilities
- enable native Codex web research only when the reviewed seat sets `codex_web_search_enabled: true`
- keep raw shell networking disabled; native search does not grant browser, app, arbitrary HTTP, environment, or MCP access
- keep built-in local tools and same-task multi-agent delegation available inside the reviewed work plane
- verify the active profile across start, resume, and turns, with bounded MCP readiness and no permissive fallback
- retain the hash-reviewed stopped-seat migration and fail-closed lifecycle, discovery, and atomic-writer protections

## Verification

- root TypeScript typecheck: passed
- dashboard TypeScript typecheck: passed
- production build: passed
- focused changed-surface capability suite: 168 passed
- dashboard suite: 112 passed
- real Codex permission-profile probes: 14 passed, including native search enabled while loopback network remains denied
- full repository suite: 2048 passed, 17 skipped, with one unchanged pre-existing macOS tmp versus private-tmp assertion failure in untouched hook code
- final adversarial review: no remaining P1 or P2 findings

## Scope

Source only at reviewed commit 7a730ec5bfc7e44fd9fb142193d441140436aee7. This PR does not install a package, migrate an installed seat, start or restart an agent, change fleet state, or advance Stage 3. Future activation requires a separate authorized installation plus host-trusted runtime collectors and candidate-bound canaries.