### PR TITLE
fix(oauth): rotateOAuth must not commit a rotation decision that lost the race

### DIFF
--- a/src/bus/oauth.ts
+++ b/src/bus/oauth.ts
@@ -458,7 +458,24 @@ export async function rotateOAuth(
     seven_day_util: current.seven_day_utilization,
   };
 
+  // Everything decided above — rotate AWAY from `currentName`, TO `nextName` —
+  // rests on a snapshot read before the refresh and preflight awaits. If another
+  // rotation (or an admin edit) moved `active` during those awaits, that premise
+  // is void: someone else has already rotated, to a destination THEY preflighted.
+  // Committing here would demote a verified newer selection to a staler one and
+  // append a from->to entry describing a transition that never happened.
+  //
+  // Abort rather than recompute. Recomputing the destination inside the lock
+  // would pick an account this call never refreshed and never preflighted, so a
+  // race that had already resolved correctly would be traded for an unverified
+  // token written to every agent's .env — the one invariant rotation exists to
+  // protect.
+  let supersededBy: string | undefined;
   const committed = withAccountsLock(ctxRoot, (reloaded) => {
+    if (reloaded.active !== currentName) {
+      supersededBy = reloaded.active;
+      return false;
+    }
     const next = reloaded.accounts[nextName];
     if (!next) return false;
     reloaded.active = nextName;
@@ -469,9 +486,14 @@ export async function rotateOAuth(
   });
 
   if (!committed) {
+    // Distinguish a lost race from a corrupted store — they need different
+    // responses, and the generic message reads as data loss for a benign race.
     return {
       rotated: false,
-      reason: `Account "${nextName}" disappeared from accounts.json before the rotation could be committed`,
+      reason: supersededBy !== undefined
+        ? `Rotation superseded: active account changed from "${currentName}" to "${supersededBy}" `
+          + `while this rotation was preflighting "${nextName}"; not overwriting the newer selection`
+        : `Account "${nextName}" disappeared from accounts.json before the rotation could be committed`,
     };
   }
 

--- a/src/bus/oauth.ts
+++ b/src/bus/oauth.ts
@@ -16,6 +16,7 @@ import { existsSync, readFileSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+import { withFileLockSync } from '../utils/lock.js';
 
 // --- Types ---
 
@@ -125,6 +126,41 @@ function saveAccounts(ctxRoot: string, store: AccountsStore): void {
   const path = accountsPath(ctxRoot);
   atomicWriteSync(path, JSON.stringify(store, null, 2));
   try { chmodSync(path, 0o600); } catch { /* ignore */ }
+}
+
+/**
+ * Run a read-modify-write against accounts.json under an inter-process mutex.
+ *
+ * The atomic rename inside `saveAccounts` makes each individual WRITE safe. It
+ * does nothing for the load → mutate → save *sequence* around it: two processes
+ * that both load before either saves will each write a whole-store snapshot,
+ * and the later writer silently reverts the earlier one's account. For an
+ * account that just refreshed, the reverted value is an already-spent
+ * refresh_token, so the next refresh fails and the account is stranded.
+ *
+ * The store is re-loaded INSIDE the lock — callers must apply their change to
+ * the store handed to `mutate`, never to a copy read before the lock.
+ *
+ * `mutate` MUST be synchronous. `withFileLockSync` is a synchronous mutex, so
+ * anything deferred past its return (an await, a callback) runs UNLOCKED. Do
+ * network work before calling this and apply only the result in here.
+ *
+ * Returns false without writing when accounts.json is missing or `mutate`
+ * returns false; callers decide whether that is benign or an error.
+ */
+function withAccountsLock(
+  ctxRoot: string,
+  mutate: (store: AccountsStore) => boolean,
+): boolean {
+  const dir = oauthDir(ctxRoot);
+  ensureDir(dir);
+  return withFileLockSync(dir, () => {
+    const store = loadAccounts(ctxRoot);
+    if (!store) return false;
+    if (!mutate(store)) return false;
+    saveAccounts(ctxRoot, store);
+    return true;
+  });
 }
 
 export function getActiveAccount(ctxRoot: string): { name: string; account: OAuthAccount } | null {
@@ -256,12 +292,16 @@ export async function checkUsageApi(
   // Update cache and accounts.json utilization fields
   saveCache(ctxRoot, snapshot);
 
-  const store = loadAccounts(ctxRoot);
-  if (store && store.accounts[accountName]) {
-    store.accounts[accountName].five_hour_utilization = fiveHour;
-    store.accounts[accountName].seven_day_utilization = sevenDay;
-    saveAccounts(ctxRoot, store);
-  }
+  // Same read-modify-write shape as the refresh path: the whole store is
+  // rewritten, so it must re-read under the lock. A missing store or account is
+  // benign here (utilization is a cache), hence the ignored return.
+  withAccountsLock(ctxRoot, (store) => {
+    const account = store.accounts[accountName];
+    if (!account) return false;
+    account.five_hour_utilization = fiveHour;
+    account.seven_day_utilization = sevenDay;
+    return true;
+  });
 
   return { ...snapshot, cached: false };
 }
@@ -310,15 +350,34 @@ export async function refreshOAuthToken(
 
   const expiresAt = Date.now() + (tokens.expires_in ?? 3600) * 1000;
 
-  // ATOMIC WRITE — must happen before any further use of the new tokens
-  store.accounts[name] = {
-    ...account,
-    access_token: tokens.access_token,
-    refresh_token: tokens.refresh_token,
-    expires_at: expiresAt,
-    last_refreshed: new Date().toISOString(),
-  };
-  saveAccounts(ctxRoot, store);
+  // ATOMIC WRITE — must happen before any further use of the new tokens.
+  // Locked read-modify-write: `store` above was loaded BEFORE the await and is
+  // now potentially stale, so the new tokens are applied to a copy re-read
+  // inside the lock. Writing `store` back here would revert any account another
+  // process refreshed while this fetch was in flight.
+  const persisted = withAccountsLock(ctxRoot, (fresh) => {
+    const current = fresh.accounts[name];
+    if (!current) return false;
+    fresh.accounts[name] = {
+      ...current,
+      access_token: tokens.access_token,
+      refresh_token: tokens.refresh_token,
+      expires_at: expiresAt,
+      last_refreshed: new Date().toISOString(),
+    };
+    return true;
+  });
+
+  if (!persisted) {
+    // The refresh already succeeded, so the OLD refresh_token is spent. Failing
+    // loudly is the only honest option — swallowing this loses the only copy of
+    // the new one and strands the account on a token the server has revoked.
+    throw new Error(
+      `Refreshed account "${name}" but could not persist the new tokens: ` +
+      `accounts.json or the account entry disappeared mid-refresh. ` +
+      `The previous refresh_token is now spent.`,
+    );
+  }
 
   return { account: name, expires_at: expiresAt };
 }
@@ -389,11 +448,7 @@ export async function rotateOAuth(
   }
 
   // PHASE 1: Update accounts.json (active + rotation_log)
-  const reloaded = loadAccounts(ctxRoot)!;
-  reloaded.active = nextName;
-  reloaded.accounts[nextName].five_hour_utilization = preflight.five_hour_utilization;
-  reloaded.accounts[nextName].seven_day_utilization = preflight.seven_day_utilization;
-
+  // Locked: the preflight above is awaited, so anything read before it is stale.
   const logEntry: RotationLogEntry = {
     timestamp: new Date().toISOString(),
     from: currentName,
@@ -402,8 +457,23 @@ export async function rotateOAuth(
     five_hour_util: current.five_hour_utilization,
     seven_day_util: current.seven_day_utilization,
   };
-  reloaded.rotation_log = [logEntry, ...reloaded.rotation_log].slice(0, ROTATION_LOG_MAX);
-  saveAccounts(ctxRoot, reloaded);
+
+  const committed = withAccountsLock(ctxRoot, (reloaded) => {
+    const next = reloaded.accounts[nextName];
+    if (!next) return false;
+    reloaded.active = nextName;
+    next.five_hour_utilization = preflight.five_hour_utilization;
+    next.seven_day_utilization = preflight.seven_day_utilization;
+    reloaded.rotation_log = [logEntry, ...reloaded.rotation_log].slice(0, ROTATION_LOG_MAX);
+    return true;
+  });
+
+  if (!committed) {
+    return {
+      rotated: false,
+      reason: `Account "${nextName}" disappeared from accounts.json before the rotation could be committed`,
+    };
+  }
 
   // PHASE 2: Write bare access token to agent .env files
   const finalStore = loadAccounts(ctxRoot)!;

--- a/tests/unit/bus/oauth.test.ts
+++ b/tests/unit/bus/oauth.test.ts
@@ -540,6 +540,132 @@ describe('rotateOAuth', () => {
   });
 });
 
+describe('rotateOAuth — active account moved during preflight', () => {
+  // rotateOAuth snapshots `active` (currentName) and the candidate list, then
+  // awaits the network for the refresh and the preflight. A competing rotation
+  // that lands inside that window leaves this call holding a decision whose
+  // premise — "active is still currentName" — is no longer true.
+
+  function deferredFetch() {
+    let resolve!: (v: unknown) => void;
+    const promise = new Promise((r) => { resolve = r; });
+    return { promise, resolve };
+  }
+
+  const usageResponse = (five: number, seven: number) => ({
+    ok: true,
+    json: async () => ({ five_hour_utilization: five, seven_day_utilization: seven }),
+  });
+
+  // primary is over threshold so rotation targets `secondary` (lowest 5h util).
+  // `tertiary` exists only as the destination a COMPETING rotation picks, so the
+  // superseding value is distinguishable from this call's own choice.
+  const THREE_ACCOUNT_STORE = {
+    active: 'primary',
+    accounts: {
+      ...SAMPLE_STORE.accounts,
+      primary: { ...SAMPLE_STORE.accounts.primary, five_hour_utilization: 0.90 },
+      tertiary: {
+        label: 'Tertiary Account',
+        access_token: 'tok_tertiary_ghi',
+        refresh_token: 'rtok_tertiary_rst',
+        expires_at: Date.now() + FOUR_HOURS_MS,
+        last_refreshed: '2026-04-05T00:00:00Z',
+        five_hour_utilization: 0.2,
+        seven_day_utilization: 0.1,
+      },
+    },
+    rotation_log: [],
+  };
+
+  function overwriteStore(mutate: (s: ReturnType<typeof loadAccounts>) => void) {
+    const store = loadAccounts(tmpDir)!;
+    mutate(store);
+    const { writeFileSync } = require('fs');
+    writeFileSync(
+      join(tmpDir, 'state', 'oauth', 'accounts.json'),
+      JSON.stringify(store, null, 2),
+    );
+  }
+
+  it('aborts instead of overwriting a newer active chosen during preflight', async () => {
+    writeStore(THREE_ACCOUNT_STORE);
+    const preflight = deferredFetch();
+    mockFetch.mockImplementationOnce(() => preflight.promise);
+
+    const call = rotateOAuth(tmpDir, '/tmp/fw', 'acme');
+
+    // A competing rotation commits primary -> tertiary while our preflight is
+    // still in flight. Ours still believes it is rotating away from primary.
+    overwriteStore((s) => { s!.active = 'tertiary'; });
+
+    preflight.resolve(usageResponse(0.1, 0.05));
+    const result = await call;
+
+    expect(result.rotated).toBe(false);
+    expect(result.reason).toMatch(/superseded/i);
+    expect(result.reason).toContain('tertiary');
+
+    const store = loadAccounts(tmpDir)!;
+    // Unguarded this is 'secondary': the newer, already-preflighted selection
+    // silently demoted by a decision taken before it existed.
+    expect(store.active).toBe('tertiary');
+    // ...and no fictional primary -> secondary entry in the audit log.
+    expect(store.rotation_log).toHaveLength(0);
+  });
+
+  it('does not push the superseded account token into agent .env files', async () => {
+    // The user-visible harm. Phase 2 writes the destination's access_token to
+    // every agent .env; if phase 1 aborted, running agents must keep the token
+    // belonging to whoever actually won the rotation.
+    const { mkdirSync, writeFileSync } = require('fs');
+    const fwRoot = mkdtempSync(join(tmpdir(), 'cortextos-fw-'));
+    const envPath = join(fwRoot, 'orgs', 'acme', 'agents', 'rally-builder', '.env');
+    mkdirSync(join(fwRoot, 'orgs', 'acme', 'agents', 'rally-builder'), { recursive: true });
+    writeFileSync(envPath, 'CLAUDE_CODE_OAUTH_TOKEN=tok_primary_abc\n');
+
+    try {
+      writeStore(THREE_ACCOUNT_STORE);
+      const preflight = deferredFetch();
+      mockFetch.mockImplementationOnce(() => preflight.promise);
+
+      const call = rotateOAuth(tmpDir, fwRoot, 'acme');
+      overwriteStore((s) => { s!.active = 'tertiary'; });
+      preflight.resolve(usageResponse(0.1, 0.05));
+
+      expect((await call).rotated).toBe(false);
+      // Unguarded, phase 2 runs and this file holds secondary's token.
+      expect(readFileSync(envPath, 'utf-8')).not.toContain('tok_secondary_def');
+      expect(readFileSync(envPath, 'utf-8')).toContain('tok_primary_abc');
+    } finally {
+      rmSync(fwRoot, { recursive: true, force: true });
+    }
+  });
+
+  it('reports a vanished destination distinctly from a superseded rotation', async () => {
+    // Both failures come back through the same `!committed` branch. Collapsing
+    // them into one message would turn a benign race into what reads as store
+    // corruption, so the two paths are pinned apart.
+    writeStore(THREE_ACCOUNT_STORE);
+    const preflight = deferredFetch();
+    mockFetch.mockImplementationOnce(() => preflight.promise);
+
+    const call = rotateOAuth(tmpDir, '/tmp/fw', 'acme');
+
+    // active is left ALONE; the destination disappears instead.
+    overwriteStore((s) => {
+      delete (s!.accounts as Record<string, unknown>).secondary;
+    });
+
+    preflight.resolve(usageResponse(0.1, 0.05));
+    const result = await call;
+
+    expect(result.rotated).toBe(false);
+    expect(result.reason).toContain('disappeared');
+    expect(result.reason).not.toMatch(/superseded/i);
+  });
+});
+
 describe('alert thresholds', () => {
   it('ALERT_5H is 0.80', () => {
     expect(ALERT_5H).toBe(0.80);

--- a/tests/unit/bus/oauth.test.ts
+++ b/tests/unit/bus/oauth.test.ts
@@ -7,6 +7,49 @@ import { tmpdir } from 'os';
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+// Delegating spy on the lock boundary: records which directory each
+// read-modify-write locked, while still running the REAL lock so behaviour is
+// unchanged. Lets a single-process test assert the lock is actually applied.
+// `lockedSections` additionally records what each locked critical section did to
+// `active`, so a test can attribute a lock to the specific write it cares about
+// rather than to a total count of acquisitions (which couples unrelated call
+// sites together and misreports which one regressed).
+const { lockedDirs, lockedSections } = vi.hoisted(() => ({
+  lockedDirs: [] as string[],
+  lockedSections: [] as { dir: string; activeBefore?: string; activeAfter?: string }[],
+}));
+vi.mock('../../../src/utils/lock.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/utils/lock.js')>();
+  return {
+    ...actual,
+    withFileLockSync: <T,>(dir: string, fn: () => T, opts?: unknown): T => {
+      lockedDirs.push(dir);
+      const { readFileSync } = require('fs') as typeof import('fs');
+      const { join: pjoin } = require('path') as typeof import('path');
+      const readActive = (): string | undefined => {
+        try {
+          return JSON.parse(readFileSync(pjoin(dir, 'accounts.json'), 'utf-8')).active;
+        } catch {
+          return undefined;
+        }
+      };
+      // Read INSIDE the delegating wrapper but OUTSIDE the real lock body is not
+      // possible without racing, so both reads happen within the real critical
+      // section by wrapping `fn` itself.
+      return actual.withFileLockSync(
+        dir,
+        () => {
+          const activeBefore = readActive();
+          const result = fn();
+          lockedSections.push({ dir, activeBefore, activeAfter: readActive() });
+          return result;
+        },
+        opts as never,
+      );
+    },
+  };
+});
+
 const {
   loadAccounts,
   getActiveAccount,
@@ -165,6 +208,29 @@ describe('checkUsageApi', () => {
     expect(call[1].headers.Authorization).toBe('Bearer tok_primary_abc');
     expect(call[1].headers['anthropic-beta']).toBe('oauth-2025-04-20');
   });
+
+  it('performs the utilization write under the inter-process lock', async () => {
+    // checkUsageApi awaits the usage API and then rewrites the WHOLE store, so
+    // it has the same read-modify-write exposure as the refresh path. In one
+    // process the re-read alone makes behaviour correct, so the lock cannot be
+    // observed behaviourally — its ACQUISITION is asserted instead. This proves
+    // the lock is applied, NOT that cross-process exclusion works.
+    //
+    // This test exists so that deleting the lock from checkUsageApi is caught by
+    // a test NAMED for checkUsageApi. Previously the only thing that went red was
+    // the rotateOAuth lock-count test, which attributed the failure to the wrong
+    // function.
+    writeStore();
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ five_hour_utilization: 0.1, seven_day_utilization: 0.05 }),
+    });
+
+    lockedDirs.length = 0;
+    await checkUsageApi(tmpDir, { force: true });
+
+    expect(lockedDirs).toEqual([join(tmpDir, 'state', 'oauth')]);
+  });
 });
 
 describe('refreshOAuthToken', () => {
@@ -223,6 +289,123 @@ describe('refreshOAuthToken', () => {
   });
 });
 
+describe('refreshOAuthToken — concurrent refresh of a different account', () => {
+  // Race 1: refreshOAuthToken loads the WHOLE store, awaits the network, then
+  // writes the WHOLE store back. Two refreshes for different accounts overlap
+  // on that await, so the second writer's snapshot — taken before the first
+  // writer's save — reverts the first account to its already-spent
+  // refresh_token. The next refresh of that account then fails: stranded.
+  function deferredFetch() {
+    let resolve!: (v: unknown) => void;
+    const promise = new Promise((r) => { resolve = r; });
+    return { promise, resolve };
+  }
+
+  function tokenResponse(access: string, refresh: string) {
+    return {
+      ok: true,
+      json: async () => ({ access_token: access, refresh_token: refresh, expires_in: 3600 }),
+    };
+  }
+
+  it('does not revert a field another writer changed on the SAME account mid-refresh', async () => {
+    // Kills the mutation `...current` -> `...account`: spreading the pre-fetch
+    // snapshot of this account would revert non-token fields written while the
+    // refresh was in flight, even though the re-read store is used elsewhere.
+    writeStore();
+    const a = deferredFetch();
+    mockFetch.mockImplementationOnce(() => a.promise);
+
+    const call = refreshOAuthToken(tmpDir, 'primary');
+
+    // Another process updates primary's utilization while the fetch is pending.
+    const mid = loadAccounts(tmpDir)!;
+    mid.accounts.primary.five_hour_utilization = 0.99;
+    const { writeFileSync } = require('fs');
+    writeFileSync(
+      join(tmpDir, 'state', 'oauth', 'accounts.json'),
+      JSON.stringify(mid, null, 2),
+    );
+
+    a.resolve(tokenResponse('tok_primary_NEW', 'rtok_primary_NEW'));
+    await call;
+
+    const store = loadAccounts(tmpDir)!;
+    expect(store.accounts.primary.refresh_token).toBe('rtok_primary_NEW');
+    expect(store.accounts.primary.five_hour_utilization).toBe(0.99);
+  });
+
+  it('performs the accounts.json read-modify-write under the inter-process lock', async () => {
+    // The two tests above run in ONE process, where the re-read alone is enough
+    // to make them pass — they cannot observe the lock at all. The lock is what
+    // makes the sequence safe against OTHER processes, so it is pinned here
+    // directly. Without this, deleting withFileLockSync leaves the suite green.
+    writeStore();
+    lockedDirs.length = 0;
+    mockFetch.mockResolvedValueOnce(tokenResponse('tok_x', 'rtok_x'));
+
+    await refreshOAuthToken(tmpDir, 'primary');
+
+    expect(lockedDirs).toContain(join(tmpDir, 'state', 'oauth'));
+  });
+
+  it('does not revert the other account to its spent refresh_token', async () => {
+    writeStore();
+    const a = deferredFetch();
+    const b = deferredFetch();
+    mockFetch
+      .mockImplementationOnce(() => a.promise)
+      .mockImplementationOnce(() => b.promise);
+
+    // Both calls run synchronously up to their `await fetch(...)`, so both
+    // hold the same pre-refresh snapshot of accounts.json.
+    const callA = refreshOAuthToken(tmpDir, 'primary');
+    const callB = refreshOAuthToken(tmpDir, 'secondary');
+
+    // A completes and saves first; B then saves its older snapshot.
+    a.resolve(tokenResponse('tok_primary_NEW', 'rtok_primary_NEW'));
+    await callA;
+    b.resolve(tokenResponse('tok_secondary_NEW', 'rtok_secondary_NEW'));
+    await callB;
+
+    const store = loadAccounts(tmpDir)!;
+    // The later writer's own account must land — this passes even unfixed.
+    expect(store.accounts.secondary.refresh_token).toBe('rtok_secondary_NEW');
+    // The earlier writer's account must survive the later write. Unfixed, this
+    // is 'rtok_primary_xyz' — the token the server has already invalidated.
+    expect(store.accounts.primary.refresh_token).toBe('rtok_primary_NEW');
+    expect(store.accounts.primary.access_token).toBe('tok_primary_NEW');
+  });
+
+  it('throws instead of reporting success when the refreshed account vanishes mid-refresh', async () => {
+    // The refresh itself SUCCEEDED, so the old refresh_token is now spent and the
+    // response holds the only copy of the new one. If the account is gone by the
+    // time we take the lock there is nowhere to persist it. Returning success
+    // would strand the account on a token the server has already revoked, and
+    // report that as a win. Failing loudly is the only honest option.
+    writeStore();
+    const a = deferredFetch();
+    mockFetch.mockImplementationOnce(() => a.promise);
+
+    const call = refreshOAuthToken(tmpDir, 'primary');
+
+    // Another process removes the account while the token fetch is in flight.
+    const mid = loadAccounts(tmpDir)!;
+    delete (mid.accounts as Record<string, unknown>).primary;
+    const { writeFileSync } = require('fs');
+    writeFileSync(
+      join(tmpDir, 'state', 'oauth', 'accounts.json'),
+      JSON.stringify(mid, null, 2),
+    );
+
+    a.resolve(tokenResponse('tok_primary_NEW', 'rtok_primary_NEW'));
+
+    await expect(call).rejects.toThrow(/could not persist the new tokens/);
+    // And it must not have resurrected the deleted account as a side effect.
+    expect(loadAccounts(tmpDir)!.accounts.primary).toBeUndefined();
+  });
+});
+
 describe('rotateOAuth', () => {
   const frameworkRoot = '/tmp/fw';
 
@@ -231,6 +414,44 @@ describe('rotateOAuth', () => {
     const result = await rotateOAuth(tmpDir, frameworkRoot, 'acme');
     expect(result.rotated).toBe(false);
     expect(result.reason).toContain('within limits');
+  });
+
+  it('commits the phase-1 accounts.json write under the inter-process lock', async () => {
+    // rotateOAuth awaits the preflight, so its phase-1 write has the same
+    // read-modify-write exposure as the refresh path. In one process the
+    // re-read alone makes rotation behave correctly, so behaviour cannot
+    // distinguish locked from unlocked — the acquisition is asserted instead.
+    // Attribution matters: asserting a total lock COUNT here would also go red
+    // if checkUsageApi's lock were removed, blaming rotateOAuth for someone
+    // else's regression. So this asserts that exactly one LOCKED critical
+    // section is the one that flipped `active` primary -> secondary. Unlocked,
+    // the phase-1 write happens outside any critical section and no locked
+    // section shows that transition.
+    const highUtilStore = {
+      ...SAMPLE_STORE,
+      accounts: {
+        ...SAMPLE_STORE.accounts,
+        primary: { ...SAMPLE_STORE.accounts.primary, five_hour_utilization: 0.90 },
+      },
+    };
+    writeStore(highUtilStore);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ five_hour_utilization: 0.1, seven_day_utilization: 0.05 }),
+    });
+
+    lockedDirs.length = 0;
+    lockedSections.length = 0;
+    const result = await rotateOAuth(tmpDir, frameworkRoot, 'acme');
+    expect(result.rotated).toBe(true);
+
+    const oauthStateDir = join(tmpDir, 'state', 'oauth');
+    const activated = lockedSections.filter(
+      (s) => s.dir === oauthStateDir
+        && s.activeBefore === 'primary'
+        && s.activeAfter === 'secondary',
+    );
+    expect(activated).toHaveLength(1);
   });
 
   it('rotates when 5h utilization exceeds threshold', async () => {


### PR DESCRIPTION
> **Stacked on #834.** This branch contains commit `38ef144` from that PR as well as its own `52af6bd`. Review/merge #834 first; this diff will shrink to just the second commit once it lands.

`rotateOAuth` snapshots `active` and the candidate list, then awaits a token refresh and a preflight before committing phase 1. The locked callback checked only that the **destination** still existed — never that `active` was still the account it decided to rotate *away from*.

So when a competing rotation (or an admin edit) landed inside that window, this call overwrote the newer selection with one chosen before it existed, and appended a `rotation_log` entry describing a from→to transition that never happened. Phase 2 then pushed the superseded account's access token into every agent `.env`, which is the user-visible half of the bug.

**Scope:** `src/bus/oauth.ts` + unit tests (27 → 30).

**Aborts rather than recomputes.** Recomputing the destination inside the lock would select an account this call never refreshed and never preflighted — trading a race that had already resolved correctly for an unverified token on every agent, which is the invariant rotation exists to protect. The winning rotation preflighted its own destination, so declining is safe by construction.

The two `!committed` paths now report distinctly: a lost race reads as "superseded", a missing destination still reads as "disappeared". Collapsing them would make a benign race look like store corruption.

**Behaviour change, scoped deliberately:** the sole caller is the `rotate-oauth` CLI, which prints `rotated:false` as "No rotation needed" and exits 0. No cron, daemon, or alerting path consumes it.

**Verified:** mutation-tested with the prediction named before each run — deleting the guard kills the abort and `.env` tests and leaves the vanished-destination test alive, as predicted; collapsing each message branch kills exactly its own test.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
