### PR TITLE
fix(oauth): usage utilization is percentage points, not a fraction

### DIFF
--- a/dashboard/src/lib/quota.ts
+++ b/dashboard/src/lib/quota.ts
@@ -102,9 +102,20 @@ async function fetchFresh(): Promise<QuotaSnapshot | null> {
     sevenDayUtilization?: number;
   };
 
+  // Convert percentage points → fraction. The usage API reports utilization on
+  // a 0–100 scale, ALWAYS — `seven_day.utilization: 4.0` means 4%, not 400%.
+  //
+  // This was previously `v > 1 ? v / 100 : v`, which assumed any value <= 1 was
+  // already a fraction and so inflated the whole 0–1% band by 100x. Here that
+  // surfaced as the remaining-quota readout: 1% real usage normalized to 1.0,
+  // and (1 - 1.0) * 100 renders as "0% remaining" — the dashboard claiming the
+  // account is exhausted when it has barely been touched.
+  //
+  // Kept deliberately identical to normalize() in src/bus/oauth.ts. These are
+  // two independent parsers of the same endpoint; when one changes, change both.
   const normalize = (v: number | undefined): number => {
     if (v === undefined || v === null) return 0;
-    return v > 1 ? v / 100 : v;
+    return v / 100;
   };
 
   const fiveH = normalize(

--- a/src/bus/oauth.ts
+++ b/src/bus/oauth.ts
@@ -232,10 +232,18 @@ export async function checkUsageApi(
     sevenDayUtilization?: number;
   };
 
-  // Normalize 0–100 → 0.0–1.0 if needed
+  // Convert percentage points → fraction. The usage API reports utilization on a
+  // 0–100 scale, ALWAYS — `seven_day.utilization: 4.0` means 4%, not 400%.
+  //
+  // This was previously `v > 1 ? v / 100 : v`, which assumed any value <= 1 was
+  // already a fraction. That inflated the entire 0–1% band by 100x: a real 1%
+  // came through as 1.0 (= 100%). Consequences were not cosmetic — the value is
+  // persisted to accounts.json below, where rotateOAuth reads it against
+  // THRESHOLD_5H (0.85), so an almost-idle account could trigger a rotation, and
+  // the watchdog fired CODE RED alerts on ~1% real usage.
   const normalize = (v: number | undefined) => {
     if (v === undefined) return 0;
-    return v > 1 ? v / 100 : v;
+    return v / 100;
   };
 
   const fiveHour = normalize(

--- a/tests/unit/bus/oauth.test.ts
+++ b/tests/unit/bus/oauth.test.ts
@@ -94,21 +94,61 @@ describe('checkUsageApi', () => {
     writeStore();
     mockFetch.mockResolvedValueOnce({
       ok: true,
-      json: async () => ({ five_hour_utilization: 0.42, seven_day_utilization: 0.18 }),
+      json: async () => ({ five_hour_utilization: 42, seven_day_utilization: 18 }),
     });
 
     const result = await checkUsageApi(tmpDir);
-    expect(result.five_hour_utilization).toBe(0.42);
-    expect(result.seven_day_utilization).toBe(0.18);
+    expect(result.five_hour_utilization).toBeCloseTo(0.42);
+    expect(result.seven_day_utilization).toBeCloseTo(0.18);
     expect(result.cached).toBe(false);
     expect(mockFetch).toHaveBeenCalledOnce();
   });
 
-  it('normalizes 0-100 values to 0.0-1.0', async () => {
+  it('converts percentage points to a fraction', async () => {
     writeStore();
     mockFetch.mockResolvedValueOnce({
       ok: true,
       json: async () => ({ five_hour_utilization: 42, seven_day_utilization: 18 }),
+    });
+
+    const result = await checkUsageApi(tmpDir, { force: true });
+    expect(result.five_hour_utilization).toBeCloseTo(0.42);
+    expect(result.seven_day_utilization).toBeCloseTo(0.18);
+  });
+
+  // Regression: normalize() used to be `v > 1 ? v / 100 : v`, so the whole
+  // 0–1% band was inflated 100x. A real 1% arrived as 1.0 (= 100%), which is
+  // both a false CODE RED and — because the value is persisted to
+  // accounts.json — enough to trip rotateOAuth's 0.85 threshold on an
+  // almost-idle account. Values above 1% were unaffected, which is why this
+  // survived: it only misfires when usage is low.
+  it('does not inflate sub-1% utilization (regression)', async () => {
+    writeStore();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        five_hour: { utilization: 1 },
+        seven_day: { utilization: 4 },
+      }),
+    });
+
+    const result = await checkUsageApi(tmpDir, { force: true });
+    expect(result.five_hour_utilization).toBeCloseTo(0.01);
+    expect(result.seven_day_utilization).toBeCloseTo(0.04);
+    // Must stay well clear of THRESHOLD_5H (0.85) — the rotation trigger.
+    expect(result.five_hour_utilization).toBeLessThan(0.85);
+  });
+
+  // The live API returns the NESTED shape; every other test here feeds the flat
+  // fallback, so without this the real response shape goes unexercised.
+  it('reads the nested five_hour/seven_day shape the live API returns', async () => {
+    writeStore();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        five_hour: { utilization: 42, resets_at: '2026-07-27T23:00:00Z' },
+        seven_day: { utilization: 18, resets_at: '2026-08-01T00:00:00Z' },
+      }),
     });
 
     const result = await checkUsageApi(tmpDir, { force: true });


### PR DESCRIPTION
Utilization from the usage API is already in percentage points; two independent call sites treated it as a 0-1 fraction, under-reporting usage by 100x.

**Scope:** `src/bus/oauth.ts` + `dashboard/src/lib/quota.ts` (the dashboard carries its own parser with the same bug) + oauth unit tests. One commit per call site.
**Verified:** unit tests. This fix has been running live in our deployment, which is what surfaced the dashboard-side duplicate.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)