### PR TITLE
fix(bus): ack-inbox reported success for message ids that do not exist

### DIFF
--- a/src/bus/message.ts
+++ b/src/bus/message.ts
@@ -166,8 +166,12 @@ export function checkInbox(paths: BusPaths): InboxMessage[] {
 /**
  * Acknowledge a message by moving it from inflight to processed.
  * Identical to bash ack-inbox.sh behavior.
+ *
+ * Returns true if a matching inflight message was found and acknowledged,
+ * false otherwise. Callers must not report success without checking: an
+ * unmatched id means the message is still inflight and will redeliver.
  */
-export function ackInbox(paths: BusPaths, messageId: string): void {
+export function ackInbox(paths: BusPaths, messageId: string): boolean {
   const { inflight, processed } = paths;
   ensureDir(processed);
 
@@ -176,7 +180,7 @@ export function ackInbox(paths: BusPaths, messageId: string): void {
   try {
     files = readdirSync(inflight).filter(f => f.endsWith('.json'));
   } catch {
-    return;
+    return false;
   }
 
   for (const file of files) {
@@ -186,12 +190,14 @@ export function ackInbox(paths: BusPaths, messageId: string): void {
       const msg = JSON.parse(content);
       if (msg.id === messageId) {
         renameSync(filePath, join(processed, file));
-        return;
+        return true;
       }
     } catch {
       // Skip corrupt files
     }
   }
+
+  return false;
 }
 
 /**

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -137,7 +137,15 @@ busCommand
   .action((id: string) => {
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
-    ackInbox(paths, id);
+    const acked = ackInbox(paths, id);
+    if (!acked) {
+      // No inflight message with this id — almost always a typo'd or stale id.
+      // Reporting success here would hide the fact that the real message is
+      // still inflight and will redeliver.
+      console.error(`No inflight message with id ${id} — nothing ACK'd`);
+      process.exitCode = 1;
+      return;
+    }
     try {
       logEvent(paths, env.agentName, env.org, 'message', 'inbox_ack', 'info', JSON.stringify({ msg_id: id }));
     } catch { /* non-fatal */ }

--- a/tests/unit/bus/message.test.ts
+++ b/tests/unit/bus/message.test.ts
@@ -130,13 +130,33 @@ describe('Message Bus', () => {
       const msgId = sendMessage(senderPaths, 'sender', 'receiver', 'normal', 'test');
       checkInbox(receiverPaths); // moves to inflight
 
-      ackInbox(receiverPaths, msgId);
+      const acked = ackInbox(receiverPaths, msgId);
 
       const inflightFiles = readdirSync(receiverPaths.inflight).filter(f => f.endsWith('.json'));
       const processedFiles = readdirSync(receiverPaths.processed).filter(f => f.endsWith('.json'));
 
+      expect(acked).toBe(true);
       expect(inflightFiles.length).toBe(0);
       expect(processedFiles.length).toBe(1);
+    });
+
+    it('reports failure for an unknown id and leaves the real message inflight', () => {
+      sendMessage(senderPaths, 'sender', 'receiver', 'normal', 'test');
+      checkInbox(receiverPaths); // moves to inflight
+
+      const acked = ackInbox(receiverPaths, 'not-a-real-message-id');
+
+      const inflightFiles = readdirSync(receiverPaths.inflight).filter(f => f.endsWith('.json'));
+      const processedFiles = readdirSync(receiverPaths.processed).filter(f => f.endsWith('.json'));
+
+      // A false confirmation here would hide that the message still redelivers.
+      expect(acked).toBe(false);
+      expect(inflightFiles.length).toBe(1);
+      expect(processedFiles.length).toBe(0);
+    });
+
+    it('reports failure when there is no inflight directory at all', () => {
+      expect(ackInbox(receiverPaths, 'anything')).toBe(false);
     });
   });
 });


### PR DESCRIPTION
`ackInbox()` returned void and silently no-opped when no inflight message matched the given id. The CLI printed `ACK'd <id>` unconditionally and logged an `inbox_ack` event, so a typo'd or stale id produced a confident success plus false telemetry — while the real message stayed inflight and redelivered five minutes later as an apparent duplicate.

**Scope:** `src/bus/message.ts` (`ackInbox` now returns whether it matched) + `src/cli/bus.ts` (reports the miss on stderr, exits non-zero, skips the `inbox_ack` event) + unit tests.
**Verified:** unit tests covering both the hit and the miss path.
**Behaviour change worth flagging:** `bus ack-inbox` now exits non-zero on an unmatched id. Any script that acks defensively with an id it is not sure is live will start seeing a failure exit where it previously saw success. That is the point of the change, but it is a change.

Found while acking a real message with a mistyped id.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
