### PR TITLE
fix(skills): agent-dir skill path resolution in list-skills CLI + dashboard install

### DIFF
--- a/dashboard/src/app/api/skills/route.ts
+++ b/dashboard/src/app/api/skills/route.ts
@@ -33,7 +33,7 @@ function getInstalledAgents(frameworkRoot: string, slug: string): string[] {
     if (!fs.existsSync(agentsDir)) continue;
     for (const agentEntry of fs.readdirSync(agentsDir, { withFileTypes: true })) {
       if (!agentEntry.isDirectory()) continue;
-      const skillPath = path.join(agentsDir, agentEntry.name, 'skills', slug);
+      const skillPath = path.join(agentsDir, agentEntry.name, '.claude', 'skills', slug);
       if (fs.existsSync(skillPath)) {
         installed.push(`${orgEntry.name}/${agentEntry.name}`);
       }
@@ -97,7 +97,7 @@ export async function POST(request: Request) {
       return Response.json({ error: `Skill not found: ${slug}` }, { status: 404 });
     }
 
-    const skillsDir = path.join(frameworkRoot, 'orgs', org, 'agents', agent, 'skills');
+    const skillsDir = path.join(frameworkRoot, 'orgs', org, 'agents', agent, '.claude', 'skills');
     fs.mkdirSync(skillsDir, { recursive: true });
     const linkPath = path.join(skillsDir, slug);
 
@@ -119,7 +119,7 @@ export async function DELETE(request: Request) {
     }
 
     const frameworkRoot = getFrameworkRoot();
-    const linkPath = path.join(frameworkRoot, 'orgs', org, 'agents', agent, 'skills', slug);
+    const linkPath = path.join(frameworkRoot, 'orgs', org, 'agents', agent, '.claude', 'skills', slug);
 
     try {
       const stat = fs.lstatSync(linkPath);

--- a/src/cli/list-skills.ts
+++ b/src/cli/list-skills.ts
@@ -1,5 +1,5 @@
 import { Command } from 'commander';
-import { existsSync, readdirSync, readFileSync } from 'fs';
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { join } from 'path';
 
 interface SkillInfo {
@@ -51,7 +51,17 @@ function scanSkillsDir(dir: string, source: string): SkillInfo[] {
   try {
     const entries = readdirSync(dir, { withFileTypes: true });
     for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
+      // readdirSync's dirent type reflects the entry itself, not its target — a
+      // symlink (what agent skill installs are) always reports isDirectory() as
+      // false. Follow it with statSync to see what it actually points at.
+      if (!entry.isDirectory() && !entry.isSymbolicLink()) continue;
+      if (entry.isSymbolicLink()) {
+        try {
+          if (!statSync(join(dir, entry.name)).isDirectory()) continue;
+        } catch {
+          continue; // broken symlink
+        }
+      }
       const skillFile = join(dir, entry.name, 'SKILL.md');
       if (!existsSync(skillFile)) continue;
 
@@ -111,7 +121,7 @@ export const listSkillsCommand = new Command('list-skills')
     }
 
     // Agent-level skills (highest priority, override others)
-    const agentSkills = join(agentDir, 'skills');
+    const agentSkills = join(agentDir, '.claude', 'skills');
     for (const skill of scanSkillsDir(agentSkills, 'agent')) {
       skillMap.set(skill.name, skill);
     }


### PR DESCRIPTION
## What

Two small, independent fixes to per-agent skill-path resolution.

1. **`src/cli/list-skills.ts`** — `list-skills --agent-dir <agent>` under-reported: it did
   not follow symlinks when enumerating an agent's skills, so skills symlinked into the
   agent's skill directory were invisible, and the agent-level skills path was resolved
   incorrectly. This follows symlinks and resolves the agent-dir skill path correctly.

2. **`dashboard/src/app/api/skills/route.ts`** — the dashboard "install skill" action wrote
   into `skills/` rather than the agent's `.claude/skills/`, so a skill installed from the
   dashboard was not picked up by the agent. This installs under `.claude/skills/`.

## Why

Both surfaced while managing per-agent skills: `list-skills --agent-dir` silently
under-counted (symlinked skills missing), and dashboard-installed skills landed in the
wrong directory. The changes are targeted and self-contained — no behavior change beyond
correcting the two paths.
