### PR TITLE
fix(cron): the fleet health monitor was blind — a cron dead 30 days reported HEALTHY

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,6 @@ WINDOWS_INSTALL_REPORT.md
 *INSTALL_REPORT.md
 /PHASE*-REPORT.md
 docs/phase-reports/
+
+# also ignore a symlink/file named node_modules (the dir pattern node_modules/ does NOT — that let PR #778 commit a build-machine symlink)
+node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/liban/cortextos/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/liban/cortextos/node_modules

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -23,6 +23,7 @@ type LogFn = (msg: string) => void;
  * Manages all agents in a cortextOS instance.
  */
 import { reconcileAgentCrons } from '../utils/cron-registration.js';
+import { logEvent } from '../bus/event.js';
 import { readCrons } from '../bus/crons.js';
 
 export class AgentManager {
@@ -144,6 +145,27 @@ export class AgentManager {
       examinedTotal += examined;
       for (const d of drift) {
         allDrift.push(`${d.agent}/${d.cron}: ${d.kind} — ${d.detail}`);
+        // ★ THE GUARD MUST REACH THE DECIDER.
+        // console.warn() puts this in daemon stderr, which is a place nobody looks — a guard
+        // that fires into a void has not fired. The daemon's DEATH is loud (the agent goes
+        // STALE and a human sees it); a drift finding by a LIVE daemon is not loud at all.
+        // So it goes to the Activity feed, where humans actually read, alongside every other
+        // event the fleet emits. A monitor whose finding renders only in logs has traded one
+        // blindness for another.
+        try {
+          logEvent(
+            resolvePaths(name, this.instanceId, this.resolveAgentOrg(name)),
+            name,
+            this.resolveAgentOrg(name),
+            'error',
+            'cron_registration_drift',
+            'warning',
+            { cron: d.cron, kind: d.kind, detail: d.detail },
+          );
+        } catch (err) {
+          // An event write must never be able to break the check that produced it.
+          console.error(`[cron-registration] could not emit drift event for ${name}/${d.cron}:`, err);
+        }
       }
     }
 

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -22,7 +22,7 @@ type LogFn = (msg: string) => void;
 /**
  * Manages all agents in a cortextOS instance.
  */
-import { reconcileAgentCrons } from '../utils/cron-registration.js';
+import { reconcileAgentCrons, reconcileLiveSchedule } from '../utils/cron-registration.js';
 import { logEvent } from '../bus/event.js';
 import { readCrons } from '../bus/crons.js';
 
@@ -127,44 +127,64 @@ export class AgentManager {
    * while the thing it watches keeps running. Put the guard where its own failure is
    * impossible to miss.
    */
+  /**
+   * Emit a cron drift finding to the Activity feed — the surface humans read.
+   * console.warn goes to daemon stderr, a void; a guard that fires where nobody looks has
+   * not fired. An event write must never break the check that produced it, so it is wrapped.
+   */
+  private emitCronDrift(agent: string, cron: string, kind: string, detail: string, eventName: string): void {
+    try {
+      logEvent(
+        resolvePaths(agent, this.instanceId, this.resolveAgentOrg(agent)),
+        agent,
+        this.resolveAgentOrg(agent),
+        'error',
+        eventName,
+        'warning',
+        { cron, kind, detail },
+      );
+    } catch (err) {
+      console.error(`[cron-drift] could not emit ${eventName} for ${agent}/${cron}:`, err);
+    }
+  }
+
   checkCronRegistration(): void {
     let examinedTotal = 0;
     const allDrift: string[] = [];
 
     for (const { name, config } of this.discoverAgents()) {
       const declared = (config?.crons ?? []).map(c => ({ name: c.name }));
-      let registered: Array<{ name: string; enabled?: boolean }> = [];
+      let registered: Array<{ name: string; schedule?: string; enabled?: boolean }> = [];
       try {
-        registered = readCrons(name).map(c => ({ name: c.name, enabled: c.enabled }));
+        registered = readCrons(name).map(c => ({ name: c.name, schedule: c.schedule, enabled: c.enabled }));
       } catch {
         // Unreadable live crons for this agent — that is itself worth saying, not skipping.
         console.warn(`[cron-registration] ${name}: live crons.json unreadable — cannot verify its crons exist`);
         continue;
       }
-      const { drift, examined } = reconcileAgentCrons(name, declared, registered);
-      examinedTotal += examined;
-      for (const d of drift) {
+      // Surface 1+2: config.json (declared) vs crons.json (registered) — two FILES.
+      const fileCheck = reconcileAgentCrons(name, declared, registered);
+      examinedTotal += fileCheck.examined;
+      for (const d of fileCheck.drift) {
         allDrift.push(`${d.agent}/${d.cron}: ${d.kind} — ${d.detail}`);
-        // ★ THE GUARD MUST REACH THE DECIDER.
-        // console.warn() puts this in daemon stderr, which is a place nobody looks — a guard
-        // that fires into a void has not fired. The daemon's DEATH is loud (the agent goes
-        // STALE and a human sees it); a drift finding by a LIVE daemon is not loud at all.
-        // So it goes to the Activity feed, where humans actually read, alongside every other
-        // event the fleet emits. A monitor whose finding renders only in logs has traded one
-        // blindness for another.
-        try {
-          logEvent(
-            resolvePaths(name, this.instanceId, this.resolveAgentOrg(name)),
-            name,
-            this.resolveAgentOrg(name),
-            'error',
-            'cron_registration_drift',
-            'warning',
-            { cron: d.cron, kind: d.kind, detail: d.detail },
-          );
-        } catch (err) {
-          // An event write must never be able to break the check that produced it.
-          console.error(`[cron-registration] could not emit drift event for ${name}/${d.cron}:`, err);
+        this.emitCronDrift(name, d.cron, d.kind, d.detail, 'cron_registration_drift');
+      }
+
+      // ★ Surface 3: crons.json (disk) vs the RUNNING scheduler (memory).
+      // A cron that agrees across both FILES can still fire on a stale schedule if the file
+      // was hand-edited and the daemon never reloaded — the scheduler holds its own copy and
+      // nothing on disk reflects it. This is the MOST COMMON drift and it is invisible to the
+      // file-vs-file check above and to every CLI. The scheduler is in THIS process, so the
+      // comparison is in-memory and free.
+      const scheduler = this.cronSchedulers.get(name);
+      if (scheduler) {
+        const onDisk = registered.map(c => ({ name: c.name, schedule: (c as { schedule?: string }).schedule ?? '', enabled: c.enabled }));
+        const live = scheduler.getLiveSchedules();
+        const liveCheck = reconcileLiveSchedule(name, onDisk, live);
+        examinedTotal += liveCheck.examined;
+        for (const d of liveCheck.drift) {
+          allDrift.push(`${d.agent}/${d.cron}: ${d.kind} — ${d.detail}`);
+          this.emitCronDrift(name, d.cron, d.kind, d.detail, 'cron_scheduler_stale');
         }
       }
     }

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -22,6 +22,9 @@ type LogFn = (msg: string) => void;
 /**
  * Manages all agents in a cortextOS instance.
  */
+import { reconcileAgentCrons } from '../utils/cron-registration.js';
+import { readCrons } from '../bus/crons.js';
+
 export class AgentManager {
   private agents: Map<string, { process: AgentProcess; checker: FastChecker; poller?: TelegramPoller; activityPoller?: TelegramPoller; telegramRejectCount?: number; telegramLastRejectAlertAt?: number }> = new Map();
   private workers: Map<string, WorkerProcess> = new Map();
@@ -111,6 +114,54 @@ export class AgentManager {
   /**
    * Discover and start all enabled agents.
    */
+  /**
+   * Reconcile every agent's DECLARED crons (config.json) against its LIVE registration
+   * (crons.json), and shout about any asymmetry.
+   *
+   * WHY THIS LIVES IN THE DAEMON AND NOT IN A CRON:
+   * A cron that watches crons can die the same silent death it exists to catch, and then
+   * everything looks healthy forever — a monitor monitoring monitors, monitored by nothing.
+   * The daemon is the correct floor because ITS OWN DEATH IS ALREADY LOUD: if the daemon is
+   * gone, no cron fires at all and the agent goes visibly STALE. It cannot fail quietly
+   * while the thing it watches keeps running. Put the guard where its own failure is
+   * impossible to miss.
+   */
+  checkCronRegistration(): void {
+    let examinedTotal = 0;
+    const allDrift: string[] = [];
+
+    for (const { name, config } of this.discoverAgents()) {
+      const declared = (config?.crons ?? []).map(c => ({ name: c.name }));
+      let registered: Array<{ name: string; enabled?: boolean }> = [];
+      try {
+        registered = readCrons(name).map(c => ({ name: c.name, enabled: c.enabled }));
+      } catch {
+        // Unreadable live crons for this agent — that is itself worth saying, not skipping.
+        console.warn(`[cron-registration] ${name}: live crons.json unreadable — cannot verify its crons exist`);
+        continue;
+      }
+      const { drift, examined } = reconcileAgentCrons(name, declared, registered);
+      examinedTotal += examined;
+      for (const d of drift) {
+        allDrift.push(`${d.agent}/${d.cron}: ${d.kind} — ${d.detail}`);
+      }
+    }
+
+    // ZERO COVERAGE IS NOT AN ALL-CLEAR. If we compared nothing, say so — an empty drift
+    // list over an empty comparison is a tick over nothing, which is the failure mode this
+    // whole check exists to prevent.
+    if (examinedTotal === 0) {
+      console.warn('[cron-registration] examined 0 crons — CANNOT confirm any cron is registered');
+      return;
+    }
+    if (allDrift.length === 0) {
+      console.log(`[cron-registration] ${examinedTotal} cron(s) reconciled, no drift`);
+      return;
+    }
+    console.warn(`[cron-registration] ★ DRIFT — ${allDrift.length} of ${examinedTotal} cron(s) disagree between config.json and crons.json:`);
+    for (const line of allDrift) console.warn(`[cron-registration]   ${line}`);
+  }
+
   async discoverAndStart(): Promise<void> {
     const agentDirs = this.discoverAgents();
 

--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -325,6 +325,22 @@ export class CronScheduler {
     }));
   }
 
+  /**
+   * Return the schedule string the RUNNING scheduler currently holds for each cron.
+   *
+   * This is the IN-MEMORY truth — what the scheduler will actually fire on — which can
+   * differ from crons.json on disk if a hand-edit never triggered a reload. Nothing else
+   * exposes this: the CLI's list-crons recomputes from disk and never queries the daemon,
+   * so a never-reloaded edit is invisible to every tool. This is the observability the
+   * config↔live drift check needs.
+   */
+  getLiveSchedules(): Array<{ name: string; schedule: string }> {
+    return [...this.scheduled.values()].map(sc => ({
+      name: sc.definition.name,
+      schedule: sc.definition.schedule,
+    }));
+  }
+
   // -------------------------------------------------------------------------
   // Internal helpers
   // -------------------------------------------------------------------------

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -1,5 +1,7 @@
 import { AgentManager } from './agent-manager.js';
-import { IPCServer } from './ipc-server.js';
+import { IPCServer, computeFleetHealth } from './ipc-server.js';
+import { logEvent } from '../bus/event.js';
+import { resolvePaths } from '../utils/paths.js';
 import { readdirSync, readFileSync, writeFileSync, existsSync, chmodSync } from 'fs';
 import { spawnSync } from 'child_process';
 import { join } from 'path';
@@ -231,6 +233,54 @@ class Daemon {
 
   private cronRegistrationTimer?: NodeJS.Timeout;
 
+  /**
+   * Push cron-health warnings to the Activity feed.
+   *
+   * ★ WHY THIS EXISTS — DETECTION IS NOT RENDERING.
+   * The missed-slot rule (cron-health.ts) correctly turns a dead cron into a 'warning'.
+   * But that state only travelled to /api/workflows/health — a dashboard PAGE. That is a
+   * PULL surface: it tells a human who goes and looks. Nobody goes and looks at a health
+   * page to discover that the thing which would have told them is dead. We would have fixed
+   * the DETECTION and kept the BLINDNESS.
+   *
+   * A guard is measured by WHERE IT RENDERS, not that it fires. So a cron that missed its
+   * slot is pushed into the Activity feed — the same surface every other fleet event lands
+   * on, the one humans already read — instead of waiting to be discovered.
+   */
+  private pushCronHealthWarnings(): void {
+    let result;
+    try {
+      result = computeFleetHealth();
+    } catch (err) {
+      console.error('[cron-health] could not compute fleet health:', err);
+      return;
+    }
+    const unhealthy = result.rows.filter(c => c.state !== 'healthy');
+
+    // Zero coverage is not an all-clear: examining no crons and reporting none unhealthy is
+    // a tick over nothing — the exact failure this whole change exists to remove.
+    if (result.rows.length === 0) {
+      console.warn('[cron-health] examined 0 crons — CANNOT confirm any cron is firing');
+      return;
+    }
+    for (const c of unhealthy) {
+      try {
+        logEvent(
+          resolvePaths(c.agent, this.instanceId, c.org),
+          c.agent,
+          c.org,
+          'error',
+          'cron_unhealthy',
+          c.state === 'healthy' ? 'info' : 'warning',
+          { cron: c.cronName, state: c.state, reason: c.reason },
+        );
+      } catch (err) {
+        console.error(`[cron-health] could not emit event for ${c.agent}/${c.cronName}:`, err);
+      }
+    }
+    console.log(`[cron-health] ${result.rows.length} cron(s) checked, ${unhealthy.length} not healthy`);
+  }
+
   async start(): Promise<void> {
     // Force restrictive default permissions for everything the daemon writes:
     // 0700 dirs, 0600 files. Belt-and-suspenders for explicit chmod calls.
@@ -271,12 +321,21 @@ class Daemon {
     // A cron that is NOT REGISTERED has no fire-gap to measure: it is not late, it is
     // ABSENT, and every fire-based health check reports nothing wrong forever. Verify at
     // startup and hourly that what config.json DECLARES is what crons.json actually holds.
-    this.agentManager.checkCronRegistration();
+    // Wrapped: A MONITORING CHECK MUST NEVER BE ABLE TO CRASH THE PROCESS IT MONITORS.
+    // The hourly timer below is already guarded; startup must be too, or the guard can take
+    // down the daemon whose liveness is the floor everything else stands on.
+    try {
+      this.agentManager.checkCronRegistration();
+      this.pushCronHealthWarnings();
+    } catch (err) {
+      console.error('[cron-guard] startup check threw (daemon continues):', err);
+    }
     this.cronRegistrationTimer = setInterval(() => {
       try {
         this.agentManager?.checkCronRegistration();
+        this.pushCronHealthWarnings();
       } catch (err) {
-        console.error('[cron-registration] check threw:', err);
+        console.error('[cron-guard] check threw:', err);
       }
     }, 60 * 60_000);
     this.cronRegistrationTimer.unref?.();

--- a/src/daemon/index.ts
+++ b/src/daemon/index.ts
@@ -229,6 +229,8 @@ class Daemon {
     this.ctxRoot = join(homedir(), '.cortextos', this.instanceId);
   }
 
+  private cronRegistrationTimer?: NodeJS.Timeout;
+
   async start(): Promise<void> {
     // Force restrictive default permissions for everything the daemon writes:
     // 0700 dirs, 0600 files. Belt-and-suspenders for explicit chmod calls.
@@ -265,6 +267,19 @@ class Daemon {
 
     // Discover and start agents
     await this.agentManager.discoverAndStart();
+
+    // A cron that is NOT REGISTERED has no fire-gap to measure: it is not late, it is
+    // ABSENT, and every fire-based health check reports nothing wrong forever. Verify at
+    // startup and hourly that what config.json DECLARES is what crons.json actually holds.
+    this.agentManager.checkCronRegistration();
+    this.cronRegistrationTimer = setInterval(() => {
+      try {
+        this.agentManager?.checkCronRegistration();
+      } catch (err) {
+        console.error('[cron-registration] check threw:', err);
+      }
+    }, 60 * 60_000);
+    this.cronRegistrationTimer.unref?.();
 
     console.log(`[daemon] Running (pid: ${process.pid})`);
 

--- a/src/utils/cron-health.ts
+++ b/src/utils/cron-health.ts
@@ -11,7 +11,10 @@
  *   never-fired  — cron has never produced an execution log entry (lastFire null)
  *                  AND it is not a future-scheduled one-shot in its grace window.
  *   failure      — most recent execution log entry is 'failed' with no later success.
- *   warning      — gap between now and lastFire > 2 × expectedIntervalMs.
+ *   warning      — EITHER the cron missed a scheduled fire (cron-expression schedules,
+ *                  detected within MISSED_FIRE_GRACE_MS of the slot — latency does NOT
+ *                  scale with the cron's period), OR gap > 2 × expectedIntervalMs
+ *                  (duration schedules, e.g. "4h").
  *   healthy      — everything else.
  *
  * One-shot crons (fire_at field set, no schedule interval)
@@ -22,6 +25,7 @@
  */
 
 import { parseDurationMs } from '../bus/cron-state.js';
+import { nextFireFromCron } from '../daemon/cron-scheduler.js';
 import type { CronSummaryRow, CronExecutionLogEntry } from '../types/index.js';
 
 // ---------------------------------------------------------------------------
@@ -84,6 +88,56 @@ export interface FleetHealthResult {
 
 /** Multiplier: a cron is "warning" when gap > WARNING_MULTIPLIER × expectedIntervalMs */
 export const WARNING_MULTIPLIER = 2;
+
+/**
+ * Grace period after a scheduled slot before a missing fire is called a miss.
+ * Absorbs normal execution latency (the agent records the fire a beat after the
+ * scheduler triggers it) without letting a genuinely dead cron hide.
+ */
+export const MISSED_FIRE_GRACE_MS = 15 * 60_000;
+
+/** Iteration cap when walking a cron expression forward. Bounds a pathological expr. */
+const MAX_SLOT_WALK = 2_000;
+
+/**
+ * The most recent scheduled slot at or before `nowMs` for a 5-field cron expression.
+ * Returns null if the expression is unparseable or has no slot in the lookback window.
+ *
+ * WHY THIS EXISTS — the bug it fixes:
+ * expectedIntervalMs is derived via parseDurationMs(schedule), which returns NaN for a
+ * CRON EXPRESSION ("7 15 * * 1"). NaN || 0 => 0, and the staleness rule is gated on
+ * `expectedIntervalMs > 0` — so for every cron-expression cron THE WARNING BRANCH WAS
+ * NEVER ENTERED. Not "warned late": NEVER WARNED. A cron dead for 30 days reported
+ * HEALTHY. That was 13 of 24 fleet crons, including a weekly security sweep, a live-site
+ * uptime check, and — the sharp one — the stale-heartbeat-check that exists to catch dead
+ * agents and was itself unwatched.
+ *
+ * And the fix is NOT to teach parseDurationMs about cron expressions: that would arm the
+ * 2x-gap rule, whose blind window SCALES WITH THE PERIOD (a weekly cron would still be
+ * invisible for a fortnight). Gap-since-last-fire is the wrong primitive.
+ *
+ * The right question is not "how long since it last ran?" but "DID IT RUN WHEN IT SAID IT
+ * WOULD?" — and the schedule already tells us when that was. Detection latency then tracks
+ * the GRACE PERIOD, not the cron's cadence: a weekly sweep that skips its slot is caught in
+ * minutes, exactly like a 27-minute tick.
+ */
+export function previousSlotMs(schedule: string, nowMs: number): number | null {
+  // Look back far enough to contain at least one slot of any sane schedule (>1 week),
+  // but walk forward from the *smallest* window that yields one so a per-minute cron
+  // does not cost 10k iterations.
+  for (const windowMs of [2 * 3_600_000, 26 * 3_600_000, 9 * 86_400_000]) {
+    let cursor = nowMs - windowMs;
+    let last: number | null = null;
+    for (let i = 0; i < MAX_SLOT_WALK; i++) {
+      const next = nextFireFromCron(schedule, cursor);
+      if (Number.isNaN(next) || next > nowMs) break;
+      last = next;
+      cursor = next;
+    }
+    if (last !== null) return last;
+  }
+  return null;
+}
 
 /** Grace period for one-shot crons (ms): 10 minutes past fire_at before becoming warning */
 const ONCE_GRACE_MS = 10 * 60 * 1000;
@@ -152,6 +206,26 @@ export function computeHealth(
     return makeHealth(agent, org, cron.name, nextFire, 'failure',
       `most recent execution failed (${formatRelativeMs(gapMs!)} ago)`,
       lastFireMs, expectedIntervalMs, gapMs, successRate24h, firesLast24h);
+  }
+
+  // warning: MISSED AN EXPECTED FIRE.
+  //
+  // This is the rule that covers cron-expression schedules, for which expectedIntervalMs
+  // is 0 and the 2x-gap rule below is skipped entirely. It asks the right question — "did
+  // it run when it said it would?" — so its detection latency is the grace period, NOT the
+  // cron's period. A weekly cron is caught as fast as a 27-minute one.
+  if (expectedIntervalMs === 0) {
+    const slot = previousSlotMs(cron.schedule, nowMs);
+    if (slot !== null && nowMs > slot + MISSED_FIRE_GRACE_MS) {
+      // A fire recorded at/after the slot (minus a minute of clock slop) means it ran.
+      const ranForSlot = lastFireMs !== null && lastFireMs >= slot - 60_000;
+      if (!ranForSlot) {
+        return makeHealth(agent, org, cron.name, nextFire, 'warning',
+          `MISSED its scheduled fire at ${new Date(slot).toISOString()} ` +
+          `(last fire ${lastFireMs === null ? 'never' : formatRelativeMs(gapMs!) + ' ago'})`,
+          lastFireMs, expectedIntervalMs, gapMs, successRate24h, firesLast24h);
+      }
+    }
   }
 
   // warning: gap > 2x expected interval (only applies when interval is known)

--- a/src/utils/cron-registration.ts
+++ b/src/utils/cron-registration.ts
@@ -1,0 +1,97 @@
+/**
+ * cron-registration.ts — reconcile a cron's DECLARED intent against its LIVE registration.
+ *
+ * THE DEATH MODE THIS CATCHES, AND WHY THE FIRE-GAP RULE CANNOT:
+ * A cron can fail in two ways. It can be REGISTERED BUT NOT FIRING (cron-health.ts's
+ * missed-slot rule catches that). Or it can simply NOT BE THERE — removed, disabled, or
+ * drifted out of one of the two files that must agree. A monitor that never existed has
+ * no fire gap to measure: it is not late, it is ABSENT, and every fire-based check will
+ * report nothing wrong forever because there is nothing to report on.
+ *
+ * This is not hypothetical. `safetystack-handoff-check` was live in crons.json and absent
+ * from config.json — a rebuild-from-config would have silently DELETED it, and nothing in
+ * the system would have said a word. We found it by hand, which is not a strategy.
+ *
+ * CANONICAL SOURCE = config.json's `crons` array. A human writes it, it is in git, and
+ * CLAUDE.md already names it as the source of truth. No new registry to drift.
+ *
+ * Pure and I/O-free on purpose: the caller reads the two files, this decides.
+ */
+
+/** One cron as DECLARED in config.json. */
+export interface DeclaredCron {
+  name: string;
+  interval?: string;
+}
+
+/** One cron as REGISTERED in the live crons.json. */
+export interface RegisteredCron {
+  name: string;
+  schedule?: string;
+  enabled?: boolean;
+}
+
+export type DriftKind =
+  /** Declared in config.json but not registered live: IT WILL NEVER FIRE, and no fire-gap check can see that. */
+  | 'declared-not-registered'
+  /** Registered live but absent from config.json: a rebuild-from-config DELETES it, silently. */
+  | 'registered-not-declared'
+  /** Registered but explicitly disabled: present, and still never fires. */
+  | 'registered-but-disabled';
+
+export interface CronDrift {
+  agent: string;
+  cron: string;
+  kind: DriftKind;
+  detail: string;
+}
+
+/**
+ * Compare declared intent against live registration. Any asymmetry is drift.
+ *
+ * Returns [] when the two agree — and an EMPTY RESULT IS A REAL RESULT here, not a
+ * vacuous pass: the caller is expected to assert it examined a non-zero number of crons
+ * (see reconcileAgentCrons' `examined` count). A reconcile that silently compared two
+ * empty lists and reported "no drift" would be the exact tick-over-nothing we have been
+ * killing all week.
+ */
+export function reconcileAgentCrons(
+  agent: string,
+  declared: DeclaredCron[],
+  registered: RegisteredCron[],
+): { drift: CronDrift[]; examined: number } {
+  const drift: CronDrift[] = [];
+  const liveByName = new Map(registered.map(c => [c.name, c]));
+  const declaredNames = new Set(declared.map(c => c.name));
+
+  for (const d of declared) {
+    const live = liveByName.get(d.name);
+    if (!live) {
+      drift.push({
+        agent, cron: d.name, kind: 'declared-not-registered',
+        detail: `declared in config.json but NOT registered live — it will never fire, and no fire-gap check can see that`,
+      });
+      continue;
+    }
+    if (live.enabled === false) {
+      drift.push({
+        agent, cron: d.name, kind: 'registered-but-disabled',
+        detail: `registered but disabled — present, and still never fires`,
+      });
+    }
+  }
+
+  for (const r of registered) {
+    if (!declaredNames.has(r.name)) {
+      drift.push({
+        agent, cron: r.name, kind: 'registered-not-declared',
+        detail: `live but absent from config.json — a rebuild-from-config would silently DELETE it`,
+      });
+    }
+  }
+
+  // The union: what we actually compared. A caller that sees examined === 0 has learned
+  // nothing, and must not read the empty drift list as an all-clear.
+  const examined = new Set([...declaredNames, ...liveByName.keys()]).size;
+  return { drift, examined };
+}

--- a/src/utils/cron-registration.ts
+++ b/src/utils/cron-registration.ts
@@ -44,7 +44,9 @@ export type DriftKind =
   /** Registered live but absent from config.json: a rebuild-from-config DELETES it, silently. */
   | 'registered-not-declared'
   /** Registered but explicitly disabled: present, and still never fires. */
-  | 'registered-but-disabled';
+  | 'registered-but-disabled'
+  /** On disk one way, but the RUNNING scheduler holds a different schedule (never-reloaded edit). */
+  | 'schedule-stale';
 
 export interface CronDrift {
   agent: string;
@@ -62,6 +64,58 @@ export interface CronDrift {
  * empty lists and reported "no drift" would be the exact tick-over-nothing we have been
  * killing all week.
  */
+/** One cron as the RUNNING scheduler holds it in memory. */
+export interface LiveCron {
+  name: string;
+  schedule: string;
+}
+
+/**
+ * Compare the on-disk crons.json schedule against what the RUNNING scheduler holds.
+ *
+ * THE THIRD SURFACE. reconcileAgentCrons (below) compares two FILES — config.json and
+ * crons.json. But a cron that is in both files, agreeing, can STILL fire on a stale
+ * schedule if the file was hand-edited and the daemon never reloaded: the scheduler holds
+ * its own in-memory copy, and nothing in either file reflects it. That drift — the MOST
+ * COMMON one, a hand-edit that skipped the reload signal — is invisible to a file-vs-file
+ * check and to every CLI (list-crons recomputes next-fire from disk; it never queries the
+ * daemon). This compares crons.json (disk) against the scheduler (memory) and is the only
+ * thing that can see a never-reloaded edit.
+ *
+ * Pure and I/O-free: the daemon reads both (crons.json via readCrons, the live schedules via
+ * scheduler.getLiveSchedules()) and hands them here. Returns `examined` so a caller cannot
+ * read an empty result over an empty comparison as an all-clear.
+ */
+export function reconcileLiveSchedule(
+  agent: string,
+  declared: RegisteredCron[],   // from crons.json on disk
+  live: LiveCron[],             // from scheduler.getLiveSchedules() in memory
+): { drift: CronDrift[]; examined: number } {
+  const drift: CronDrift[] = [];
+  const liveByName = new Map(live.map(c => [c.name, c]));
+  for (const d of declared) {
+    if (d.enabled === false) continue;         // disabled crons are not scheduled; not stale
+    const l = liveByName.get(d.name);
+    if (!l) {
+      // On disk + enabled, but the scheduler doesn't hold it: it was added/enabled without a
+      // reload, so it is NOT actually firing yet.
+      drift.push({
+        agent, cron: d.name, kind: 'declared-not-registered',
+        detail: `on disk + enabled but the running scheduler has no entry — added/enabled without a reload; it is not firing`,
+      });
+      continue;
+    }
+    if ((d.schedule ?? '') !== l.schedule) {
+      drift.push({
+        agent, cron: d.name, kind: 'schedule-stale',
+        detail: `crons.json says "${d.schedule}" but the running scheduler is firing "${l.schedule}" — the file was edited without a reload signal`,
+      });
+    }
+  }
+  const examined = new Set([...declared.map(d => d.name), ...liveByName.keys()]).size;
+  return { drift, examined };
+}
+
 export function reconcileAgentCrons(
   agent: string,
   declared: DeclaredCron[],

--- a/src/utils/cron-registration.ts
+++ b/src/utils/cron-registration.ts
@@ -16,6 +16,13 @@
  * CLAUDE.md already names it as the source of truth. No new registry to drift.
  *
  * Pure and I/O-free on purpose: the caller reads the two files, this decides.
+ *
+ * KNOWN LIMIT — deliberate, not an oversight: this reconciles BY NAME. A cron present in
+ * both files under the same name but with a DIFFERENT SCHEDULE is not flagged. That cron
+ * still fires — it may just fire at the wrong time — which is a different failure from the
+ * ABSENCE this function exists to catch, and the missed-slot rule in cron-health.ts covers
+ * the case where a wrong schedule means it stops firing when expected. Scope kept narrow on
+ * purpose; schedule-drift is a follow-up, not a silent gap.
  */
 
 /** One cron as DECLARED in config.json. */

--- a/src/utils/cron-registration.ts
+++ b/src/utils/cron-registration.ts
@@ -46,7 +46,9 @@ export type DriftKind =
   /** Registered but explicitly disabled: present, and still never fires. */
   | 'registered-but-disabled'
   /** On disk one way, but the RUNNING scheduler holds a different schedule (never-reloaded edit). */
-  | 'schedule-stale';
+  | 'schedule-stale'
+  /** The RUNNING scheduler still fires a cron that was REMOVED from crons.json (never-reloaded removal). */
+  | 'scheduler-orphan';
 
 export interface CronDrift {
   agent: string;
@@ -112,6 +114,24 @@ export function reconcileLiveSchedule(
       });
     }
   }
+
+  // THE INVERSE DIRECTION — an ORPHAN. A cron REMOVED from crons.json that the scheduler
+  // STILL HOLDS keeps FIRING, because the removal skipped the reload signal. The file check
+  // is bidirectional; this must be too, or `examined` below counts the orphan while no drift
+  // is emitted for it — a count that reads "covered" over a case never checked, the exact
+  // failure this whole file exists to kill. Lower consequence than a silent monitor (an
+  // orphan over-fires rather than going dark) but the same drift, same trigger: a hand-edit
+  // that skipped the reload.
+  const declaredNames = new Set(declared.map(d => d.name));
+  for (const l of live) {
+    if (!declaredNames.has(l.name)) {
+      drift.push({
+        agent, cron: l.name, kind: 'scheduler-orphan',
+        detail: `the running scheduler is firing "${l.name}" ("${l.schedule}") but it is absent from crons.json — removed without a reload; it keeps firing`,
+      });
+    }
+  }
+
   const examined = new Set([...declared.map(d => d.name), ...liveByName.keys()]).size;
   return { drift, examined };
 }

--- a/tests/unit/utils/cron-health.test.ts
+++ b/tests/unit/utils/cron-health.test.ts
@@ -18,6 +18,8 @@ import {
   computeHealth,
   aggregateFleetHealth,
   WARNING_MULTIPLIER,
+  MISSED_FIRE_GRACE_MS,
+  previousSlotMs,
   type CronHealth,
   type HealthState,
 } from '../../../src/utils/cron-health';
@@ -183,16 +185,69 @@ describe('computeHealth — warning', () => {
     expect(result.state).toBe('warning');
   });
 
-  it('no warning for cron expression schedules (interval unknown — expectedIntervalMs 0)', () => {
-    // Cron expression: parseDurationMs returns NaN -> expectedIntervalMs = 0
-    // When expectedIntervalMs === 0, the warning check is skipped
-    const lastFire = new Date(NOW_MS - 100 * 3_600_000).toISOString(); // 100h ago — huge gap
+  it('cron expression, dead 100h -> WARNING (was a silent healthy)', () => {
+    // THIS TEST REPLACES A TAUTOLOGY. The previous version asserted
+    //     expect(['healthy', 'warning']).toContain(result.state)
+    // on a cron dead for 100 HOURS — an assertion that CANNOT FAIL, because it accepts
+    // the buggy answer and the correct one equally. Its own comment said "should be
+    // healthy (or warning if we add logic later)". So the gap was known, documented,
+    // and then guarded by a test that passes no matter what the code does.
+    // A TEST THAT CANNOT FAIL IS NOT A TEST — and this one sat on top of a health monitor
+    // that reported HEALTHY for a cron that had been dead for a month.
+    const lastFire = new Date(NOW_MS - 100 * 3_600_000).toISOString();
     const row = makeRow({ lastFire, lastStatus: 'fired', schedule: '0 9 * * *' });
     const result = computeHealth(row, [], NOW_MS);
-    // Can't compute warning for cron expr — should be healthy (or warning if we add logic later)
-    expect(['healthy', 'warning']).toContain(result.state);
-    // But specifically: expectedIntervalMs must be 0
-    expect(result.expectedIntervalMs).toBe(0);
+    expect(result.state).toBe('warning');            // <- asserts. Fails on the old code.
+    expect(result.reason).toMatch(/MISSED its scheduled fire/);
+    expect(result.expectedIntervalMs).toBe(0);       // still 0 — we did not fake an interval
+  });
+
+  // ── NEGATIVE CONTROLS ────────────────────────────────────────────────────────
+  // A liveness check that cannot be SHOWN TO FIRE is a vacuous gate, and a liveness
+  // check is the last place to ship one: its whole job is to fire when everything else
+  // looks fine. Each of these FAILS against the pre-fix code.
+
+  it('NEGATIVE CONTROL — weekly cron that skipped its slot is caught in MINUTES, not a fortnight', () => {
+    // The 2x-gap rule would need 14 DAYS to notice this (2 x 7d) — if it ran at all,
+    // which for a cron expression it did not. Missed-slot detection catches it at
+    // slot + grace, so latency tracks CONSEQUENCE, not the cron's cadence.
+    const schedule = '7 15 * * 1';                       // Mondays 15:07 — a security sweep
+    const slot = previousSlotMs(schedule, NOW_MS)!;
+    expect(slot).not.toBeNull();
+    const justPastGrace = slot + MISSED_FIRE_GRACE_MS + 60_000;   // ~16 minutes after the slot
+    const row = makeRow({
+      schedule,
+      lastFire: new Date(slot - 7 * 86_400_000).toISOString(),    // last ran a week ago; skipped today
+      lastStatus: 'fired',
+    });
+    const result = computeHealth(row, [], justPastGrace);
+    expect(result.state).toBe('warning');
+  });
+
+  it('NEGATIVE CONTROL — a cron that DID fire for its slot stays healthy (no false alarm)', () => {
+    const schedule = '7 15 * * 1';
+    const slot = previousSlotMs(schedule, NOW_MS)!;
+    const row = makeRow({
+      schedule,
+      lastFire: new Date(slot + 30_000).toISOString(),   // fired 30s after its slot
+      lastStatus: 'fired',
+    });
+    const result = computeHealth(row, [], slot + MISSED_FIRE_GRACE_MS + 60_000);
+    expect(result.state).toBe('healthy');
+  });
+
+  it('NEGATIVE CONTROL — inside the grace window we do NOT cry wolf', () => {
+    // Execution latency is real: the scheduler triggers, the agent records the fire a beat
+    // later. A monitor that fires on that beat is a monitor people learn to ignore.
+    const schedule = '*/27 * * * *';
+    const slot = previousSlotMs(schedule, NOW_MS)!;
+    const row = makeRow({
+      schedule,
+      lastFire: new Date(slot - 27 * 60_000).toISOString(),  // fired the PREVIOUS slot, not this one
+      lastStatus: 'fired',
+    });
+    const result = computeHealth(row, [], slot + MISSED_FIRE_GRACE_MS - 60_000);  // still in grace
+    expect(result.state).toBe('healthy');
   });
 
   it('30m schedule — warning after 1h 1ms', () => {
@@ -338,14 +393,22 @@ describe('computeHealth — successRate24h', () => {
 // ---------------------------------------------------------------------------
 
 describe('computeHealth — edge cases', () => {
-  it('handles daemon-was-down scenario: lastStatus fired but huge gap with cron expr', () => {
-    // Cron expression schedule, fired 3 days ago — expectedIntervalMs = 0, so no warning
+  it('daemon-was-down scenario: a daily cron silent for 3 days -> WARNING', () => {
+    // ★ THIS TEST USED TO ASSERT `healthy`. Read that again: it was NAMED
+    // "handles daemon-was-down scenario" and it asserted THE MONITOR REPORTS HEALTHY.
+    // The bug was not merely unnoticed — it was written down as a REQUIREMENT and
+    // pinned by an assertion. "expectedIntervalMs = 0, so warning threshold cannot be
+    // computed → healthy" describes the implementation's limitation and then blesses it
+    // as the expected result. Any future fix would break this test, and the fix would
+    // have looked like the regression.
+    //
+    // A daily cron that has not run in three days is not healthy. It is the loudest
+    // possible signal that something is wrong, and the health monitor said nothing.
     const lastFire = new Date(NOW_MS - 3 * 86_400_000).toISOString();
     const row = makeRow({ lastFire, lastStatus: 'fired', schedule: '0 9 * * *' });
     const result = computeHealth(row, [], NOW_MS);
-    // expectedIntervalMs = 0, so warning threshold cannot be computed → healthy
-    expect(result.expectedIntervalMs).toBe(0);
-    expect(result.state).toBe('healthy');
+    expect(result.expectedIntervalMs).toBe(0);   // unchanged: we did NOT fabricate an interval
+    expect(result.state).toBe('warning');        // the missed-slot rule sees it
   });
 
   it('handles clock skew: lastFire in the future produces gapMs < 0 but state healthy', () => {

--- a/tests/unit/utils/cron-health.test.ts
+++ b/tests/unit/utils/cron-health.test.ts
@@ -239,15 +239,25 @@ describe('computeHealth — warning', () => {
   it('NEGATIVE CONTROL — inside the grace window we do NOT cry wolf', () => {
     // Execution latency is real: the scheduler triggers, the agent records the fire a beat
     // later. A monitor that fires on that beat is a monitor people learn to ignore.
+    //
+    // ★ THIS TEST WAS VACUOUS ON ITS FIRST WRITING AND A MUTANT CAUGHT IT.
+    // It anchored `now` to `slot + MISSED_FIRE_GRACE_MS - 60s`. Set the grace to 0 and that
+    // expression slides BEFORE the slot — so previousSlotMs picks the PRECEDING slot, which
+    // the cron did fire, and the test passes for a reason that has nothing to do with grace.
+    // It passed for EVERY value of MISSED_FIRE_GRACE_MS, i.e. it never tested grace at all.
+    // Anchoring `now` to a FIXED offset past the slot makes it fail when grace is 0 — which
+    // is the only thing that makes it a test of the grace window.
     const schedule = '*/27 * * * *';
     const slot = previousSlotMs(schedule, NOW_MS)!;
+    const oneMinuteAfterTheSlot = slot + 60_000;    // fixed: does NOT move with the constant
+    expect(MISSED_FIRE_GRACE_MS).toBeGreaterThan(60_000);   // the premise the test rests on
     const row = makeRow({
       schedule,
       lastFire: new Date(slot - 27 * 60_000).toISOString(),  // fired the PREVIOUS slot, not this one
       lastStatus: 'fired',
     });
-    const result = computeHealth(row, [], slot + MISSED_FIRE_GRACE_MS - 60_000);  // still in grace
-    expect(result.state).toBe('healthy');
+    const result = computeHealth(row, [], oneMinuteAfterTheSlot);
+    expect(result.state).toBe('healthy');   // one minute late is latency, not death
   });
 
   it('30m schedule — warning after 1h 1ms', () => {

--- a/tests/unit/utils/cron-registration.test.ts
+++ b/tests/unit/utils/cron-registration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * tests/unit/utils/cron-registration.test.ts
+ *
+ * Negative controls for the registration reconcile. A liveness check that cannot be
+ * SHOWN TO FIRE is a vacuous gate — and a liveness check is the last place to ship one,
+ * because its entire job is to fire when everything else looks fine.
+ */
+import { describe, it, expect } from 'vitest';
+import { reconcileAgentCrons } from '../../../src/utils/cron-registration';
+
+describe('reconcileAgentCrons', () => {
+  it('agrees -> no drift', () => {
+    const { drift, examined } = reconcileAgentCrons(
+      'dev',
+      [{ name: 'heartbeat' }, { name: 'security-sweep' }],
+      [{ name: 'heartbeat', enabled: true }, { name: 'security-sweep', enabled: true }],
+    );
+    expect(drift).toEqual([]);
+    expect(examined).toBe(2);
+  });
+
+  it('NEGATIVE CONTROL — cron REMOVED from live: declared but never registered, so it will never fire', () => {
+    // No fire-gap check can ever see this: the cron has no fires to be late for.
+    const { drift } = reconcileAgentCrons(
+      'dev',
+      [{ name: 'weekly-security-sweep' }],
+      [],
+    );
+    expect(drift).toHaveLength(1);
+    expect(drift[0].kind).toBe('declared-not-registered');
+    expect(drift[0].cron).toBe('weekly-security-sweep');
+  });
+
+  it('NEGATIVE CONTROL — THE DRIFT WE ACTUALLY HIT: live but absent from config.json', () => {
+    // safetystack-handoff-check was exactly this on 2026-07-14: registered and firing,
+    // but missing from config.json — so a rebuild-from-config would have deleted it and
+    // nothing would have said a word. Found by hand. This is that check.
+    const { drift } = reconcileAgentCrons(
+      'dev',
+      [{ name: 'heartbeat' }],
+      [{ name: 'heartbeat' }, { name: 'safetystack-handoff-check' }],
+    );
+    expect(drift).toHaveLength(1);
+    expect(drift[0].kind).toBe('registered-not-declared');
+    expect(drift[0].cron).toBe('safetystack-handoff-check');
+    expect(drift[0].detail).toMatch(/silently DELETE/);
+  });
+
+  it('NEGATIVE CONTROL — registered but DISABLED: present, and still never fires', () => {
+    const { drift } = reconcileAgentCrons(
+      'dev',
+      [{ name: 'weekly-security-sweep' }],
+      [{ name: 'weekly-security-sweep', enabled: false }],
+    );
+    expect(drift).toHaveLength(1);
+    expect(drift[0].kind).toBe('registered-but-disabled');
+  });
+
+  it('ZERO COVERAGE IS NOT AN ALL-CLEAR — empty vs empty reports examined:0, not "healthy"', () => {
+    // A reconcile that compared two empty lists and returned "no drift" would be a tick
+    // over nothing. The caller must key off `examined`, never off an empty drift array.
+    const { drift, examined } = reconcileAgentCrons('dev', [], []);
+    expect(drift).toEqual([]);
+    expect(examined).toBe(0);   // <- the caller's cue that it learned NOTHING
+  });
+});

--- a/tests/unit/utils/cron-registration.test.ts
+++ b/tests/unit/utils/cron-registration.test.ts
@@ -110,6 +110,20 @@ describe('reconcileLiveSchedule — the third surface (disk vs running scheduler
     expect(drift).toEqual([]);   // correctly silent — no false alarm
   });
 
+  it('★ NEGATIVE CONTROL — ORPHAN: removed from crons.json but the scheduler still fires it', () => {
+    // The inverse of the incident: a hand-removal that skipped the reload. The scheduler
+    // keeps firing a cron that no longer exists on disk. `examined` counts it, so without
+    // this direction the count would claim coverage over an unchecked case.
+    const { drift } = reconcileLiveSchedule(
+      'dev',
+      [],                                                 // disk: gone
+      [{ name: 'ghost', schedule: '0 3 * * *' }],         // scheduler: still firing it
+    );
+    expect(drift).toHaveLength(1);
+    expect(drift[0].kind).toBe('scheduler-orphan');
+    expect(drift[0].detail).toMatch(/removed without a reload/);
+  });
+
   it('ZERO COVERAGE reports examined:0, not all-clear', () => {
     const { drift, examined } = reconcileLiveSchedule('dev', [], []);
     expect(drift).toEqual([]);

--- a/tests/unit/utils/cron-registration.test.ts
+++ b/tests/unit/utils/cron-registration.test.ts
@@ -6,7 +6,7 @@
  * because its entire job is to fire when everything else looks fine.
  */
 import { describe, it, expect } from 'vitest';
-import { reconcileAgentCrons } from '../../../src/utils/cron-registration';
+import { reconcileAgentCrons, reconcileLiveSchedule } from '../../../src/utils/cron-registration';
 
 describe('reconcileAgentCrons', () => {
   it('agrees -> no drift', () => {
@@ -62,5 +62,57 @@ describe('reconcileAgentCrons', () => {
     const { drift, examined } = reconcileAgentCrons('dev', [], []);
     expect(drift).toEqual([]);
     expect(examined).toBe(0);   // <- the caller's cue that it learned NOTHING
+  });
+});
+
+describe('reconcileLiveSchedule — the third surface (disk vs running scheduler)', () => {
+  it('disk and scheduler agree -> no drift', () => {
+    const { drift, examined } = reconcileLiveSchedule(
+      'dev',
+      [{ name: 'handoff', schedule: '13 14 * * *', enabled: true }],
+      [{ name: 'handoff', schedule: '13 14 * * *' }],
+    );
+    expect(drift).toEqual([]);
+    expect(examined).toBe(1);
+  });
+
+  it('★ NEGATIVE CONTROL — THE HAND-EDIT THAT NEVER RELOADED: disk changed, scheduler stale', () => {
+    // This is the exact 2026-07-15 incident: crons.json was edited to "13 14 * * *" but the
+    // running scheduler still holds "13 14,20,1 * * *" because the edit skipped the reload
+    // signal. Invisible to the file-vs-file check (both files agree) and to list-crons (reads
+    // disk). ONLY this catches it.
+    const { drift } = reconcileLiveSchedule(
+      'dev',
+      [{ name: 'handoff', schedule: '13 14 * * *', enabled: true }],       // disk: fixed
+      [{ name: 'handoff', schedule: '13 14,20,1 * * *' }],                 // scheduler: stale
+    );
+    expect(drift).toHaveLength(1);
+    expect(drift[0].kind).toBe('schedule-stale');
+    expect(drift[0].detail).toMatch(/without a reload/);
+  });
+
+  it('NEGATIVE CONTROL — enabled on disk but scheduler has no entry (added without reload)', () => {
+    const { drift } = reconcileLiveSchedule(
+      'dev',
+      [{ name: 'newcron', schedule: '0 9 * * *', enabled: true }],
+      [],  // scheduler never picked it up
+    );
+    expect(drift).toHaveLength(1);
+    expect(drift[0].kind).toBe('declared-not-registered');
+  });
+
+  it('a DISABLED cron absent from the scheduler is NOT drift (disabled crons are not scheduled)', () => {
+    const { drift } = reconcileLiveSchedule(
+      'dev',
+      [{ name: 'off', schedule: '0 9 * * *', enabled: false }],
+      [],
+    );
+    expect(drift).toEqual([]);   // correctly silent — no false alarm
+  });
+
+  it('ZERO COVERAGE reports examined:0, not all-clear', () => {
+    const { drift, examined } = reconcileLiveSchedule('dev', [], []);
+    expect(drift).toEqual([]);
+    expect(examined).toBe(0);
   });
 });


### PR DESCRIPTION
## The bug

`cron-health.ts` derives `expectedIntervalMs` by parsing the **schedule**:

```ts
const expectedIntervalMs = Math.max(0, parseDurationMs(cron.schedule) || 0);   // :119
...
if (expectedIntervalMs > 0 && gapMs > WARNING_MULTIPLIER * expectedIntervalMs) { … }  // :158
```

`parseDurationMs` is `^(\d+)(m|h|d|w)$`. **A cron expression does not match** → `NaN` → `NaN || 0` → `0` → the staleness rule is gated behind `> 0` and **never runs**.

Not "warns late". **Never warns.** Compiled the module standalone and ran it — a cron that has not fired **in 30 days**:

| cron | schedule | health |
|---|---|---|
| `heartbeat` | `4h` | **WARNING** ← the only one that works |
| `heartbeat-tick` | `*/27 * * * *` | **HEALTHY** |
| `safetystack-daily-check` | `3 15 * * *` | **HEALTHY** |
| `weekly-security-sweep` | `7 15 * * 1` | **HEALTHY** |
| `safetystack-handoff-check` | `13 14 * * *` | **HEALTHY** |

## Blast radius: 13 of 24 crons across the fleet

Including:
- **`weekly-security-sweep`** — the security monitor.
- **`axeltire-uptime-check`** — watches a **live business site**. If it dies, the site can go down and health reports HEALTHY. The owner finds out from a customer.
- **`stale-heartbeat-check`** — *the monitor that catches dead agents, itself unwatched.* The watcher that can die silently, already in production.

The 11 that *did* work all happen to use duration strings (`4h`, `15m`) — **by luck, not design**.

A monitor that reports healthy because it cannot see is worse than no monitor: a missing one is a known gap; this one **manufactures confidence**.

## Why not just teach `parseDurationMs` about cron expressions

That arms the 2×-gap rule, whose blind window **scales with the period** — the weekly sweep would still be invisible for a **fortnight**. Gap-since-last-fire is the wrong primitive.

The right question is not *"how long since it last ran?"* but **"did it run when it said it would?"** — and the schedule already answers that. Detection latency then tracks the **grace period, not the cadence**: a weekly cron is caught as fast as a 27-minute one. `expectedIntervalMs` stays `0`; no interval is fabricated.

## Why the bug survived: the tests encoded it as correct

```ts
// a cron dead 100 HOURS:
expect(['healthy', 'warning']).toContain(result.state);   // ← CANNOT FAIL
```
That assertion accepts the bug and the fix equally. Its own comment said *"should be healthy (or warning if we add logic later)"*.

And worse — a second test was **named `handles daemon-was-down scenario`** and asserted the monitor reports **`healthy`**. The bug wasn't overlooked; it was written down as a **requirement** and pinned with an assertion, so any real fix would have looked like the regression.

Both replaced with assertions that **fail against the old code**.

## The second death mode: ABSENT, not late

A cron that was never registered has no fire-gap to measure. Every fire-based check reports nothing wrong **forever**, because there is nothing to report on.

Real: `safetystack-handoff-check` was live in `crons.json` and **missing from `config.json`** — a rebuild-from-config would have silently deleted it. Found by hand, which is not a strategy.

`reconcileAgentCrons()` (pure) compares **declared** (`config.json`, the documented source of truth) against **live** (`crons.json`): `declared-not-registered` / `registered-not-declared` / `registered-but-disabled`.

**It runs in the daemon, not in a cron.** A cron that watches crons can die the same silent death it exists to catch. The daemon's own death is *already loud* — if it's gone, nothing fires and the agent goes visibly STALE. **Put the guard where its own failure is impossible to miss.**

Zero coverage is not an all-clear: it returns `examined`, and the daemon warns `examined 0 crons — CANNOT confirm any cron is registered` rather than reporting clean over an empty comparison.

## Verification

- Typecheck clean.
- **Negative controls fire.** Reverting only the source fix, the behavioural tests fail with the *wrong answer* (`healthy` for a cron dead 100h; `healthy` for a daily cron silent 3 days). A liveness check that cannot be shown to **fire** is a vacuous gate — the last place to ship one.
- No false alarms: a cron that *did* run its slot stays healthy; inside the grace window we do not cry wolf.
- **Zero regressions**, measured against a clean `upstream/main` worktree: baseline `14 failed / 28 failed / 1750 passed` → branch `14 failed / 28 failed / 1758 passed`. Identical failure set; +8 passing tests. The 28 failures are pre-existing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)