### PR TITLE
chore(pm2): pass whisper/ffmpeg binary paths through the daemon env

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -24,6 +24,9 @@ module.exports = {
         CTX_FRAMEWORK_ROOT: FRAMEWORK_ROOT,
         CTX_PROJECT_ROOT: PROJECT_ROOT,
         CTX_ORG: CTX_ORG,
+        CTX_WHISPER_BIN: process.env.CTX_WHISPER_BIN || '/usr/local/bin/whisper-cli',
+        CTX_FFMPEG_BIN: process.env.CTX_FFMPEG_BIN || '/usr/bin/ffmpeg',
+        CTX_WHISPER_MODEL: process.env.CTX_WHISPER_MODEL || path.join(os.homedir(), '.cortextos', 'models', 'ggml-tiny.en.bin'),
         // Debug-only: set to '1' to enable SIGUSR2 signal → controlled
         // uncaughtException for testing the crash-visibility path
         // (.daemon-crashed markers + crash-loop operator Telegram alert).


### PR DESCRIPTION
Voice-note transcription reads `CTX_WHISPER_BIN`, `CTX_FFMPEG_BIN` and `CTX_WHISPER_MODEL`, but the pm2 ecosystem config never forwarded them — so the daemon started without them and the feature fell back to whatever the process happened to inherit.

**Scope:** `ecosystem.config.js`, +3 lines.

Follows the convention the file already documents at the top ("Override any value with environment variables before `pm2 start`"): each entry is `process.env.X || <default>`, and the model path is built with `path.join(os.homedir(), …)` like `CTX_ROOT` above it rather than hardcoding `/home/<user>`.

**Verified:** `require('./ecosystem.config.js')` loads and resolves all three. `path` and `os` are already required at the top of the file (lines 5-6), so the additions introduce no new dependency.

**Caveat worth stating:** the two binary defaults (`/usr/local/bin/whisper-cli`, `/usr/bin/ffmpeg`) are conventional install locations, not portable guarantees. They are the right default for the deployment this was written against and are overridable everywhere else, which is why they are defaults rather than fixed values. Happy to drop the defaults entirely and forward only `process.env.X` if you'd prefer this config stay fully machine-agnostic.

---
**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
