### PR TITLE
feat(dashboard): resolve org vault path from context.json (fallback to knowledge.md)

### DIFF
--- a/dashboard/src/lib/__tests__/vault-getvaultroot.test.ts
+++ b/dashboard/src/lib/__tests__/vault-getvaultroot.test.ts
@@ -1,0 +1,77 @@
+/**
+ * vault-getvaultroot.test.ts — getVaultRoot() org→vault resolution.
+ *
+ * Covers the per-org vault-path config field: getVaultRoot() prefers
+ * orgs/<org>/context.json { "vaultPath": "…" } and falls back to the legacy
+ * "Obsidian vault" prose line in knowledge.md when the field is absent or
+ * points at an invalid path.
+ *
+ * Coverage:
+ *   - context.json vaultPath is preferred when it points at a real dir
+ *   - absent vaultPath falls back to the knowledge.md regex
+ *   - a configured-but-invalid vaultPath falls through to the regex
+ *
+ * CTX_FRAMEWORK_ROOT is a module-load const in config.ts, so we set it in
+ * beforeAll and import vault.ts dynamically afterwards.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+const tmp = path.join(os.tmpdir(), `vaultroot-test-${process.pid}`);
+const fw = path.join(tmp, 'fw');
+// Vault dirs must END in "vault" — the fallback regex captures `…vault/?`.
+const vaultCfg = path.join(tmp, 'orgA', 'vault');
+const vaultKnow = path.join(tmp, 'orgB', 'vault');
+
+function makeVault(dir: string) {
+  fs.mkdirSync(path.join(dir, '00-inbox'), { recursive: true });
+}
+
+function writeOrg(org: string, context: object, knowledge?: string) {
+  const dir = path.join(fw, 'orgs', org);
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, 'context.json'), JSON.stringify(context));
+  if (knowledge !== undefined) {
+    fs.writeFileSync(path.join(dir, 'knowledge.md'), knowledge);
+  }
+}
+
+describe('getVaultRoot() per-org vault-path resolution', () => {
+  beforeAll(() => {
+    makeVault(vaultCfg);
+    makeVault(vaultKnow);
+    // org1: context.json vaultPath -> real dir (config-first wins)
+    writeOrg('org1', { vaultPath: vaultCfg });
+    // org2: no vaultPath, knowledge.md manifest -> fallback
+    writeOrg('org2', { name: 'org2' }, `## Wiki\n- Obsidian vault: \`${vaultKnow}\`\n`);
+    // org3: vaultPath -> nonexistent, knowledge.md manifest -> fall through to regex
+    writeOrg(
+      'org3',
+      { vaultPath: path.join(tmp, 'nope', 'vault') },
+      `## Wiki\n- Obsidian vault: \`${vaultKnow}\`\n`,
+    );
+    process.env.CTX_FRAMEWORK_ROOT = fw;
+  });
+
+  afterAll(() => {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it('prefers context.json vaultPath when it points at a real directory', async () => {
+    const { getVaultRoot } = await import('../vault');
+    expect(getVaultRoot('org1')).toBe(vaultCfg);
+  });
+
+  it('falls back to the knowledge.md regex when vaultPath is absent', async () => {
+    const { getVaultRoot } = await import('../vault');
+    expect(getVaultRoot('org2')).toBe(vaultKnow);
+  });
+
+  it('falls through to the knowledge.md regex when configured vaultPath is invalid', async () => {
+    const { getVaultRoot } = await import('../vault');
+    expect(getVaultRoot('org3')).toBe(vaultKnow);
+  });
+});

--- a/dashboard/src/lib/vault.ts
+++ b/dashboard/src/lib/vault.ts
@@ -7,7 +7,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
-import { CTX_FRAMEWORK_ROOT } from './config';
+import { CTX_FRAMEWORK_ROOT, getOrgContextPath } from './config';
 
 export const PARA_DIRS = [
   '00-inbox',
@@ -25,7 +25,23 @@ const VAULT_FALLBACK = process.env.CTX_VAULT_PATH
   ?? path.join(os.homedir(), 'storage', 'Documents', 'Github', 'sondres-orchestrator', 'vault');
 
 export function getVaultRoot(org: string): string | null {
-  // 1. Try parsing orgs/<org>/knowledge.md for an "Obsidian vault" path entry
+  // 1. Explicit per-org config field (preferred): orgs/<org>/context.json { "vaultPath": "…" }
+  const contextPath = getOrgContextPath(org);
+  if (fs.existsSync(contextPath)) {
+    try {
+      const ctx = JSON.parse(fs.readFileSync(contextPath, 'utf-8')) as {
+        vaultPath?: string;
+      };
+      const configured = ctx.vaultPath?.trim();
+      if (configured && fs.existsSync(configured) && fs.statSync(configured).isDirectory()) {
+        return configured;
+      }
+    } catch {
+      /* ignore malformed context.json, fall through to knowledge.md */
+    }
+  }
+
+  // 2. Legacy: parse orgs/<org>/knowledge.md for an "Obsidian vault" path entry
   const knowledgePath = path.join(CTX_FRAMEWORK_ROOT, 'orgs', org, 'knowledge.md');
   if (fs.existsSync(knowledgePath)) {
     try {
@@ -43,7 +59,7 @@ export function getVaultRoot(org: string): string | null {
     }
   }
 
-  // 2. Fallback to the known sondre-hq vault location
+  // 3. Fallback to the known sondre-hq vault location
   if (fs.existsSync(VAULT_FALLBACK) && fs.statSync(VAULT_FALLBACK).isDirectory()) {
     return VAULT_FALLBACK;
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -474,6 +474,11 @@ export interface OrgContext {
    *  save-output. The instruction is injected into the boot prompt
    *  dynamically — no agent markdown files are modified. */
   require_deliverables?: boolean;
+  /** Absolute path to this org's Obsidian vault, rendered read-only by the
+   *  dashboard /wiki page. Preferred over parsing the "Obsidian vault" prose
+   *  line in knowledge.md (which stays as a fallback for orgs without this
+   *  field). Optional — unset orgs fall through to the knowledge.md regex. */
+  vaultPath?: string;
 }
 
 // Telegram Types


### PR DESCRIPTION
## What

`getVaultRoot()` currently discovers an org's Obsidian vault by regex-matching an
`` Obsidian vault: `…` `` line inside `orgs/<org>/knowledge.md`. That couples vault
resolution to free-form prose and silently breaks if that line is reworded or moved.

This adds an explicit, optional per-org config field and prefers it:

- New optional `OrgContext.vaultPath` field (`src/types/index.ts`).
- `getVaultRoot(org)` now reads `orgs/<org>/context.json` first; if `vaultPath` is set
  and points at a real directory, it is used. Otherwise it falls back to the existing
  `knowledge.md` regex, and then the existing `CTX_VAULT_PATH` / default fallback —
  unchanged.

## Why

- Explicit config over prose-parsing: robust to `knowledge.md` edits.
- Fully backward compatible: `vaultPath` is optional, so orgs without it behave exactly
  as before (the regex path is untouched). Mirrors the existing optional-field pattern
  (`require_deliverables`) — no default-fill in `init`, `undefined` simply falls through.
- Read directly via `getOrgContextPath(org)` in `vault.ts`, not threaded through the
  display-only `getOrganizationContext()` subset reader.

## Testing

Adds `dashboard/src/lib/__tests__/vault-getvaultroot.test.ts` covering:

1. `context.json` `vaultPath` is preferred when it points at a real directory.
2. Falls back to the `knowledge.md` regex when `vaultPath` is absent.
3. Falls through to the regex when a configured `vaultPath` is invalid.

`tsc --noEmit` clean (root + dashboard); 3/3 tests pass.
