### PR TITLE
fix(templates): quote date format strings in heartbeat/memory snippets

### DIFF
--- a/community/agents/agent/AGENTS.md
+++ b/community/agents/agent/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/agent/HEARTBEAT.md
+++ b/community/agents/agent/HEARTBEAT.md
@@ -63,7 +63,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/agentic-crm-assistant/HEARTBEAT.md
+++ b/community/agents/agentic-crm-assistant/HEARTBEAT.md
@@ -42,7 +42,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC)
+## Heartbeat Update - $(date -u +'%H:%M UTC')
 - WORKING ON: <task_id or none>
 - CRM status: <contacts/followups/drafts/meetings>
 - Inbox: <clear / pending / blocked>

--- a/community/agents/analyst/AGENTS.md
+++ b/community/agents/analyst/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/analyst/HEARTBEAT.md
+++ b/community/agents/analyst/HEARTBEAT.md
@@ -54,7 +54,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/orchestrator/AGENTS.md
+++ b/community/agents/orchestrator/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/orchestrator/HEARTBEAT.md
+++ b/community/agents/orchestrator/HEARTBEAT.md
@@ -91,7 +91,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/research-agent/.claude/skills/memory/SKILL.md
+++ b/community/agents/research-agent/.claude/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/community/agents/research-agent/AGENTS.md
+++ b/community/agents/research-agent/AGENTS.md
@@ -72,7 +72,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -254,7 +254,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -263,7 +263,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/research-agent/HEARTBEAT.md
+++ b/community/agents/research-agent/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/security/HEARTBEAT.md
+++ b/community/agents/security/HEARTBEAT.md
@@ -63,7 +63,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/skills/memory/SKILL.md
+++ b/community/skills/memory/SKILL.md
@@ -27,7 +27,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -38,7 +38,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -47,7 +47,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -61,7 +61,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent-codex/AGENTS.md
+++ b/templates/agent-codex/AGENTS.md
@@ -71,7 +71,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-   ## Session End - $(date -u +%H:%M:%S UTC)
+   ## Session End - $(date -u +'%H:%M:%S UTC')
    - Status: [done/interrupted/context-full]
    - Current state: [where things stand — specific enough that the next session can resume cold]
    - Active threads: [anything in progress or mid-task with current state]
@@ -260,7 +260,7 @@ This is your session journal. It survives crashes and context compactions. The g
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 
 ```bash
@@ -268,7 +268,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/agent-codex/HEARTBEAT.md
+++ b/templates/agent-codex/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent-opencode/AGENTS.md
+++ b/templates/agent-opencode/AGENTS.md
@@ -71,7 +71,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-   ## Session End - $(date -u +%H:%M:%S UTC)
+   ## Session End - $(date -u +'%H:%M:%S UTC')
    - Status: [done/interrupted/context-full]
    - Current state: [where things stand — specific enough that the next session can resume cold]
    - Active threads: [anything in progress or mid-task with current state]
@@ -266,7 +266,7 @@ This is your session journal. It survives crashes and context compactions. The g
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 
 ```bash
@@ -274,7 +274,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/agent-opencode/HEARTBEAT.md
+++ b/templates/agent-opencode/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/agent-opencode/plugins/cortextos-agent-skills/skills/memory/SKILL.md
+++ b/templates/agent-opencode/plugins/cortextos-agent-skills/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent/.claude/skills/memory/SKILL.md
+++ b/templates/agent/.claude/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -55,7 +55,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -266,7 +266,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -275,7 +275,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/agent/HEARTBEAT.md
+++ b/templates/agent/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/analyst/.claude/skills/memory/SKILL.md
+++ b/templates/analyst/.claude/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/analyst/AGENTS.md
+++ b/templates/analyst/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/analyst/HEARTBEAT.md
+++ b/templates/analyst/HEARTBEAT.md
@@ -83,7 +83,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/orchestrator/AGENTS.md
+++ b/templates/orchestrator/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/orchestrator/HEARTBEAT.md
+++ b/templates/orchestrator/HEARTBEAT.md
@@ -97,7 +97,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>


### PR DESCRIPTION
Unquoted `date` format strings in template snippets break when the shell word-splits them.

**Scope:** docs/templates only — 26 files under `templates/` and `community/`. **Zero `src/` changes**, no runtime surface.
**Verified:** by inspection; documentation-correctness change with no executable surface in-repo.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)