### PR TITLE
fix(heartbeat): derive staleness from the agent's own interval via one shared helper

### DIFF
--- a/src/bus/heartbeat-staleness.ts
+++ b/src/bus/heartbeat-staleness.ts
@@ -1,0 +1,50 @@
+/**
+ * Single source of truth for "is this agent's heartbeat stale?".
+ *
+ * Previously TWO call sites hardcoded DIFFERENT thresholds — the CLI display
+ * (src/cli/bus.ts) flagged STALE at 2h, the metrics counter (src/bus/metrics.ts)
+ * counted healthy until 5h. They disagreed, so any agent on an interval between
+ * 2h and 5h displayed STALE for part of every cycle while simultaneously being
+ * counted healthy — two monitors, same agent, same instant, opposite verdicts.
+ *
+ * The fix is not "make the two constants match" — that just drifts apart again
+ * the next time one is edited. It is ONE helper both sites call, and staleness
+ * DERIVED from the agent's own configured heartbeat cadence (its `loop_interval`,
+ * populated from its heartbeat cron), not a fleet-wide magic number.
+ */
+import { parseDurationMs } from './cron-state';
+
+/** Fallback cadence when an agent's loop_interval isn't recorded — the standard
+ *  heartbeat cron interval in this fleet. Only used when we can't do better. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 4 * 60 * 60 * 1000; // 4h
+
+/** Never call an agent stale sooner than this, however short its interval, so a
+ *  tick landing a little late doesn't flap the flag. */
+export const MIN_STALE_MS = 60 * 60 * 1000; // 1h
+
+/**
+ * How old a heartbeat may get before it is stale: two missed cycles of the
+ * agent's OWN interval (with a 1h floor). A 4h-interval agent is stale only past
+ * 8h — so it is never flagged mid-cycle; a 27m-tick agent is stale past ~1h.
+ */
+export function heartbeatStaleThresholdMs(loopInterval?: string | null): number {
+  const parsed = loopInterval ? parseDurationMs(loopInterval) : NaN;
+  const base = Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_HEARTBEAT_INTERVAL_MS;
+  return Math.max(base * 2, MIN_STALE_MS);
+}
+
+/**
+ * True if the heartbeat is stale for an agent whose refresh cadence is
+ * `loopInterval`. Missing/unparseable timestamps are treated as stale (fail
+ * toward "not confirmed alive", the safe direction for a liveness check).
+ */
+export function isHeartbeatStale(
+  lastHeartbeat: string | null | undefined,
+  loopInterval?: string | null,
+  now: number = Date.now(),
+): boolean {
+  if (!lastHeartbeat) return true;
+  const t = new Date(lastHeartbeat).getTime();
+  if (!Number.isFinite(t)) return true;
+  return now - t > heartbeatStaleThresholdMs(loopInterval);
+}

--- a/src/bus/metrics.ts
+++ b/src/bus/metrics.ts
@@ -7,6 +7,7 @@ import { existsSync, readFileSync, writeFileSync, appendFileSync, readdirSync, m
 import { join, basename, dirname } from 'path';
 import { execSync } from 'child_process';
 import { ensureDir } from '../utils/atomic.js';
+import { isHeartbeatStale } from './heartbeat-staleness.js';
 
 // --- Types ---
 
@@ -177,19 +178,17 @@ export function collectMetrics(ctxRoot: string, org?: string): MetricsReport {
       }
     }
 
-    // Check heartbeat staleness (stale if >5 hours old)
+    // Heartbeat staleness via the SHARED helper — same verdict as the CLI display
+    // (src/cli/bus.ts), derived from the agent's own configured interval. These
+    // used to be two hardcoded thresholds (5h here, 2h there) that disagreed.
     let heartbeatStale = true;
     const hbFile = join(ctxRoot, 'state', agent, 'heartbeat.json');
     if (existsSync(hbFile)) {
       try {
         const hb = JSON.parse(readFileSync(hbFile, 'utf-8'));
-        if (hb.last_heartbeat) {
-          const hbTime = new Date(hb.last_heartbeat).getTime();
-          const age = Date.now() - hbTime;
-          if (age < 5 * 60 * 60 * 1000) {
-            heartbeatStale = false;
-            agentsHealthy++;
-          }
+        if (!isHeartbeatStale(hb.last_heartbeat, hb.loop_interval)) {
+          heartbeatStale = false;
+          agentsHealthy++;
         }
       } catch { /* stale by default */ }
     }

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -8,6 +8,7 @@ import { createTask, updateTask, completeTask, claimTask, readTaskAudit, checkTa
 import { saveOutput } from '../bus/save-output.js';
 import { logEvent } from '../bus/event.js';
 import { updateHeartbeat, readAllHeartbeats } from '../bus/heartbeat.js';
+import { isHeartbeatStale } from '../bus/heartbeat-staleness.js';
 import { selfRestart, hardRestart, autoCommit, checkGoalStaleness, postActivity } from '../bus/system.js';
 import { createExperiment, runExperiment, evaluateExperiment, listExperiments, gatherContext, manageCycle, loadExperimentConfig } from '../bus/experiment.js';
 import { browseCatalog, installCommunityItem, prepareSubmission, submitCommunityItem } from '../bus/catalog.js';
@@ -461,10 +462,35 @@ busCommand
       }
     }
 
+    // Record the agent's heartbeat cadence so staleness is measured against ITS
+    // OWN interval, not a fleet-wide constant. When --interval isn't passed,
+    // derive it from the agent's config.json — the SHORTEST heartbeat-named cron
+    // (the tightest bound on how fresh the heartbeat should be). Best-effort: if
+    // config can't be read, leave it empty and the staleness helper falls back.
+    let loopInterval = opts.interval;
+    if (!loopInterval && frameworkRoot) {
+      for (const cfgPath of [
+        join(frameworkRoot, 'orgs', env.org, 'agents', env.agentName, 'config.json'),
+        join(frameworkRoot, 'agents', env.agentName, 'config.json'),
+      ]) {
+        if (!existsSync(cfgPath)) continue;
+        try {
+          const cfg = JSON.parse(readFileSync(cfgPath, 'utf-8'));
+          const hb = (cfg.crons || [])
+            .filter((c: { name?: string }) => /heartbeat/i.test(c.name || ''))
+            .map((c: { interval?: string }) => ({ s: c.interval || '', ms: parseDurationMs(c.interval || '') }))
+            .filter((x: { ms: number }) => Number.isFinite(x.ms) && x.ms > 0)
+            .sort((a: { ms: number }, b: { ms: number }) => a.ms - b.ms);
+          if (hb.length) loopInterval = hb[0].s;
+        } catch { /* leave undefined — staleness helper uses its default */ }
+        break;
+      }
+    }
+
     updateHeartbeat(paths, env.agentName, status, {
       org: env.org,
       timezone: opts.timezone,
-      loopInterval: opts.interval,
+      loopInterval,
       currentTask: opts.task,
       displayName,
     });
@@ -499,10 +525,14 @@ busCommand
     }
 
     for (const hb of heartbeats) {
-      const stale = new Date(hb.last_heartbeat) < new Date(Date.now() - 2 * 60 * 60 * 1000);
-      const staleFlag = stale ? ' [STALE]' : '';
+      const stale = isHeartbeatStale(hb.last_heartbeat, hb.loop_interval);
       const label = hb.display_name ? `${hb.display_name} (${hb.agent})` : hb.agent;
-      console.log(`${label} (${hb.org}) — ${hb.status}${staleFlag} — last seen ${hb.last_heartbeat}`);
+      // Provenance: `status` is authored by the AGENT; the stale flag is emitted by
+      // the MONITOR. Keep them clearly separated — the flag goes after "last seen"
+      // and is explicitly namespaced — so a system-emitted STALE can never be read
+      // as agent-authored status text (that misattribution is what this fixes).
+      const staleFlag = stale ? '  ⟨monitor: heartbeat STALE⟩' : '';
+      console.log(`${label} (${hb.org}) — ${hb.status} — last seen ${hb.last_heartbeat}${staleFlag}`);
       if (hb.current_task) console.log(`  task: ${hb.current_task}`);
     }
   });

--- a/tests/heartbeat-staleness.test.ts
+++ b/tests/heartbeat-staleness.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from 'vitest';
+import { isHeartbeatStale, heartbeatStaleThresholdMs } from '../src/bus/heartbeat-staleness.js';
+
+const NOW = 1_000_000_000_000;
+const H = 3_600_000;
+const M = 60_000;
+const ago = (ms: number) => new Date(NOW - ms).toISOString();
+
+describe('heartbeatStaleThresholdMs', () => {
+  it('derives from the agent interval (two missed cycles), with a 1h floor', () => {
+    expect(heartbeatStaleThresholdMs('4h')).toBe(8 * H);
+    expect(heartbeatStaleThresholdMs('27m')).toBe(H);       // 2*27m=54m -> floored to 1h
+    expect(heartbeatStaleThresholdMs('3h')).toBe(6 * H);
+  });
+  it('falls back to a default when the interval is unknown/unparseable', () => {
+    expect(heartbeatStaleThresholdMs('')).toBe(8 * H);        // default 4h base
+    expect(heartbeatStaleThresholdMs(null)).toBe(8 * H);
+    expect(heartbeatStaleThresholdMs('0 8 * * *')).toBe(8 * H); // cron expr -> NaN -> default
+  });
+});
+
+describe('isHeartbeatStale', () => {
+  it('does NOT flag an agent well inside its interval', () => {
+    expect(isHeartbeatStale(ago(1 * H), '4h', NOW)).toBe(false);
+  });
+  it('does NOT flag a long-interval agent at 3h (the reported false-STALE bug)', () => {
+    expect(isHeartbeatStale(ago(3 * H), '4h', NOW)).toBe(false);
+  });
+  it('DOES flag an agent well past its interval', () => {
+    expect(isHeartbeatStale(ago(10 * H), '4h', NOW)).toBe(true);
+  });
+  it('flags a short-interval agent that missed several ticks', () => {
+    expect(isHeartbeatStale(ago(30 * M), '27m', NOW)).toBe(false);
+    expect(isHeartbeatStale(ago(90 * M), '27m', NOW)).toBe(true);
+  });
+  it('treats missing/unparseable timestamps as stale (fail toward not-confirmed-alive)', () => {
+    expect(isHeartbeatStale(undefined, '4h', NOW)).toBe(true);
+    expect(isHeartbeatStale('not-a-date', '4h', NOW)).toBe(true);
+  });
+});

--- a/tests/sprint5-metrics.test.ts
+++ b/tests/sprint5-metrics.test.ts
@@ -74,10 +74,13 @@ describe('Sprint 5: Observability & Metrics', () => {
       const stateDir = join(ctxRoot, 'state', 'bot1');
       mkdirSync(stateDir, { recursive: true });
 
-      // Old heartbeat (6 hours ago)
+      // Heartbeat 6h old for an agent whose configured cadence is 2h — well past
+      // the derived stale threshold (2 x 2h = 4h). Staleness is derived from the
+      // agent's OWN loop_interval, not a fleet-wide constant.
       const oldTime = new Date(Date.now() - 6 * 60 * 60 * 1000).toISOString();
       writeFileSync(join(stateDir, 'heartbeat.json'), JSON.stringify({
         last_heartbeat: oldTime,
+        loop_interval: '2h',
       }), 'utf-8');
 
       const report = collectMetrics(ctxRoot);


### PR DESCRIPTION
## Problem
Two call sites hardcoded **different** heartbeat-staleness thresholds:
- `src/cli/bus.ts` flagged `[STALE]` at **2h**
- `src/bus/metrics.ts` counted an agent **healthy until 5h**

They disagreed, so **any agent on an interval between 2h and 5h displayed STALE for part of every cycle while simultaneously being counted healthy** — two monitors, same agent, same instant, opposite verdicts. It fires forever for any agent whose interval exceeds 2h. (This is how a perfectly healthy 4h-cron agent got told its heartbeat was stale.) Fourth "monitor fails in the direction of a wrong verdict" issue found on this fleet.

## Fix
- **`src/bus/heartbeat-staleness.ts`** — one source of truth. Staleness is **derived from the agent's OWN configured interval** (`loop_interval`): stale after two missed cycles, with a 1h floor. Both call sites now call `isHeartbeatStale()`, so they cannot drift apart again — the same shape as consolidating two copies of a resolver into one.
- **`update-heartbeat`** now records `loop_interval` by deriving it from the agent's own `config.json` heartbeat crons (the shortest heartbeat-named cron — the tightest bound on how fresh the heartbeat should be) when `--interval` isn't passed, so the derivation is real per-agent, not a fleet-wide default.
- **Provenance** (`src/cli/bus.ts`): `status` is authored by the agent; the stale flag is emitted by the monitor. The flag moved after `last seen` and is namespaced `⟨monitor: heartbeat STALE⟩` so a system-emitted flag can never be misread as agent-authored status text — the exact misattribution this fixes.

## Behaviour
| agent interval | age | stale? |
|---|---|---|
| 4h | 1h / 3h | no (never flagged mid-cycle) |
| 4h | 10h | yes |
| 27m | 30m / 90m | no / yes |
| unknown | 3h / 10h | no / yes (default 4h base) |
| missing/unparseable timestamp | — | yes (fail toward not-confirmed-alive) |

## Tests
- New `tests/heartbeat-staleness.test.ts`: derivation, inside-interval no-flag, well-past flag, **3h-no-flag for a long interval** (the reported bug), short-interval flag, fail-safe.
- `tests/sprint5-metrics.test.ts` staleness case updated to the derivation contract (sets `loop_interval`, asserts stale past the *derived* threshold).
- `tsc --noEmit` clean; `npm run build` succeeds; 39 targeted tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Latency trade-off (deliberate — not an accident)
Two missed cycles means a 4h agent's death isn't flagged for **~8h**, which is *slower* than the old 5h metrics threshold. This is intentional:
- The old CLI flagged at 2h and was **wrong every single cycle** for any agent slower than 2h. A monitor that cries wolf gets ignored — which is exactly what happened (a healthy agent was reported stale, and the flag stopped being trusted). We deliberately **bought precision with latency**.
- Two missed cycles is the standard heartbeat-liveness convention.
- **Fast death is covered elsewhere**: the process watchdog (kill → restart within one cron cycle) is the seconds-to-minutes signal. This staleness flag is the slow, *reliable* signal — the two are complementary, not redundant. For context, an agent recently sat dead for **4.7 days** behind a watchdog that silently never fired; an 8h reliable flag would have been transformative there.