### PR TITLE
fix(dashboard): stop writeGoals from deleting north_star on every save

### DIFF
--- a/dashboard/src/lib/data/__tests__/goals.test.ts
+++ b/dashboard/src/lib/data/__tests__/goals.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, beforeAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'goals-data-test-'));
+process.env.CTX_ROOT = tmpDir;
+process.env.CTX_FRAMEWORK_ROOT = tmpDir;
+
+const ORG = 'acme';
+const goalsPath = path.join(tmpDir, 'orgs', ORG, 'goals.json');
+
+let getGoals: typeof import('../goals')['getGoals'];
+let writeGoals: typeof import('../goals')['writeGoals'];
+
+beforeAll(async () => {
+  const mod = await import('../goals');
+  getGoals = mod.getGoals;
+  writeGoals = mod.writeGoals;
+});
+
+/**
+ * Seed goals.json with the shape the CLI/agents actually write: the four fields
+ * the dashboard models, plus `north_star` and `updated_at`, which it does not.
+ */
+function seed(): void {
+  fs.mkdirSync(path.dirname(goalsPath), { recursive: true });
+  fs.writeFileSync(
+    goalsPath,
+    JSON.stringify(
+      {
+        north_star: 'Ship the thing',
+        bottleneck: 'old bottleneck',
+        goals: [{ id: 'g1', title: 'First goal', progress: 25, order: 0 }],
+        daily_focus: 'focus text',
+        daily_focus_set_at: '2026-07-28T00:00:00Z',
+        updated_at: '2026-07-28T00:00:00Z',
+      },
+      null,
+      2,
+    ) + '\n',
+    'utf-8',
+  );
+}
+
+function readRaw(): Record<string, unknown> {
+  return JSON.parse(fs.readFileSync(goalsPath, 'utf-8'));
+}
+
+beforeEach(seed);
+
+describe('goals read-modify-write round-trip', () => {
+  it('preserves fields the dashboard does not model', () => {
+    const data = getGoals(ORG);
+    data.bottleneck = 'new bottleneck';
+    writeGoals(ORG, data);
+
+    const onDisk = readRaw();
+    // The modelled field is updated...
+    expect(onDisk.bottleneck).toBe('new bottleneck');
+    // ...and the unmodelled ones survive rather than being silently dropped.
+    expect(onDisk.north_star).toBe('Ship the thing');
+    expect(onDisk.updated_at).toBe('2026-07-28T00:00:00Z');
+  });
+
+  it('preserves keys it has never heard of', () => {
+    const seeded = readRaw();
+    seeded.some_future_field = { nested: true };
+    fs.writeFileSync(goalsPath, JSON.stringify(seeded, null, 2) + '\n', 'utf-8');
+
+    const data = getGoals(ORG);
+    data.bottleneck = 'changed';
+    writeGoals(ORG, data);
+
+    expect(readRaw().some_future_field).toEqual({ nested: true });
+  });
+
+  it('still round-trips the fields it does model', () => {
+    const data = getGoals(ORG);
+    data.goals = [
+      ...data.goals,
+      { id: 'g2', title: 'Second goal', progress: 0, order: 1 },
+    ];
+    data.daily_focus = 'new focus';
+    writeGoals(ORG, data);
+
+    const onDisk = readRaw() as {
+      goals: Array<Record<string, unknown>>;
+      daily_focus: string;
+    };
+    expect(onDisk.goals).toHaveLength(2);
+    expect(onDisk.goals[0].title).toBe('First goal');
+    expect(onDisk.goals[1].title).toBe('Second goal');
+    expect(onDisk.daily_focus).toBe('new focus');
+  });
+
+  it('clears a modelled optional field when it is explicitly removed', () => {
+    // A merge must not resurrect a field the caller deliberately dropped.
+    const data = getGoals(ORG);
+    delete data.daily_focus;
+    writeGoals(ORG, data);
+
+    const onDisk = readRaw();
+    expect(onDisk.daily_focus).toBeUndefined();
+    // ...while still leaving unmodelled fields alone.
+    expect(onDisk.north_star).toBe('Ship the thing');
+  });
+
+  it('writes a fresh file when none exists', () => {
+    fs.rmSync(goalsPath);
+    writeGoals(ORG, { bottleneck: 'first', goals: [] });
+    expect(readRaw().bottleneck).toBe('first');
+  });
+});

--- a/dashboard/src/lib/data/goals.ts
+++ b/dashboard/src/lib/data/goals.ts
@@ -53,8 +53,23 @@ export function getGoals(org: string): GoalsData {
   }
 }
 
+// The fields getGoals() reconstructs, and therefore the only ones writeGoals()
+// is entitled to overwrite. Everything else in the file belongs to another
+// writer (the CLI, the agents) and is passed through untouched.
+const MODELLED_KEYS = [
+  'bottleneck',
+  'goals',
+  'daily_focus',
+  'daily_focus_set_at',
+] as const;
+
 /**
  * Atomic write of goals.json for an org (write to tmp, then rename).
+ *
+ * Merges onto the current file rather than replacing it: getGoals() returns
+ * only the modelled fields, so serializing that object over the whole file
+ * would silently drop every key the dashboard does not model — north_star and
+ * updated_at among them.
  */
 export function writeGoals(org: string, data: GoalsData): void {
   const filePath = getGoalsPath(org);
@@ -62,8 +77,30 @@ export function writeGoals(org: string, data: GoalsData): void {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true });
   }
+
+  let merged: Record<string, unknown> = {};
+  try {
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf-8'));
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      merged = parsed as Record<string, unknown>;
+    }
+  } catch {
+    // Missing or malformed file — fall back to writing just the modelled fields.
+  }
+
+  const incoming = data as unknown as Record<string, unknown>;
+  for (const key of MODELLED_KEYS) {
+    // An absent modelled field is a deliberate clear, not "leave it alone" —
+    // so it must be removed rather than inherited back from the old file.
+    if (incoming[key] === undefined) {
+      delete merged[key];
+    } else {
+      merged[key] = incoming[key];
+    }
+  }
+
   const tmp = path.join(os.tmpdir(), `goals-${org}-${Date.now()}.json`);
-  fs.writeFileSync(tmp, JSON.stringify(data, null, 2) + '\n', 'utf-8');
+  fs.writeFileSync(tmp, JSON.stringify(merged, null, 2) + '\n', 'utf-8');
   fs.renameSync(tmp, filePath);
 }
 


### PR DESCRIPTION
`writeGoals` rebuilt the goals object without carrying `north_star` through, so every save silently dropped it.

**Scope:** `dashboard/src/lib/data/goals.ts` + unit test. Single-purpose, independent of the other open PRs.
**Verified:** unit test covering round-trip preservation, run in an isolated worktree.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)