### PR TITLE
fix(oauth): serialize accounts.json read-modify-write to stop cross-account clobber

### DIFF
--- a/src/bus/oauth.ts
+++ b/src/bus/oauth.ts
@@ -16,6 +16,7 @@ import { existsSync, readFileSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+import { withFileLockSync } from '../utils/lock.js';
 
 // --- Types ---
 
@@ -125,6 +126,41 @@ function saveAccounts(ctxRoot: string, store: AccountsStore): void {
   const path = accountsPath(ctxRoot);
   atomicWriteSync(path, JSON.stringify(store, null, 2));
   try { chmodSync(path, 0o600); } catch { /* ignore */ }
+}
+
+/**
+ * Run a read-modify-write against accounts.json under an inter-process mutex.
+ *
+ * The atomic rename inside `saveAccounts` makes each individual WRITE safe. It
+ * does nothing for the load → mutate → save *sequence* around it: two processes
+ * that both load before either saves will each write a whole-store snapshot,
+ * and the later writer silently reverts the earlier one's account. For an
+ * account that just refreshed, the reverted value is an already-spent
+ * refresh_token, so the next refresh fails and the account is stranded.
+ *
+ * The store is re-loaded INSIDE the lock — callers must apply their change to
+ * the store handed to `mutate`, never to a copy read before the lock.
+ *
+ * `mutate` MUST be synchronous. `withFileLockSync` is a synchronous mutex, so
+ * anything deferred past its return (an await, a callback) runs UNLOCKED. Do
+ * network work before calling this and apply only the result in here.
+ *
+ * Returns false without writing when accounts.json is missing or `mutate`
+ * returns false; callers decide whether that is benign or an error.
+ */
+function withAccountsLock(
+  ctxRoot: string,
+  mutate: (store: AccountsStore) => boolean,
+): boolean {
+  const dir = oauthDir(ctxRoot);
+  ensureDir(dir);
+  return withFileLockSync(dir, () => {
+    const store = loadAccounts(ctxRoot);
+    if (!store) return false;
+    if (!mutate(store)) return false;
+    saveAccounts(ctxRoot, store);
+    return true;
+  });
 }
 
 export function getActiveAccount(ctxRoot: string): { name: string; account: OAuthAccount } | null {
@@ -256,12 +292,16 @@ export async function checkUsageApi(
   // Update cache and accounts.json utilization fields
   saveCache(ctxRoot, snapshot);
 
-  const store = loadAccounts(ctxRoot);
-  if (store && store.accounts[accountName]) {
-    store.accounts[accountName].five_hour_utilization = fiveHour;
-    store.accounts[accountName].seven_day_utilization = sevenDay;
-    saveAccounts(ctxRoot, store);
-  }
+  // Same read-modify-write shape as the refresh path: the whole store is
+  // rewritten, so it must re-read under the lock. A missing store or account is
+  // benign here (utilization is a cache), hence the ignored return.
+  withAccountsLock(ctxRoot, (store) => {
+    const account = store.accounts[accountName];
+    if (!account) return false;
+    account.five_hour_utilization = fiveHour;
+    account.seven_day_utilization = sevenDay;
+    return true;
+  });
 
   return { ...snapshot, cached: false };
 }
@@ -310,15 +350,34 @@ export async function refreshOAuthToken(
 
   const expiresAt = Date.now() + (tokens.expires_in ?? 3600) * 1000;
 
-  // ATOMIC WRITE — must happen before any further use of the new tokens
-  store.accounts[name] = {
-    ...account,
-    access_token: tokens.access_token,
-    refresh_token: tokens.refresh_token,
-    expires_at: expiresAt,
-    last_refreshed: new Date().toISOString(),
-  };
-  saveAccounts(ctxRoot, store);
+  // ATOMIC WRITE — must happen before any further use of the new tokens.
+  // Locked read-modify-write: `store` above was loaded BEFORE the await and is
+  // now potentially stale, so the new tokens are applied to a copy re-read
+  // inside the lock. Writing `store` back here would revert any account another
+  // process refreshed while this fetch was in flight.
+  const persisted = withAccountsLock(ctxRoot, (fresh) => {
+    const current = fresh.accounts[name];
+    if (!current) return false;
+    fresh.accounts[name] = {
+      ...current,
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_at: expiresAt,
+      last_refreshed: new Date().toISOString(),
+    };
+    return true;
+  });
+
+  if (!persisted) {
+    // The refresh already succeeded, so the OLD refresh_token is spent. Failing
+    // loudly is the only honest option — swallowing this loses the only copy of
+    // the new one and strands the account on a token the server has revoked.
+    throw new Error(
+      `Refreshed account "${name}" but could not persist the new tokens: ` +
+      `accounts.json or the account entry disappeared mid-refresh. ` +
+      `The previous refresh_token is now spent.`,
+    );
+  }
 
   return { account: name, expires_at: expiresAt };
 }
@@ -389,11 +448,7 @@ export async function rotateOAuth(
   }
 
   // PHASE 1: Update accounts.json (active + rotation_log)
-  const reloaded = loadAccounts(ctxRoot)!;
-  reloaded.active = nextName;
-  reloaded.accounts[nextName].five_hour_utilization = preflight.five_hour_utilization;
-  reloaded.accounts[nextName].seven_day_utilization = preflight.seven_day_utilization;
-
+  // Locked: the preflight above is awaited, so anything read before it is stale.
   const logEntry: RotationLogEntry = {
     timestamp: new Date().toISOString(),
     from: currentName,
@@ -402,8 +457,23 @@ export async function rotateOAuth(
     five_hour_util: current.five_hour_utilization,
     seven_day_util: current.seven_day_utilization,
   };
-  reloaded.rotation_log = [logEntry, ...reloaded.rotation_log].slice(0, ROTATION_LOG_MAX);
-  saveAccounts(ctxRoot, reloaded);
+
+  const committed = withAccountsLock(ctxRoot, (reloaded) => {
+    const next = reloaded.accounts[nextName];
+    if (!next) return false;
+    reloaded.active = nextName;
+    next.five_hour_utilization = preflight.five_hour_utilization;
+    next.seven_day_utilization = preflight.seven_day_utilization;
+    reloaded.rotation_log = [logEntry, ...reloaded.rotation_log].slice(0, ROTATION_LOG_MAX);
+    return true;
+  });
+
+  if (!committed) {
+    return {
+      rotated: false,
+      reason: `Account "${nextName}" disappeared from accounts.json before the rotation could be committed`,
+    };
+  }
 
   // PHASE 2: Write bare access token to agent .env files
   const finalStore = loadAccounts(ctxRoot)!;

--- a/tests/unit/bus/oauth.test.ts
+++ b/tests/unit/bus/oauth.test.ts
@@ -7,6 +7,49 @@ import { tmpdir } from 'os';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+// Delegating spy on the lock boundary: records which directory each
+// read-modify-write locked, while still running the REAL lock so behaviour is
+// unchanged. Lets a single-process test assert the lock is actually applied.
+// `lockedSections` additionally records what each locked critical section did to
+// `active`, so a test can attribute a lock to the specific write it cares about
+// rather than to a total count of acquisitions (which couples unrelated call
+// sites together and misreports which one regressed).
+const { lockedDirs, lockedSections } = vi.hoisted(() => ({
+  lockedDirs: [] as string[],
+  lockedSections: [] as { dir: string; activeBefore?: string; activeAfter?: string }[],
+}));
+vi.mock('../../../src/utils/lock.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/utils/lock.js')>();
+  return {
+    ...actual,
+    withFileLockSync: <T,>(dir: string, fn: () => T, opts?: unknown): T => {
+      lockedDirs.push(dir);
+      const { readFileSync } = require('fs') as typeof import('fs');
+      const { join: pjoin } = require('path') as typeof import('path');
+      const readActive = (): string | undefined => {
+        try {
+          return JSON.parse(readFileSync(pjoin(dir, 'accounts.json'), 'utf-8')).active;
+        } catch {
+          return undefined;
+        }
+      };
+      // Read INSIDE the delegating wrapper but OUTSIDE the real lock body is not
+      // possible without racing, so both reads happen within the real critical
+      // section by wrapping `fn` itself.
+      return actual.withFileLockSync(
+        dir,
+        () => {
+          const activeBefore = readActive();
+          const result = fn();
+          lockedSections.push({ dir, activeBefore, activeAfter: readActive() });
+          return result;
+        },
+        opts as never,
+      );
+    },
+  };
+});
+
 const {
   loadAccounts,
   getActiveAccount,
@@ -165,6 +208,29 @@ describe('checkUsageApi', () => {
     expect(call[1].headers.Authorization).toBe('Bearer tok_primary_abc');
     expect(call[1].headers['anthropic-beta']).toBe('oauth-2025-04-20');
   });
+
+  it('performs the utilization write under the inter-process lock', async () => {
+    // checkUsageApi awaits the usage API and then rewrites the WHOLE store, so
+    // it has the same read-modify-write exposure as the refresh path. In one
+    // process the re-read alone makes behaviour correct, so the lock cannot be
+    // observed behaviourally — its ACQUISITION is asserted instead. This proves
+    // the lock is applied, NOT that cross-process exclusion works.
+    //
+    // This test exists so that deleting the lock from checkUsageApi is caught by
+    // a test NAMED for checkUsageApi. Previously the only thing that went red was
+    // the rotateOAuth lock-count test, which attributed the failure to the wrong
+    // function.
+    writeStore();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ five_hour_utilization: 0.1, seven_day_utilization: 0.05 }),
+    });
+
+    lockedDirs.length = 0;
+    await checkUsageApi(tmpDir, { force: true });
+
+    expect(lockedDirs).toEqual([join(tmpDir, 'state', 'oauth')]);
+  });
 });
 
 describe('refreshOAuthToken', () => {
@@ -223,6 +289,123 @@ describe('refreshOAuthToken', () => {
   });
 });
 
+describe('refreshOAuthToken — concurrent refresh of a different account', () => {
+  // Race 1: refreshOAuthToken loads the WHOLE store, awaits the network, then
+  // writes the WHOLE store back. Two refreshes for different accounts overlap
+  // on that await, so the second writer's snapshot — taken before the first
+  // writer's save — reverts the first account to its already-spent
+  // refresh_token. The next refresh of that account then fails: stranded.
+  function deferredFetch() {
+    let resolve!: (v: unknown) => void;
+    const promise = new Promise((r) => { resolve = r; });
+    return { promise, resolve };
+  }
+
+  function tokenResponse(access: string, refresh: string) {
+    return {
+      ok: true,
+      json: async () => ({ access_token: access, refresh_token: refresh, expires_in: 3600 }),
+    };
+  }
+
+  it('does not revert a field another writer changed on the SAME account mid-refresh', async () => {
+    // Kills the mutation `...current` -> `...account`: spreading the pre-fetch
+    // snapshot of this account would revert non-token fields written while the
+    // refresh was in flight, even though the re-read store is used elsewhere.
+    writeStore();
+    const a = deferredFetch();
+    mockFetch.mockImplementationOnce(() => a.promise);
+
+    const call = refreshOAuthToken(tmpDir, 'primary');
+
+    // Another process updates primary's utilization while the fetch is pending.
+    const mid = loadAccounts(tmpDir)!;
+    mid.accounts.primary.five_hour_utilization = 0.99;
+    const { writeFileSync } = require('fs');
+    writeFileSync(
+      join(tmpDir, 'state', 'oauth', 'accounts.json'),
+      JSON.stringify(mid, null, 2),
+    );
+
+    a.resolve(tokenResponse('tok_primary_NEW', 'rtok_primary_NEW'));
+    await call;
+
+    const store = loadAccounts(tmpDir)!;
+    expect(store.accounts.primary.refresh_token).toBe('rtok_primary_NEW');
+    expect(store.accounts.primary.five_hour_utilization).toBe(0.99);
+  });
+
+  it('performs the accounts.json read-modify-write under the inter-process lock', async () => {
+    // The two tests above run in ONE process, where the re-read alone is enough
+    // to make them pass — they cannot observe the lock at all. The lock is what
+    // makes the sequence safe against OTHER processes, so it is pinned here
+    // directly. Without this, deleting withFileLockSync leaves the suite green.
+    writeStore();
+    lockedDirs.length = 0;
+    mockFetch.mockResolvedValueOnce(tokenResponse('tok_x', 'rtok_x'));
+
+    await refreshOAuthToken(tmpDir, 'primary');
+
+    expect(lockedDirs).toContain(join(tmpDir, 'state', 'oauth'));
+  });
+
+  it('does not revert the other account to its spent refresh_token', async () => {
+    writeStore();
+    const a = deferredFetch();
+    const b = deferredFetch();
+    mockFetch
+      .mockImplementationOnce(() => a.promise)
+      .mockImplementationOnce(() => b.promise);
+
+    // Both calls run synchronously up to their `await fetch(...)`, so both
+    // hold the same pre-refresh snapshot of accounts.json.
+    const callA = refreshOAuthToken(tmpDir, 'primary');
+    const callB = refreshOAuthToken(tmpDir, 'secondary');
+
+    // A completes and saves first; B then saves its older snapshot.
+    a.resolve(tokenResponse('tok_primary_NEW', 'rtok_primary_NEW'));
+    await callA;
+    b.resolve(tokenResponse('tok_secondary_NEW', 'rtok_secondary_NEW'));
+    await callB;
+
+    const store = loadAccounts(tmpDir)!;
+    // The later writer's own account must land — this passes even unfixed.
+    expect(store.accounts.secondary.refresh_token).toBe('rtok_secondary_NEW');
+    // The earlier writer's account must survive the later write. Unfixed, this
+    // is 'rtok_primary_xyz' — the token the server has already invalidated.
+    expect(store.accounts.primary.refresh_token).toBe('rtok_primary_NEW');
+    expect(store.accounts.primary.access_token).toBe('tok_primary_NEW');
+  });
+
+  it('throws instead of reporting success when the refreshed account vanishes mid-refresh', async () => {
+    // The refresh itself SUCCEEDED, so the old refresh_token is now spent and the
+    // response holds the only copy of the new one. If the account is gone by the
+    // time we take the lock there is nowhere to persist it. Returning success
+    // would strand the account on a token the server has already revoked, and
+    // report that as a win. Failing loudly is the only honest option.
+    writeStore();
+    const a = deferredFetch();
+    mockFetch.mockImplementationOnce(() => a.promise);
+
+    const call = refreshOAuthToken(tmpDir, 'primary');
+
+    // Another process removes the account while the token fetch is in flight.
+    const mid = loadAccounts(tmpDir)!;
+    delete (mid.accounts as Record<string, unknown>).primary;
+    const { writeFileSync } = require('fs');
+    writeFileSync(
+      join(tmpDir, 'state', 'oauth', 'accounts.json'),
+      JSON.stringify(mid, null, 2),
+    );
+
+    a.resolve(tokenResponse('tok_primary_NEW', 'rtok_primary_NEW'));
+
+    await expect(call).rejects.toThrow(/could not persist the new tokens/);
+    // And it must not have resurrected the deleted account as a side effect.
+    expect(loadAccounts(tmpDir)!.accounts.primary).toBeUndefined();
+  });
+});
+
 describe('rotateOAuth', () => {
   const frameworkRoot = '/tmp/fw';
 
@@ -231,6 +414,44 @@ describe('rotateOAuth', () => {
     const result = await rotateOAuth(tmpDir, frameworkRoot, 'acme');
     expect(result.rotated).toBe(false);
     expect(result.reason).toContain('within limits');
+  });
+
+  it('commits the phase-1 accounts.json write under the inter-process lock', async () => {
+    // rotateOAuth awaits the preflight, so its phase-1 write has the same
+    // read-modify-write exposure as the refresh path. In one process the
+    // re-read alone makes rotation behave correctly, so behaviour cannot
+    // distinguish locked from unlocked — the acquisition is asserted instead.
+    // Attribution matters: asserting a total lock COUNT here would also go red
+    // if checkUsageApi's lock were removed, blaming rotateOAuth for someone
+    // else's regression. So this asserts that exactly one LOCKED critical
+    // section is the one that flipped `active` primary -> secondary. Unlocked,
+    // the phase-1 write happens outside any critical section and no locked
+    // section shows that transition.
+    const highUtilStore = {
+      ...SAMPLE_STORE,
+      accounts: {
+        ...SAMPLE_STORE.accounts,
+        primary: { ...SAMPLE_STORE.accounts.primary, five_hour_utilization: 0.90 },
+      },
+    };
+    writeStore(highUtilStore);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ five_hour_utilization: 0.1, seven_day_utilization: 0.05 }),
+    });
+
+    lockedDirs.length = 0;
+    lockedSections.length = 0;
+    const result = await rotateOAuth(tmpDir, frameworkRoot, 'acme');
+    expect(result.rotated).toBe(true);
+
+    const oauthStateDir = join(tmpDir, 'state', 'oauth');
+    const activated = lockedSections.filter(
+      (s) => s.dir === oauthStateDir
+        && s.activeBefore === 'primary'
+        && s.activeAfter === 'secondary',
+    );
+    expect(activated).toHaveLength(1);
   });
 
   it('rotates when 5h utilization exceeds threshold', async () => {


### PR DESCRIPTION
`refreshOAuthToken` loaded the **whole** accounts store, awaited the token endpoint, then wrote the **whole** store back. Two refreshes for *different* accounts that overlap on that await both hold a pre-refresh snapshot; the later writer reverts the earlier account to its already-spent `refresh_token`. That account's next refresh then fails and it is stranded with no way back.

The atomic rename in `saveAccounts` made each individual **write** safe but did nothing for the load → mutate → save **sequence** around it.

**Scope:** `src/bus/oauth.ts` + unit tests. Reuses the existing `withFileLockSync` (`src/utils/lock.ts`) rather than adding a new primitive — atomic mkdir, PID-based stale detection, fails closed. A new `withAccountsLock()` helper re-reads `accounts.json` *inside* the lock so callers can never apply a change to a snapshot taken before it. Applied at all three sites with the same shape, not just the reported one: `refreshOAuthToken`, `checkUsageApi`, `rotateOAuth` phase-1 commit.

`refreshOAuthToken` now throws if it cannot persist after a successful refresh. The old refresh token is spent by then and the response holds the only copy of the new one, so reporting success would strand the account and call it a win.

**Limits, stated deliberately:**
- Same-account double-spend (two concurrent refreshes of the *same* account spending one one-time token) is **not** fixed here. It needs the lock held across the network call, which is a real availability tradeoff.
- The lock-application tests assert the lock is **applied**, via a delegating spy on `withFileLockSync`. They do **not** prove cross-process exclusion; that cannot be observed from a single process, where the re-read alone already makes behaviour correct. The test comments say so.

**Verified:** unit tests, every mutation pinned by a test named for it (A: fix removed, B/D/E: lock removed per site, C: stale spread, F: persistence throw removed).

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
