### PR TITLE
fix(cli): lock the org context.json and install/dashboard credential read-modify-writes

### DIFF
--- a/src/cli/add-agent.ts
+++ b/src/cli/add-agent.ts
@@ -4,6 +4,7 @@ import { join, resolve } from 'path';
 import { homedir } from 'os';
 import { OrgContext } from '../types';
 import { validateAgentName, validateOrgName } from '../utils/validate';
+import { mutateOrgContext } from '../utils/org-context';
 
 const VALID_RUNTIMES = ['claude-code', 'hermes', 'codex-app-server', 'opencode'] as const;
 type RuntimeKind = typeof VALID_RUNTIMES[number];
@@ -302,17 +303,30 @@ export const addAgentCommand = new Command('add-agent')
       }
     }
 
-    // Update org context.json if this is the orchestrator
+    // Update org context.json if this is the orchestrator.
+    //
+    // Previously a read-modify-write with no lock, racing `cortextos init`'s own
+    // mutation of this file. Now one locked transaction.
+    //
+    // The old `existsSync(contextPath)` guard is deliberately gone. It meant a
+    // missing context.json silently dropped the orchestrator on the floor; the
+    // helper creates the file instead, and init's upgrade pass now fills in every
+    // other field, so the stub heals on the next `cortextos init` rather than
+    // persisting as a half-formed org context.
     if (options.template === 'orchestrator') {
-      const contextPath = join(projectRoot, 'orgs', org, 'context.json');
-      if (existsSync(contextPath)) {
-        try {
-          const context = JSON.parse(readFileSync(contextPath, 'utf-8'));
-          if (!context.orchestrator) {
-            context.orchestrator = name;
-            writeFileSync(contextPath, JSON.stringify(context, null, 2) + '\n', 'utf-8');
-          }
-        } catch { /* ignore */ }
+      try {
+        mutateOrgContext(projectRoot, org, (ctx) => {
+          // Already claimed: decline the write rather than churn the mtime.
+          if (ctx.orchestrator) return false;
+          ctx.orchestrator = name;
+        });
+      } catch (err) {
+        // Non-fatal on purpose, and for a reason specific to this call site: the
+        // agent directory has already been created by the time we get here, so
+        // throwing would leave a fully-created agent behind a non-zero exit. The
+        // old code swallowed this silently; warn instead, since the symptom
+        // otherwise is an org that never learns who its orchestrator is.
+        console.warn(`  Warning: could not record orchestrator in context.json — ${(err as Error).message}`);
       }
     }
 

--- a/src/cli/dashboard.ts
+++ b/src/cli/dashboard.ts
@@ -1,29 +1,12 @@
 import { Command } from 'commander';
-import { existsSync, readFileSync, writeFileSync, chmodSync, mkdirSync, openSync } from 'fs';
+import { existsSync, writeFileSync, chmodSync, mkdirSync, openSync } from 'fs';
 import { join } from 'path';
 import { homedir, platform } from 'os';
 import { randomBytes } from 'crypto';
 
-const IS_WINDOWS = platform() === 'win32';
+import { dashboardEnvPath, mutateDashboardEnv } from '../utils/dashboard-env.js';
 
-function parseEnvFile(filePath: string): Record<string, string> {
-  const result: Record<string, string> = {};
-  try {
-    for (const line of readFileSync(filePath, 'utf-8').split('\n')) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) continue;
-      const idx = trimmed.indexOf('=');
-      if (idx > 0) {
-        let val = trimmed.slice(idx + 1);
-        if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-          val = val.slice(1, -1);
-        }
-        result[trimmed.slice(0, idx)] = val;
-      }
-    }
-  } catch { /* ignore */ }
-  return result;
-}
+const IS_WINDOWS = platform() === 'win32';
 
 export const dashboardCommand = new Command('dashboard')
   .option('--port <port>', 'Port to run dashboard on', '3000')
@@ -44,30 +27,48 @@ export const dashboardCommand = new Command('dashboard')
     // ─── Load / generate dashboard credentials ────────────────────────────────
 
     const ctxRoot = join(homedir(), '.cortextos', options.instance);
-    const dashEnvPath = join(ctxRoot, 'dashboard.env');
+    const dashEnvPath = dashboardEnvPath(ctxRoot);
 
+    // Read-and-maybe-generate under the file lock. `cortextos install` writes
+    // this same file; when both run with the file absent or missing AUTH_SECRET,
+    // an unlocked read-modify-write let each generate its own credentials. The
+    // last writer won the file while this process kept its own values in memory
+    // and printed them — so the admin password shown to the user was not the one
+    // stored, and AUTH_SECRET changed under the running dashboard.
+    const envAuthSecret = process.env.AUTH_SECRET;
     let dashCreds: Record<string, string> = {};
-    if (existsSync(dashEnvPath)) {
-      dashCreds = parseEnvFile(dashEnvPath);
-    }
+    let generatedSecret = false;
+    let generatedPassword = false;
 
-    // Auth secret: env > dashboard.env > auto-generate
-    let authSecret = process.env.AUTH_SECRET || dashCreds['AUTH_SECRET'];
-    if (!authSecret) {
-      authSecret = randomBytes(32).toString('hex');
+    mutateDashboardEnv(ctxRoot, creds => {
+      dashCreds = creds;
+      // Precedence is unchanged: env > dashboard.env > generate. An AUTH_SECRET
+      // from the environment is deliberately NOT persisted, and an existing one
+      // needs no write — returning false keeps merely starting the dashboard
+      // from churning the file.
+      if (envAuthSecret || creds['AUTH_SECRET']) return false;
+
+      creds['AUTH_SECRET'] = randomBytes(32).toString('hex');
+      creds['ADMIN_USERNAME'] ||= 'admin';
+      generatedSecret = true;
+      if (!creds['ADMIN_PASSWORD']) {
+        creds['ADMIN_PASSWORD'] = randomBytes(12).toString('hex');
+        generatedPassword = true;
+      }
+    });
+
+    // Logging stays outside the callback so writing to a slow TTY cannot hold
+    // the lock — other writers block on it, and the dashboard's own wait is
+    // short.
+    if (generatedSecret) {
       console.log('\n  AUTH_SECRET not set — generating one automatically.');
-      // Persist it so future runs don't regenerate
-      dashCreds['AUTH_SECRET'] = authSecret;
-      dashCreds['ADMIN_USERNAME'] = dashCreds['ADMIN_USERNAME'] || 'admin';
-      if (!dashCreds['ADMIN_PASSWORD']) {
-        dashCreds['ADMIN_PASSWORD'] = randomBytes(12).toString('hex');
+      if (generatedPassword) {
         console.log(`  Generated admin credentials saved to: ${dashEnvPath}`);
         console.log(`  (View password with: cat ${dashEnvPath})`);
       }
-      const content = Object.entries(dashCreds).map(([k, v]) => `${k}=${v}`).join('\n') + '\n';
-      writeFileSync(dashEnvPath, content, 'utf-8');
-      try { chmodSync(dashEnvPath, 0o600); } catch { /* ignore on Windows */ }
     }
+
+    const authSecret = envAuthSecret || dashCreds['AUTH_SECRET'];
 
     // Admin password: env > dashboard.env > hard fail
     const adminPassword = process.env.ADMIN_PASSWORD || dashCreds['ADMIN_PASSWORD'];

--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -6,6 +6,7 @@ import { homedir } from 'os';
 import { ensureDir } from '../utils/atomic.js';
 import { validateOrgName } from '../utils/validate.js';
 import { stripBom } from '../utils/strip-bom.js';
+import { mutateOrgContext, CorruptOrgContextError } from '../utils/org-context.js';
 import type { OrgContext } from '../types/index.js';
 
 export const initCommand = new Command('init')
@@ -70,38 +71,55 @@ export const initCommand = new Command('init')
       console.log('  Copied org template files');
     }
 
-    // Create org context.json (if not already from template)
-    const contextPath = join(orgDir, 'context.json');
-    if (!existsSync(contextPath)) {
-      writeFileSync(contextPath, JSON.stringify({
-        name: orgName,
-        description: '',
-        industry: '',
-        icp: '',
-        value_prop: '',
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-        orchestrator: '',
-        day_mode_start: '08:00',
-        day_mode_end: '00:00',
-        default_approval_categories: ['external-comms', 'financial', 'deployment', 'data-deletion'],
-        communication_style: 'direct and casual',
-      }, null, 2) + '\n', 'utf-8');
-      console.log('  Created org context.json');
-    } else {
-      // Fill in any missing fields (handles upgrades from older context.json without new fields)
-      try {
-        // stripBom: see src/utils/strip-bom.ts. Skipping this would make
-        // every re-run of `cortextos init` silently fall through to the
-        // catch block, leaving context.json un-upgraded.
-        const ctx = JSON.parse(stripBom(readFileSync(contextPath, 'utf-8')));
-        if (!ctx.timezone) ctx.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    // Create-or-upgrade the org context.json (it may already exist from the template).
+    //
+    // This used to be an `existsSync` check followed by either a full write or a
+    // separate read/mutate/write. That is a TOCTOU against a concurrent
+    // `add-agent --template orchestrator`, which does its own read-modify-write on
+    // this same file: both could read, both mutate, and the later write wins
+    // wholesale. Collapsing the two branches into ONE locked transaction closes
+    // the window; `existed` now only picks the console message.
+    //
+    // Every field is filled with `if (!ctx.x)` semantics, including the five the
+    // old upgrade branch never touched (description, industry, icp, value_prop,
+    // orchestrator). The old create branch wrote them, so leaving them out here
+    // would silently drop them from a fresh org.
+    let contextCreated = false;
+    try {
+      mutateOrgContext(projectRoot, orgName, (ctx, existed) => {
+        contextCreated = !existed;
+        const before = JSON.stringify(ctx);
         if (!ctx.name) ctx.name = orgName;
+        if (!ctx.description) ctx.description = '';
+        if (!ctx.industry) ctx.industry = '';
+        if (!ctx.icp) ctx.icp = '';
+        if (!ctx.value_prop) ctx.value_prop = '';
+        if (!ctx.timezone) ctx.timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+        if (!ctx.orchestrator) ctx.orchestrator = '';
         if (!ctx.day_mode_start) ctx.day_mode_start = '08:00';
         if (!ctx.day_mode_end) ctx.day_mode_end = '00:00';
         if (!ctx.default_approval_categories) ctx.default_approval_categories = ['external-comms', 'financial', 'deployment', 'data-deletion'];
         if (!ctx.communication_style) ctx.communication_style = 'direct and casual';
-        writeFileSync(contextPath, JSON.stringify(ctx, null, 2) + '\n', 'utf-8');
-      } catch { /* ignore */ }
+        // Nothing missing: decline the write rather than rewrite identical bytes
+        // and churn the mtime the dashboard's file watcher keys on.
+        return JSON.stringify(ctx) !== before;
+      });
+      if (contextCreated) console.log('  Created org context.json');
+    } catch (err) {
+      // A corrupt context.json is left untouched on disk (the helper backs it up
+      // and refuses to overwrite) — the old code's blanket `catch { /* ignore */ }`
+      // had the same effect but gave the user no signal at all that their org
+      // context was unreadable and would never be upgraded. Warn and carry on:
+      // the rest of init's work is still valid, and failing here would abort a
+      // command whose other output is already on disk.
+      //
+      // Anything else — lock timeout, EACCES, a failed write — propagates. The
+      // old create branch had no catch and already crashed on exactly those, so
+      // this makes the two paths consistent rather than introducing new
+      // behaviour; and silently skipping the upgrade would have init report
+      // success having done nothing.
+      if (!(err instanceof CorruptOrgContextError)) throw err;
+      console.warn(`  Warning: ${(err as Error).message}`);
     }
 
     // Create goals.json if not from template

--- a/src/cli/install.ts
+++ b/src/cli/install.ts
@@ -1,9 +1,13 @@
 import { Command } from 'commander';
-import { existsSync, mkdirSync, writeFileSync, chmodSync, readFileSync, readdirSync, statSync } from 'fs';
+import { existsSync, mkdirSync, chmodSync, readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { homedir, platform, arch } from 'os';
 import { execSync, spawnSync } from 'child_process';
 import { randomBytes } from 'crypto';
+
+import { atomicWriteSync } from '../utils/atomic.js';
+import { dashboardEnvPath, mutateDashboardEnv } from '../utils/dashboard-env.js';
+import { withFileLockSync } from '../utils/lock.js';
 
 const IS_WINDOWS = platform() === 'win32';
 const IS_MAC = platform() === 'darwin';
@@ -359,68 +363,67 @@ export const installCommand = new Command('install')
     }
     console.log(`  Created ${dirs.length} directories at ${ctxRoot}`);
 
-    // enabled-agents.json
-    const enabledPath = join(ctxRoot, 'config', 'enabled-agents.json');
-    if (!existsSync(enabledPath)) {
-      writeFileSync(enabledPath, '{}', 'utf-8');
-      console.log('  Created enabled-agents.json');
-    }
+    // enabled-agents.json and the bus signing key both live in <ctxRoot>/config,
+    // so one lock on that directory covers both. Re-checking `existsSync` INSIDE
+    // the lock is the point: the bare check-then-write these replaced could see
+    // "absent", lose the CPU, and clobber a file another process created in the
+    // gap. For enabled-agents.json that clobber is not cosmetic — a missing
+    // entry means ENABLED (`src/bus/agents.ts:90-91`, matching the daemon's
+    // default-on discovery), so overwriting a populated roster with `{}` drops
+    // every explicit `enabled:false` and silently restarts disabled agents.
+    const configDir = join(ctxRoot, 'config');
+    const enabledPath = join(configDir, 'enabled-agents.json');
+    const signingKeyPath = join(configDir, 'bus-signing-key');
+
+    withFileLockSync(configDir, () => {
+      if (!existsSync(enabledPath)) {
+        atomicWriteSync(enabledPath, '{}');
+        console.log('  Created enabled-agents.json');
+      }
+
+      if (!existsSync(signingKeyPath)) {
+        // `atomicWriteSync` renames the key into place instead of truncating and
+        // rewriting, so a concurrent reader can never observe a half-written
+        // key. That matters here because `loadSigningKey`
+        // (`src/bus/message.ts:19-27`) returns `readFileSync(...).trim()` and so
+        // would hand back `''` — a truthy-enough wrong key that produces bad
+        // signatures — rather than falling back to `null` on a torn read.
+        atomicWriteSync(signingKeyPath, randomBytes(32).toString('hex'));
+        console.log('  Generated bus-signing-key (HMAC-SHA256)');
+      }
+    });
 
     // Instance .env
     const envPath = join(ctxRoot, '.env');
-    if (!existsSync(envPath)) {
-      writeFileSync(envPath, [
-        `CTX_INSTANCE_ID=${instanceId}`,
-        `CTX_ROOT=${ctxRoot}`,
-        '',
-      ].join('\n'), 'utf-8');
-      try { chmodSync(envPath, 0o600); } catch { /* ignore on Windows */ }
-      console.log('  Created .env');
-    }
-
-    // Bus signing key
-    const signingKeyPath = join(ctxRoot, 'config', 'bus-signing-key');
-    if (!existsSync(signingKeyPath)) {
-      const signingKey = randomBytes(32).toString('hex');
-      writeFileSync(signingKeyPath, signingKey, 'utf-8');
-      try { chmodSync(signingKeyPath, 0o600); } catch { /* ignore on Windows */ }
-      console.log('  Generated bus-signing-key (HMAC-SHA256)');
-    }
+    withFileLockSync(ctxRoot, () => {
+      if (!existsSync(envPath)) {
+        atomicWriteSync(envPath, [
+          `CTX_INSTANCE_ID=${instanceId}`,
+          `CTX_ROOT=${ctxRoot}`,
+        ].join('\n'));
+        console.log('  Created .env');
+      }
+    });
 
     // ─── Dashboard credentials ────────────────────────────────────────────────
 
-    const dashEnvPath = join(ctxRoot, 'dashboard.env');
-    let authSecret: string;
-    let adminPassword: string;
+    const dashEnvPath = dashboardEnvPath(ctxRoot);
 
-    if (existsSync(dashEnvPath)) {
-      // Read existing values so we don't overwrite them
-      const existing = readFileSync(dashEnvPath, 'utf-8');
-      const lines = Object.fromEntries(
-        existing.split('\n')
-          .filter(l => l.includes('='))
-          .map(l => [l.slice(0, l.indexOf('=')), l.slice(l.indexOf('=') + 1)])
-      );
-      authSecret = lines['AUTH_SECRET'] || randomBytes(32).toString('hex');
-      adminPassword = lines['ADMIN_PASSWORD'] || randomBytes(12).toString('hex');
-    } else {
-      authSecret = randomBytes(32).toString('hex');
-      adminPassword = randomBytes(12).toString('hex');
-    }
-
-    writeFileSync(
-      dashEnvPath,
-      [
-        `AUTH_SECRET=${authSecret}`,
-        `ADMIN_USERNAME=admin`,
-        `ADMIN_PASSWORD=${adminPassword}`,
-        `CTX_ROOT=${ctxRoot}`,
-        `CTX_FRAMEWORK_ROOT=${process.cwd()}`,
-        '',
-      ].join('\n'),
-      'utf-8',
-    );
-    try { chmodSync(dashEnvPath, 0o600); } catch { /* ignore on Windows */ }
+    // Merge-preserving and locked. Previously this read the file, kept only
+    // AUTH_SECRET and ADMIN_PASSWORD, and rewrote a fixed five-key list — so any
+    // other key in dashboard.env was silently dropped on every install, with no
+    // concurrency required. `mutateDashboardEnv` hands back the whole map and
+    // writes the whole map, so keys this command does not own survive; the lock
+    // additionally keeps `cortextos dashboard` (the other writer, which
+    // generates its own credentials when the file lacks them) from interleaving
+    // and leaving the two processes disagreeing about the admin password.
+    mutateDashboardEnv(ctxRoot, creds => {
+      creds['AUTH_SECRET'] ||= randomBytes(32).toString('hex');
+      creds['ADMIN_USERNAME'] ||= 'admin';
+      creds['ADMIN_PASSWORD'] ||= randomBytes(12).toString('hex');
+      creds['CTX_ROOT'] = ctxRoot;
+      creds['CTX_FRAMEWORK_ROOT'] = process.cwd();
+    });
     console.log(`  Generated dashboard credentials at ${dashEnvPath}`);
 
     // Register cortextos CLI globally so agent PTY sessions can find it

--- a/src/utils/dashboard-env.ts
+++ b/src/utils/dashboard-env.ts
@@ -1,0 +1,78 @@
+/**
+ * Locked, merge-preserving access to `<ctxRoot>/dashboard.env`.
+ *
+ * Two independent processes write this file:
+ *   - `cortextos install` (src/cli/install.ts) — generates credentials on first
+ *     run and rewrites the file on every subsequent run.
+ *   - `cortextos dashboard` (src/cli/dashboard.ts) — generates and persists an
+ *     AUTH_SECRET/ADMIN_PASSWORD when neither the environment nor the file
+ *     supplies one.
+ *
+ * Both used to do a bare read-modify-write. If they interleave while the file
+ * is absent or partial, each generates its own secrets and the last writer wins
+ * the file — but the dashboard has already captured its own values in memory,
+ * passed them to the Next.js child, and printed the admin password to the user.
+ * The result is a printed password that does not match the stored one, and an
+ * AUTH_SECRET change that invalidates every session on the next boot.
+ *
+ * Serializing the read-modify-write behind the directory lock is what makes the
+ * two writers agree on a single set of credentials.
+ */
+import { existsSync, mkdirSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+import { atomicWriteSync } from './atomic.js';
+import { parseEnvContent, serializeEnvContent } from './env.js';
+import { withFileLockSync } from './lock.js';
+
+/** Path to the instance's dashboard credential file. */
+export function dashboardEnvPath(ctxRoot: string): string {
+  return join(ctxRoot, 'dashboard.env');
+}
+
+/**
+ * Read `dashboard.env`, apply `mutate`, and write it back — all while holding
+ * `ctxRoot`'s lock, so a concurrent writer cannot land between the read and the
+ * write.
+ *
+ * The write is merge-preserving: `mutate` receives every key currently in the
+ * file and the whole map is written back. Callers that only care about the
+ * credential keys therefore no longer silently drop unrelated keys the user or
+ * the other writer put there. (Comments and blank lines are not preserved —
+ * neither writer preserved them before this, and the file is generated.)
+ *
+ * @param ctxRoot Instance root, e.g. `~/.cortextos/default`.
+ * @param mutate Mutates the credential map in place. Return `false` to skip the
+ *   write entirely — used by the read-only path, so merely starting the
+ *   dashboard does not churn the file's mtime or rewrite credentials it did not
+ *   change.
+ * @returns `true` if the file was written, `false` if `mutate` declined.
+ * @throws if the lock cannot be acquired within the timeout, if the existing
+ *   file exists but cannot be read, or if the write fails.
+ */
+export function mutateDashboardEnv(
+  ctxRoot: string,
+  mutate: (creds: Record<string, string>, existed: boolean) => boolean | void,
+): boolean {
+  const file = dashboardEnvPath(ctxRoot);
+  mkdirSync(ctxRoot, { recursive: true });
+
+  return withFileLockSync(ctxRoot, () => {
+    // Deliberately not `parseEnvFile`: that swallows read errors and returns
+    // `{}`, which here would be indistinguishable from "no file yet" and would
+    // make an unreadable file get overwritten with freshly generated
+    // credentials. Absent means absent; unreadable throws.
+    const existed = existsSync(file);
+    const creds = existed ? parseEnvContent(readFileSync(file, 'utf-8')) : {};
+
+    const proceed = mutate(creds, existed);
+    if (proceed === false) return false;
+
+    // `atomicWriteSync` writes a temp file in this same directory with mode
+    // 0o600 and renames it into place, so the credentials are never readable by
+    // other users and a crash mid-write cannot leave a truncated file. It
+    // appends the trailing newline itself.
+    atomicWriteSync(file, serializeEnvContent(creds));
+    return true;
+  });
+}

--- a/src/utils/env.ts
+++ b/src/utils/env.ts
@@ -199,41 +199,76 @@ export function writeCortextosEnv(agentDir: string, env: CtxEnv): void {
  * Lines with no `=` are skipped.
  */
 export function parseEnvFile(filePath: string): Record<string, string> {
-  const result: Record<string, string> = {};
   try {
-    // stripBom + CRLF-aware split: Windows tooling (PowerShell Out-File,
-    // Notepad) writes .env files with a UTF-8 BOM at position 0 AND CRLF
-    // line endings. Without stripBom the first KEY line never matches
-    // because position 0 is the BOM byte; without the regex split, each
-    // value gets a trailing \r that breaks downstream validators.
-    const content = stripBom(readFileSync(filePath, 'utf-8'));
-    for (const line of content.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      if (!trimmed || trimmed.startsWith('#')) continue;
-      const eqIdx = trimmed.indexOf('=');
-      if (eqIdx <= 0) continue; // no '=' or empty key
-
-      const key = trimmed.slice(0, eqIdx).trim();
-      let value = trimmed.slice(eqIdx + 1).trim();
-
-      if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
-        value = value.slice(1, -1);
-      } else if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
-        value = value.slice(1, -1);
-      } else {
-        // Unquoted: strip inline comments starting with ' #'
-        const hashIdx = value.indexOf(' #');
-        if (hashIdx >= 0) {
-          value = value.slice(0, hashIdx).trim();
-        }
-      }
-
-      result[key] = value;
-    }
+    return parseEnvContent(readFileSync(filePath, 'utf-8'));
   } catch {
     // Ignore read errors
+    return {};
+  }
+}
+
+/**
+ * Parse already-read env-file text. Split out from `parseEnvFile` so callers
+ * that must do their own read — e.g. a read-modify-write under a file lock,
+ * which has to tell "file absent" apart from "file unreadable" instead of
+ * collapsing both to `{}` — get identical parsing semantics rather than
+ * hand-rolling a fourth variant.
+ */
+export function parseEnvContent(raw: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  // stripBom + CRLF-aware split: Windows tooling (PowerShell Out-File,
+  // Notepad) writes .env files with a UTF-8 BOM at position 0 AND CRLF
+  // line endings. Without stripBom the first KEY line never matches
+  // because position 0 is the BOM byte; without the regex split, each
+  // value gets a trailing \r that breaks downstream validators.
+  const content = stripBom(raw);
+  for (const line of content.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eqIdx = trimmed.indexOf('=');
+    if (eqIdx <= 0) continue; // no '=' or empty key
+
+    const key = trimmed.slice(0, eqIdx).trim();
+    let value = trimmed.slice(eqIdx + 1).trim();
+
+    if (value.length >= 2 && value.startsWith('"') && value.endsWith('"')) {
+      value = value.slice(1, -1);
+    } else if (value.length >= 2 && value.startsWith("'") && value.endsWith("'")) {
+      value = value.slice(1, -1);
+    } else {
+      // Unquoted: strip inline comments starting with ' #'
+      const hashIdx = value.indexOf(' #');
+      if (hashIdx >= 0) {
+        value = value.slice(0, hashIdx).trim();
+      }
+    }
+
+    result[key] = value;
   }
   return result;
+}
+
+/**
+ * Serialize a KEY=VALUE map back to env-file text (no trailing newline —
+ * `atomicWriteSync` appends it).
+ *
+ * Values are quoted only when the bare form would not survive a round-trip
+ * through `parseEnvContent`: that parser trims each value and strips inline
+ * ` #` comments, so a preserved third-party value containing either would come
+ * back altered. This matters because the dashboard-credential writers now
+ * round-trip keys they do not own.
+ */
+export function serializeEnvContent(vars: Record<string, string>): string {
+  return Object.entries(vars)
+    .map(([key, value]) => {
+      const looksQuoted =
+        value.length >= 2 &&
+        ((value.startsWith('"') && value.endsWith('"')) ||
+          (value.startsWith("'") && value.endsWith("'")));
+      const needsQuoting = value !== value.trim() || value.includes(' #') || looksQuoted;
+      return `${key}=${needsQuoting ? `"${value}"` : value}`;
+    })
+    .join('\n');
 }
 
 /**

--- a/src/utils/org-context.ts
+++ b/src/utils/org-context.ts
@@ -1,0 +1,184 @@
+/**
+ * Locked read-modify-write for the per-org context file
+ * (`<frameworkRoot>/orgs/<org>/context.json`).
+ *
+ * Three CLI sites used to do this by hand — `existsSync` then `writeFileSync`,
+ * or read/mutate/write — with no lock, so two concurrent commands could lose
+ * each other's changes wholesale. `cortextos init` racing
+ * `cortextos add-agent --template orchestrator` is the realistic pair: both
+ * read the whole object, mutate a few fields, and write the whole object back.
+ *
+ * SCOPE OF THE EXCLUSION — do not overstate it. A lock only excludes writers
+ * that take THIS lock, on THIS directory:
+ *   - Other CLI commands using this helper: excluded.
+ *   - The dashboard: `dashboard/src/lib/file-lock.ts` re-exports
+ *     `src/utils/lock.ts` rather than reimplementing the protocol, and both
+ *     sides resolve this file to `<frameworkRoot>/orgs/<org>/`, so the
+ *     rendezvous is real — but the dashboard does not take it yet.
+ *     `dashboard/src/app/api/org/config/route.ts:72-77` is still an unlocked
+ *     read-modify-write. Until that lands, CLI<->dashboard is still open.
+ *   - Already-installed older binaries writing this file: NOT excluded, and
+ *     not fixable from here.
+ *
+ * The sibling per-agent `config.json` deliberately does NOT get a helper here.
+ * The dashboard's `getAgentDir()` falls back to `<CTX_ROOT>/...` when the
+ * framework-root path is missing, while the CLI only ever looks under the
+ * framework root — so the two sides can resolve different directories for the
+ * same agent, precisely during creation. A directory lock there would exclude
+ * nothing in the window where the race lives. Tracked separately; reconcile the
+ * path resolution first.
+ *
+ * The lock is NOT reentrant. Calling `mutateOrgContext` from inside a `mutate`
+ * callback deadlocks until the lock times out.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { withFileLockSync } from './lock.js';
+import { atomicWriteSync } from './atomic.js';
+import { stripBom } from './strip-bom.js';
+
+/** Directory whose `.lock.d` marker guards this org's context file. */
+export function orgContextDir(frameworkRoot: string, org: string): string {
+  return join(frameworkRoot, 'orgs', org);
+}
+
+export function orgContextPath(frameworkRoot: string, org: string): string {
+  return join(orgContextDir(frameworkRoot, org), 'context.json');
+}
+
+/**
+ * Thrown when the context file exists but is not a JSON object. The original
+ * file is left untouched on disk and a copy is preserved at `backupPath`.
+ */
+export class CorruptOrgContextError extends Error {
+  readonly path: string;
+  readonly backupPath: string | null;
+
+  constructor(path: string, backupPath: string | null, detail: string) {
+    super(
+      `context.json is ${detail} at ${path}. Refusing to overwrite it.\n` +
+        (backupPath ? `  A copy was saved to ${backupPath}\n` : '') +
+        `  Repair the file, or delete it to reset the org context, then re-run.`,
+    );
+    this.name = 'CorruptOrgContextError';
+    this.path = path;
+    this.backupPath = backupPath;
+  }
+}
+
+/**
+ * Read-modify-write this org's context file while holding the inter-process
+ * lock on its directory.
+ *
+ * `mutate` MUST be synchronous, and so must every fs call inside it.
+ * `withFileLockSync` releases the lock in a `finally` the moment the callback
+ * RETURNS — an `async` callback returns a pending Promise immediately, so the
+ * lock would be dropped before the write ever ran. That failure is silent: the
+ * code still looks locked, protects nothing, and type-checks clean (`T` simply
+ * infers `Promise<void>`), so the compiler will never catch it.
+ *
+ * Hold time matters here beyond the usual. The dashboard caps its lock wait at
+ * 250ms (`dashboard/src/lib/enabled-agents.ts:18`) because `Atomics.wait`
+ * blocks a whole Next.js worker — so a CLI that holds this lock longer than
+ * that makes dashboard writes *throw*, not queue. Keep `mutate` to in-memory
+ * work; do no I/O beyond the read and write this function already performs.
+ *
+ * The read happens INSIDE the lock, so callers must not pass in state they read
+ * earlier — `mutate` receives the freshly-read context.
+ *
+ * @param mutate Mutates the context in place. Receives `existed: false` when
+ *   the file was absent and `ctx` is therefore a fresh `{}` — that is how the
+ *   old `existsSync`-then-create branch is expressed without the TOCTOU.
+ *   Return `false` to skip the write entirely (for "nothing to change" paths —
+ *   writing anyway churns the mtime that the dashboard's file watcher keys on).
+ * @returns `true` if the file was written, `false` if `mutate` declined.
+ * @throws {CorruptOrgContextError} if the on-disk file is not a JSON object.
+ * @throws if the lock cannot be acquired within the timeout, or the write fails.
+ */
+export function mutateOrgContext(
+  frameworkRoot: string,
+  org: string,
+  mutate: (ctx: Record<string, any>, existed: boolean) => boolean | void,
+): boolean {
+  const dir = orgContextDir(frameworkRoot, org);
+  const file = orgContextPath(frameworkRoot, org);
+  mkdirSync(dir, { recursive: true });
+
+  return withFileLockSync(dir, () => {
+    const { ctx, existed } = readContextLocked(file);
+    const proceed = mutate(ctx, existed);
+    if (proceed === false) return false;
+
+    // `atomicWriteSync` writes a temp file in this same directory and renames
+    // it into place, so a crash mid-write cannot leave truncated JSON. The
+    // three call sites this replaced all used a bare `writeFileSync`, which is
+    // not atomic per-write either — and every reader of this file swallows
+    // parse errors and silently keeps defaults (`src/utils/env.ts:76-88`,
+    // `src/daemon/agent-manager.ts:736-742`), so a torn read here disables
+    // org wiring with no diagnostic at all. It appends the trailing newline
+    // itself, matching the bytes the old calls produced.
+    atomicWriteSync(file, JSON.stringify(ctx, null, 2));
+    return true;
+  });
+}
+
+/**
+ * Read the context file. Caller must already hold the lock.
+ *
+ * Policy on a malformed file: back it up, warn, and THROW — never overwrite.
+ *
+ * This is the same policy as the agent registry, but it is NOT justified by the
+ * same consequence, so it is worth restating. Losing this file does not cause
+ * unwanted execution; it degrades quietly. `resolveEnv` stops resolving the org
+ * timezone and orchestrator, `AgentManager` stops starting the activity-channel
+ * poller, and `checkDeliverableRequirement` fails open so the deliverables gate
+ * silently turns off. Every one of those readers swallows the error.
+ *
+ * The reason to refuse the write is what the WRITERS would otherwise do. Both
+ * remaining mutations are fill-in-the-missing-fields passes over a parsed
+ * object. If a parse failure were treated as "start from `{}`", `cortextos init`
+ * would helpfully rewrite a corrupt-but-recoverable file down to bare defaults
+ * — discarding the org's description, ICP, value prop and orchestrator, and
+ * reporting success. Refusing costs a re-run; the alternative destroys data
+ * that only exists here.
+ */
+function readContextLocked(file: string): { ctx: Record<string, any>; existed: boolean } {
+  let raw: string;
+  try {
+    raw = readFileSync(file, 'utf-8');
+  } catch (err) {
+    // Only "not there yet" is recoverable — a brand-new org legitimately has no
+    // context file. A permissions or I/O error must propagate rather than be
+    // mistaken for one and then overwritten.
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+    return { ctx: {}, existed: false };
+  }
+
+  let parsed: unknown;
+  try {
+    // stripBom: see src/utils/strip-bom.ts. Without it a BOM-prefixed file
+    // fails to parse, which previously made every re-run of `cortextos init`
+    // fall through to its catch and leave the file un-upgraded forever.
+    parsed = JSON.parse(stripBom(raw));
+  } catch {
+    throw new CorruptOrgContextError(file, backup(file, raw), 'not valid JSON');
+  }
+
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    const kind = parsed === null ? 'null' : Array.isArray(parsed) ? 'an array' : `a ${typeof parsed}`;
+    throw new CorruptOrgContextError(file, backup(file, raw), `${kind}, not a JSON object`);
+  }
+
+  return { ctx: parsed as Record<string, any>, existed: true };
+}
+
+/** Best-effort copy of a bad context file. Returns the path, or null if it failed. */
+function backup(file: string, raw: string): string | null {
+  const path = `${file}.broken-${Date.now()}`;
+  try {
+    writeFileSync(path, raw, 'utf-8');
+    return path;
+  } catch {
+    return null; // the throw that follows is what matters, not the backup
+  }
+}

--- a/tests/integration/concurrent-dashboard-env-mutations.test.ts
+++ b/tests/integration/concurrent-dashboard-env-mutations.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Inter-process exclusion and merge-preservation on `<ctxRoot>/dashboard.env`.
+ *
+ * TWO independent writers touch this file:
+ *   - `cortextos install`   (src/cli/install.ts)
+ *   - `cortextos dashboard` (src/cli/dashboard.ts)
+ * Both did a bare read-modify-write. With the file absent or missing
+ * AUTH_SECRET, each generates its own secrets; the last writer wins the file
+ * while the dashboard has already captured ITS values in memory, handed them to
+ * the Next.js child, and printed the admin password. The user is then shown a
+ * password that is not the stored one. Both call sites now go through
+ * `mutateDashboardEnv` (src/utils/dashboard-env.ts).
+ *
+ * Separately, and needing no concurrency at all: install rewrote the file from a
+ * FIXED five-key list, so every install silently dropped any other key.
+ *
+ * WHY REAL CHILD PROCESSES: an in-process test cannot prove this. Vitest is
+ * single-threaded, so the lock is uncontended on every acquire and the test
+ * would go green with or without it — pinning the refactor, not the exclusion.
+ * The exclusion is between OS processes, so the test spawns OS processes.
+ *
+ * SCOPE — READ THIS BEFORE QUOTING THE GREEN. Unlike the org-context suite, the
+ * children here run the shared helper via `tsx`, NOT the production binary.
+ * `cortextos install` runs `npm link` + `npm install` and `cortextos dashboard`
+ * starts a server, so neither is spawnable from a test. So this file proves:
+ *   (a) the helper serializes read-modify-write across real processes, and
+ *   (b) it preserves keys it does not own.
+ * It does NOT re-prove that install.ts/dashboard.ts route through the helper —
+ * that rests on both call sites importing it and typechecking. If someone
+ * reintroduces a bare writeFileSync at either call site, THIS FILE STAYS GREEN.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync, chmodSync } from 'fs';
+import { join, resolve } from 'path';
+import { tmpdir } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { mutateDashboardEnv, dashboardEnvPath } from '../../src/utils/dashboard-env';
+import { parseEnvContent, serializeEnvContent } from '../../src/utils/env';
+
+const execFileAsync = promisify(execFile);
+
+const REPO_ROOT = resolve(__dirname, '..', '..');
+const TSX_BIN = join(REPO_ROOT, 'node_modules', '.bin', 'tsx');
+const HELPER_SRC = join(REPO_ROOT, 'src', 'utils', 'dashboard-env.ts');
+
+/** Root is only meaningful as a real dir; each test gets a fresh one. */
+let ctxRoot: string;
+let scriptPath: string;
+
+/**
+ * Child: add one uniquely-named key, holding the lock for `holdMs` so the
+ * critical sections genuinely overlap rather than happening to serialize.
+ */
+const ADD_KEY_SCRIPT = `
+import { mutateDashboardEnv } from ${JSON.stringify(HELPER_SRC)};
+const [ctxRoot, key, holdMs] = process.argv.slice(2);
+mutateDashboardEnv(ctxRoot, creds => {
+  const until = Date.now() + Number(holdMs);
+  // Busy-wait, not a timer: the callback must stay synchronous. An async
+  // callback would release the lock before the write and still typecheck.
+  while (Date.now() < until) { /* widen the critical section */ }
+  creds[key] = 'v-' + key;
+});
+`;
+
+/**
+ * Child: reproduce the credential-divergence shape. Generates AUTH_SECRET and
+ * ADMIN_PASSWORD only when absent, then prints the values it would show the
+ * user. The invariant under test is that what a writer believes it stored is
+ * what is actually on disk afterwards.
+ */
+const CREDS_SCRIPT = `
+import { mutateDashboardEnv } from ${JSON.stringify(HELPER_SRC)};
+import { randomBytes } from 'crypto';
+const [ctxRoot, holdMs] = process.argv.slice(2);
+let observedSecret = '', observedPassword = '';
+mutateDashboardEnv(ctxRoot, creds => {
+  const until = Date.now() + Number(holdMs);
+  while (Date.now() < until) { /* widen the critical section */ }
+  creds['AUTH_SECRET'] ||= randomBytes(16).toString('hex');
+  creds['ADMIN_PASSWORD'] ||= randomBytes(8).toString('hex');
+  observedSecret = creds['AUTH_SECRET'];
+  observedPassword = creds['ADMIN_PASSWORD'];
+});
+process.stdout.write(JSON.stringify({ observedSecret, observedPassword }));
+`;
+
+beforeEach(() => {
+  ctxRoot = mkdtempSync(join(tmpdir(), 'ctx-dashenv-'));
+  scriptPath = join(ctxRoot, 'child.ts');
+});
+
+afterEach(() => {
+  try { rmSync(ctxRoot, { recursive: true, force: true }); } catch { /* best effort */ }
+});
+
+describe('dashboard.env round-trip', () => {
+  it('preserves values that the parser would otherwise alter', () => {
+    // These are exactly the values a naive `k=v` join would corrupt: the parser
+    // trims and strips inline ` #' comments, so an unquoted round-trip loses
+    // them. Third-party keys are now preserved, so their values must survive.
+    const original = {
+      AUTH_SECRET: 'deadbeef',
+      WITH_HASH: 'value #notacomment',
+      PADDED: '  spaced  ',
+      QUOTED_LOOKING: '"already"',
+      EMPTY: '',
+    };
+    expect(parseEnvContent(serializeEnvContent(original))).toEqual(original);
+  });
+
+  it('ignores comments and blank lines when reading', () => {
+    expect(parseEnvContent('# lead\n\nA=1\n  \nB=2\n')).toEqual({ A: '1', B: '2' });
+  });
+});
+
+describe('mutateDashboardEnv', () => {
+  it('preserves keys it does not own (the fixed-key-list data loss)', () => {
+    const file = dashboardEnvPath(ctxRoot);
+    writeFileSync(file, 'AUTH_SECRET=keepme\nUSER_ADDED=precious\nPORT_HINT=8080\n', 'utf-8');
+
+    mutateDashboardEnv(ctxRoot, creds => {
+      creds['AUTH_SECRET'] ||= 'generated';
+      creds['CTX_ROOT'] = ctxRoot;
+    });
+
+    const after = parseEnvContent(readFileSync(file, 'utf-8'));
+    expect(after['AUTH_SECRET']).toBe('keepme');       // existing value not regenerated
+    expect(after['USER_ADDED']).toBe('precious');      // would be dropped pre-fix
+    expect(after['PORT_HINT']).toBe('8080');           // would be dropped pre-fix
+    expect(after['CTX_ROOT']).toBe(ctxRoot);
+  });
+
+  it('reports existed=false and creates the file when absent', () => {
+    const seen: boolean[] = [];
+    mutateDashboardEnv(ctxRoot, (creds, existed) => { seen.push(existed); creds['A'] = '1'; });
+    expect(seen).toEqual([false]);
+    expect(existsSync(dashboardEnvPath(ctxRoot))).toBe(true);
+
+    mutateDashboardEnv(ctxRoot, (_creds, existed) => { seen.push(existed); return false; });
+    expect(seen).toEqual([false, true]);
+  });
+
+  it('does not write when the callback declines', () => {
+    // The dashboard's read-only path returns false; starting the dashboard must
+    // not churn the file the daemon's watcher keys on.
+    const wrote = mutateDashboardEnv(ctxRoot, () => false);
+    expect(wrote).toBe(false);
+    expect(existsSync(dashboardEnvPath(ctxRoot))).toBe(false);
+  });
+
+  it('writes files that are not world-readable', () => {
+    mutateDashboardEnv(ctxRoot, creds => { creds['ADMIN_PASSWORD'] = 'hunter2'; });
+    const mode = require('fs').statSync(dashboardEnvPath(ctxRoot)).mode & 0o777;
+    expect(mode & 0o077).toBe(0);
+  });
+
+  it('throws rather than overwriting a file it cannot read', () => {
+    // "Unreadable" must not collapse into "absent" — that would regenerate
+    // credentials on top of a file whose contents are still there.
+    if (typeof process.getuid === 'function' && process.getuid() === 0) {
+      return; // root bypasses the permission bit; the assertion would be vacuous
+    }
+    const file = dashboardEnvPath(ctxRoot);
+    writeFileSync(file, 'AUTH_SECRET=secret\n', 'utf-8');
+    chmodSync(file, 0o000);
+    try {
+      expect(() => mutateDashboardEnv(ctxRoot, creds => { creds['X'] = '1'; })).toThrow();
+      chmodSync(file, 0o600);
+      expect(readFileSync(file, 'utf-8')).toContain('AUTH_SECRET=secret');
+    } finally {
+      try { chmodSync(file, 0o600); } catch { /* best effort */ }
+    }
+  });
+});
+
+describe('under real inter-process contention', () => {
+  it('loses no concurrent mutation (6 processes, overlapping critical sections)', async () => {
+    writeFileSync(scriptPath, ADD_KEY_SCRIPT, 'utf-8');
+    const keys = ['K0', 'K1', 'K2', 'K3', 'K4', 'K5'];
+
+    await Promise.all(
+      keys.map(key =>
+        execFileAsync(TSX_BIN, [scriptPath, ctxRoot, key, '40'], { cwd: REPO_ROOT }),
+      ),
+    );
+
+    const after = parseEnvContent(readFileSync(dashboardEnvPath(ctxRoot), 'utf-8'));
+    // Unlocked, the later writers read a stale map and drop earlier keys.
+    for (const key of keys) {
+      expect(after[key], `${key} was lost — a concurrent writer clobbered it`).toBe(`v-${key}`);
+    }
+  }, 60_000);
+
+  it('never shows a writer credentials that differ from what is stored', async () => {
+    writeFileSync(scriptPath, CREDS_SCRIPT, 'utf-8');
+
+    const results = await Promise.all(
+      [0, 1, 2, 3].map(() =>
+        execFileAsync(TSX_BIN, [scriptPath, ctxRoot, '40'], { cwd: REPO_ROOT }),
+      ),
+    );
+
+    const stored = parseEnvContent(readFileSync(dashboardEnvPath(ctxRoot), 'utf-8'));
+    const observed = results.map(r => JSON.parse(r.stdout));
+
+    // Every process must agree with disk. Pre-fix, concurrent generators each
+    // minted their own secret and only the last one survived — so a process
+    // printed an admin password the file did not contain.
+    for (const o of observed) {
+      expect(o.observedSecret).toBe(stored['AUTH_SECRET']);
+      expect(o.observedPassword).toBe(stored['ADMIN_PASSWORD']);
+    }
+    // Sanity: the generation actually happened (guards a vacuous pass where all
+    // four somehow read empty strings).
+    expect(stored['AUTH_SECRET']).toMatch(/^[0-9a-f]{32}$/);
+    expect(stored['ADMIN_PASSWORD']).toMatch(/^[0-9a-f]{16}$/);
+  }, 60_000);
+});

--- a/tests/integration/concurrent-org-context-mutations.test.ts
+++ b/tests/integration/concurrent-org-context-mutations.test.ts
@@ -1,0 +1,330 @@
+/**
+ * Inter-process exclusion on `<frameworkRoot>/orgs/<org>/context.json`.
+ *
+ * `cortextos init` and `cortextos add-agent --template orchestrator` both did an
+ * unlocked read-modify-write on this file, over DISJOINT field sets — init fills
+ * in missing org fields, add-agent claims `orchestrator`. That disjointness is
+ * exactly what makes the race destructive rather than benign: each writes the
+ * whole object back, so the later writer silently discards the other's field.
+ * `mutateOrgContext` (src/utils/org-context.ts) now wraps read+mutate+write in
+ * `withFileLockSync`. This file demonstrates that under real contention instead
+ * of arguing it from reading the code.
+ *
+ * WHY REAL CHILD PROCESSES: an in-process test cannot prove this. Vitest is
+ * single-threaded, so the lock is uncontended on every acquire and the test goes
+ * green whether or not the lock exists — it would only be pinning the refactor.
+ * The exclusion is between OS processes, so the test spawns OS processes.
+ *
+ * WHY THE PRODUCTION BINARY: the children run `node dist/cli.js`, not the helper
+ * directly. Calling the helper would only prove the helper works; spawning the
+ * CLI proves the two call sites actually route through it.
+ *
+ * SANDBOXING: `init` derives projectRoot from `process.cwd()` and ctxRoot from
+ * `join(homedir(), '.cortextos', <instance>)`; `add-agent` derives projectRoot
+ * from CTX_FRAMEWORK_ROOT/CTX_PROJECT_ROOT/cwd. So the children run with cwd set
+ * to a temp dir, HOME overridden (os.homedir() honours $HOME on POSIX), and
+ * those three CTX_* vars deleted so the real installation cannot leak in.
+ * Overriding HOME also sandboxes getIpcPath(), so the children cannot reach the
+ * real daemon.
+ *
+ * NOTE: the CLI arms invoke compiled `dist/cli.js` and skip themselves if it is
+ * absent (`npm run build` first). The control arm needs no build and always runs.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { mutateOrgContext, orgContextDir, orgContextPath, CorruptOrgContextError } from '../../src/utils/org-context';
+
+const execFileAsync = promisify(execFile);
+
+const REPO_ROOT = join(__dirname, '..', '..');
+const DIST_CLI = join(REPO_ROOT, 'dist', 'cli.js');
+const ORG = 'raceorg';
+const ORCHESTRATOR = 'boss';
+
+/** Sandboxed $HOME, which doubles as the project root (cwd) for the children. */
+let sandbox: string;
+
+beforeEach(() => {
+  sandbox = mkdtempSync(join(tmpdir(), 'org-context-race-'));
+  mkdirSync(join(sandbox, 'orgs', ORG), { recursive: true });
+});
+
+afterEach(() => {
+  try { rmSync(sandbox, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+const contextPath = () => join(sandbox, 'orgs', ORG, 'context.json');
+
+/**
+ * Padding keys nobody mutates, present only to make the file big.
+ *
+ * Load-bearing, not decoration. The unlocked window is
+ * parse -> mutate -> serialise -> write, and against a file this small that
+ * window is far shorter than the startup jitter of two different CLI commands,
+ * so the children would rarely overlap and a broken build would go green.
+ * Padding widens the window enough that loss becomes reliable — see the
+ * detection rate recorded on the CLI arm below. Both writers preserve unknown
+ * keys, so padding survives a correct run untouched.
+ */
+const PADDING_ENTRIES = 3000;
+
+/** Fields `init`'s upgrade pass fills in, and that add-agent must not discard. */
+const INIT_FIELDS = [
+  'name', 'description', 'industry', 'icp', 'value_prop', 'timezone',
+  'day_mode_start', 'day_mode_end', 'default_approval_categories', 'communication_style',
+];
+
+/**
+ * Seed a context.json that BOTH commands have real work to do on: every field
+ * `init` fills is absent, and `orchestrator` is unset so add-agent will claim it.
+ * If either side had nothing to write, the race could not be observed at all.
+ */
+function seed(): void {
+  const ctx: Record<string, any> = {};
+  for (let i = 0; i < PADDING_ENTRIES; i++) ctx[`padding_${i}`] = 'x'.repeat(200);
+  writeFileSync(contextPath(), JSON.stringify(ctx, null, 2) + '\n');
+}
+
+/**
+ * The detector, shared by both arms so the control arm validates the exact
+ * assertion the CLI arm relies on. Returns the list of things that were lost;
+ * empty means both mutations survived intact.
+ */
+function losses(): string[] {
+  const raw = readFileSync(contextPath(), 'utf-8');
+  let ctx: Record<string, any>;
+  try {
+    ctx = JSON.parse(raw);
+  } catch {
+    // A torn/truncated file is the worst outcome, not merely a lost field:
+    // every reader of context.json swallows parse errors and keeps defaults.
+    return [`context.json is not valid JSON (${raw.length} bytes)`];
+  }
+
+  const lost: string[] = [];
+  if (ctx.orchestrator !== ORCHESTRATOR) {
+    lost.push(`orchestrator: expected "${ORCHESTRATOR}", got ${JSON.stringify(ctx.orchestrator)}`);
+  }
+  for (const field of INIT_FIELDS) {
+    if (ctx[field] === undefined) lost.push(`init field missing: ${field}`);
+  }
+  // A stale-snapshot write drops keys wholesale, including ones nobody touched.
+  const paddingPresent = Object.keys(ctx).filter(k => k.startsWith('padding_')).length;
+  if (paddingPresent !== PADDING_ENTRIES) {
+    lost.push(`padding keys: expected ${PADDING_ENTRIES}, found ${paddingPresent}`);
+  }
+  return lost;
+}
+
+/** Child env: sandboxed HOME, and every projectRoot override cleared. */
+function childEnv(): NodeJS.ProcessEnv {
+  const env = { ...process.env, HOME: sandbox };
+  delete env.CTX_ROOT;
+  delete env.CTX_FRAMEWORK_ROOT;
+  delete env.CTX_PROJECT_ROOT;
+  return env;
+}
+
+/**
+ * Control-arm harness: the *unlocked* read-modify-write these two call sites
+ * used to do, as a standalone script with no repo imports. Its job is to prove
+ * the detector above can actually see a lost update — without it, a green CLI
+ * arm is indistinguishable from a test that checks nothing.
+ *
+ * Takes a wall-clock start deadline so both children read the same instant.
+ * Relying on startup jitter to produce overlap would make the control arm
+ * flaky, and a flaky control arm proves nothing on the runs where it passes.
+ */
+const UNSAFE_HARNESS = `
+const { readFileSync, writeFileSync } = require('fs');
+const [file, role, startAtMs] = process.argv.slice(2);
+const sleep = (ms) => Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+
+const waitFor = Number(startAtMs) - Date.now();
+if (waitFor > 0) sleep(waitFor);
+
+const ctx = JSON.parse(readFileSync(file, 'utf-8'));   // read...
+sleep(200);                                             // ...window...
+if (role === 'init') {
+  ctx.name = 'raceorg';
+  ctx.description = ''; ctx.industry = ''; ctx.icp = ''; ctx.value_prop = '';
+  ctx.timezone = 'UTC';
+  ctx.day_mode_start = '08:00'; ctx.day_mode_end = '00:00';
+  ctx.default_approval_categories = ['external-comms'];
+  ctx.communication_style = 'direct and casual';
+} else {
+  ctx.orchestrator = 'boss';
+}
+writeFileSync(file, JSON.stringify(ctx, null, 2) + '\\n');  // ...write. No lock.
+`;
+
+describe('context.json: concurrent org-context mutation', () => {
+  it('CONTROL ARM: unlocked read-modify-write loses updates, and the detector sees it', async () => {
+    const harness = join(sandbox, 'unsafe-rmw.cjs');
+    writeFileSync(harness, UNSAFE_HARNESS);
+    seed();
+
+    const startAt = Date.now() + 1000;
+    await Promise.all(
+      ['init', 'orchestrator'].map(role =>
+        execFileAsync(process.execPath, [harness, contextPath(), role, String(startAt)], {
+          env: childEnv(),
+        }),
+      ),
+    );
+
+    // Both read the same snapshot, so only the last writer's fields survive —
+    // whichever order they land in, the other side's work is gone.
+    expect(
+      losses(),
+      'control arm lost nothing — the detector cannot see the failure the CLI ' +
+        'arm claims to rule out, so the CLI arm would prove nothing',
+    ).not.toEqual([]);
+  }, 60_000);
+
+  describe.skipIf(!existsSync(DIST_CLI))('via the production CLI (requires npm run build)', () => {
+    /**
+     * THIS TEST MUST STILL BE ABLE TO FAIL. Verified by mutation: replacing the
+     * `withFileLockSync` call in src/utils/org-context.ts with a direct call to
+     * its callback and rebuilding makes it fail. Detection rate is recorded in
+     * the commit message — a single observed failure would not have been
+     * enough, because whether the two commands' write windows actually overlap
+     * is probabilistic. Re-run that experiment if you change PADDING_ENTRIES,
+     * ITERATIONS, or the commands being spawned: every one of those knobs
+     * controls whether the children collide, and a green here means nothing if
+     * they never do.
+     */
+    it('concurrent `init` and `add-agent --template orchestrator`: both mutations survive', async () => {
+      const ITERATIONS = 6;
+      const failures: string[] = [];
+
+      for (let iter = 0; iter < ITERATIONS; iter++) {
+        rmSync(join(sandbox, 'orgs'), { recursive: true, force: true });
+        mkdirSync(join(sandbox, 'orgs', ORG), { recursive: true });
+        seed();
+
+        await Promise.all([
+          execFileAsync(process.execPath, [DIST_CLI, 'init', ORG], {
+            cwd: sandbox,
+            env: childEnv(),
+          }),
+          execFileAsync(
+            process.execPath,
+            [DIST_CLI, 'add-agent', ORCHESTRATOR, '--template', 'orchestrator', '--org', ORG],
+            { cwd: sandbox, env: childEnv() },
+          ),
+        ]);
+
+        const lost = losses();
+        if (lost.length) failures.push(`iteration ${iter}: ${lost.join('; ')}`);
+      }
+
+      expect(
+        failures,
+        'concurrent init/add-agent must not lose each other\'s fields',
+      ).toEqual([]);
+    }, 180_000);
+  });
+});
+
+describe('context.json: lock protocol', () => {
+  const lockDir = () => join(sandbox, 'orgs', ORG, '.lock.d');
+
+  /**
+   * Pins the literal rendezvous path. NOT a concurrency claim — a path
+   * assertion, and it matters because the lock only excludes writers that lock
+   * the SAME directory. The dashboard resolves this file to the same
+   * `<frameworkRoot>/orgs/<org>/` and re-exports the same lock module, so if
+   * this side ever locked somewhere else, every test here would still pass
+   * while the two processes locked different doors.
+   */
+  it('holds <frameworkRoot>/orgs/<org>/.lock.d during the mutation, and releases it', () => {
+    expect(orgContextDir(sandbox, ORG)).toBe(join(sandbox, 'orgs', ORG));
+    expect(orgContextPath(sandbox, ORG)).toBe(join(sandbox, 'orgs', ORG, 'context.json'));
+    expect(existsSync(lockDir())).toBe(false);
+
+    let heldDuringMutate: boolean | null = null;
+    mutateOrgContext(sandbox, ORG, (ctx) => {
+      heldDuringMutate = existsSync(lockDir());
+      ctx.name = ORG;
+    });
+
+    expect(heldDuringMutate, 'lock marker must exist while mutate runs').toBe(true);
+    expect(existsSync(lockDir()), 'lock marker must be released afterwards').toBe(false);
+  });
+
+  it('creates the file when absent, reporting existed=false', () => {
+    let sawExisted: boolean | null = null;
+    const wrote = mutateOrgContext(sandbox, ORG, (ctx, existed) => {
+      sawExisted = existed;
+      ctx.orchestrator = ORCHESTRATOR;
+    });
+
+    expect(sawExisted).toBe(false);
+    expect(wrote).toBe(true);
+    expect(JSON.parse(readFileSync(contextPath(), 'utf-8')).orchestrator).toBe(ORCHESTRATOR);
+  });
+
+  it('declines the write when mutate returns false, leaving the file byte-identical', () => {
+    writeFileSync(contextPath(), JSON.stringify({ name: ORG }, null, 2) + '\n');
+    const before = readFileSync(contextPath(), 'utf-8');
+
+    const wrote = mutateOrgContext(sandbox, ORG, (ctx) => {
+      ctx.orchestrator = 'ignored-because-we-decline';
+      return false;
+    });
+
+    expect(wrote).toBe(false);
+    // Byte-identical matters beyond the field values: declining exists so a
+    // no-op run does not churn the mtime the dashboard's watcher keys on.
+    expect(readFileSync(contextPath(), 'utf-8')).toBe(before);
+  });
+
+  /**
+   * The refusal is the whole reason the helper can be trusted to run inside
+   * `init`, whose mutate is a fill-in-the-missing-fields pass: treating a parse
+   * failure as `{}` would rewrite a recoverable file down to bare defaults and
+   * report success.
+   */
+  it('refuses to overwrite a corrupt file, and preserves a backup of it', () => {
+    const corrupt = '{ this is not json';
+    writeFileSync(contextPath(), corrupt);
+
+    let err: unknown;
+    try {
+      mutateOrgContext(sandbox, ORG, (ctx) => { ctx.name = 'clobbered'; });
+    } catch (e) { err = e; }
+
+    expect(err).toBeInstanceOf(CorruptOrgContextError);
+    expect(readFileSync(contextPath(), 'utf-8'), 'original must be untouched').toBe(corrupt);
+
+    const backupPath = (err as CorruptOrgContextError).backupPath;
+    expect(backupPath).not.toBeNull();
+    expect(readFileSync(backupPath!, 'utf-8')).toBe(corrupt);
+    expect(existsSync(lockDir()), 'lock must be released even on refusal').toBe(false);
+  });
+
+  it('refuses a JSON array, which would otherwise pass a bare typeof check', () => {
+    writeFileSync(contextPath(), '[]');
+    expect(() => mutateOrgContext(sandbox, ORG, () => { /* must never run */ })).toThrow(
+      CorruptOrgContextError,
+    );
+    expect(readFileSync(contextPath(), 'utf-8')).toBe('[]');
+  });
+
+  it('upgrades a BOM-prefixed file instead of silently skipping it', () => {
+    // Without stripBom the parse throws, which is what used to make every
+    // re-run of `cortextos init` leave a BOM'd context.json un-upgraded forever.
+    writeFileSync(contextPath(), '﻿' + JSON.stringify({ name: ORG }, null, 2) + '\n');
+
+    const wrote = mutateOrgContext(sandbox, ORG, (ctx) => { ctx.orchestrator = ORCHESTRATOR; });
+
+    expect(wrote).toBe(true);
+    expect(JSON.parse(readFileSync(contextPath(), 'utf-8')).orchestrator).toBe(ORCHESTRATOR);
+  });
+});


### PR DESCRIPTION
> **Shares `src/cli/add-agent.ts` with #831 — that one should land first.**

Two related unlocked read-modify-writes in the CLI.

**1. Org `context.json`.** `cortextos init` and `cortextos add-agent --template orchestrator` both did an unlocked RMW on `<frameworkRoot>/orgs/<org>/context.json`. Run concurrently, both read the whole object, mutate a few fields, and write the whole object back — the later write wins wholesale. `init` additionally had an `existsSync`-then-write TOCTOU between its create and upgrade branches.

New `src/utils/org-context.ts`: `mutateOrgContext()` does read+decide+write inside one `withFileLockSync` closure, modelled on `src/bus/crons.ts`. Plain reads stay unlocked, matching that precedent. Writes go through `atomicWriteSync` — all three old call sites used bare `writeFileSync`, so readers could observe a truncated file, and every reader of this file swallows parse errors and silently keeps defaults. A malformed `context.json` is backed up and refused rather than overwritten, because both writers are fill-missing-fields passes and treating a parse failure as `{}` would rewrite a recoverable file down to bare defaults and report success.

**2. `install`/`dashboard` credential writes.** `install.ts` did four bare check-then-write sequences on ctxRoot state files, and `dashboard.ts` independently generated and persisted the same credentials. `enabled-agents.json` + `bus-signing-key` now write under one lock on `<ctxRoot>/config`, re-checking `existsSync` **inside** the lock. Clobbering a populated roster with `{}` is not cosmetic: a missing entry means ENABLED (`src/bus/agents.ts:90-91`), so it silently restarts explicitly-disabled agents. New `src/utils/dashboard-env.ts` gives both writers a shared locked, merge-preserving RMW for `dashboard.env` — beyond the race, `install` rewrote that file from a fixed five-key list and so dropped any other key on every run, with no concurrency required.

**Scope:** `src/cli/{add-agent,dashboard,init,install}.ts`, `src/utils/{org-context,dashboard-env,env}.ts` + two real-process contention tests.

**Verified:** both tests spawn real processes, because vitest is single-threaded and an in-process lock is uncontended on every acquire — such a test goes green whether or not the lock exists. Mutation-tested with a **rate**, not a single failure: bypassing `withFileLockSync` makes the context.json arm fail 10/10 runs (`orchestrator: expected "boss", got ""`) and the dashboard.env arm 10/10; restored, 5/5 and 3/3 green. Each has a control arm replicating the old unlocked RMW, so a green cannot mean the detector sees nothing. Suite reconciled against an `a15baad` baseline re-run in the same session with failing test **names** diffed, not just counts.

**Scope limits, stated:**
- This does **not** close CLI↔dashboard. The dashboard resolves the same path and re-exports the same lock module, so the rendezvous is real, but `api/org/config/route.ts` is still an unlocked RMW. Already-installed older binaries are never excluded.
- The dashboard.env test runs the shared helper via `tsx`, not the production binary (`install` runs `npm link`, `dashboard` starts a server), so it does not re-prove that those two call sites route through it. The file header says so.
- The sibling per-agent `config.json` is deliberately untouched: the dashboard's `getAgentDir()` falls back to `<CTX_ROOT>/…` when the framework-root path is missing while the CLI never looks there, so the two sides can resolve *different* directories for the same agent precisely during creation. A lock there would exclude nothing in the window where the race lives. Tracked separately.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
