### PR TITLE
Guard against Anthropic token overrides

### DIFF
--- a/src/cli/doctor.ts
+++ b/src/cli/doctor.ts
@@ -11,6 +11,68 @@ interface Check {
   fix?: string;
 }
 
+const CLAUDE_OAUTH_OVERRIDE_KEYS = ['ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_API_KEY'] as const;
+
+function envFileHasKey(content: string, key: string): boolean {
+  return content.split(/\r?\n/).some((line) => {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) return false;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx <= 0) return false;
+    return trimmed.slice(0, eqIdx).trim() === key && trimmed.slice(eqIdx + 1).trim().length > 0;
+  });
+}
+
+export function findClaudeOAuthOverrideChecks(
+  frameworkRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): Check[] {
+  const checks: Check[] = [];
+
+  for (const key of CLAUDE_OAUTH_OVERRIDE_KEYS) {
+    if (env[key]) {
+      checks.push({
+        name: `Claude OAuth override: process env ${key}`,
+        status: 'fail',
+        message: `${key} is set in the current process environment and overrides CLAUDE_CODE_OAUTH_TOKEN`,
+        fix: `Unset ${key}; persistent agents should use CLAUDE_CODE_OAUTH_TOKEN only.`,
+      });
+    }
+  }
+
+  const orgsDir = join(frameworkRoot, 'orgs');
+  if (!existsSync(orgsDir)) return checks;
+
+  try {
+    for (const org of readdirSync(orgsDir)) {
+      const agentsRoot = join(orgsDir, org, 'agents');
+      if (!existsSync(agentsRoot)) continue;
+      for (const agent of readdirSync(agentsRoot)) {
+        const envPath = join(agentsRoot, agent, '.env');
+        if (!existsSync(envPath)) continue;
+        let content = '';
+        try {
+          content = readFileSync(envPath, 'utf-8');
+        } catch {
+          continue;
+        }
+        const keys = CLAUDE_OAUTH_OVERRIDE_KEYS.filter(key => envFileHasKey(content, key));
+        if (keys.length === 0) continue;
+        checks.push({
+          name: `Claude OAuth override: ${org}/${agent}`,
+          status: 'fail',
+          message: `.env contains ${keys.join(', ')}; these override CLAUDE_CODE_OAUTH_TOKEN and can silently redirect billing`,
+          fix: `Remove ${keys.join(' and ')} from orgs/${org}/agents/${agent}/.env, then restart the agent.`,
+        });
+      }
+    }
+  } catch {
+    // Doctor is best-effort; other checks can still run.
+  }
+
+  return checks;
+}
+
 export const doctorCommand = new Command('doctor')
   .option('--instance <id>', 'Instance ID', 'default')
   .description('Diagnose common issues')
@@ -168,6 +230,8 @@ export const doctorCommand = new Command('doctor')
         fix: 'Run: claude login',
       });
     }
+
+    checks.push(...findClaudeOAuthOverrideChecks(process.cwd()));
 
     // ── Tunnel checks (macOS only) ──────────────────────────────────────
     if (process.platform === 'darwin') {

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -5,6 +5,18 @@ import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
 import { injectMessage as injectMessageIntoPty } from './inject.js';
 
+const CLAUDE_OAUTH_OVERRIDE_KEYS = ['ANTHROPIC_AUTH_TOKEN', 'ANTHROPIC_API_KEY'] as const;
+
+export function assertNoClaudeOAuthOverride(env: Record<string, string>, agentName: string): void {
+  const overrideKey = CLAUDE_OAUTH_OVERRIDE_KEYS.find(key => env[key] !== undefined && env[key] !== '');
+  if (!overrideKey) return;
+
+  throw new Error(
+    `Refusing to spawn ${agentName}: ${overrideKey} overrides CLAUDE_CODE_OAUTH_TOKEN; ` +
+    'remove it from agent .env or parent process env',
+  );
+}
+
 // node-pty types
 interface IPty {
   pid: number;
@@ -138,6 +150,7 @@ export class AgentPTY {
     }
 
     this.customizeEnv(ptyEnv);
+    assertNoClaudeOAuthOverride(ptyEnv, this.env.agentName);
 
     // Spawn the agent binary directly (no shell wrapper) — cross-platform, no shell escaping needed.
     // env is passed natively via node-pty options; no bash export commands required.
@@ -390,7 +403,7 @@ export class AgentPTY {
     // Copy essential env vars
     const keepVars = [
       'PATH', 'HOME', 'USER', 'SHELL', 'TERM', 'LANG', 'LC_ALL',
-      'TMPDIR', 'TEMP', 'TMP', 'ANTHROPIC_API_KEY', 'CLAUDE_API_KEY',
+      'TMPDIR', 'TEMP', 'TMP',
       'NODE_PATH', 'COMSPEC', 'USERPROFILE',
       // Windows path-expansion essentials. Stripping these causes phantom
       // %SystemDrive% directories from inherited Search Indexer processes

--- a/tests/unit/cli/doctor-token-overrides.test.ts
+++ b/tests/unit/cli/doctor-token-overrides.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { findClaudeOAuthOverrideChecks } from '../../../src/cli/doctor';
+
+describe('doctor Claude OAuth override audit', () => {
+  let root: string | undefined;
+
+  afterEach(() => {
+    if (root) rmSync(root, { recursive: true, force: true });
+    root = undefined;
+  });
+
+  function makeRoot(): string {
+    root = mkdtempSync(join(tmpdir(), 'doctor-token-overrides-'));
+    mkdirSync(join(root, 'orgs', 'acme', 'agents', 'alice'), { recursive: true });
+    return root;
+  }
+
+  it('flags Anthropic override credentials in an agent .env', () => {
+    const frameworkRoot = makeRoot();
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice', '.env'), [
+      'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-good',
+      'ANTHROPIC_AUTH_TOKEN = legacy-bearer',
+      'ANTHROPIC_API_KEY=legacy-api',
+      '# ANTHROPIC_AUTH_TOKEN=commented-out-is-ignored',
+      'ANTHROPIC_API_KEY=',
+      '',
+    ].join('\n'), 'utf-8');
+
+    const checks = findClaudeOAuthOverrideChecks(frameworkRoot, {});
+
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({
+      name: 'Claude OAuth override: acme/alice',
+      status: 'fail',
+    });
+    expect(checks[0].message).toContain('ANTHROPIC_AUTH_TOKEN, ANTHROPIC_API_KEY');
+    expect(checks[0].fix).toContain('orgs/acme/agents/alice/.env');
+  });
+
+  it('flags Anthropic override credentials in the current process env', () => {
+    const frameworkRoot = makeRoot();
+
+    const checks = findClaudeOAuthOverrideChecks(frameworkRoot, {
+      ANTHROPIC_AUTH_TOKEN: 'legacy-bearer',
+    });
+
+    expect(checks).toHaveLength(1);
+    expect(checks[0]).toMatchObject({
+      name: 'Claude OAuth override: process env ANTHROPIC_AUTH_TOKEN',
+      status: 'fail',
+    });
+    expect(checks[0].fix).toContain('Unset ANTHROPIC_AUTH_TOKEN');
+  });
+
+  it('passes when only CLAUDE_CODE_OAUTH_TOKEN is present', () => {
+    const frameworkRoot = makeRoot();
+    writeFileSync(join(frameworkRoot, 'orgs', 'acme', 'agents', 'alice', '.env'), [
+      'CLAUDE_CODE_OAUTH_TOKEN=sk-ant-oat01-good',
+      '',
+    ].join('\n'), 'utf-8');
+
+    expect(findClaudeOAuthOverrideChecks(frameworkRoot, {})).toEqual([]);
+  });
+});

--- a/tests/unit/pty/agent-pty.test.ts
+++ b/tests/unit/pty/agent-pty.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import * as fs from 'fs';
 
 // node-pty is native; stub it so constructing AgentPTY never touches it.
 vi.mock('node-pty', () => ({ spawn: vi.fn() }));
@@ -14,7 +15,7 @@ vi.mock('fs', async () => {
   };
 });
 
-const { AgentPTY } = await import('../../../src/pty/agent-pty.js');
+const { AgentPTY, assertNoClaudeOAuthOverride } = await import('../../../src/pty/agent-pty.js');
 
 const mockEnv = {
   instanceId: 'test',
@@ -57,6 +58,64 @@ describe('AgentPTY --dangerously-skip-permissions toggle', () => {
       expect(warn).toHaveBeenCalled();
     } finally {
       warn.mockRestore();
+    }
+  });
+});
+
+describe('AgentPTY Claude OAuth override guard', () => {
+  it('rejects Anthropic auth token overrides directly', () => {
+    expect(() => assertNoClaudeOAuthOverride({
+      ANTHROPIC_AUTH_TOKEN: 'legacy-token',
+      CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-good',
+    }, 'alice')).toThrow(/ANTHROPIC_AUTH_TOKEN overrides CLAUDE_CODE_OAUTH_TOKEN/);
+  });
+
+  it('rejects Anthropic API key overrides directly', () => {
+    expect(() => assertNoClaudeOAuthOverride({
+      CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-good',
+      ANTHROPIC_API_KEY: 'sk-ant-api03-legacy',
+    }, 'alice')).toThrow(/ANTHROPIC_API_KEY overrides CLAUDE_CODE_OAUTH_TOKEN/);
+  });
+
+  it('allows empty override values', () => {
+    expect(() => assertNoClaudeOAuthOverride({
+      ANTHROPIC_AUTH_TOKEN: '',
+      ANTHROPIC_API_KEY: '',
+      CLAUDE_CODE_OAUTH_TOKEN: 'sk-ant-oat01-good',
+    }, 'alice')).not.toThrow();
+  });
+
+  it('does not pass parent Anthropic API credentials into spawned agent env', () => {
+    const originalAnthropic = process.env.ANTHROPIC_API_KEY;
+    const originalClaude = process.env.CLAUDE_API_KEY;
+    process.env.ANTHROPIC_API_KEY = 'parent-anthropic-key';
+    process.env.CLAUDE_API_KEY = 'parent-claude-key';
+    try {
+      const agent = new AgentPTY(mockEnv, {});
+      const baseEnv = (agent as unknown as { getBaseEnv(): Record<string, string> }).getBaseEnv();
+
+      expect(baseEnv.ANTHROPIC_API_KEY).toBeUndefined();
+      expect(baseEnv.CLAUDE_API_KEY).toBeUndefined();
+    } finally {
+      if (originalAnthropic === undefined) delete process.env.ANTHROPIC_API_KEY;
+      else process.env.ANTHROPIC_API_KEY = originalAnthropic;
+      if (originalClaude === undefined) delete process.env.CLAUDE_API_KEY;
+      else process.env.CLAUDE_API_KEY = originalClaude;
+    }
+  });
+
+  it('refuses to spawn when the agent .env contains an Anthropic override', async () => {
+    vi.mocked(fs.existsSync).mockImplementation((path) => String(path).endsWith('/.env'));
+    vi.mocked(fs.readFileSync).mockImplementation(() => 'ANTHROPIC_AUTH_TOKEN=legacy-token\n');
+    try {
+      const agent = new AgentPTY(mockEnv, {});
+      (agent as unknown as { spawnFn: unknown }).spawnFn = vi.fn();
+
+      await expect(agent.spawn('fresh', 'PROMPT'))
+        .rejects.toThrow(/ANTHROPIC_AUTH_TOKEN overrides CLAUDE_CODE_OAUTH_TOKEN/);
+    } finally {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      vi.mocked(fs.readFileSync).mockReset();
     }
   });
 });


### PR DESCRIPTION
## Summary

- refuse Claude agent spawn when ANTHROPIC_AUTH_TOKEN or ANTHROPIC_API_KEY is present in the resolved PTY environment
- stop inheriting parent ANTHROPIC_API_KEY/CLAUDE_API_KEY into spawned agent env
- add cortextos doctor findings for process/env-file Anthropic OAuth overrides
- add unit coverage for PTY guard and doctor audit

## Spawn Guard Liveness

- Staged, not live until daemon bounce. Normal agent spawn/restart goes through daemon in-process PTY: CLI self-restart/hard-restart sends IPC restart-agent, AgentManager creates AgentProcess, AgentProcess creates AgentPTY, then AgentPTY.spawn runs. It does not shell out through dist/cli.js for the spawn itself.
- Worker spawn also uses daemon-side AgentPTY directly.

## Doctor Audit Correctness

- The doctor audit scans current process env for non-empty ANTHROPIC_AUTH_TOKEN/ANTHROPIC_API_KEY.
- For agent .env files, it mirrors the agent env loader key shape: ignores comments, trims whitespace around the key/value, matches the exact key before =, and ignores empty values.

## Anchor Drift / Not Included

- scripts/deploy-agent-token.sh is absent on current upstream/main, so I did not resurrect the deleted script.
- The routed upstream-main deploy-strip path src/bus/switch-agent-account.ts is also absent from current upstream/main/GitHub main. It exists only on the local feature branch codex/guard-fix-a-send-guard, so adding it to this upstream-main PR would resurrect a branch-only file. Needs target-branch/path routing before implementing that half.

## Validation

- PASS: env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" npm run build
- PASS: env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" npm run typecheck
- PASS: env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" npx vitest run tests/unit/pty/agent-pty.test.ts tests/unit/cli/doctor-token-overrides.test.ts (13 tests)
- PASS: env -i PATH="$PATH" HOME="$HOME" TMPDIR="${TMPDIR:-/tmp}" bash tests/leak-guard.test.sh

## Full npm test baseline

- PR branch, clean shell: 6 failing tests / 6 failed files; 1908 passed, 50 skipped.
- upstream/main clean baseline, same shell: same 6 failing test identities / 6 failed files; 1893 passed, 57 skipped.
- Net-new failures from this PR: 0.

Failing identities on both PR and upstream/main:
- dashboard/src/lib/__tests__/cost-parser-codex.test.ts
- dashboard/src/lib/__tests__/cost-parser.test.ts
- dashboard/src/lib/__tests__/sync.test.ts
- tests/integration/phase4-performance.test.ts > Perf: GET /api/workflows/crons — 50 crons (5 agents) > p95 < 2000ms
- tests/integration/phase4-performance.test.ts > Perf: GET /api/workflows/crons — 100 crons (10 agents) > p95 < 2000ms
- tests/unit/daemon/fast-checker.test.ts > FastChecker > heartbeat watchdog > fires exec after bootstrap at 50-min interval
- tests/unit/daemon/fast-checker.test.ts > FastChecker > heartbeat watchdog > clears timer on stop — no further exec calls after stop
- tests/unit/daemon/fast-checker.test.ts > FastChecker > heartbeat watchdog > does not fire before bootstrap completes
- tests/unit/hooks/hooks.test.ts > Hook Utilities > isClaudeDirOperation (permission-gate hardening) > refuses a write that escapes via a symlink inside .claude (#18, codex)

## Notes

- Draft PR only. Do not merge without approval.
