### PR TITLE
fix(bus): checkInbox must not report a wedged lock as an empty inbox

### DIFF
--- a/src/bus/message.ts
+++ b/src/bus/message.ts
@@ -4,7 +4,7 @@ import { createHmac, timingSafeEqual } from 'crypto';
 import type { InboxMessage, Priority, BusPaths } from '../types/index.js';
 import { PRIORITY_MAP } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
-import { acquireLock, releaseLock } from '../utils/lock.js';
+import { withFileLockSync, type FileLockOptions } from '../utils/lock.js';
 import { randomString } from '../utils/random.js';
 import { validateAgentName, validatePriority } from '../utils/validate.js';
 
@@ -91,19 +91,37 @@ export function sendMessage(
  * Check inbox for pending messages.
  * Reads inbox directory, moves messages to inflight, returns sorted array.
  * Recovers stale inflight messages (>5 minutes old).
- * Identical to bash check-inbox.sh behavior.
+ *
+ * An empty array means ONE thing: the inbox was read and held no messages.
+ * It previously also meant "the lock was busy so the inbox was never read at
+ * all" — two states the caller had no way to tell apart, so a wedged lock
+ * looked exactly like a quiet inbox and messages sat unnoticed. `acquireLock`
+ * is single-shot and non-blocking (see utils/lock.ts), and it declines on
+ * ordinary transient contention — including the benign mid-acquire window —
+ * on the assumption that the caller retries. This one never did.
+ *
+ * Routing through `withFileLockSync` supplies that retry: transient contention
+ * now resolves by backing off, and a genuinely wedged lock throws instead of
+ * masquerading as an empty inbox. Callers must handle that throw; the two call
+ * sites deliberately handle it differently (the daemon announces and carries
+ * on, the CLI exits non-zero).
+ *
+ * @param lockOpts Lock-acquisition tuning. The default 5s timeout suits a
+ *   one-shot CLI process. The daemon passes something well under its poll
+ *   interval, because `withFileLockSync` blocks the calling thread while it
+ *   retries and every agent's poll loop shares one event loop.
+ * @throws if the inbox lock cannot be acquired within the timeout.
  */
-export function checkInbox(paths: BusPaths): InboxMessage[] {
+export function checkInbox(paths: BusPaths, lockOpts?: FileLockOptions): InboxMessage[] {
   const { inbox, inflight } = paths;
+  // Both must exist BEFORE the lock is attempted: the lock is a .lock.d
+  // directory created inside `inbox`, and mkdir into a nonexistent parent
+  // fails ENOENT, which acquireLock rethrows as a hard error rather than
+  // treating as contention.
   ensureDir(inbox);
   ensureDir(inflight);
 
-  // Acquire lock
-  if (!acquireLock(inbox)) {
-    return [];
-  }
-
-  try {
+  return withFileLockSync(inbox, () => {
     // Recover stale inflight messages (>5 min old)
     recoverStaleInflight(inflight, inbox, 300);
 
@@ -112,6 +130,7 @@ export function checkInbox(paths: BusPaths): InboxMessage[] {
       .filter(f => f.endsWith('.json') && !f.startsWith('.'))
       .sort();
 
+    // The one legitimate empty result: the inbox was read and held nothing.
     if (files.length === 0) {
       return [];
     }
@@ -158,9 +177,9 @@ export function checkInbox(paths: BusPaths): InboxMessage[] {
     }
 
     return messages;
-  } finally {
-    releaseLock(inbox);
-  }
+    // withFileLockSync's own finally releases the lock, including when the
+    // body throws — this function must not release it a second time.
+  }, lockOpts);
 }
 
 /**

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -127,8 +127,18 @@ busCommand
   .action(() => {
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
-    const messages = checkInbox(paths);
-    console.log(JSON.stringify(messages));
+    // Deliberately asymmetric with the daemon, which announces the failure and
+    // carries on. A CLI that printed `[]` when it never managed to read the
+    // inbox would hand every shell caller the same silent outage one level up,
+    // so on failure nothing goes to stdout and the exit status is non-zero.
+    try {
+      const messages = checkInbox(paths);
+      console.log(JSON.stringify(messages));
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`check-inbox: inbox could not be read — ${message}`);
+      process.exitCode = 1;
+    }
   });
 
 busCommand

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -383,6 +383,8 @@ export class AgentManager {
       // FastChecker only needs the first ID for its single-recipient typing
       // indicator / quick-checks. Multi-user is enforced by the gates above.
       allowedUserId: allowedUserId ? parseInt(allowedUserId.split(',')[0].trim(), 10) : undefined,
+      // Needed to attribute inbox-lock events; BusPaths doesn't carry it.
+      org: env.org,
     });
 
     // Send Telegram notification on crashes and session refreshes

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -5,6 +5,7 @@ import { createHash } from 'crypto';
 import { hardRestart } from '../bus/system.js';
 import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
 import { checkInbox, ackInbox } from '../bus/message.js';
+import { logEvent } from '../bus/event.js';
 import { updateApproval } from '../bus/approval.js';
 import { AgentProcess } from './agent-process.js';
 import type { TelegramAPI } from '../telegram/api.js';
@@ -26,6 +27,33 @@ export function handoffGraceMs(runtime: string | undefined): number {
   if (runtime === 'codex-app-server' || runtime === 'opencode') return 600_000;
   return 120_000;
 }
+
+/**
+ * How long checkInbox may block this thread retrying for the inbox lock.
+ * Deliberately under the default 1000ms poll interval: withFileLockSync
+ * blocks synchronously, and one daemon process runs every agent's poll loop
+ * on a single event loop, so this cost is paid fleet-wide, not per agent.
+ */
+export const INBOX_LOCK_TIMEOUT_MS = 750;
+
+/** Consecutive wedged cycles before the breaker opens. */
+export const INBOX_LOCK_CIRCUIT_THRESHOLD = 5;
+
+/**
+ * Retry spacing once the breaker is open. A wedged lock is not always
+ * recoverable — releaseLock swallows rmSync failures, and a leaked lock
+ * holding a live PID can never be stale-detected — so without this the
+ * daemon would block INBOX_LOCK_TIMEOUT_MS every cycle indefinitely.
+ */
+export const INBOX_LOCK_CIRCUIT_BACKOFF_MS = 30_000;
+
+/**
+ * Minimum spacing between inbox-lock events. A wedge at a 1s poll interval
+ * would otherwise emit ~1 event/sec forever, and a *flapping* lock would emit
+ * an unavailable/recovered pair per flap. A flooded activity feed hides the
+ * signal as effectively as the silence this whole fix exists to remove.
+ */
+export const INBOX_LOCK_EVENT_INTERVAL_MS = 60_000;
 
 /**
  * Fast message checker for a single agent.
@@ -59,6 +87,19 @@ export class FastChecker {
   // SIGUSR1 wake: resolve to immediately wake from sleep
   private wakeResolve: (() => void) | null = null;
 
+  // Org name, needed to attribute inbox-lock events. Not on BusPaths, and
+  // AgentProcess keeps its env private, so the manager passes it in.
+  private org: string;
+
+  // Inbox-lock outage tracking. See handleInboxLockFailure for why each
+  // piece exists.
+  private inboxLockFailures: number = 0;
+  private inboxLockFirstFailureAt: number = 0;
+  private inboxLockLastEventAt: number = 0;
+  private inboxLockOutageAnnounced: boolean = false;
+  private inboxLockSuppressedEvents: number = 0;
+  private inboxLockNextAttemptAt: number = 0;
+
   // Idle-session heartbeat watchdog
   private heartbeatTimer: NodeJS.Timeout | null = null;
 
@@ -81,10 +122,11 @@ export class FastChecker {
     agent: AgentProcess,
     paths: BusPaths,
     frameworkRoot: string,
-    options: { pollInterval?: number; log?: LogFn; telegramApi?: TelegramAPI; chatId?: string; allowedUserId?: number } = {},
+    options: { pollInterval?: number; log?: LogFn; telegramApi?: TelegramAPI; chatId?: string; allowedUserId?: number; org?: string } = {},
   ) {
     this.agent = agent;
     this.paths = paths;
+    this.org = options.org || 'default';
     this.frameworkRoot = frameworkRoot;
     this.pollInterval = options.pollInterval || 1000;
     this.log = options.log || ((msg) => console.log(`[fast-checker/${agent.name}] ${msg}`));
@@ -195,8 +237,58 @@ export class FastChecker {
       hasTelegramMessage = true;
     }
 
-    // Check agent inbox
-    const inboxMessages = checkInbox(this.paths);
+    // Check agent inbox.
+    //
+    // This catch must be HERE, not left to the poll loop's catch. The queued
+    // Telegram messages above have already been shifted off this.telegramMessages
+    // into messageBlock; if a throw escaped to the loop's handler, messageBlock
+    // would be discarded with them still dequeued — permanently lost, never
+    // injected. Letting the throw escape would trade a silent inbox gap for
+    // silent Telegram message loss, which is strictly worse.
+    //
+    // The circuit breaker skips the attempt entirely while a wedge persists.
+    // checkInbox blocks the thread while it retries, and every agent's poll
+    // loop shares one event loop, so paying that on every cycle forever would
+    // degrade the whole fleet — see handleInboxLockFailure.
+    let inboxMessages: InboxMessage[] = [];
+    if (Date.now() >= this.inboxLockNextAttemptAt) {
+      let lockError: unknown = null;
+      let acquired = false;
+      try {
+        inboxMessages = checkInbox(this.paths, { timeoutMs: INBOX_LOCK_TIMEOUT_MS });
+        acquired = true;
+      } catch (err) {
+        lockError = err;
+      }
+
+      // The outage bookkeeping is deliberately OUTSIDE the try above, and
+      // guarded separately. Two distinct reasons, both load-bearing:
+      //
+      //   1. Inside that try, a throw from handleInboxLockSuccess would be
+      //      caught by the catch meant for checkInbox and misreported as a
+      //      lock failure — a phantom outage, and one that also advances the
+      //      circuit breaker toward opening.
+      //
+      //   2. A throw from EITHER handler must never escape pollCycle. `this.log`
+      //      is an injected LogFn and logEvent touches the filesystem; neither
+      //      is guaranteed not to throw. The Telegram messages are already
+      //      dequeued into messageBlock at this point, so letting accounting
+      //      throw would discard exactly the messages this catch exists to
+      //      protect. Bookkeeping must never cost a message.
+      try {
+        if (acquired) {
+          this.handleInboxLockSuccess();
+        } else {
+          this.handleInboxLockFailure(lockError);
+        }
+      } catch (e) {
+        // Last resort. The logger is the most likely thing to have thrown, so
+        // even this is guarded — there is nothing left to fall back to.
+        try {
+          this.log(`Inbox lock bookkeeping failed: ${e}`);
+        } catch { /* swallow: losing a log line beats losing a message */ }
+      }
+    }
     for (const msg of inboxMessages) {
       messageBlock += this.formatInboxMessage(msg);
       ackIds.push(msg.id);
@@ -229,6 +321,124 @@ export class FastChecker {
 
     // Context monitor: check usage thresholds and fire warnings/handoffs
     await this.checkContextStatus();
+  }
+
+  /**
+   * The inbox lock could not be acquired, so the inbox was NOT read.
+   *
+   * Announce it and carry on as "no messages". Never rethrow: a crashing
+   * fast-checker is strictly worse than the gap it replaces.
+   *
+   * Loud, but bounded. The event is emitted on entry into the outage and then
+   * at most once per INBOX_LOCK_EVENT_INTERVAL_MS — and that same window gates
+   * entry events too, so a lock that flaps between held and free cannot emit a
+   * pair per flap. Suppressed occurrences are counted and reported in the next
+   * event that does go out, so the throttle never makes an outage look smaller
+   * than it was. The log line is written every time; the log file is cheap and
+   * the activity feed is not.
+   */
+  private handleInboxLockFailure(err: unknown): void {
+    const now = Date.now();
+    this.inboxLockFailures++;
+    if (this.inboxLockFailures === 1) {
+      this.inboxLockFirstFailureAt = now;
+    }
+
+    const message = err instanceof Error ? err.message : String(err);
+    this.log(`Inbox lock unavailable (${this.inboxLockFailures} consecutive): ${message}`);
+
+    // Open the breaker: stop paying the blocking retry every cycle.
+    const circuitOpen = this.inboxLockFailures >= INBOX_LOCK_CIRCUIT_THRESHOLD;
+    if (circuitOpen) {
+      this.inboxLockNextAttemptAt = now + INBOX_LOCK_CIRCUIT_BACKOFF_MS;
+    }
+
+    const firstEver = this.inboxLockLastEventAt === 0;
+    const windowElapsed = now - this.inboxLockLastEventAt >= INBOX_LOCK_EVENT_INTERVAL_MS;
+    if (!firstEver && !windowElapsed) {
+      this.inboxLockSuppressedEvents++;
+      return;
+    }
+
+    this.emitInboxLockEvent('error', 'inbox_lock_unavailable', {
+      error: message,
+      consecutive_failures: this.inboxLockFailures,
+      outage_ms: now - this.inboxLockFirstFailureAt,
+      suppressed_since_last_event: this.inboxLockSuppressedEvents,
+      circuit_open: circuitOpen,
+      next_attempt_in_ms: circuitOpen ? INBOX_LOCK_CIRCUIT_BACKOFF_MS : 0,
+    });
+    this.inboxLockLastEventAt = now;
+    this.inboxLockSuppressedEvents = 0;
+    this.inboxLockOutageAnnounced = true;
+  }
+
+  /**
+   * The inbox was read successfully. Closes out any announced outage and
+   * resets the breaker. Only emits when an outage was actually announced, so
+   * a recovery event never appears without its matching failure event.
+   */
+  private handleInboxLockSuccess(): void {
+    if (this.inboxLockFailures === 0) return;
+
+    const now = Date.now();
+    const failures = this.inboxLockFailures;
+    const outageMs = now - this.inboxLockFirstFailureAt;
+
+    this.inboxLockFailures = 0;
+    this.inboxLockFirstFailureAt = 0;
+    this.inboxLockNextAttemptAt = 0;
+
+    this.log(`Inbox lock recovered after ${failures} failed cycle(s), ${outageMs}ms`);
+
+    if (!this.inboxLockOutageAnnounced) {
+      // This outage was never announced — every one of its failures fell inside
+      // the throttle window left behind by a PREVIOUS event. Do NOT clear the
+      // suppressed counter here.
+      //
+      // Clearing it was a real defect: an outage that begins and ends inside
+      // one 60s window would emit no unavailable event, no recovery event, and
+      // then discard the evidence that it happened at all — a lock flapping on
+      // a ~30s period could stay permanently invisible in the activity feed,
+      // which is the exact silence this whole change exists to remove. Carrying
+      // the count forward means the next event that does go out reports the
+      // true total instead of understating it.
+      return;
+    }
+    this.emitInboxLockEvent('info', 'inbox_lock_recovered', {
+      failed_cycles: failures,
+      outage_ms: outageMs,
+      suppressed_since_last_event: this.inboxLockSuppressedEvents,
+    });
+    this.inboxLockLastEventAt = now;
+    this.inboxLockSuppressedEvents = 0;
+    this.inboxLockOutageAnnounced = false;
+  }
+
+  /**
+   * Write an inbox-lock event to the activity feed. Console output alone is
+   * not sufficient for these — the whole point is dashboard visibility.
+   *
+   * Both the failure and the recovery go under the 'error' category so one
+   * feed filter shows a complete outage, open and close together; severity is
+   * what separates them.
+   *
+   * Failures here are swallowed: an event write must never escalate into the
+   * daemon crash this handling exists to prevent.
+   */
+  private emitInboxLockEvent(
+    severity: 'error' | 'info',
+    eventName: string,
+    meta: Record<string, unknown>,
+  ): void {
+    try {
+      logEvent(this.paths, this.agent.name, this.org, 'error', eventName, severity, {
+        agent: this.agent.name,
+        ...meta,
+      });
+    } catch (e) {
+      this.log(`Failed to log ${eventName} event: ${e}`);
+    }
   }
 
   /**

--- a/tests/integration/check-inbox-cli-exit.test.ts
+++ b/tests/integration/check-inbox-cli-exit.test.ts
@@ -1,0 +1,101 @@
+/**
+ * `bus check-inbox` CLI contract when the inbox lock cannot be acquired.
+ *
+ * The CLI is deliberately ASYMMETRIC with the daemon. The daemon announces the
+ * failure and carries on as "no messages", because a crashing fast-checker is
+ * worse than a gap. The CLI has no such constraint: it is a one-shot process
+ * whose stdout is routinely consumed by shell callers, so printing `[]` when
+ * the inbox was never read would propagate the exact silent outage this whole
+ * change exists to remove — one level up, into every caller.
+ *
+ * So: on failure, nothing on stdout, and a non-zero exit status.
+ *
+ * NOTE: this test invokes the compiled `dist/cli.js` and is skipped when that
+ * file is absent (matching the other CLI integration tests, which assume CI
+ * ran `npm run build`). Be aware that a skipped test reads as a green one in
+ * summary output — if you are using this suite to clear the change, confirm
+ * the tests below actually RAN.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { spawn, spawnSync, type ChildProcess } from 'child_process';
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const DIST_CLI = join(REPO_ROOT, 'dist', 'cli.js');
+
+const AGENT = 'probe';
+const INSTANCE = 'default';
+
+const suite = existsSync(DIST_CLI) ? describe : describe.skip;
+
+suite('bus check-inbox — CLI exit contract on lock failure', () => {
+  let home: string;
+  let holder: ChildProcess | null = null;
+
+  // resolvePaths() derives everything from homedir(), not from an env var, so
+  // an isolated HOME is what keeps this off the real inbox.
+  const inboxDir = () => join(home, '.cortextos', INSTANCE, 'inbox', AGENT);
+
+  const runCheckInbox = () =>
+    spawnSync(process.execPath, [DIST_CLI, 'bus', 'check-inbox'], {
+      env: {
+        ...process.env,
+        HOME: home,
+        CTX_AGENT_NAME: AGENT,
+        CTX_INSTANCE_ID: INSTANCE,
+        CTX_ORG: 'testorg',
+      },
+      encoding: 'utf-8',
+    });
+
+  beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'cortextos-cli-inbox-'));
+  });
+
+  afterEach(() => {
+    if (holder) {
+      try { holder.kill('SIGKILL'); } catch { /* already gone */ }
+      holder = null;
+    }
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  it('exits non-zero and prints nothing to stdout when the lock is held', () => {
+    mkdirSync(inboxDir(), { recursive: true });
+    const lockDir = join(inboxDir(), '.lock.d');
+    mkdirSync(lockDir, { recursive: true });
+
+    // A genuinely live holder process. acquireLock's staleness check is
+    // process.kill(pid, 0); a dead pid would be STOLEN on the first attempt,
+    // the CLI would succeed, and this test would silently stop testing
+    // anything.
+    holder = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 60000)'], { stdio: 'ignore' });
+    writeFileSync(join(lockDir, 'pid'), String(holder.pid));
+
+    const res = runCheckInbox();
+
+    expect(res.status).not.toBe(0);
+    // The specific regression: never `[]` on stdout. Asserting emptiness alone
+    // would be weaker — `[]` is the exact string a caller would misread as a
+    // healthy empty inbox.
+    expect(res.stdout).not.toContain('[]');
+    expect(res.stdout.trim()).toBe('');
+    // The reason goes to stderr, where it cannot be captured by `$(...)` into
+    // a caller's message list.
+    expect(res.stderr).toMatch(/inbox could not be read/i);
+  }, 30_000);
+
+  it('exits zero and prints [] for a genuinely empty inbox', () => {
+    // The control arm. Without it, a CLI that failed for some unrelated reason
+    // (missing dist, bad env, wrong agent name) would satisfy the assertions
+    // above for entirely the wrong reason.
+    const res = runCheckInbox();
+
+    expect(res.status).toBe(0);
+    expect(res.stdout.trim()).toBe('[]');
+    expect(res.stderr).not.toMatch(/inbox could not be read/i);
+  }, 30_000);
+});

--- a/tests/unit/bus/check-inbox-lock.test.ts
+++ b/tests/unit/bus/check-inbox-lock.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readdirSync } from 'fs';
+import { spawn, type ChildProcess } from 'child_process';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { sendMessage, checkInbox } from '../../../src/bus/message';
+import type { BusPaths } from '../../../src/types';
+
+/**
+ * checkInbox used to return `[]` from two states a caller could not tell apart:
+ * the inbox was read and was empty, or the lock was busy and the inbox was
+ * never read at all. Every test here exists to separate those two states.
+ *
+ * A test that only asserts "returns []" is the vacuous check that let the
+ * original defect ship — it passes just as happily against the broken code.
+ */
+describe('checkInbox — lock failure is distinguishable from an empty inbox', () => {
+  let testDir: string;
+  let paths: BusPaths;
+  let children: ChildProcess[] = [];
+
+  const lockDir = () => join(paths.inbox, '.lock.d');
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-inbox-lock-'));
+    paths = {
+      ctxRoot: testDir,
+      inbox: join(testDir, 'inbox', 'receiver'),
+      inflight: join(testDir, 'inflight', 'receiver'),
+      processed: join(testDir, 'processed', 'receiver'),
+      logDir: join(testDir, 'logs', 'receiver'),
+      stateDir: join(testDir, 'state', 'receiver'),
+      taskDir: join(testDir, 'tasks'),
+      approvalDir: join(testDir, 'approvals'),
+      analyticsDir: join(testDir, 'analytics'),
+      deliverablesDir: join(testDir, 'deliverables'),
+    };
+  });
+
+  afterEach(() => {
+    for (const c of children) {
+      try { c.kill('SIGKILL'); } catch { /* already gone */ }
+    }
+    children = [];
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  /** Sleep without yielding to the event loop, matching the lock's own sleep. */
+  const spinSleep = (ms: number) => {
+    const sab = new Int32Array(new SharedArrayBuffer(4));
+    Atomics.wait(sab, 0, 0, ms);
+  };
+
+  // -------------------------------------------------------------------------
+  // State B: the lock is held, the inbox is NOT read.
+  // -------------------------------------------------------------------------
+
+  it('throws when the lock is held by a live process, instead of returning []', () => {
+    // Seed a real message so an empty result could not be blamed on an empty
+    // inbox — if this ever returns [], it is hiding a message.
+    sendMessage(paths, 'sender', 'receiver', 'normal', 'must not be silently skipped');
+
+    // process.pid is alive by construction, and acquireLock's staleness check
+    // is process.kill(pid, 0) — a self-signal succeeds, so this lands on the
+    // genuine "held by a live process" branch rather than the stale-steal path.
+    mkdirSync(lockDir(), { recursive: true });
+    writeFileSync(join(lockDir(), 'pid'), String(process.pid));
+
+    expect(() => checkInbox(paths, { timeoutMs: 100 })).toThrow(/failed to acquire lock/i);
+  });
+
+  it('leaves the message in the inbox when the lock is held', () => {
+    sendMessage(paths, 'sender', 'receiver', 'normal', 'still here');
+    mkdirSync(lockDir(), { recursive: true });
+    writeFileSync(join(lockDir(), 'pid'), String(process.pid));
+
+    try { checkInbox(paths, { timeoutMs: 100 }); } catch { /* expected */ }
+
+    // Nothing was consumed: the message is still queued, not lost mid-move.
+    const queued = readdirSync(paths.inbox).filter(f => f.endsWith('.json'));
+    expect(queued).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // State A: the inbox IS read and is genuinely empty. This is the mutation
+  // guard — it must fail if checkInbox is "fixed" by throwing unconditionally.
+  // -------------------------------------------------------------------------
+
+  it('returns [] for a genuinely empty inbox, without throwing', () => {
+    expect(checkInbox(paths)).toEqual([]);
+  });
+
+  it('still returns messages normally when the lock is free', () => {
+    sendMessage(paths, 'sender', 'receiver', 'normal', 'hello');
+    const messages = checkInbox(paths);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe('hello');
+  });
+
+  it('releases the lock after a successful read', () => {
+    sendMessage(paths, 'sender', 'receiver', 'normal', 'first');
+    checkInbox(paths);
+    expect(existsSync(lockDir())).toBe(false);
+
+    // Provable by the next call succeeding rather than blocking.
+    sendMessage(paths, 'sender', 'receiver', 'normal', 'second');
+    expect(checkInbox(paths, { timeoutMs: 100 })).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // The retry loop itself. This is the only new mechanism in the fix, and it
+  // is the easiest thing to test vacuously.
+  //
+  // It CANNOT be tested with an in-process timer: withFileLockSync's retry
+  // loop is fully synchronous, so no macrotask can run until it returns.
+  // It also cannot be tested with a dead-PID stale lock — acquireLock steals
+  // that on the FIRST call, so the retry body executes zero times and the test
+  // would pass against an implementation with no retry at all.
+  //
+  // The releaser has to be a genuinely separate process.
+  // -------------------------------------------------------------------------
+
+  it('retries past transient contention rather than failing (real retry, not a stale steal)', () => {
+    sendMessage(paths, 'sender', 'receiver', 'normal', 'delivered after contention');
+
+    const HOLD_MS = 400;
+    const dir = lockDir();
+    // Holds the lock with its OWN live pid, then drops it. Because this is a
+    // separate process it keeps running while our thread is blocked.
+    const script = `
+      const { mkdirSync, writeFileSync, rmSync } = require('fs');
+      const { join } = require('path');
+      mkdirSync(${JSON.stringify(dir)}, { recursive: true });
+      writeFileSync(join(${JSON.stringify(dir)}, 'pid'), String(process.pid));
+      setTimeout(() => { rmSync(${JSON.stringify(dir)}, { recursive: true, force: true }); }, ${HOLD_MS});
+      setTimeout(() => {}, ${HOLD_MS + 2000});
+    `;
+    const child = spawn(process.execPath, ['-e', script], { stdio: 'ignore' });
+    children.push(child);
+
+    // Wait for the child to actually own the lock before we try, otherwise we
+    // might acquire first and never exercise contention at all.
+    const waitStart = Date.now();
+    while (!existsSync(join(dir, 'pid')) && Date.now() - waitStart < 5000) {
+      spinSleep(10);
+    }
+    expect(existsSync(join(dir, 'pid'))).toBe(true);
+
+    const start = Date.now();
+    const messages = checkInbox(paths, { timeoutMs: 5000 });
+    const elapsed = Date.now() - start;
+
+    // Succeeded rather than throwing...
+    expect(messages).toHaveLength(1);
+    expect(messages[0].text).toBe('delivered after contention');
+    // ...and actually waited for the holder. Without a retry loop this would
+    // have thrown immediately; with a stale-steal shortcut it would have
+    // returned in ~0ms. The elapsed time is what makes this test non-vacuous.
+    expect(elapsed).toBeGreaterThan(100);
+  }, 20_000);
+
+  it('gives up and throws when the holder never releases', () => {
+    const dir = lockDir();
+    const script = `
+      const { mkdirSync, writeFileSync } = require('fs');
+      const { join } = require('path');
+      mkdirSync(${JSON.stringify(dir)}, { recursive: true });
+      writeFileSync(join(${JSON.stringify(dir)}, 'pid'), String(process.pid));
+      setTimeout(() => {}, 30000);
+    `;
+    const child = spawn(process.execPath, ['-e', script], { stdio: 'ignore' });
+    children.push(child);
+
+    const waitStart = Date.now();
+    while (!existsSync(join(dir, 'pid')) && Date.now() - waitStart < 5000) {
+      spinSleep(10);
+    }
+    expect(existsSync(join(dir, 'pid'))).toBe(true);
+
+    // A held lock that outlasts the timeout is the wedge case: loud, not [].
+    expect(() => checkInbox(paths, { timeoutMs: 300 })).toThrow(/failed to acquire lock/i);
+  }, 20_000);
+});

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -4,7 +4,12 @@ vi.mock('child_process', () => ({ execFile: vi.fn() }));
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { FastChecker } from '../../../src/daemon/fast-checker';
+import {
+  FastChecker,
+  INBOX_LOCK_CIRCUIT_THRESHOLD,
+  INBOX_LOCK_CIRCUIT_BACKOFF_MS,
+  INBOX_LOCK_EVENT_INTERVAL_MS,
+} from '../../../src/daemon/fast-checker';
 import type { BusPaths, TelegramCallbackQuery } from '../../../src/types';
 
 // Minimal mock for AgentProcess
@@ -1020,5 +1025,289 @@ describe('FastChecker', () => {
       expect(handoffPrompts.length).toBe(2); // 3rd fire tripped the breaker instead of handing off
       expect((checker as any).ctxCircuitBrokenAt).not.toBeNull();
     });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbox-lock failure handling.
+  //
+  // pollCycle shifts queued Telegram messages off this.telegramMessages into
+  // messageBlock BEFORE checkInbox runs. checkInbox now throws when the inbox
+  // lock is wedged, so if that throw escaped to the poll loop's catch,
+  // messageBlock would be discarded with those messages already dequeued —
+  // permanently lost. The local catch exists to prevent exactly that, and this
+  // is the test that holds it in place.
+  //
+  // Note what is NOT asserted here: "pollCycle does not throw". That check is
+  // vacuous — it passes just as happily against an implementation that drops
+  // the Telegram message on the floor. The assertion that matters is that the
+  // dequeued text reaches injectMessage.
+  // -------------------------------------------------------------------------
+  const inboxLockDir = () => join(paths.inbox, '.lock.d');
+
+  /**
+   * Hold the inbox lock with a PID that is alive by construction.
+   * acquireLock's staleness check is process.kill(pid, 0), and a self-signal
+   * succeeds, so this lands on the genuine "held by a live process" branch
+   * rather than the stale-steal path (which would let checkInbox succeed and
+   * quietly make these tests vacuous).
+   */
+  const holdInboxLock = () => {
+    mkdirSync(inboxLockDir(), { recursive: true });
+    writeFileSync(join(inboxLockDir(), 'pid'), String(process.pid));
+  };
+
+  const releaseInboxLock = () => {
+    rmSync(inboxLockDir(), { recursive: true, force: true });
+  };
+
+  const readEvents = (agentName: string): any[] => {
+    const today = new Date().toISOString().split('T')[0];
+    const f = join(paths.analyticsDir, 'events', agentName, `${today}.jsonl`);
+    if (!existsSync(f)) return [];
+    return readFileSync(f, 'utf-8').trim().split('\n').filter(Boolean).map(l => JSON.parse(l));
+  };
+
+  describe('inbox lock wedged — queued Telegram messages must survive', () => {
+    it('injects the queued Telegram message anyway, and logs an error-category event', async () => {
+      const agent = createMockAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org' });
+
+      checker.queueTelegramMessage('=== TELEGRAM from ryan (chat_id:1) ===\nship it\n');
+      holdInboxLock();
+
+      await (checker as any).pollCycle();
+
+      // Premise of the regression: the message really was dequeued before
+      // checkInbox ran, so it existed only inside messageBlock at throw time.
+      expect((checker as any).telegramMessages).toHaveLength(0);
+
+      // The regression itself: it was still delivered.
+      expect(agent.injectMessage).toHaveBeenCalledTimes(1);
+      expect(agent.injectMessage.mock.calls[0][0]).toContain('ship it');
+
+      // And the inbox gap was announced rather than silently swallowed.
+      // This assertion doubles as the control: it is the proof that checkInbox
+      // actually failed. Without it, a lock that was never really held would
+      // let the injection assertion above pass for the wrong reason.
+      const ev = readEvents(agent.name).find(e => e.event === 'inbox_lock_unavailable');
+      expect(ev).toBeDefined();
+      expect(ev.category).toBe('error');
+      expect(ev.severity).toBe('error');
+      expect(ev.metadata.consecutive_failures).toBe(1);
+    }, 30_000);
+
+    it('does not log an inbox-lock event when the lock is free', async () => {
+      const agent = createMockAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org' });
+
+      checker.queueTelegramMessage('=== TELEGRAM from ryan (chat_id:1) ===\nno contention\n');
+      await (checker as any).pollCycle();
+
+      expect(agent.injectMessage).toHaveBeenCalledTimes(1);
+      // A recovery event must never appear without a failure event, and a
+      // healthy cycle must stay silent — otherwise the feed teaches operators
+      // to ignore these.
+      const names = readEvents(agent.name).map(e => e.event);
+      expect(names).not.toContain('inbox_lock_unavailable');
+      expect(names).not.toContain('inbox_lock_recovered');
+    }, 30_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // The outage bookkeeping must not itself become a way to lose a message.
+  //
+  // `this.log` is an injected LogFn and logEvent touches the filesystem, so
+  // neither is guaranteed not to throw. The handlers run at the point in
+  // pollCycle where the Telegram messages are already dequeued into
+  // messageBlock, so a throw from the accounting discards exactly the messages
+  // the surrounding catch exists to protect: the guard written to hold the
+  // invariant could violate it.
+  // -------------------------------------------------------------------------
+  describe('inbox-lock bookkeeping must never cost a message', () => {
+    it('delivers the queued Telegram message even when the outage logger throws', async () => {
+      const agent = createMockAgent();
+      // Throw only on the inbox-lock lines. A logger that throws on everything
+      // would also blow up the post-injection "Injected N bytes" line, so the
+      // test would no longer isolate the handler as the throw site.
+      const log = vi.fn((msg: string) => {
+        if (msg.includes('Inbox lock')) throw new Error('log sink is down');
+      });
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org', log });
+
+      checker.queueTelegramMessage('=== TELEGRAM from ryan (chat_id:1) ===\nship it\n');
+      holdInboxLock();
+
+      await (checker as any).pollCycle();
+
+      // Premise: the message was dequeued before the throwing handler ran, so
+      // it existed only inside messageBlock at that moment.
+      expect((checker as any).telegramMessages).toHaveLength(0);
+      // The regression: it was still delivered.
+      expect(agent.injectMessage).toHaveBeenCalledTimes(1);
+      expect(agent.injectMessage.mock.calls[0][0]).toContain('ship it');
+
+      // Control. Without this the test passes for the wrong reason: if the lock
+      // were never really held, the handler would never run, nothing would
+      // throw, and "the message got through" would prove nothing at all.
+      expect(log.mock.calls.some(c => String(c[0]).includes('Inbox lock unavailable'))).toBe(true);
+    }, 30_000);
+
+    it('does not invent a phantom outage when the recovery logger throws', async () => {
+      const agent = createMockAgent();
+      const log = vi.fn((msg: string) => {
+        if (msg.includes('Inbox lock recovered')) throw new Error('log sink is down');
+      });
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org', log });
+
+      holdInboxLock();
+      await (checker as any).pollCycle();
+      expect((checker as any).inboxLockFailures).toBe(1); // premise: a real outage
+
+      releaseInboxLock();
+      await (checker as any).pollCycle();
+
+      // handleInboxLockSuccess throws after it has already cleared state. If it
+      // ran inside checkInbox's own try, that throw would land in the catch
+      // meant for the lock and be misread as a failure — a recovery recorded as
+      // an outage, which also walks the circuit breaker toward opening.
+      expect((checker as any).inboxLockFailures).toBe(0);
+      expect(log.mock.calls.some(c => String(c[0]).includes('Inbox lock recovered'))).toBe(true);
+    }, 30_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Throttle accounting. An outage that begins AND ends inside one event window
+  // emits neither an unavailable nor a recovery event; if the suppressed count
+  // were cleared on the way out, a lock flapping faster than the window could
+  // stay permanently invisible in the activity feed — the exact silence this
+  // whole change exists to remove.
+  // -------------------------------------------------------------------------
+  describe('inbox-lock event throttle', () => {
+    it('carries a fully-suppressed outage forward instead of discarding it', async () => {
+      const agent = createMockAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org' });
+
+      // An event went out moments ago, so everything below falls inside one
+      // throttle window and is never announced.
+      (checker as any).inboxLockLastEventAt = Date.now();
+      (checker as any).inboxLockOutageAnnounced = false;
+
+      holdInboxLock();
+      await (checker as any).pollCycle();
+      expect((checker as any).inboxLockSuppressedEvents).toBe(1); // premise
+
+      releaseInboxLock();
+      await (checker as any).pollCycle();
+
+      // The fix: recovery from an unannounced outage must not erase the
+      // evidence that the outage happened.
+      expect((checker as any).inboxLockSuppressedEvents).toBe(1);
+
+      // And the evidence actually reaches the feed on the next event that goes
+      // out — carrying it forward is only worth anything if it surfaces.
+      (checker as any).inboxLockLastEventAt = Date.now() - INBOX_LOCK_EVENT_INTERVAL_MS - 1;
+      holdInboxLock();
+      await (checker as any).pollCycle();
+
+      const ev = readEvents(agent.name).find(e => e.event === 'inbox_lock_unavailable');
+      expect(ev).toBeDefined();
+      expect(ev.metadata.suppressed_since_last_event).toBe(1);
+    }, 30_000);
+  });
+
+  // -------------------------------------------------------------------------
+  // Circuit breaker. checkInbox blocks this thread while it retries and every
+  // agent's poll loop shares one event loop, so a persistent wedge must stop
+  // costing a blocking retry every cycle — without ever becoming permanent.
+  // -------------------------------------------------------------------------
+  describe('inbox-lock circuit breaker', () => {
+    let clock = 0;
+    let nowSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // Anchor on the real clock so event files still land on today's date;
+      // only the offsets are synthetic. withFileLockSync times out on
+      // process.hrtime, not Date.now, so stubbing this cannot wedge its retry.
+      clock = Date.now();
+      nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => clock);
+    });
+
+    afterEach(() => {
+      nowSpy.mockRestore();
+    });
+
+    const advance = (ms: number) => { clock += ms; };
+
+    const driveToOpenBreaker = async (checker: any) => {
+      holdInboxLock();
+      for (let i = 0; i < INBOX_LOCK_CIRCUIT_THRESHOLD; i++) {
+        await checker.pollCycle();
+      }
+    };
+
+    it('stays closed below the threshold and opens on the Nth consecutive failure', async () => {
+      const agent = createMockAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org' });
+      holdInboxLock();
+
+      for (let i = 1; i < INBOX_LOCK_CIRCUIT_THRESHOLD; i++) {
+        await (checker as any).pollCycle();
+        expect((checker as any).inboxLockFailures).toBe(i);
+        expect((checker as any).inboxLockNextAttemptAt).toBe(0); // still closed
+      }
+
+      await (checker as any).pollCycle();
+      expect((checker as any).inboxLockFailures).toBe(INBOX_LOCK_CIRCUIT_THRESHOLD);
+      expect((checker as any).inboxLockNextAttemptAt).toBe(clock + INBOX_LOCK_CIRCUIT_BACKOFF_MS);
+    }, 30_000);
+
+    it('skips the blocking inbox read while open, but still delivers Telegram', async () => {
+      const agent = createMockAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org' });
+      await driveToOpenBreaker(checker);
+      const deadline = (checker as any).inboxLockNextAttemptAt;
+
+      advance(INBOX_LOCK_CIRCUIT_BACKOFF_MS - 1);
+      checker.queueTelegramMessage('=== TELEGRAM from ryan (chat_id:1) ===\nstill listening\n');
+      await (checker as any).pollCycle();
+
+      // No attempt was made: another attempt would have failed and incremented.
+      expect((checker as any).inboxLockFailures).toBe(INBOX_LOCK_CIRCUIT_THRESHOLD);
+      // And a skipped cycle must not push the retry further out — that would
+      // turn a bounded backoff into a wedge that never probes again.
+      expect((checker as any).inboxLockNextAttemptAt).toBe(deadline);
+      // An open breaker suppresses the inbox read, nothing else.
+      expect(agent.injectMessage).toHaveBeenCalledTimes(1);
+      expect(agent.injectMessage.mock.calls[0][0]).toContain('still listening');
+    }, 30_000);
+
+    it('probes again once the backoff elapses', async () => {
+      const agent = createMockAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org' });
+      await driveToOpenBreaker(checker);
+
+      advance(INBOX_LOCK_CIRCUIT_BACKOFF_MS);
+      await (checker as any).pollCycle();
+
+      // The breaker is a delay, not a decision. A next-attempt time that is
+      // never reachable (Infinity, or one pushed out on every skipped cycle)
+      // wedges this agent's inbox for the life of the process, and every other
+      // assertion about the breaker would still pass.
+      expect((checker as any).inboxLockFailures).toBe(INBOX_LOCK_CIRCUIT_THRESHOLD + 1);
+    }, 30_000);
+
+    it('closes and resets once the inbox is readable again', async () => {
+      const agent = createMockAgent();
+      const checker = new FastChecker(agent, paths, '/tmp/framework', { org: 'test-org' });
+      await driveToOpenBreaker(checker);
+
+      releaseInboxLock();
+      advance(INBOX_LOCK_CIRCUIT_BACKOFF_MS);
+      await (checker as any).pollCycle();
+
+      expect((checker as any).inboxLockFailures).toBe(0);
+      expect((checker as any).inboxLockNextAttemptAt).toBe(0);
+      expect(readEvents(agent.name).map(e => e.event)).toContain('inbox_lock_recovered');
+    }, 30_000);
   });
 });


### PR DESCRIPTION
`checkInbox` returned `[]` from two states the caller could not tell apart: the inbox was read and held nothing, and the lock was busy so the inbox was never read at all. `acquireLock` is single-shot and declines on ordinary transient contention on the assumption that the caller retries — `checkInbox` never did, so a skipped inbox round needed no genuinely wedged lock at all. Messages sat unnoticed and nothing anywhere said so.

Routes through `withFileLockSync` instead: transient contention resolves by backing off, and a genuinely stuck lock throws rather than impersonating a quiet inbox.

**Scope:** `src/bus/message.ts`, `src/cli/bus.ts`, `src/daemon/fast-checker.ts`, `src/daemon/agent-manager.ts` + 18 tests.

**The two call sites handle the throw deliberately differently**, and the asymmetry is the design, not an oversight:
- **Daemon** catches locally and continues as "no messages", logging an error-category event. The catch must be local: `pollCycle` shifts queued Telegram messages off `this.telegramMessages` into `messageBlock` *before* `checkInbox` runs, so a throw escaping to the poll loop's handler would discard them while already dequeued — trading a silent inbox gap for silent Telegram message loss, which is strictly worse.
- **CLI** exits non-zero and prints nothing to stdout. Printing `[]` would hand every shell caller the same silent outage one level up.

Also bounds the cost of a persistent wedge: a circuit breaker (5 consecutive failures, 30s backoff) stops paying a blocking retry every cycle, since `checkInbox` blocks the calling thread and every agent's poll loop shares one event loop. Outage events are throttled to one per 60s, with suppressed occurrences counted and reported in the next event so the throttle never makes an outage look smaller than it was.

**Verified:** every new test carries mutation evidence — each was run against a mutant built to differ from the real code in one dimension, with the expected failure named before the run. Notably the breaker's next-attempt time is pinned finite and reachable: setting it to `Infinity` wedges an agent's inbox for the life of the process and previously survived the entire suite.

**Depends on #832** — both touch `src/bus/message.ts` and `src/cli/bus.ts`. #832 should land first; this will need a trivial rebase if it does not.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
