### PR TITLE
fix(cli): list-tasks renders full ids + supports --project filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
-node_modules/
+# No trailing slash: `node_modules/` matches only real directories, so a
+# SYMLINKED node_modules (common in worktree checkouts) evades it and can be
+# committed — which once took down every agent sharing this checkout's bus.
+node_modules
 .claude/
 !.claude/commands/
 !.claude/commands/**

--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -527,6 +527,7 @@ export function listTasks(
     agent?: string;
     status?: TaskStatus;
     priority?: Priority;
+    project?: string;
     respectDeps?: boolean;
   },
 ): Task[] {
@@ -550,6 +551,7 @@ export function listTasks(
       if (filters?.agent && task.assigned_to !== filters.agent) continue;
       if (filters?.status && task.status !== filters.status) continue;
       if (filters?.priority && task.priority !== filters.priority) continue;
+      if (filters?.project && task.project !== filters.project) continue;
       if (task.archived) continue;
 
       tasks.push(task);

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -350,14 +350,16 @@ busCommand
   .command('list-tasks')
   .option('--agent <name>', 'Filter by agent')
   .option('--status <s>', 'Filter by status')
+  .option('--project <name>', 'Filter by project (e.g. human-tasks)')
   .option('--format <fmt>', 'Output format: json or text', 'text')
   .option('--respect-deps', 'Sort DAG-aware: unblocked tasks first, blocked tasks last')
-  .action((opts: { agent?: string; status?: string; format?: string; respectDeps?: boolean }) => {
+  .action((opts: { agent?: string; status?: string; project?: string; format?: string; respectDeps?: boolean }) => {
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
     const tasks = listTasks(paths, {
       agent: opts.agent,
       status: opts.status as TaskStatus,
+      project: opts.project,
       respectDeps: opts.respectDeps ?? false,
     });
 
@@ -371,26 +373,42 @@ busCommand
       console.log('  No tasks found.');
       return;
     }
-
-    const PRIORITY_ICON: Record<string, string> = { urgent: '🔴', high: '🟠', normal: '🔵', low: '⚪' };
-    const STATUS_ICON: Record<string, string> = { pending: '○', in_progress: '●', blocked: '◑', completed: '✓', done: '✓', cancelled: '✗' };
-
-    console.log(`\n  Tasks (${tasks.length})\n`);
-    const header = '  Status  Pri  ID                        Assignee         Title';
-    const separator = '  ' + '-'.repeat(header.length - 2);
-    console.log(header);
-    console.log(separator);
-
-    for (const t of tasks) {
-      const statusIcon = (STATUS_ICON[t.status] || '?').padEnd(8);
-      const priIcon = (PRIORITY_ICON[t.priority] || '·').padEnd(5);
-      const id = t.id.substring(0, 26).padEnd(26);
-      const assignee = (t.assigned_to || '-').substring(0, 16).padEnd(17);
-      const title = t.title.substring(0, 50);
-      console.log(`  ${statusIcon}${priIcon}${id}${assignee}${title}`);
-    }
-    console.log('');
+    console.log(formatTaskTable(tasks));
   });
+
+/**
+ * Render the list-tasks text table. IDs are copy-paste targets for
+ * update-task/complete-task, so they are NEVER truncated — column widths
+ * come from the data (same pattern as the crons table). Every column is
+ * separated by 2+ spaces; the only column that may truncate is the trailing
+ * title, and truncation is marked with "…". (The previous fixed-width render
+ * cut every 27-char id to 26 with no delimiter before the assignee, which
+ * produced plausible-but-wrong ids when copied.)
+ */
+export function formatTaskTable(tasks: Task[]): string {
+  const PRIORITY_ICON: Record<string, string> = { urgent: '🔴', high: '🟠', normal: '🔵', low: '⚪' };
+  const STATUS_ICON: Record<string, string> = { pending: '○', in_progress: '●', blocked: '◑', completed: '✓', done: '✓', cancelled: '✗' };
+  const TITLE_MAX = 50;
+
+  const idW = Math.max(2, ...tasks.map(t => t.id.length));
+  const assigneeW = Math.max(8, ...tasks.map(t => (t.assigned_to || '-').length));
+
+  const lines: string[] = [];
+  lines.push(`\n  Tasks (${tasks.length})\n`);
+  const header = `  Status  Pri  ${'ID'.padEnd(idW)}  ${'Assignee'.padEnd(assigneeW)}  Title`;
+  lines.push(header);
+  lines.push('  ' + '-'.repeat(header.length - 2));
+  for (const t of tasks) {
+    const statusIcon = (STATUS_ICON[t.status] || '?').padEnd(8);
+    const priIcon = (PRIORITY_ICON[t.priority] || '·').padEnd(5);
+    const id = t.id.padEnd(idW);
+    const assignee = (t.assigned_to || '-').padEnd(assigneeW);
+    const title = t.title.length > TITLE_MAX ? t.title.substring(0, TITLE_MAX - 1) + '…' : t.title;
+    lines.push(`  ${statusIcon}${priIcon}${id}  ${assignee}  ${title}`);
+  }
+  lines.push('');
+  return lines.join('\n');
+}
 
 busCommand
   .command('log-event')

--- a/templates/orchestrator/HEARTBEAT.md
+++ b/templates/orchestrator/HEARTBEAT.md
@@ -46,10 +46,12 @@ Human tasks reference: `.claude/skills/human-tasks/SKILL.md`
 cortextos bus read-all-heartbeats
 
 # Check all pending approvals
-cortextos bus list-approvals --format json 2>/dev/null
+cortextos bus list-approvals --format json
 
 # Check stale human tasks
-cortextos bus list-tasks --project human-tasks --status pending 2>/dev/null
+# (no 2>/dev/null here: if this command errors, the error must be SEEN —
+# suppressed stderr once turned a broken flag into "0 stale human tasks")
+cortextos bus list-tasks --project human-tasks --status pending
 ```
 
 For each agent: if heartbeat is older than 5 hours, send an alert to that agent and flag in memory.

--- a/tests/unit/bus/task.test.ts
+++ b/tests/unit/bus/task.test.ts
@@ -166,6 +166,19 @@ describe('Task Management', () => {
       const pending = listTasks(paths, { status: 'pending' });
       expect(pending.length).toBe(1);
     });
+
+    it('filters by project (human-tasks detector path)', () => {
+      createTask(paths, 'paul', 'acme', 'Approve the invoice', { project: 'human-tasks' });
+      createTask(paths, 'paul', 'acme', 'Regular agent work');
+
+      const human = listTasks(paths, { project: 'human-tasks' });
+      expect(human.length).toBe(1);
+      expect(human[0].title).toBe('Approve the invoice');
+
+      // No-match project returns empty, not everything — a wrong project
+      // name must not silently degrade into an unfiltered list.
+      expect(listTasks(paths, { project: 'no-such-project' }).length).toBe(0);
+    });
   });
 });
 

--- a/tests/unit/cli/task-table.test.ts
+++ b/tests/unit/cli/task-table.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { formatTaskTable } from '../../../src/cli/bus';
+import type { Task } from '../../../src/types';
+
+// Regression tests for the list-tasks text render. The previous fixed-width
+// table cut every 27-char `task_<13-digit-ms>_<8-digit>` id down to 26 chars
+// AND left zero spacing before the assignee column — so copying an id out of
+// the table yielded a plausible-but-wrong value (last digit swallowed, or the
+// assignee's first characters glued on). Ids in the table must round-trip.
+
+function makeTask(overrides: Partial<Task>): Task {
+  return {
+    id: 'task_1784904117380_59872553',
+    title: 'A task',
+    description: '',
+    type: 'agent',
+    needs_approval: false,
+    status: 'pending',
+    assigned_to: 'dev',
+    created_by: 'chief',
+    org: 'acme',
+    priority: 'normal',
+    project: '',
+    kpi_key: null,
+    created_at: '2026-07-24T00:00:00Z',
+    updated_at: '2026-07-24T00:00:00Z',
+    completed_at: null,
+    due_date: null,
+    archived: false,
+    ...overrides,
+  } as Task;
+}
+
+describe('formatTaskTable', () => {
+  it('renders the full task id — never truncated', () => {
+    const id = 'task_1784904117380_59872553'; // 27 chars, the real id shape
+    const out = formatTaskTable([makeTask({ id })]);
+    expect(out).toContain(id);
+  });
+
+  it('separates every column with at least two spaces (id never touches assignee)', () => {
+    const id = 'task_1784904117380_59872553';
+    const out = formatTaskTable([makeTask({ id, assigned_to: 'dev' })]);
+    const row = out.split('\n').find(l => l.includes(id))!;
+    expect(row).toBeDefined();
+    // The character run starting at the id must end exactly at the id —
+    // followed by spacing, not glued to the assignee.
+    expect(row).toMatch(new RegExp(id.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '\\s{2,}dev'));
+    expect(row).not.toContain(id + 'dev');
+  });
+
+  it('sizes the id column from the data, so longer ids still fit', () => {
+    const longId = 'task_1784904117380_598725531234'; // longer than the standard shape
+    const out = formatTaskTable([makeTask({ id: longId })]);
+    expect(out).toContain(longId);
+  });
+
+  it('marks title truncation visibly with an ellipsis', () => {
+    const longTitle = 'x'.repeat(80);
+    const out = formatTaskTable([makeTask({ title: longTitle })]);
+    expect(out).toContain('…');
+    expect(out).not.toContain(longTitle);
+  });
+
+  it('keeps short titles untouched', () => {
+    const out = formatTaskTable([makeTask({ title: 'Short title' })]);
+    expect(out).toContain('Short title');
+    expect(out).not.toContain('…');
+  });
+});


### PR DESCRIPTION
## Summary
- **list-tasks text table**: task ids (27 chars) were truncated to 26 with zero spacing before the assignee — copying an id from the table yielded a plausible-but-wrong value. The table now sizes columns from the data (same pattern as the crons table), never truncates ids, keeps 2+ spaces between columns, and marks title truncation with `…`. Rendering extracted to an exported `formatTaskTable()` with regression tests.
- **`--project` filter**: orchestrator templates instruct `list-tasks --project human-tasks`, but the option didn't exist — and with `2>/dev/null` the error read as "0 stale human tasks" (silent false negative on the human-task detector). `listTasks()` + CLI now support `--project`; the template's detector path drops the error-suppressing redirect.
- **.gitignore hardening**: `node_modules/` (trailing slash) matches only real directories, so a symlinked node_modules evades it — the mechanism of a past committed-symlink incident that broke every agent sharing the checkout. Changed to `node_modules`.

## Testing
- `npm run build` clean, `tsc --noEmit` clean
- New: `tests/unit/cli/task-table.test.ts` (5 render regression tests) + project-filter test in `tests/unit/bus/task.test.ts`
- Touched-area suites all green (60/60: task, task-deps, task-table, e2e lifecycle)
- Full-suite failures (dashboard/phase4/phase5/hooks) reproduce identically on clean upstream/main with these changes stashed — pre-existing environmental, not introduced here
- Live-verified against real task data: full 27-char ids render, `--project human-tasks` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)