### PR TITLE
fix(cli): lock the read-modify-write of enabled-agents.json

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'path';
 import { homedir } from 'os';
 import { OrgContext } from '../types';
 import { validateAgentName, validateOrgName } from '../utils/validate';
+import { mutateEnabledAgents } from '../utils/enabled-agents.js';
 
 const VALID_RUNTIMES = ['claude-code', 'hermes', 'codex-app-server', 'opencode'] as const;
 type RuntimeKind = typeof VALID_RUNTIMES[number];
@@ -316,27 +317,29 @@ export const addAgentCommand = new Command('add-agent')
       }
     }
 
-    // Register in enabled-agents.json
+    // Register in enabled-agents.json under the registry lock — `cortextos
+    // start`, `enable`, `import-agent` and the dashboard mutate this same file,
+    // and an unlocked read-modify-write here loses whichever entry lands second.
     const instanceId = options.instance;
     const ctxRoot = join(homedir(), '.cortextos', instanceId);
-    const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-    const configDir = join(ctxRoot, 'config');
-    mkdirSync(configDir, { recursive: true });
 
-    let enabledAgents: Record<string, any> = {};
+    let registered = false;
     try {
-      if (existsSync(enabledPath)) {
-        enabledAgents = JSON.parse(readFileSync(enabledPath, 'utf-8'));
-      }
-    } catch { /* start fresh */ }
-
-    if (!enabledAgents[name]) {
-      enabledAgents[name] = {
-        enabled: true,
-        status: 'configured',
-        ...(org ? { org } : {}),
-      };
-      writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+      registered = mutateEnabledAgents(ctxRoot, (enabledAgents) => {
+        if (enabledAgents[name]) return false; // already registered — leave it as-is
+        enabledAgents[name] = {
+          enabled: true,
+          status: 'configured',
+          ...(org ? { org } : {}),
+        };
+      });
+    } catch (err) {
+      console.error(`Error: could not register "${name}" in the agent registry.`);
+      console.error(`  ${err instanceof Error ? err.message : String(err)}`);
+      console.error(`  The agent files were created — re-run once the registry is writable.`);
+      process.exit(1);
+    }
+    if (registered) {
       console.log(`  Registered in enabled-agents.json`);
     }
 

--- a/src/cli/enable-agent.ts
+++ b/src/cli/enable-agent.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { TelegramAPI, formatValidateError } from '../telegram/api.js';
+import { mutateEnabledAgents } from '../utils/enabled-agents.js';
 
 /**
  * BUG-035 fix: discover the cortextOS framework root without depending on
@@ -46,55 +47,37 @@ function parseEnvFile(path: string): Record<string, string> {
   return vars;
 }
 
-function getEnabledAgentsPath(instanceId: string): string {
-  return join(homedir(), '.cortextos', instanceId, 'config', 'enabled-agents.json');
+function ctxRootFor(instanceId: string): string {
+  return join(homedir(), '.cortextos', instanceId);
 }
 
 /**
- * BUG-013 fix: validate enabled-agents.json on read instead of silently
- * returning {} on any error. The original implementation hid two real failure
- * modes from the user:
- *   1. Corrupt JSON (file exists but won't parse) → silently empty, then
- *      writeEnabledAgents() overwrites the corrupt file with {}, destroying
- *      the user's enable state with no warning.
- *   2. Wrong shape (file exists, parses to an array/null/string) → same
- *      silent destruction.
+ * Apply `mutate` to the instance registry under the registry lock, and turn any
+ * failure into a clean CLI error instead of a raw stack through commander.
  *
- * The fix backs the bad file up as `enabled-agents.json.broken-<timestamp>`,
- * logs a clear warning to stderr, and returns {} only after preserving the
- * original. Users can recover from a backup, and they know WHY their agents
- * disappeared.
+ * Replaces the old unlocked `readEnabledAgents()` / `writeEnabledAgents()`
+ * pair. BUG-013 gave that pair the right instinct — never destroy a corrupt
+ * registry silently, back it up and warn — but it still continued with `{}`
+ * and wrote that back, so it was an atomic wipe with a receipt. The shared
+ * helper keeps the backup and the warning and then refuses to write at all.
+ * That matters more than it looks: a lost registry does not deregister agents
+ * (`AgentManager.readInstanceEnableList` treats a missing entry as enabled), it
+ * drops the `enabled: false` flags — so the next daemon discovery pass starts
+ * every agent the user deliberately disabled.
  */
-export function readEnabledAgents(instanceId: string): Record<string, any> {
-  const path = getEnabledAgentsPath(instanceId);
-  if (!existsSync(path)) return {}; // legit: no file = empty state, not an error
-
-  let raw: string;
+function updateRegistry(
+  instanceId: string,
+  agent: string,
+  verb: string,
+  mutate: (agents: Record<string, any>) => boolean | void,
+): void {
   try {
-    raw = readFileSync(path, 'utf-8');
+    mutateEnabledAgents(ctxRootFor(instanceId), mutate);
   } catch (err) {
-    console.error(`[enable] Failed to read ${path}: ${err}`);
-    return {};
+    console.error(`Error: could not ${verb} "${agent}" — the agent registry could not be updated.`);
+    console.error(`  ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
   }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    const backup = `${path}.broken-${Date.now()}`;
-    try { writeFileSync(backup, raw); } catch { /* ignore backup failure */ }
-    console.error(`[enable] WARNING: ${path} contains invalid JSON. Backed up to ${backup}. Treating as empty.`);
-    return {};
-  }
-
-  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
-    const backup = `${path}.broken-${Date.now()}`;
-    try { writeFileSync(backup, raw); } catch { /* ignore backup failure */ }
-    console.error(`[enable] WARNING: ${path} is not a JSON object (got ${parsed === null ? 'null' : Array.isArray(parsed) ? 'array' : typeof parsed}). Backed up to ${backup}. Treating as empty.`);
-    return {};
-  }
-
-  return parsed as Record<string, any>;
 }
 
 /**
@@ -110,13 +93,6 @@ export function writeDisableMarker(instanceId: string, agent: string, reason: st
     mkdirSync(stateDir, { recursive: true });
     writeFileSync(join(stateDir, '.user-disable'), reason);
   } catch { /* don't block disable on marker-write failure */ }
-}
-
-function writeEnabledAgents(instanceId: string, agents: Record<string, any>): void {
-  const path = getEnabledAgentsPath(instanceId);
-  const dir = join(homedir(), '.cortextos', instanceId, 'config');
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(path, JSON.stringify(agents, null, 2) + '\n', 'utf-8');
 }
 
 export const enableAgentCommand = new Command('enable')
@@ -220,16 +196,16 @@ export const enableAgentCommand = new Command('enable')
       console.error('  Continuing enable. Investigate the validator if this recurs.');
     }
 
-    const agents = readEnabledAgents(options.instance);
-    agents[agent] = {
-      enabled: true,
-      status: 'configured',
-      ...(options.org ? { org: options.org } : {}),
-    };
-    writeEnabledAgents(options.instance, agents);
+    updateRegistry(options.instance, agent, 'enable', (agents) => {
+      agents[agent] = {
+        enabled: true,
+        status: 'configured',
+        ...(options.org ? { org: options.org } : {}),
+      };
+    });
 
     // Create per-agent state directories
-    const ctxRoot = join(homedir(), '.cortextos', options.instance);
+    const ctxRoot = ctxRootFor(options.instance);
     const agentDirs = [
       join(ctxRoot, 'inbox', agent),
       join(ctxRoot, 'inflight', agent),
@@ -262,11 +238,11 @@ export const disableAgentCommand = new Command('disable')
   .option('--instance <id>', 'Instance ID', 'default')
   .description('Disable an agent (stop and deregister)')
   .action(async (agent: string, options: { instance: string }) => {
-    const agents = readEnabledAgents(options.instance);
-    if (agents[agent]) {
-      agents[agent].enabled = false;
-    }
-    writeEnabledAgents(options.instance, agents);
+    updateRegistry(options.instance, agent, 'disable', (agents) => {
+      if (agents[agent]) {
+        agents[agent].enabled = false;
+      }
+    });
 
     // Try to stop via daemon IPC
     const ipc = new IPCClient(options.instance);

--- a/src/cli/import-agent.ts
+++ b/src/cli/import-agent.ts
@@ -6,6 +6,7 @@ import { spawnSync } from 'child_process';
 import { validateAgentName } from '../utils/validate.js';
 import { IPCClient } from '../daemon/ipc-server.js';
 import { resolvePaths } from '../utils/paths.js';
+import { mutateEnabledAgents } from '../utils/enabled-agents.js';
 
 interface ExportManifest {
   version: string;
@@ -154,18 +155,21 @@ export const importAgentCommand = new Command('import-agent')
       }
     }
 
-    // Register in enabled-agents.json
+    // Register in enabled-agents.json under the registry lock — `add-agent`,
+    // `start`, `enable` and the dashboard mutate this same file, and an unlocked
+    // read-modify-write loses whichever entry lands second.
     const ctxRoot = join(homedir(), '.cortextos', options.instance);
-    const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-    let enabledAgents: Record<string, any> = {};
+
     try {
-      if (existsSync(enabledPath)) {
-        enabledAgents = JSON.parse(readFileSync(enabledPath, 'utf-8'));
-      }
-    } catch { /* start fresh */ }
-    enabledAgents[agentName] = { enabled: true, status: 'configured', org };
-    mkdirSync(join(ctxRoot, 'config'), { recursive: true });
-    writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+      mutateEnabledAgents(ctxRoot, (enabledAgents) => {
+        enabledAgents[agentName] = { enabled: true, status: 'configured', org };
+      });
+    } catch (err) {
+      console.error(`Error: could not register "${agentName}" in the agent registry.`);
+      console.error(`  ${err instanceof Error ? err.message : String(err)}`);
+      console.error(`  The agent files were imported — re-run once the registry is writable.`);
+      process.exit(1);
+    }
     console.log(`  Registered in enabled-agents.json`);
 
     cleanup(tmpDir);

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -4,6 +4,7 @@ import { join } from 'path';
 import { homedir, platform, arch } from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { randomBytes } from 'crypto';
+import { enabledAgentsPath, mutateEnabledAgents } from '../utils/enabled-agents.js';
 
 const IS_WINDOWS = platform() === 'win32';
 const IS_MAC = platform() === 'darwin';
@@ -359,11 +360,26 @@ export const installCommand = new Command('install')
     }
     console.log(`  Created ${dirs.length} directories at ${ctxRoot}`);
 
-    // enabled-agents.json
-    const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-    if (!existsSync(enabledPath)) {
-      writeFileSync(enabledPath, '{}', 'utf-8');
-      console.log('  Created enabled-agents.json');
+    // enabled-agents.json — create it if absent, never touch it if it exists.
+    //
+    // The bare `existsSync` -> `writeFileSync('{}')` this replaced was a TOCTOU,
+    // and not a harmless one: install re-runs over an existing instance on
+    // upgrade/reinstall, so a concurrent `cortextos add-agent`/`enable` landing
+    // between the two calls got clobbered back to an empty registry. Losing the
+    // registry does not deregister agents — it drops their `enabled: false`
+    // flags, and the daemon's next discovery pass starts every agent the user
+    // deliberately disabled. Both checks now happen under the registry lock.
+    const enabledPath = enabledAgentsPath(ctxRoot);
+    try {
+      // `mutate` runs holding the lock, so this existsSync is no longer a race.
+      // Returning false means "already there, don't rewrite it".
+      const created = mutateEnabledAgents(ctxRoot, () => !existsSync(enabledPath));
+      if (created) console.log('  Created enabled-agents.json');
+    } catch (err) {
+      // A corrupt registry must not abort the whole install — the rest of it is
+      // still worth doing, and the file has been backed up by now. Warn loudly
+      // and leave it alone rather than overwriting it.
+      console.warn(`  WARNING: could not initialize enabled-agents.json: ${(err as Error).message}`);
     }
 
     // Instance .env

--- a/src/cli/start.ts
+++ b/src/cli/start.ts
@@ -1,9 +1,10 @@
 import { Command } from 'commander';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { homedir, platform } from 'os';
 import { execSync, spawn, spawnSync } from 'child_process';
 import { IPCClient } from '../daemon/ipc-server.js';
+import { mutateEnabledAgents } from '../utils/enabled-agents.js';
 
 const IS_WINDOWS = platform() === 'win32';
 const SAFE_CMD = /^[@a-z0-9._/-]+$/i;
@@ -163,26 +164,29 @@ export const startCommand = new Command('start')
 
     // Daemon already running
     if (agent) {
-      // Auto-register in enabled-agents.json if not already present
+      // Auto-register in enabled-agents.json if not already present. Under the
+      // registry lock: `add-agent`, `enable` and the dashboard mutate this same
+      // file, and an unlocked read-modify-write loses whichever entry lands second.
       const ctxRoot = join(homedir(), '.cortextos', options.instance);
-      const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-      let enabledAgents: Record<string, any> = {};
-      try {
-        if (existsSync(enabledPath)) {
-          enabledAgents = JSON.parse(readFileSync(enabledPath, 'utf-8'));
-        }
-      } catch { /* ignore */ }
 
-      if (!enabledAgents[agent]) {
-        // Try to detect org from existing entries or project structure
-        const existingOrg = Object.values(enabledAgents as Record<string, any>).find((e: any) => e.org)?.org;
-        enabledAgents[agent] = {
-          enabled: true,
-          status: 'configured',
-          ...(existingOrg ? { org: existingOrg } : {}),
-        };
-        mkdirSync(join(ctxRoot, 'config'), { recursive: true });
-        writeFileSync(enabledPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+      let registered = false;
+      try {
+        registered = mutateEnabledAgents(ctxRoot, (enabledAgents) => {
+          if (enabledAgents[agent]) return false; // already registered
+          // Try to detect org from existing entries or project structure
+          const existingOrg = Object.values(enabledAgents).find((e: any) => e.org)?.org;
+          enabledAgents[agent] = {
+            enabled: true,
+            status: 'configured',
+            ...(existingOrg ? { org: existingOrg } : {}),
+          };
+        });
+      } catch (err) {
+        console.error(`Error: could not register "${agent}" in the agent registry.`);
+        console.error(`  ${err instanceof Error ? err.message : String(err)}`);
+        process.exit(1);
+      }
+      if (registered) {
         console.log(`  Registered ${agent} in enabled-agents.json`);
       }
 

--- a/src/utils/enabled-agents.ts
+++ b/src/utils/enabled-agents.ts
@@ -1,0 +1,161 @@
+/**
+ * Locked read-modify-write for the instance agent registry
+ * (`<ctxRoot>/config/enabled-agents.json`).
+ *
+ * Five CLI call sites across four files used to do this by hand — read,
+ * mutate, `writeFileSync` — with no lock and no shared policy, so two
+ * concurrent commands could lose each other's entry. The protocol is easy to
+ * get subtly, silently wrong, so it lives here once instead of five times.
+ *
+ * SCOPE OF THE EXCLUSION — do not overstate it. A lock only excludes writers
+ * that take THIS lock, on THIS directory. That means:
+ *   - Other CLI commands using this helper: excluded.
+ *   - The daemon and any agent process using `withFileLockSync` on the same
+ *     directory: excluded.
+ *   - The dashboard: excluded only once its own locked helper lands — it
+ *     rendezvouses on this same `<ctxRoot>/config/.lock.d` marker via
+ *     `dashboard/src/lib/file-lock.ts`, which re-exports `src/utils/lock.ts`
+ *     rather than reimplementing the protocol. Until both halves ship, the
+ *     CLI<->dashboard race is still open. Do not describe this file as
+ *     "closing the race".
+ *   - Already-installed older binaries writing this file: NOT excluded, and
+ *     not fixable from here. They keep racing until upgraded.
+ *
+ * The lock is NOT reentrant. Calling `mutateEnabledAgents` from inside a
+ * `mutate` callback deadlocks until the lock times out.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { withFileLockSync } from './lock.js';
+import { atomicWriteSync } from './atomic.js';
+
+/** Directory whose `.lock.d` marker guards the registry. */
+export function enabledAgentsDir(ctxRoot: string): string {
+  return join(ctxRoot, 'config');
+}
+
+export function enabledAgentsPath(ctxRoot: string): string {
+  return join(enabledAgentsDir(ctxRoot), 'enabled-agents.json');
+}
+
+/**
+ * Thrown when the registry exists but is not a JSON object. The original file
+ * is left untouched on disk and a copy is preserved at `backupPath`.
+ */
+export class CorruptRegistryError extends Error {
+  readonly path: string;
+  readonly backupPath: string | null;
+
+  constructor(path: string, backupPath: string | null, detail: string) {
+    super(
+      `enabled-agents.json is ${detail} at ${path}. Refusing to overwrite it.\n` +
+        (backupPath ? `  A copy was saved to ${backupPath}\n` : '') +
+        `  Repair the file, or delete it to reset the registry, then re-run.`,
+    );
+    this.name = 'CorruptRegistryError';
+    this.path = path;
+    this.backupPath = backupPath;
+  }
+}
+
+/**
+ * Read-modify-write the registry while holding the inter-process lock on its
+ * directory.
+ *
+ * `mutate` MUST be synchronous, and so must every fs call inside it.
+ * `withFileLockSync` releases the lock in a `finally` the moment the callback
+ * RETURNS — an `async` callback returns a pending Promise immediately, so the
+ * lock would be dropped before the write ever ran. That failure is silent: the
+ * code still looks locked, protects nothing, and type-checks clean (`T` simply
+ * infers `Promise<void>`), so the compiler will never catch it.
+ *
+ * The read happens INSIDE the lock, so callers must not pass in state they
+ * read earlier — `mutate` receives the freshly-read registry.
+ *
+ * @param mutate Mutates the registry in place. Return `false` to skip the
+ *   write entirely (for "already registered, nothing to do" paths — writing
+ *   anyway churns the mtime that the dashboard's file watcher keys on, and
+ *   makes callers log a registration that did not happen).
+ * @returns `true` if the registry was written, `false` if `mutate` declined.
+ * @throws {CorruptRegistryError} if the on-disk registry is not a JSON object.
+ * @throws if the lock cannot be acquired within the timeout, or the write fails.
+ */
+export function mutateEnabledAgents(
+  ctxRoot: string,
+  mutate: (agents: Record<string, any>) => boolean | void,
+): boolean {
+  const file = enabledAgentsPath(ctxRoot);
+  const dir = enabledAgentsDir(ctxRoot);
+  mkdirSync(dir, { recursive: true });
+
+  return withFileLockSync(dir, () => {
+    const agents = readRegistryLocked(file);
+    const proceed = mutate(agents);
+    if (proceed === false) return false;
+
+    // `atomicWriteSync` writes a temp file in this same directory and renames
+    // it into place, so a crash mid-write cannot leave truncated JSON — which,
+    // combined with the throw above, would otherwise brick every later registry
+    // command until someone repaired the file by hand. It appends the trailing
+    // newline itself, matching the bytes the old `writeFileSync` calls produced.
+    atomicWriteSync(file, JSON.stringify(agents, null, 2));
+    return true;
+  });
+}
+
+/**
+ * Read the registry. Caller must already hold the lock.
+ *
+ * Policy on a malformed file: back it up, warn, and THROW — never overwrite.
+ *
+ * The three call sites this replaced disagreed on this. `add-agent`, `start`
+ * and `import-agent` swallowed the parse error and started from `{}`, which
+ * silently rewrote the registry down to a single entry. `enable`/`disable`
+ * (BUG-013) at least backed the file up first — but still continued with `{}`,
+ * so it was an atomic wipe with a receipt.
+ *
+ * Both are worse than they look, because a missing entry does NOT mean
+ * "disabled". `AgentManager.readInstanceEnableList` returns `{}` when the file
+ * is missing or unreadable, and `discoverAndStart` only skips an agent when it
+ * finds an explicit `enabled === false`. So losing the registry does not
+ * deregister agents — it drops the `enabled: false` flags, and the daemon's
+ * next discovery pass STARTS every agent the user deliberately disabled.
+ * Unwanted execution, not just lost data. Hence: refuse to write.
+ */
+function readRegistryLocked(file: string): Record<string, any> {
+  let raw: string;
+  try {
+    raw = readFileSync(file, 'utf-8');
+  } catch (err) {
+    // Only "not there yet" is recoverable — an empty registry is a legitimate
+    // starting state. A permissions or I/O error must propagate rather than be
+    // mistaken for one.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return {};
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new CorruptRegistryError(file, backup(file, raw), 'not valid JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    const kind = parsed === null ? 'null' : Array.isArray(parsed) ? 'an array' : `a ${typeof parsed}`;
+    throw new CorruptRegistryError(file, backup(file, raw), `${kind}, not a JSON object`);
+  }
+
+  return parsed as Record<string, any>;
+}
+
+/** Best-effort copy of a bad registry. Returns the path, or null if it failed. */
+function backup(file: string, raw: string): string | null {
+  const path = `${file}.broken-${Date.now()}`;
+  try {
+    writeFileSync(path, raw, 'utf-8');
+    return path;
+  } catch {
+    return null; // the throw that follows is what matters, not the backup
+  }
+}

--- a/tests/integration/concurrent-enabled-agents-mutations.test.ts
+++ b/tests/integration/concurrent-enabled-agents-mutations.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Inter-process exclusion on `<ctxRoot>/config/enabled-agents.json`.
+ *
+ * Five CLI call sites used to read-modify-write this registry unlocked, so two
+ * concurrent commands could lose each other's entry. `mutateEnabledAgents`
+ * (src/utils/enabled-agents.ts) now wraps the whole read-mutate-write in
+ * `withFileLockSync`. This file is what demonstrates that under real
+ * contention, rather than arguing it from reading the code.
+ *
+ * WHY REAL CHILD PROCESSES: an in-process test cannot prove this. Vitest is
+ * single-threaded, so the lock is uncontended on every acquire and the test
+ * goes green whether or not the lock exists — it would only be pinning the
+ * refactor. The exclusion is between OS processes, so the test has to spawn
+ * OS processes.
+ *
+ * WHY THE PRODUCTION BINARY: the children run `node dist/cli.js disable`, not
+ * the helper directly. Calling the helper would only prove the helper works;
+ * spawning the CLI proves the call sites actually route through it. `disable`
+ * is the lightest full-stack mutator — no .env or Telegram preflight — and it
+ * mutates the registry before it touches anything else.
+ *
+ * SANDBOXING: these call sites derive ctxRoot as `join(homedir(), '.cortextos',
+ * <instance>)`, NOT from CTX_ROOT — so unlike tests/integration/
+ * concurrent-cron-mutations.test.ts, setting CTX_ROOT in the child env does
+ * nothing here. We override HOME instead (`os.homedir()` honours $HOME on
+ * POSIX). That also sandboxes `getIpcPath()`, which is derived the same way,
+ * so `isDaemonRunning()` finds no socket and the children cannot reach the
+ * real daemon or stop real agents.
+ *
+ * NOTE: the CLI arm invokes compiled `dist/cli.js` and skips itself if that is
+ * absent (`npm run build` first). The control arm and the lock-protocol cases
+ * below need no build and always run.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+  readFileSync,
+  existsSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFile, spawn } from 'child_process';
+import { promisify } from 'util';
+import { mutateEnabledAgents, enabledAgentsDir, enabledAgentsPath } from '../../src/utils/enabled-agents';
+
+const execFileAsync = promisify(execFile);
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const DIST_CLI = join(REPO_ROOT, 'dist', 'cli.js');
+const INSTANCE = 'default';
+
+/** Sandboxed $HOME; ctxRoot lives underneath it. */
+let sandboxHome: string;
+let ctxRoot: string;
+
+beforeEach(() => {
+  sandboxHome = mkdtempSync(join(tmpdir(), 'enabled-agents-race-'));
+  ctxRoot = join(sandboxHome, '.cortextos', INSTANCE);
+  mkdirSync(join(ctxRoot, 'config'), { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(sandboxHome, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const registryPath = () => join(ctxRoot, 'config', 'enabled-agents.json');
+const agentNames = (n: number) => Array.from({ length: n }, (_, i) => `race-agent-${i}`);
+
+/**
+ * Padding entries nobody mutates, present only to make the registry big.
+ *
+ * This is load-bearing, not decoration. The unlocked window is
+ * parse -> mutate -> serialise -> write, and against a tiny file that window
+ * is so much shorter than process-startup jitter that the children rarely
+ * overlap. Measured against a deliberately lock-bypassed build (see the
+ * "must still be able to fail" note on the CLI arm): at N=8 with no padding
+ * only 2 of 5 iterations lost anything, so a broken build would have gone
+ * green most runs. Padding the registry widens the window enough that loss
+ * became reliable. A registry this size is realistic for a large fleet.
+ */
+const PADDING_ENTRIES = 400;
+
+/** Seed N agents, all enabled. Each child will flip exactly one to disabled. */
+function seed(names: string[]): void {
+  const agents: Record<string, any> = {};
+  for (const name of names) agents[name] = { enabled: true, org: 'lifeos' };
+  for (let i = 0; i < PADDING_ENTRIES; i++) {
+    agents[`padding-agent-${i}`] = {
+      enabled: true,
+      org: 'lifeos',
+      status: 'configured',
+      note: 'x'.repeat(80),
+    };
+  }
+  writeFileSync(registryPath(), JSON.stringify(agents, null, 2) + '\n');
+}
+
+/**
+ * The detector, shared by both arms so the control arm validates the exact
+ * assertion the CLI arm relies on. A "lost" entry is one whose disable did not
+ * survive — either overwritten back to enabled, or dropped from the file
+ * entirely by a stale-snapshot write.
+ */
+function countLost(names: string[]): number {
+  const agents = JSON.parse(readFileSync(registryPath(), 'utf-8'));
+  let lost = 0;
+  for (const name of names) {
+    if (!agents[name] || agents[name].enabled !== false) lost++;
+  }
+  return lost;
+}
+
+/** Child env: sandboxed HOME, and CTX_ROOT cleared so nothing leaks in. */
+function childEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env, HOME: sandboxHome };
+  delete env.CTX_ROOT;
+  return env;
+}
+
+/**
+ * Control-arm harness: the *unlocked* read-modify-write these call sites used
+ * to do, as a standalone script with no repo imports. Its job is to prove the
+ * detector above can actually see a lost update — without it, a green CLI arm
+ * is indistinguishable from a test that checks nothing.
+ *
+ * It takes a wall-clock start deadline so every child reads at the same
+ * instant. Relying on process-startup jitter to produce overlap would make the
+ * control arm flaky, and a flaky control arm proves nothing on the runs where
+ * it happens to pass.
+ */
+const UNSAFE_HARNESS = `
+const { readFileSync, writeFileSync } = require('fs');
+const [file, name, startAtMs] = process.argv.slice(2);
+const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+// Barrier: line every child up on the same wall-clock instant.
+const waitFor = Number(startAtMs) - Date.now();
+if (waitFor > 0) sleep(waitFor);
+
+const agents = JSON.parse(readFileSync(file, 'utf-8'));   // read...
+sleep(150);                                                // ...window...
+agents[name].enabled = false;
+writeFileSync(file, JSON.stringify(agents, null, 2) + '\\n'); // ...write. No lock.
+`;
+
+describe('enabled-agents.json: concurrent registry mutation', () => {
+  it('CONTROL ARM: unlocked read-modify-write loses updates, and the detector sees it', async () => {
+    const harness = join(sandboxHome, 'unsafe-rmw.cjs');
+    writeFileSync(harness, UNSAFE_HARNESS);
+
+    const names = agentNames(8);
+    seed(names);
+
+    const startAt = Date.now() + 1000;
+    await Promise.all(
+      names.map(name =>
+        execFileAsync(process.execPath, [harness, registryPath(), name, String(startAt)], {
+          env: childEnv(),
+        }),
+      ),
+    );
+
+    // Every child read the same snapshot, so only the last writer's flip
+    // survives. The exact count depends on write ordering; what must hold is
+    // that the detector reports loss at all.
+    const lost = countLost(names);
+    expect(
+      lost,
+      'control arm did not lose any updates — the detector cannot see the failure ' +
+        'the CLI arm claims to rule out, so the CLI arm proves nothing',
+    ).toBeGreaterThan(0);
+  }, 60_000);
+
+  describe.skipIf(!existsSync(DIST_CLI))('via the production CLI (requires npm run build)', () => {
+    /**
+     * THIS TEST MUST STILL BE ABLE TO FAIL. Verified by mutation: bypassing
+     * `withFileLockSync` in src/utils/enabled-agents.ts and rebuilding makes it
+     * fail, with loss in 25 of 25 iterations across five runs at this N and
+     * padding. Re-run that experiment if you change N, PADDING_ENTRIES, or the
+     * command being spawned — every one of those knobs controls whether the
+     * children actually collide, and a green here means nothing if they don't.
+     */
+    it('N concurrent `cortextos disable` processes: every mutation survives', async () => {
+      const N = 16;
+      const ITERATIONS = 5;
+      const lostPerIteration: number[] = [];
+
+      for (let iter = 0; iter < ITERATIONS; iter++) {
+        const names = agentNames(N);
+        seed(names);
+
+        await Promise.all(
+          names.map(name =>
+            execFileAsync(
+              process.execPath,
+              [DIST_CLI, 'disable', name, '--instance', INSTANCE],
+              { env: childEnv() },
+            ),
+          ),
+        );
+
+        lostPerIteration.push(countLost(names));
+
+        // A stale-snapshot write drops entries wholesale, including ones no
+        // child touched. Nothing may vanish, not just the mutated agents.
+        const onDisk = JSON.parse(readFileSync(registryPath(), 'utf-8'));
+        expect(Object.keys(onDisk).length, 'registry entries must not vanish').toBe(
+          N + PADDING_ENTRIES,
+        );
+      }
+
+      const totalLost = lostPerIteration.reduce((a, b) => a + b, 0);
+      if (totalLost > 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[enabled-agents race] lost per iteration: ${lostPerIteration.join(', ')} ` +
+            `(total ${totalLost} of ${N * ITERATIONS})`,
+        );
+      }
+      expect(totalLost, 'concurrent `cortextos disable` must not lose any updates').toBe(0);
+    }, 120_000);
+  });
+});
+
+describe('enabled-agents.json: lock protocol', () => {
+  const lockDir = () => join(ctxRoot, 'config', '.lock.d');
+
+  /**
+   * Pins the literal rendezvous path. This is NOT a concurrency claim — it is
+   * a path assertion, and it matters because the lock only excludes writers
+   * that lock the SAME directory. The dashboard's helper locks
+   * `dirname(enabled-agents.json)`; if this side ever locked somewhere else,
+   * every test here would still pass while the two processes locked different
+   * doors. Until both branches merge, this pin is the only thing holding the
+   * two sides to one marker.
+   */
+  it('holds <ctxRoot>/config/.lock.d for the duration of the mutation, and releases it', () => {
+    expect(enabledAgentsDir(ctxRoot)).toBe(join(ctxRoot, 'config'));
+    expect(enabledAgentsPath(ctxRoot)).toBe(join(ctxRoot, 'config', 'enabled-agents.json'));
+    expect(existsSync(lockDir())).toBe(false);
+
+    let heldDuringMutate: boolean | null = null;
+    mutateEnabledAgents(ctxRoot, (agents) => {
+      heldDuringMutate = existsSync(lockDir());
+      agents.alpha = { enabled: true };
+    });
+
+    expect(heldDuringMutate, 'lock marker must exist while mutate runs').toBe(true);
+    expect(existsSync(lockDir()), 'lock marker must be released afterwards').toBe(false);
+  });
+
+  it('steals a .lock.d whose recorded PID is dead, and completes the mutation', async () => {
+    // A PID that is genuinely dead: spawn a process and wait for it to exit.
+    // Guessing a high number risks colliding with a live process.
+    const child = spawn(process.execPath, ['-e', 'process.exit(0)']);
+    await new Promise<void>(resolve => child.on('exit', () => resolve()));
+    const deadPid = child.pid!;
+
+    mkdirSync(lockDir());
+    writeFileSync(join(lockDir(), 'pid'), String(deadPid));
+
+    const wrote = mutateEnabledAgents(ctxRoot, (agents) => {
+      agents.alpha = { enabled: false };
+    });
+
+    expect(wrote).toBe(true);
+    expect(JSON.parse(readFileSync(registryPath(), 'utf-8')).alpha.enabled).toBe(false);
+    expect(existsSync(lockDir()), 'stolen lock must still be released').toBe(false);
+  }, 20_000);
+
+  it('refuses a .lock.d held by a live process and throws at the timeout', () => {
+    // Our own PID is unambiguously alive, so acquireLock must never steal it.
+    mkdirSync(lockDir());
+    writeFileSync(join(lockDir(), 'pid'), String(process.pid));
+
+    const started = Date.now();
+    expect(() => mutateEnabledAgents(ctxRoot, () => { /* must never run */ })).toThrow(
+      /failed to acquire lock/i,
+    );
+    const elapsed = Date.now() - started;
+
+    // Default timeout is 5s; assert it actually waited rather than failing fast.
+    expect(elapsed).toBeGreaterThanOrEqual(4_500);
+    expect(existsSync(registryPath()), 'must not have written anything').toBe(false);
+  }, 20_000);
+});

--- a/tests/unit/cli/enable-agent-validation.test.ts
+++ b/tests/unit/cli/enable-agent-validation.test.ts
@@ -2,16 +2,18 @@
  * Regression tests for the multi-bug batch PR:
  *
  * - BUG-035: discoverProjectRoot() — cwd-independent project root discovery
- * - BUG-013: readEnabledAgents() — defensive validation + backup of corrupt files
+ * - BUG-013: corrupt-registry handling, now owned by mutateEnabledAgents()
  *
  * The point of these tests is to lock in the contract: enable's CLI must work
- * from any cwd, and corrupt JSON must NEVER be silently destroyed.
+ * from any cwd, and corrupt JSON must NEVER be silently destroyed. See the
+ * comment on the second describe block for what changed and why.
  */
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readdirSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { discoverProjectRoot, readEnabledAgents } from '../../../src/cli/enable-agent';
+import { discoverProjectRoot } from '../../../src/cli/enable-agent';
+import { mutateEnabledAgents, CorruptRegistryError } from '../../../src/utils/enabled-agents';
 
 describe('BUG-035 + BUG-013: enable-agent validation', () => {
   let tmpHome: string;
@@ -64,77 +66,113 @@ describe('BUG-035 + BUG-013: enable-agent validation', () => {
     });
   });
 
-  describe('readEnabledAgents (BUG-013)', () => {
-    function setupConfigFile(instanceId: string, content: string): string {
-      const configDir = join(tmpHome, '.cortextos', instanceId, 'config');
-      mkdirSync(configDir, { recursive: true });
-      const path = join(configDir, 'enabled-agents.json');
-      writeFileSync(path, content);
-      return path;
+  /**
+   * These cases used to target `readEnabledAgents()` in `src/cli/enable-agent.ts`.
+   * That function is gone: the five hand-rolled read/mutate/write sequences across
+   * add-agent, start, import-agent, install and enable-agent are now one locked
+   * helper, `mutateEnabledAgents()`. The tests were rewritten rather than deleted,
+   * because the invariant they were protecting still matters — but ONE ASSERTION
+   * HAS DELIBERATELY FLIPPED, and it is not a relaxation:
+   *
+   *   old: back the corrupt file up, warn, and RETURN `{}` — the caller then
+   *        carried on and wrote a fresh registry over it.
+   *   new: back the corrupt file up, warn, and THROW. Nothing is written.
+   *
+   * The old behaviour was an atomic wipe with a receipt. It looked safe because
+   * the bytes were preserved in a `.broken-*` copy, but the live registry still
+   * lost every entry — and a missing entry does not mean "disabled".
+   * `AgentManager.readInstanceEnableList()` returns `{}` for a missing or
+   * unreadable registry, and `discoverAndStart()` only skips an agent on an
+   * explicit `enabled === false`. So wiping the registry drops those flags and
+   * the daemon's next discovery pass STARTS every agent the user deliberately
+   * disabled. The failure mode is unwanted execution, not just lost data.
+   *
+   * Hence the assertion that carries the weight below is not "it threw" — it is
+   * that the on-disk registry is byte-identical afterwards.
+   */
+  describe('mutateEnabledAgents (supersedes readEnabledAgents / BUG-013)', () => {
+    const ctxRoot = () => join(tmpHome, '.cortextos', 'default');
+    const configDir = () => join(ctxRoot(), 'config');
+    const registry = () => join(configDir(), 'enabled-agents.json');
+
+    function setupConfigFile(content: string): string {
+      mkdirSync(configDir(), { recursive: true });
+      writeFileSync(registry(), content);
+      return registry();
     }
 
-    it('returns {} when the file does not exist (legitimate empty state)', () => {
-      const result = readEnabledAgents('default');
-      expect(result).toEqual({});
+    const backups = () =>
+      readdirSync(configDir()).filter(f => f.startsWith('enabled-agents.json.broken-'));
+
+    it('passes {} to the mutator when the file does not exist (legitimate empty state)', () => {
+      let seen: Record<string, any> | undefined;
+      const wrote = mutateEnabledAgents(ctxRoot(), agents => { seen = { ...agents }; });
+
+      expect(seen).toEqual({});
+      expect(wrote).toBe(true);
+      expect(JSON.parse(readFileSync(registry(), 'utf-8'))).toEqual({});
     });
 
-    it('returns the parsed object on valid JSON', () => {
-      setupConfigFile('default', '{"commander":{"enabled":true,"org":"testorg"}}');
-      const result = readEnabledAgents('default');
-      expect(result).toEqual({ commander: { enabled: true, org: 'testorg' } });
+    it('passes the parsed object to the mutator on valid JSON', () => {
+      setupConfigFile('{"commander":{"enabled":true,"org":"testorg"}}');
+
+      let seen: Record<string, any> | undefined;
+      mutateEnabledAgents(ctxRoot(), agents => { seen = { ...agents }; });
+
+      expect(seen).toEqual({ commander: { enabled: true, org: 'testorg' } });
     });
 
-    it('backs up corrupt JSON instead of silently returning {}', () => {
-      const path = setupConfigFile('default', 'this is not json{{{');
-      const result = readEnabledAgents('default');
-      expect(result).toEqual({});
+    it('persists the mutation, preserving entries it did not touch', () => {
+      setupConfigFile('{"commander":{"enabled":true}}');
 
-      // The corrupt file should be backed up, not destroyed
-      const backups = readdirSync(join(tmpHome, '.cortextos', 'default', 'config'))
-        .filter(f => f.startsWith('enabled-agents.json.broken-'));
-      expect(backups.length).toBeGreaterThan(0);
+      mutateEnabledAgents(ctxRoot(), agents => { agents.scout = { enabled: false }; });
 
-      // The original file is still there (caller may decide to overwrite)
-      expect(existsSync(path)).toBe(true);
+      expect(JSON.parse(readFileSync(registry(), 'utf-8'))).toEqual({
+        commander: { enabled: true },
+        scout: { enabled: false },
+      });
     });
 
-    it('rejects array values (wrong shape) and backs them up', () => {
-      setupConfigFile('default', '["this", "should", "be", "an", "object"]');
-      const result = readEnabledAgents('default');
-      expect(result).toEqual({});
+    it('skips the write entirely when the mutator returns false', () => {
+      const path = setupConfigFile('{"commander":{"enabled":true}}');
+      const before = statSync(path).mtimeMs;
 
-      const backups = readdirSync(join(tmpHome, '.cortextos', 'default', 'config'))
-        .filter(f => f.startsWith('enabled-agents.json.broken-'));
-      expect(backups.length).toBeGreaterThan(0);
+      const wrote = mutateEnabledAgents(ctxRoot(), () => false);
+
+      expect(wrote).toBe(false);
+      // mtime is the point, not just the content: the dashboard's file watcher
+      // keys on it, so a no-op "registration" must not look like a change.
+      expect(statSync(path).mtimeMs).toBe(before);
     });
 
-    it('rejects null values and backs them up', () => {
-      setupConfigFile('default', 'null');
-      const result = readEnabledAgents('default');
-      expect(result).toEqual({});
+    // The four corrupt-input shapes. Each asserts the same three things: it
+    // throws, it leaves a backup, and — the one that actually matters — the
+    // live registry is untouched.
+    const corrupt: Array<[string, string]> = [
+      ['malformed JSON', 'this is not json{{{'],
+      ['an array', '["this", "should", "be", "an", "object"]'],
+      ['null', 'null'],
+      ['a bare string', '"a string"'],
+    ];
 
-      const backups = readdirSync(join(tmpHome, '.cortextos', 'default', 'config'))
-        .filter(f => f.startsWith('enabled-agents.json.broken-'));
-      expect(backups.length).toBeGreaterThan(0);
-    });
+    for (const [label, content] of corrupt) {
+      it(`throws on ${label}, backs it up, and leaves the registry byte-identical`, () => {
+        const path = setupConfigFile(content);
 
-    it('rejects primitive values (string) and backs them up', () => {
-      setupConfigFile('default', '"a string"');
-      const result = readEnabledAgents('default');
-      expect(result).toEqual({});
+        expect(() => mutateEnabledAgents(ctxRoot(), agents => { agents.scout = {}; }))
+          .toThrow(CorruptRegistryError);
 
-      const backups = readdirSync(join(tmpHome, '.cortextos', 'default', 'config'))
-        .filter(f => f.startsWith('enabled-agents.json.broken-'));
-      expect(backups.length).toBeGreaterThan(0);
-    });
+        expect(backups().length).toBeGreaterThan(0);
+        // The whole point: no overwrite, no wipe, no resurrected agents.
+        expect(existsSync(path)).toBe(true);
+        expect(readFileSync(path, 'utf-8')).toBe(content);
+      });
+    }
 
     it('does not back up the file when JSON is valid', () => {
-      setupConfigFile('default', '{}');
-      readEnabledAgents('default');
-
-      const backups = readdirSync(join(tmpHome, '.cortextos', 'default', 'config'))
-        .filter(f => f.startsWith('enabled-agents.json.broken-'));
-      expect(backups.length).toBe(0);
+      setupConfigFile('{}');
+      mutateEnabledAgents(ctxRoot(), () => {});
+      expect(backups()).toHaveLength(0);
     });
   });
 });


### PR DESCRIPTION
CLI commands that enable/disable/add agents each did an unlocked read-modify-write of `enabled-agents.json`; concurrent invocations could lose an entry.

**Scope:** `src/utils/enabled-agents.ts` and its CLI callers (`add-agent`, `enable-agent`, `import-agent`, `install`, `start`) + an integration test under real process contention.
**Note:** a missing roster entry means ENABLED, so a lost write fails open — practical impact is a re-enabled agent, not a silently disabled one.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)