### PR TITLE
docs(kb): correct the collection model — two collections, and no --collection flag

### DIFF
--- a/community/agents/agent/AGENTS.md
+++ b/community/agents/agent/AGENTS.md
@@ -278,25 +278,29 @@ This is the knowledge you have synthesised over time. Not a log — a living doc
 
 Also update GUARDRAILS.md when you identify a pattern of behaviour that should be explicitly prohibited or corrected — not just for yourself but as a guardrail for future sessions.
 
-Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection so it is semantically searchable.
+Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection so it is semantically searchable.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
 The knowledge base is a semantic vector store (ChromaDB, Gemini Embedding 2). Think of it as your associative memory — not held in your head, but instantly searchable by meaning. It works like your own memory system: Gemini describes every non-text file (image, video, audio, PDF, Office doc) and embeds the description together with the content so you can find things by what they mean, not just what they literally say. Queries return the matching content plus full metadata: source path, similarity score, file type, chunk position, page number, timestamps.
 
-**Three collections — different management models:**
+**Two collections — different management models:**
 
 | Collection | Scope | What goes in | How managed |
 |---|---|---|---|
-| `memory-{agent}` | Private | MEMORY.md + daily memory files | **Auto** — re-indexed on every heartbeat |
-| `private-{agent}` | Private | Your outputs, research docs, workspace files | **Agent-managed** — ingest when you produce something worth keeping |
+| `agent-{agent}` | Private | MEMORY.md, daily memory files, **and** your outputs/research/workspace files — all one collection | Memory files re-ingested every heartbeat; everything else agent-managed |
 | `shared-{org}` | Org-wide | Research findings, reports, org knowledge | **Agent-managed** — ingest when the whole org benefits |
 
-**memory-{agent} is automatic.** On every heartbeat cycle, re-ingest your memory files so they stay current and searchable:
+There is no `memory-{agent}` and no `private-{agent}` collection: both entry points compute the name
+as `agent-<agent>` or `shared-<org>` and nothing else. **Consequence worth knowing — you cannot query
+your memory separately from your outputs.** They share one collection, so narrow by wording the
+question, not by picking a collection.
+
+**Memory re-ingestion is on you every heartbeat.** Re-ingest your memory files so they stay current:
 ```bash
 # Run on every heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
 
 **When to query — before starting any task:**
@@ -304,23 +308,23 @@ cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
 - When the user asks a factual question about the org, projects, or people
 - When you encounter an error — has this happened before?
 - When referencing named entities (clients, projects, systems)
-- To recall your own past work: query `memory-{agent}` or `private-{agent}` specifically
+- To recall your own past work: `--scope private --agent $CTX_AGENT_NAME` (there is no separate memory-only collection to target)
 
-**When to ingest private-{agent} and shared-{org} — your judgment:**
-- After completing a task with a notable output → `private-{agent}`
+**When to ingest to `agent-{agent}` and `shared-{org}` — your judgment:**
+- After completing a task with a notable output → `agent-{agent}` (`--scope private`)
 - After completing research → `shared-{org}` (the whole org benefits)
 - After producing a document, report, or significant file → appropriate scope
-- After the user shares a file with you → `private-{agent}`
+- After the user shares a file with you → `agent-{agent}` (`--scope private`)
 - After a workflow completes → ingest the artifacts
 
 ```bash
 # Query before any task (searches all your collections by default)
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME
 
-# Query only your memory (past experiences, patterns)
-cortextos bus kb-query "question" --org $CTX_ORG --collection memory-$CTX_AGENT_NAME
+# Query your own past work (memory and outputs share one collection)
+cortextos bus kb-query "question" --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
-# Ingest output to your private collection
+# Ingest an output to your private collection (same place as your memory)
 cortextos bus kb-ingest /path/to/output --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
 # Ingest research to org shared collection

--- a/community/agents/agent/HEARTBEAT.md
+++ b/community/agents/agent/HEARTBEAT.md
@@ -129,8 +129,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 

--- a/community/agents/analyst/AGENTS.md
+++ b/community/agents/analyst/AGENTS.md
@@ -278,25 +278,29 @@ This is the knowledge you have synthesised over time. Not a log — a living doc
 
 Also update GUARDRAILS.md when you identify a pattern of behaviour that should be explicitly prohibited or corrected — not just for yourself but as a guardrail for future sessions.
 
-Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection so it is semantically searchable.
+Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection so it is semantically searchable.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
 The knowledge base is a semantic vector store (ChromaDB, Gemini Embedding 2). Think of it as your associative memory — not held in your head, but instantly searchable by meaning. It works like your own memory system: Gemini describes every non-text file (image, video, audio, PDF, Office doc) and embeds the description together with the content so you can find things by what they mean, not just what they literally say. Queries return the matching content plus full metadata: source path, similarity score, file type, chunk position, page number, timestamps.
 
-**Three collections — different management models:**
+**Two collections — different management models:**
 
 | Collection | Scope | What goes in | How managed |
 |---|---|---|---|
-| `memory-{agent}` | Private | MEMORY.md + daily memory files | **Auto** — re-indexed on every heartbeat |
-| `private-{agent}` | Private | Your outputs, research docs, workspace files | **Agent-managed** — ingest when you produce something worth keeping |
+| `agent-{agent}` | Private | MEMORY.md, daily memory files, **and** your outputs/research/workspace files — all one collection | Memory files re-ingested every heartbeat; everything else agent-managed |
 | `shared-{org}` | Org-wide | Research findings, reports, org knowledge | **Agent-managed** — ingest when the whole org benefits |
 
-**memory-{agent} is automatic.** On every heartbeat cycle, re-ingest your memory files so they stay current and searchable:
+There is no `memory-{agent}` and no `private-{agent}` collection: both entry points compute the name
+as `agent-<agent>` or `shared-<org>` and nothing else. **Consequence worth knowing — you cannot query
+your memory separately from your outputs.** They share one collection, so narrow by wording the
+question, not by picking a collection.
+
+**Memory re-ingestion is on you every heartbeat.** Re-ingest your memory files so they stay current:
 ```bash
 # Run on every heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
 
 **When to query — before starting any task:**
@@ -304,23 +308,23 @@ cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
 - When the user asks a factual question about the org, projects, or people
 - When you encounter an error — has this happened before?
 - When referencing named entities (clients, projects, systems)
-- To recall your own past work: query `memory-{agent}` or `private-{agent}` specifically
+- To recall your own past work: `--scope private --agent $CTX_AGENT_NAME` (there is no separate memory-only collection to target)
 
-**When to ingest private-{agent} and shared-{org} — your judgment:**
-- After completing a task with a notable output → `private-{agent}`
+**When to ingest to `agent-{agent}` and `shared-{org}` — your judgment:**
+- After completing a task with a notable output → `agent-{agent}` (`--scope private`)
 - After completing research → `shared-{org}` (the whole org benefits)
 - After producing a document, report, or significant file → appropriate scope
-- After the user shares a file with you → `private-{agent}`
+- After the user shares a file with you → `agent-{agent}` (`--scope private`)
 - After a workflow completes → ingest the artifacts
 
 ```bash
 # Query before any task (searches all your collections by default)
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME
 
-# Query only your memory (past experiences, patterns)
-cortextos bus kb-query "question" --org $CTX_ORG --collection memory-$CTX_AGENT_NAME
+# Query your own past work (memory and outputs share one collection)
+cortextos bus kb-query "question" --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
-# Ingest output to your private collection
+# Ingest an output to your private collection (same place as your memory)
 cortextos bus kb-ingest /path/to/output --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
 # Ingest research to org shared collection

--- a/community/agents/orchestrator/AGENTS.md
+++ b/community/agents/orchestrator/AGENTS.md
@@ -278,25 +278,29 @@ This is the knowledge you have synthesised over time. Not a log — a living doc
 
 Also update GUARDRAILS.md when you identify a pattern of behaviour that should be explicitly prohibited or corrected — not just for yourself but as a guardrail for future sessions.
 
-Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection so it is semantically searchable.
+Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection so it is semantically searchable.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
 The knowledge base is a semantic vector store (ChromaDB, Gemini Embedding 2). Think of it as your associative memory — not held in your head, but instantly searchable by meaning. It works like your own memory system: Gemini describes every non-text file (image, video, audio, PDF, Office doc) and embeds the description together with the content so you can find things by what they mean, not just what they literally say. Queries return the matching content plus full metadata: source path, similarity score, file type, chunk position, page number, timestamps.
 
-**Three collections — different management models:**
+**Two collections — different management models:**
 
 | Collection | Scope | What goes in | How managed |
 |---|---|---|---|
-| `memory-{agent}` | Private | MEMORY.md + daily memory files | **Auto** — re-indexed on every heartbeat |
-| `private-{agent}` | Private | Your outputs, research docs, workspace files | **Agent-managed** — ingest when you produce something worth keeping |
+| `agent-{agent}` | Private | MEMORY.md, daily memory files, **and** your outputs/research/workspace files — all one collection | Memory files re-ingested every heartbeat; everything else agent-managed |
 | `shared-{org}` | Org-wide | Research findings, reports, org knowledge | **Agent-managed** — ingest when the whole org benefits |
 
-**memory-{agent} is automatic.** On every heartbeat cycle, re-ingest your memory files so they stay current and searchable:
+There is no `memory-{agent}` and no `private-{agent}` collection: both entry points compute the name
+as `agent-<agent>` or `shared-<org>` and nothing else. **Consequence worth knowing — you cannot query
+your memory separately from your outputs.** They share one collection, so narrow by wording the
+question, not by picking a collection.
+
+**Memory re-ingestion is on you every heartbeat.** Re-ingest your memory files so they stay current:
 ```bash
 # Run on every heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
 
 **When to query — before starting any task:**
@@ -304,23 +308,23 @@ cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
 - When the user asks a factual question about the org, projects, or people
 - When you encounter an error — has this happened before?
 - When referencing named entities (clients, projects, systems)
-- To recall your own past work: query `memory-{agent}` or `private-{agent}` specifically
+- To recall your own past work: `--scope private --agent $CTX_AGENT_NAME` (there is no separate memory-only collection to target)
 
-**When to ingest private-{agent} and shared-{org} — your judgment:**
-- After completing a task with a notable output → `private-{agent}`
+**When to ingest to `agent-{agent}` and `shared-{org}` — your judgment:**
+- After completing a task with a notable output → `agent-{agent}` (`--scope private`)
 - After completing research → `shared-{org}` (the whole org benefits)
 - After producing a document, report, or significant file → appropriate scope
-- After the user shares a file with you → `private-{agent}`
+- After the user shares a file with you → `agent-{agent}` (`--scope private`)
 - After a workflow completes → ingest the artifacts
 
 ```bash
 # Query before any task (searches all your collections by default)
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME
 
-# Query only your memory (past experiences, patterns)
-cortextos bus kb-query "question" --org $CTX_ORG --collection memory-$CTX_AGENT_NAME
+# Query your own past work (memory and outputs share one collection)
+cortextos bus kb-query "question" --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
-# Ingest output to your private collection
+# Ingest an output to your private collection (same place as your memory)
 cortextos bus kb-ingest /path/to/output --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
 # Ingest research to org shared collection

--- a/community/agents/orchestrator/HEARTBEAT.md
+++ b/community/agents/orchestrator/HEARTBEAT.md
@@ -160,8 +160,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 

--- a/community/agents/research-agent/.claude/skills/memory/SKILL.md
+++ b/community/agents/research-agent/.claude/skills/memory/SKILL.md
@@ -105,8 +105,14 @@ Update at every heartbeat and session end. Ingest to KB after updating.
 Re-ingest MEMORY.md and today's daily memory on every heartbeat so they stay semantically searchable:
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 ---
 

--- a/community/agents/research-agent/AGENTS.md
+++ b/community/agents/research-agent/AGENTS.md
@@ -300,25 +300,29 @@ This is the knowledge you have synthesised over time. Not a log — a living doc
 
 Also update GUARDRAILS.md when you identify a pattern of behaviour that should be explicitly prohibited or corrected — not just for yourself but as a guardrail for future sessions.
 
-Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection so it is semantically searchable.
+Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection so it is semantically searchable.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
 The knowledge base is a semantic vector store (ChromaDB, Gemini Embedding 2). Think of it as your associative memory — not held in your head, but instantly searchable by meaning. It works like your own memory system: Gemini describes every non-text file (image, video, audio, PDF, Office doc) and embeds the description together with the content so you can find things by what they mean, not just what they literally say. Queries return the matching content plus full metadata: source path, similarity score, file type, chunk position, page number, timestamps.
 
-**Three collections — different management models:**
+**Two collections — different management models:**
 
 | Collection | Scope | What goes in | How managed |
 |---|---|---|---|
-| `memory-{agent}` | Private | MEMORY.md + daily memory files | **Auto** — re-indexed on every heartbeat |
-| `private-{agent}` | Private | Your outputs, research docs, workspace files | **Agent-managed** — ingest when you produce something worth keeping |
+| `agent-{agent}` | Private | MEMORY.md, daily memory files, **and** your outputs/research/workspace files — all one collection | Memory files re-ingested every heartbeat; everything else agent-managed |
 | `shared-{org}` | Org-wide | Research findings, reports, org knowledge | **Agent-managed** — ingest when the whole org benefits |
 
-**memory-{agent} is automatic.** On every heartbeat cycle, re-ingest your memory files so they stay current and searchable:
+There is no `memory-{agent}` and no `private-{agent}` collection: both entry points compute the name
+as `agent-<agent>` or `shared-<org>` and nothing else. **Consequence worth knowing — you cannot query
+your memory separately from your outputs.** They share one collection, so narrow by wording the
+question, not by picking a collection.
+
+**Memory re-ingestion is on you every heartbeat.** Re-ingest your memory files so they stay current:
 ```bash
 # Run on every heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
 
 **When to query — before starting any task:**
@@ -326,23 +330,23 @@ cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
 - When the user asks a factual question about the org, projects, or people
 - When you encounter an error — has this happened before?
 - When referencing named entities (clients, projects, systems)
-- To recall your own past work: query `memory-{agent}` or `private-{agent}` specifically
+- To recall your own past work: `--scope private --agent $CTX_AGENT_NAME` (there is no separate memory-only collection to target)
 
-**When to ingest private-{agent} and shared-{org} — your judgment:**
-- After completing a task with a notable output → `private-{agent}`
+**When to ingest to `agent-{agent}` and `shared-{org}` — your judgment:**
+- After completing a task with a notable output → `agent-{agent}` (`--scope private`)
 - After completing research → `shared-{org}` (the whole org benefits)
 - After producing a document, report, or significant file → appropriate scope
-- After the user shares a file with you → `private-{agent}`
+- After the user shares a file with you → `agent-{agent}` (`--scope private`)
 - After a workflow completes → ingest the artifacts
 
 ```bash
 # Query before any task (searches all your collections by default)
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME
 
-# Query only your memory (past experiences, patterns)
-cortextos bus kb-query "question" --org $CTX_ORG --collection memory-$CTX_AGENT_NAME
+# Query your own past work (memory and outputs share one collection)
+cortextos bus kb-query "question" --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
-# Ingest output to your private collection
+# Ingest an output to your private collection (same place as your memory)
 cortextos bus kb-ingest /path/to/output --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
 # Ingest research to org shared collection

--- a/community/agents/research-agent/HEARTBEAT.md
+++ b/community/agents/research-agent/HEARTBEAT.md
@@ -135,8 +135,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 

--- a/community/agents/research-agent/ONBOARDING.md
+++ b/community/agents/research-agent/ONBOARDING.md
@@ -243,7 +243,7 @@ After workflows and tools are configured:
       "$CTX_AGENT_DIR/IDENTITY.md" \
       --org $CTX_ORG --scope private \
       --agent $CTX_AGENT_NAME \
-      --collection "memory-$CTX_AGENT_NAME" --force
+      --force
     ```
 
     Ingest any additional files the user specified in their answers.

--- a/community/agents/security/HEARTBEAT.md
+++ b/community/agents/security/HEARTBEAT.md
@@ -129,8 +129,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 

--- a/community/agents/security/ONBOARDING.md
+++ b/community/agents/security/ONBOARDING.md
@@ -232,7 +232,7 @@ After workflows and tools are configured:
       "$CTX_AGENT_DIR/IDENTITY.md" \
       --org $CTX_ORG --scope private \
       --agent $CTX_AGENT_NAME \
-      --collection "memory-$CTX_AGENT_NAME" --force
+      --force
     ```
 
     Ingest any additional files the user specified in their answers.

--- a/community/skills/memory/SKILL.md
+++ b/community/skills/memory/SKILL.md
@@ -106,8 +106,14 @@ Update at every heartbeat and session end. Ingest to KB after updating.
 Re-ingest MEMORY.md and today's daily memory on every heartbeat so they stay semantically searchable:
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 ---
 

--- a/templates/agent-codex/AGENTS.md
+++ b/templates/agent-codex/AGENTS.md
@@ -280,16 +280,16 @@ MEMEOF
 
 ### Layer 2: Long-Term Memory — Consolidated Knowledge (MEMORY.md)
 
-Knowledge synthesised over time. Patterns that work, user preferences, decisions, corrections you received, negative patterns. Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection.
+Knowledge synthesised over time. Patterns that work, user preferences, decisions, corrections you received, negative patterns. Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
-Semantic vector store. Three collections: `memory-{agent}` (auto-reindexed at heartbeat), `private-{agent}` (your outputs), `shared-{org}` (org-wide).
+Semantic vector store. Two collections: `agent-{agent}` (private — your memory files *and* your outputs; re-ingest memory at heartbeat) and `shared-{org}` (org-wide). There is no `memory-{agent}` or `private-{agent}`. Do not add `--collection`: the `cortextos bus` CLI rejects it, and the `bash bus/kb-ingest.sh` wrapper that accepts it would file memory where `kb-query` cannot read it back.
 
 ```bash
 # Re-index memory at heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 
 # Query before any task
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME

--- a/templates/agent-codex/HEARTBEAT.md
+++ b/templates/agent-codex/HEARTBEAT.md
@@ -135,8 +135,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 

--- a/templates/agent-codex/ONBOARDING.md
+++ b/templates/agent-codex/ONBOARDING.md
@@ -245,7 +245,7 @@ After workflows and tools are configured:
       "$CTX_AGENT_DIR/IDENTITY.md" \
       --org $CTX_ORG --scope private \
       --agent $CTX_AGENT_NAME \
-      --collection "memory-$CTX_AGENT_NAME" --force
+      --force
     ```
 
     Ingest any additional files the user specified in their answers.

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
@@ -105,8 +105,14 @@ Update at every heartbeat and session end. Ingest to KB after updating.
 Re-ingest MEMORY.md and today's daily memory on every heartbeat so they stay semantically searchable:
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 ---
 

--- a/templates/agent-opencode/AGENTS.md
+++ b/templates/agent-opencode/AGENTS.md
@@ -286,16 +286,16 @@ MEMEOF
 
 ### Layer 2: Long-Term Memory — Consolidated Knowledge (MEMORY.md)
 
-Knowledge synthesised over time. Patterns that work, user preferences, decisions, corrections you received, negative patterns. Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection.
+Knowledge synthesised over time. Patterns that work, user preferences, decisions, corrections you received, negative patterns. Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
-Semantic vector store. Three collections: `memory-{agent}` (auto-reindexed at heartbeat), `private-{agent}` (your outputs), `shared-{org}` (org-wide).
+Semantic vector store. Two collections: `agent-{agent}` (private — your memory files *and* your outputs; re-ingest memory at heartbeat) and `shared-{org}` (org-wide). There is no `memory-{agent}` or `private-{agent}`. Do not add `--collection`: the `cortextos bus` CLI rejects it, and the `bash bus/kb-ingest.sh` wrapper that accepts it would file memory where `kb-query` cannot read it back.
 
 ```bash
 # Re-index memory at heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 
 # Query before any task
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME

--- a/templates/agent-opencode/HEARTBEAT.md
+++ b/templates/agent-opencode/HEARTBEAT.md
@@ -135,8 +135,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 

--- a/templates/agent-opencode/ONBOARDING.md
+++ b/templates/agent-opencode/ONBOARDING.md
@@ -245,7 +245,7 @@ After workflows and tools are configured:
       "$CTX_AGENT_DIR/IDENTITY.md" \
       --org $CTX_ORG --scope private \
       --agent $CTX_AGENT_NAME \
-      --collection "memory-$CTX_AGENT_NAME" --force
+      --force
     ```
 
     Ingest any additional files the user specified in their answers.

--- a/templates/agent-opencode/plugins/cortextos-agent-skills/skills/memory/SKILL.md
+++ b/templates/agent-opencode/plugins/cortextos-agent-skills/skills/memory/SKILL.md
@@ -105,8 +105,14 @@ Update at every heartbeat and session end. Ingest to KB after updating.
 Re-ingest MEMORY.md and today's daily memory on every heartbeat so they stay semantically searchable:
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 ---
 

--- a/templates/agent/.claude/skills/memory/SKILL.md
+++ b/templates/agent/.claude/skills/memory/SKILL.md
@@ -105,8 +105,14 @@ Update at every heartbeat and session end. Ingest to KB after updating.
 Re-ingest MEMORY.md and today's daily memory on every heartbeat so they stay semantically searchable:
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 ---
 

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -312,25 +312,29 @@ This is the knowledge you have synthesised over time. Not a log — a living doc
 
 Also update GUARDRAILS.md when you identify a pattern of behaviour that should be explicitly prohibited or corrected — not just for yourself but as a guardrail for future sessions.
 
-Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection so it is semantically searchable.
+Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection so it is semantically searchable.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
 The knowledge base is a semantic vector store (ChromaDB, Gemini Embedding 2). Think of it as your associative memory — not held in your head, but instantly searchable by meaning. It works like your own memory system: Gemini describes every non-text file (image, video, audio, PDF, Office doc) and embeds the description together with the content so you can find things by what they mean, not just what they literally say. Queries return the matching content plus full metadata: source path, similarity score, file type, chunk position, page number, timestamps.
 
-**Three collections — different management models:**
+**Two collections — different management models:**
 
 | Collection | Scope | What goes in | How managed |
 |---|---|---|---|
-| `memory-{agent}` | Private | MEMORY.md + daily memory files | **Auto** — re-indexed on every heartbeat |
-| `private-{agent}` | Private | Your outputs, research docs, workspace files | **Agent-managed** — ingest when you produce something worth keeping |
+| `agent-{agent}` | Private | MEMORY.md, daily memory files, **and** your outputs/research/workspace files — all one collection | Memory files re-ingested every heartbeat; everything else agent-managed |
 | `shared-{org}` | Org-wide | Research findings, reports, org knowledge | **Agent-managed** — ingest when the whole org benefits |
 
-**memory-{agent} is automatic.** On every heartbeat cycle, re-ingest your memory files so they stay current and searchable:
+There is no `memory-{agent}` and no `private-{agent}` collection: both entry points compute the name
+as `agent-<agent>` or `shared-<org>` and nothing else. **Consequence worth knowing — you cannot query
+your memory separately from your outputs.** They share one collection, so narrow by wording the
+question, not by picking a collection.
+
+**Memory re-ingestion is on you every heartbeat.** Re-ingest your memory files so they stay current:
 ```bash
 # Run on every heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
 
 **When to query — before starting any task:**
@@ -338,23 +342,23 @@ cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
 - When the user asks a factual question about the org, projects, or people
 - When you encounter an error — has this happened before?
 - When referencing named entities (clients, projects, systems)
-- To recall your own past work: query `memory-{agent}` or `private-{agent}` specifically
+- To recall your own past work: `--scope private --agent $CTX_AGENT_NAME` (there is no separate memory-only collection to target)
 
-**When to ingest private-{agent} and shared-{org} — your judgment:**
-- After completing a task with a notable output → `private-{agent}`
+**When to ingest to `agent-{agent}` and `shared-{org}` — your judgment:**
+- After completing a task with a notable output → `agent-{agent}` (`--scope private`)
 - After completing research → `shared-{org}` (the whole org benefits)
 - After producing a document, report, or significant file → appropriate scope
-- After the user shares a file with you → `private-{agent}`
+- After the user shares a file with you → `agent-{agent}` (`--scope private`)
 - After a workflow completes → ingest the artifacts
 
 ```bash
 # Query before any task (searches all your collections by default)
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME
 
-# Query only your memory (past experiences, patterns)
-cortextos bus kb-query "question" --org $CTX_ORG --collection memory-$CTX_AGENT_NAME
+# Query your own past work (memory and outputs share one collection)
+cortextos bus kb-query "question" --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
-# Ingest output to your private collection
+# Ingest an output to your private collection (same place as your memory)
 cortextos bus kb-ingest /path/to/output --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
 # Ingest research to org shared collection

--- a/templates/agent/HEARTBEAT.md
+++ b/templates/agent/HEARTBEAT.md
@@ -135,8 +135,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 

--- a/templates/agent/ONBOARDING.md
+++ b/templates/agent/ONBOARDING.md
@@ -243,7 +243,7 @@ After workflows and tools are configured:
       "$CTX_AGENT_DIR/IDENTITY.md" \
       --org $CTX_ORG --scope private \
       --agent $CTX_AGENT_NAME \
-      --collection "memory-$CTX_AGENT_NAME" --force
+      --force
     ```
 
     Ingest any additional files the user specified in their answers.

--- a/templates/analyst/.claude/skills/memory/SKILL.md
+++ b/templates/analyst/.claude/skills/memory/SKILL.md
@@ -105,8 +105,14 @@ Update at every heartbeat and session end. Ingest to KB after updating.
 Re-ingest MEMORY.md and today's daily memory on every heartbeat so they stay semantically searchable:
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 ---
 

--- a/templates/analyst/AGENTS.md
+++ b/templates/analyst/AGENTS.md
@@ -278,25 +278,29 @@ This is the knowledge you have synthesised over time. Not a log — a living doc
 
 Also update GUARDRAILS.md when you identify a pattern of behaviour that should be explicitly prohibited or corrected — not just for yourself but as a guardrail for future sessions.
 
-Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection so it is semantically searchable.
+Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection so it is semantically searchable.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
 The knowledge base is a semantic vector store (ChromaDB, Gemini Embedding 2). Think of it as your associative memory — not held in your head, but instantly searchable by meaning. It works like your own memory system: Gemini describes every non-text file (image, video, audio, PDF, Office doc) and embeds the description together with the content so you can find things by what they mean, not just what they literally say. Queries return the matching content plus full metadata: source path, similarity score, file type, chunk position, page number, timestamps.
 
-**Three collections — different management models:**
+**Two collections — different management models:**
 
 | Collection | Scope | What goes in | How managed |
 |---|---|---|---|
-| `memory-{agent}` | Private | MEMORY.md + daily memory files | **Auto** — re-indexed on every heartbeat |
-| `private-{agent}` | Private | Your outputs, research docs, workspace files | **Agent-managed** — ingest when you produce something worth keeping |
+| `agent-{agent}` | Private | MEMORY.md, daily memory files, **and** your outputs/research/workspace files — all one collection | Memory files re-ingested every heartbeat; everything else agent-managed |
 | `shared-{org}` | Org-wide | Research findings, reports, org knowledge | **Agent-managed** — ingest when the whole org benefits |
 
-**memory-{agent} is automatic.** On every heartbeat cycle, re-ingest your memory files so they stay current and searchable:
+There is no `memory-{agent}` and no `private-{agent}` collection: both entry points compute the name
+as `agent-<agent>` or `shared-<org>` and nothing else. **Consequence worth knowing — you cannot query
+your memory separately from your outputs.** They share one collection, so narrow by wording the
+question, not by picking a collection.
+
+**Memory re-ingestion is on you every heartbeat.** Re-ingest your memory files so they stay current:
 ```bash
 # Run on every heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
 
 **When to query — before starting any task:**
@@ -304,23 +308,23 @@ cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
 - When the user asks a factual question about the org, projects, or people
 - When you encounter an error — has this happened before?
 - When referencing named entities (clients, projects, systems)
-- To recall your own past work: query `memory-{agent}` or `private-{agent}` specifically
+- To recall your own past work: `--scope private --agent $CTX_AGENT_NAME` (there is no separate memory-only collection to target)
 
-**When to ingest private-{agent} and shared-{org} — your judgment:**
-- After completing a task with a notable output → `private-{agent}`
+**When to ingest to `agent-{agent}` and `shared-{org}` — your judgment:**
+- After completing a task with a notable output → `agent-{agent}` (`--scope private`)
 - After completing research → `shared-{org}` (the whole org benefits)
 - After producing a document, report, or significant file → appropriate scope
-- After the user shares a file with you → `private-{agent}`
+- After the user shares a file with you → `agent-{agent}` (`--scope private`)
 - After a workflow completes → ingest the artifacts
 
 ```bash
 # Query before any task (searches all your collections by default)
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME
 
-# Query only your memory (past experiences, patterns)
-cortextos bus kb-query "question" --org $CTX_ORG --collection memory-$CTX_AGENT_NAME
+# Query your own past work (memory and outputs share one collection)
+cortextos bus kb-query "question" --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
-# Ingest output to your private collection
+# Ingest an output to your private collection (same place as your memory)
 cortextos bus kb-ingest /path/to/output --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
 # Ingest research to org shared collection

--- a/templates/hermes/HEARTBEAT.md
+++ b/templates/hermes/HEARTBEAT.md
@@ -67,8 +67,14 @@ MEMORY
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 ## Step 7: Check GOALS.md
 

--- a/templates/orchestrator/AGENTS.md
+++ b/templates/orchestrator/AGENTS.md
@@ -278,25 +278,29 @@ This is the knowledge you have synthesised over time. Not a log — a living doc
 
 Also update GUARDRAILS.md when you identify a pattern of behaviour that should be explicitly prohibited or corrected — not just for yourself but as a guardrail for future sessions.
 
-Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `memory-{agent}` KB collection so it is semantically searchable.
+Update on every heartbeat and at session end. When you update MEMORY.md, ingest it to your `agent-{agent}` KB collection so it is semantically searchable.
 
 ### Layer 3: Knowledge Base — Associative Memory (RAG/ChromaDB)
 
 The knowledge base is a semantic vector store (ChromaDB, Gemini Embedding 2). Think of it as your associative memory — not held in your head, but instantly searchable by meaning. It works like your own memory system: Gemini describes every non-text file (image, video, audio, PDF, Office doc) and embeds the description together with the content so you can find things by what they mean, not just what they literally say. Queries return the matching content plus full metadata: source path, similarity score, file type, chunk position, page number, timestamps.
 
-**Three collections — different management models:**
+**Two collections — different management models:**
 
 | Collection | Scope | What goes in | How managed |
 |---|---|---|---|
-| `memory-{agent}` | Private | MEMORY.md + daily memory files | **Auto** — re-indexed on every heartbeat |
-| `private-{agent}` | Private | Your outputs, research docs, workspace files | **Agent-managed** — ingest when you produce something worth keeping |
+| `agent-{agent}` | Private | MEMORY.md, daily memory files, **and** your outputs/research/workspace files — all one collection | Memory files re-ingested every heartbeat; everything else agent-managed |
 | `shared-{org}` | Org-wide | Research findings, reports, org knowledge | **Agent-managed** — ingest when the whole org benefits |
 
-**memory-{agent} is automatic.** On every heartbeat cycle, re-ingest your memory files so they stay current and searchable:
+There is no `memory-{agent}` and no `private-{agent}` collection: both entry points compute the name
+as `agent-<agent>` or `shared-<org>` and nothing else. **Consequence worth knowing — you cannot query
+your memory separately from your outputs.** They share one collection, so narrow by wording the
+question, not by picking a collection.
+
+**Memory re-ingestion is on you every heartbeat.** Re-ingest your memory files so they stay current:
 ```bash
 # Run on every heartbeat
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
 
 **When to query — before starting any task:**
@@ -304,23 +308,23 @@ cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
 - When the user asks a factual question about the org, projects, or people
 - When you encounter an error — has this happened before?
 - When referencing named entities (clients, projects, systems)
-- To recall your own past work: query `memory-{agent}` or `private-{agent}` specifically
+- To recall your own past work: `--scope private --agent $CTX_AGENT_NAME` (there is no separate memory-only collection to target)
 
-**When to ingest private-{agent} and shared-{org} — your judgment:**
-- After completing a task with a notable output → `private-{agent}`
+**When to ingest to `agent-{agent}` and `shared-{org}` — your judgment:**
+- After completing a task with a notable output → `agent-{agent}` (`--scope private`)
 - After completing research → `shared-{org}` (the whole org benefits)
 - After producing a document, report, or significant file → appropriate scope
-- After the user shares a file with you → `private-{agent}`
+- After the user shares a file with you → `agent-{agent}` (`--scope private`)
 - After a workflow completes → ingest the artifacts
 
 ```bash
 # Query before any task (searches all your collections by default)
 cortextos bus kb-query "your question" --org $CTX_ORG --agent $CTX_AGENT_NAME
 
-# Query only your memory (past experiences, patterns)
-cortextos bus kb-query "question" --org $CTX_ORG --collection memory-$CTX_AGENT_NAME
+# Query your own past work (memory and outputs share one collection)
+cortextos bus kb-query "question" --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
-# Ingest output to your private collection
+# Ingest an output to your private collection (same place as your memory)
 cortextos bus kb-ingest /path/to/output --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private
 
 # Ingest research to org shared collection

--- a/templates/orchestrator/HEARTBEAT.md
+++ b/templates/orchestrator/HEARTBEAT.md
@@ -166,8 +166,14 @@ Keep your memory collection searchable and current:
 
 ```bash
 cortextos bus kb-ingest ./MEMORY.md ./memory/$(date -u +%Y-%m-%d).md \
-  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --collection memory-$CTX_AGENT_NAME --force
+  --org $CTX_ORG --agent $CTX_AGENT_NAME --scope private --force
 ```
+
+**Do not add `--collection` here.** The `cortextos bus` CLI does not accept the flag (it exits with
+`unknown option '--collection'`), and the `bash bus/kb-ingest.sh` wrapper — which does accept it —
+would file your memory under a collection `cortextos bus kb-query` can never read back, since that
+command only ever searches `shared-<org>` and `agent-<agent>`. You do not need it either way:
+`--scope private --agent <name>` already resolves to `agent-<name>`.
 
 This runs automatically on every heartbeat cycle. It ensures past experiences, user preferences, and learned patterns are semantically searchable for future tasks. Skip if GEMINI_API_KEY is not configured.
 


### PR DESCRIPTION
Agent-facing docs across `templates/` and `community/` described a **three**-collection knowledge base (`memory-{agent}`, `private-{agent}`, `shared-{org}`) and instructed agents to pass `--collection memory-$CTX_AGENT_NAME` when ingesting. Both are wrong, and the combination is the damaging part: the flag files an agent's memory under a collection that `kb-query` can never read back.

**Scope:** 29 doc files (`templates/`, `community/`). Doc-only — no source or behaviour change.

**Verified against source, not inferred:**
- `src/bus/knowledge-base.ts:284-286` computes the name as `` `agent-${agent}` `` for private scope and `` `shared-${org}` `` otherwise. There is no `memory-{agent}` and no `private-{agent}` — an agent's memory files and its outputs share **one** collection.
- `src/bus/knowledge-base.ts:162-169` shows `kb-query` only ever searches `` `shared-${org}` `` and `` `agent-${agent}` ``. So anything ingested under a custom collection name is unreachable by the documented query path.
- `cortextos bus kb-ingest` has no `--collection` option at all; passing it exits with `unknown option '--collection'` — the exact string now quoted in the docs.
- `bus/kb-ingest.sh:11,40` **does** accept `--collection` and overrides the name directly.

That last asymmetry is why the old instructions looked like they worked: whichever entry point an agent reached decided whether the flag was a hard error or a silent misfile.

The docs now say two collections, do not pass `--collection` at either entry point, and narrow a search by wording the question rather than by picking a collection. The consequence agents most need is stated explicitly — **you cannot query your memory separately from your outputs**, because they are the same collection.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
