### PR TITLE
fix(dashboard): atomic-write the config.json PATCH

### DIFF
--- a/dashboard/src/app/api/agents/[name]/__tests__/config-atomic-write.test.ts
+++ b/dashboard/src/app/api/agents/[name]/__tests__/config-atomic-write.test.ts
@@ -1,0 +1,144 @@
+/**
+ * The config PATCH must REPLACE config.json, not rewrite it in place.
+ *
+ * The bug this guards is invisible to the obvious test.  A test that PATCHes
+ * and then asserts the resulting contents passes identically against
+ * `writeFileSync` and against `atomicWriteSync` — both leave the same bytes on
+ * disk.  What differs is only observable DURING the write: `writeFileSync`
+ * truncates the target and then refills it, so a concurrent reader can see a
+ * half-written file, while temp-file-plus-rename leaves the old inode intact
+ * and swaps a complete new one into its place.
+ *
+ * So the first test below asserts that swap directly, by hard-linking the file
+ * before the write.  A link is a second name for the SAME inode: if the handler
+ * rewrote the file in place, the link sees the new bytes; if it replaced the
+ * file, the link still holds the whole old contents.  That is exactly the
+ * property "no reader observes a torn file" rests on, and it is what fails if
+ * someone swaps `atomicWriteSync` back for `writeFileSync` — verified by making
+ * that mutation and watching this test go red.
+ *
+ * HONEST SCOPE.  This is a single-process test.  It proves the write is a
+ * whole-file replacement; it does NOT run a reader concurrently with a writer,
+ * and it says nothing about durability — `atomicWriteSync` does not fsync, so
+ * the guarantee is "no torn read", not "survives power loss".
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import type { NextRequest } from 'next/server';
+
+const stateRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cfgatomic-state-'));
+const frameworkRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'cfgatomic-fw-'));
+process.env.CTX_ROOT = stateRoot;
+process.env.CTX_FRAMEWORK_ROOT = frameworkRoot;
+
+const ORG = 'acme';
+const AGENT = 'testbot';
+const agentDir = path.join(frameworkRoot, 'orgs', ORG, 'agents', AGENT);
+const configPath = path.join(agentDir, 'config.json');
+const snapshotPath = path.join(frameworkRoot, 'config.json.link');
+
+let configRoute: typeof import('../config/route');
+
+beforeAll(async () => {
+  fs.mkdirSync(path.join(stateRoot, 'config'), { recursive: true });
+  fs.writeFileSync(
+    path.join(stateRoot, 'config', 'enabled-agents.json'),
+    JSON.stringify({ [AGENT]: { enabled: true, org: ORG } }),
+  );
+  fs.mkdirSync(agentDir, { recursive: true });
+
+  configRoute = await import('../config/route');
+});
+
+afterAll(() => {
+  for (const dir of [stateRoot, frameworkRoot]) {
+    try { fs.rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+beforeEach(() => {
+  fs.rmSync(snapshotPath, { force: true });
+  // 0o644 is what a config.json written by the CLI actually carries, and one of
+  // the assertions below is about that mode changing — so set it explicitly
+  // rather than inheriting whatever the test runner's umask produces.
+  fs.writeFileSync(
+    configPath,
+    JSON.stringify(
+      {
+        agent_name: AGENT,
+        enabled: true,
+        startup_delay: 0,
+        max_session_seconds: 3600,
+        working_directory: '.',
+        timezone: 'UTC',
+      },
+      null,
+      2,
+    ) + '\n',
+    { mode: 0o644 },
+  );
+  fs.chmodSync(configPath, 0o644);
+});
+
+const params = () => ({ params: Promise.resolve({ name: AGENT }) });
+const patchBody = (): NextRequest =>
+  ({ json: async () => ({ timezone: 'America/New_York' }) }) as unknown as NextRequest;
+const readConfig = (p: string) => JSON.parse(fs.readFileSync(p, 'utf-8'));
+
+describe('config PATCH writes config.json atomically', () => {
+  it('replaces the file rather than rewriting the existing inode in place', async () => {
+    // A hard link is a second name for the same inode. Whatever the handler
+    // does to `configPath` in place is visible through it.
+    fs.linkSync(configPath, snapshotPath);
+    const originalIno = fs.statSync(configPath).ino;
+
+    const res = await configRoute.PATCH(patchBody(), params());
+    expect(res.status).toBe(200);
+
+    // Control arm: the write has to have actually landed, or "the old inode is
+    // untouched" would be trivially true for a handler that wrote nothing.
+    expect(readConfig(configPath).timezone).toBe('America/New_York');
+
+    // The claim. Under `writeFileSync` this reads 'America/New_York' — the
+    // truncate-and-refill happened to the inode the link still points at, which
+    // is the same inode a concurrent reader would have had open.
+    expect(readConfig(snapshotPath).timezone).toBe('UTC');
+    expect(fs.statSync(configPath).ino).not.toBe(originalIno);
+  });
+
+  it('leaves no temp file behind on the success path', async () => {
+    const res = await configRoute.PATCH(patchBody(), params());
+    expect(res.status).toBe(200);
+
+    // A leftover `.tmp.*` would mean the rename never completed. Note this one
+    // is vacuously green under a plain `writeFileSync` — it guards the atomic
+    // path's own failure mode, it does not distinguish the two writers.
+    expect(fs.readdirSync(agentDir).filter(f => f.startsWith('.tmp.'))).toEqual([]);
+  });
+
+  it('writes exactly one trailing newline', async () => {
+    expect((await configRoute.PATCH(patchBody(), params())).status).toBe(200);
+
+    // `atomicWriteSync` appends its own "\n". A caller that also appends one —
+    // as this route did before — would leave the file ending in "\n\n".
+    const raw = fs.readFileSync(configPath, 'utf-8');
+    expect(raw.endsWith('}\n')).toBe(true);
+    expect(raw.endsWith('\n\n')).toBe(false);
+  });
+
+  it('narrows config.json from 0644 to 0600', async () => {
+    expect(fs.statSync(configPath).mode & 0o777).toBe(0o644);
+
+    expect((await configRoute.PATCH(patchBody(), params())).status).toBe(200);
+
+    // Not a goal of this change — a consequence of it, asserted so it is a
+    // recorded decision rather than a surprise. `atomicWriteSync` creates its
+    // temp file 0o600 and rename preserves the mode, so the first write through
+    // this path narrows the file. Nothing in the fleet reads config.json as
+    // another user; if that ever changes, this test is where it surfaces.
+    expect(fs.statSync(configPath).mode & 0o777).toBe(0o600);
+  });
+});

--- a/dashboard/src/app/api/agents/[name]/config/route.ts
+++ b/dashboard/src/app/api/agents/[name]/config/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest } from 'next/server';
-import { existsSync, readFileSync, writeFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 import { getFrameworkRoot, getAllAgents, getAgentDir } from '@/lib/config';
+import { atomicWriteSync } from '@/lib/atomic-write';
 import { spawnSync } from 'child_process';
 
 export const dynamic = 'force-dynamic';
@@ -125,7 +126,14 @@ export async function PATCH(
     for (const key of allowed) {
       if (body[key] !== undefined) config[key] = body[key];
     }
-    writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+    // `writeFileSync` truncated this file and then refilled it, so a concurrent
+    // reader could observe it half-written — and every reader of config.json
+    // parses inside a try/catch that falls back to defaults, so a torn read
+    // surfaces as an agent silently running with DEFAULT settings rather than as
+    // an error.  `atomicWriteSync` renames a complete temp file over the target
+    // instead, so a reader sees either the whole old file or the whole new one.
+    // It supplies its own trailing newline, hence none here.
+    atomicWriteSync(configPath, JSON.stringify(config, null, 2));
 
     // Notify agent immediately (non-fatal if offline)
     try {

--- a/dashboard/src/app/api/agents/[name]/lifecycle/route.ts
+++ b/dashboard/src/app/api/agents/[name]/lifecycle/route.ts
@@ -1,10 +1,9 @@
 import { NextRequest } from 'next/server';
 import fs from 'fs/promises';
-import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import { getFrameworkRoot, getCTXRoot } from '@/lib/config';
 import { IPCClient } from '@/lib/ipc-client';
-import { withFileLockSync } from '@/lib/file-lock';
+import { mutateEnabledAgents } from '@/lib/enabled-agents';
 
 export const dynamic = 'force-dynamic';
 
@@ -16,57 +15,7 @@ function isValidName(name: string): boolean {
   return /^[a-z0-9_-]+$/.test(name);
 }
 
-// The framework's lock blocks the thread via Atomics.wait.  In a route handler
-// that stalls every other request this worker is serving, so we wait far less
-// than the library's 5s default: the critical section is two small synchronous
-// fs calls, so real contention clears in single-digit milliseconds.  Anything
-// slower is a stuck holder, and failing fast beats freezing the dashboard.
-const REGISTRY_LOCK_TIMEOUT_MS = 250;
-
-/**
- * Read-modify-write `enabled-agents.json` while holding the framework's
- * inter-process lock on its directory.
- *
- * `mutate` MUST stay synchronous, and so must every fs call inside it.
- * `withFileLockSync` releases the lock in a `finally` the moment the callback
- * RETURNS — an `async` callback returns a pending Promise immediately, so the
- * lock would be dropped before the write ever ran.  That failure is silent:
- * the code still looks locked and protects nothing.  Hence `readFileSync` /
- * `writeFileSync` here rather than the `fs/promises` used elsewhere in this file.
- *
- * The read happens INSIDE the lock, so callers must not pass state they read
- * earlier — `mutate` receives the freshly-read registry.
- *
- * Locking here excludes other dashboard requests and the agent processes that
- * take this same lock.  It does NOT exclude the CLI writers of this file
- * (`enable-agent.ts`, `start.ts`, `import-agent.ts`, `install.ts`), which
- * currently take no lock at all — that half is tracked separately.
- */
-function mutateEnabledAgents(mutate: (agents: Record<string, any>) => void): void {
-  const dir = path.join(getCTXRoot(), 'config');
-  const file = path.join(dir, 'enabled-agents.json');
-  mkdirSync(dir, { recursive: true });
-
-  withFileLockSync(dir, () => {
-    let raw: string;
-    try {
-      raw = readFileSync(file, 'utf-8');
-    } catch (err) {
-      // Only "not there yet" is recoverable.  A permissions or I/O error must
-      // propagate rather than be treated as an empty registry.
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      raw = '{}';
-    }
-    // Deliberately NOT caught: a malformed registry means we cannot know what
-    // the other entries were, and writing our mutation on top of `{}` would
-    // deregister every other agent.  Fail loudly and leave the file intact.
-    const agents: Record<string, any> = JSON.parse(raw);
-    mutate(agents);
-    writeFileSync(file, JSON.stringify(agents, null, 2) + '\n', 'utf-8');
-  }, { timeoutMs: REGISTRY_LOCK_TIMEOUT_MS });
-}
-
-const VALID_ACTIONS = ['enable', 'disable', 'restart', 'start', 'stop', 'restart_continue', 'restart_fresh'];
+const VALID_ACTIONS =['enable', 'disable', 'restart', 'start', 'stop', 'restart_continue', 'restart_fresh'];
 
 // Security (C4): Validate org and name against allowlist before use in shell commands or path.join.
 function validateIdentifier(value: string | null | undefined, field: string): string {

--- a/dashboard/src/app/api/agents/[name]/lifecycle/route.ts
+++ b/dashboard/src/app/api/agents/[name]/lifecycle/route.ts
@@ -1,8 +1,10 @@
 import { NextRequest } from 'next/server';
 import fs from 'fs/promises';
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
 import path from 'path';
 import { getFrameworkRoot, getCTXRoot } from '@/lib/config';
 import { IPCClient } from '@/lib/ipc-client';
+import { withFileLockSync } from '@/lib/file-lock';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +14,56 @@ export const dynamic = 'force-dynamic';
 
 function isValidName(name: string): boolean {
   return /^[a-z0-9_-]+$/.test(name);
+}
+
+// The framework's lock blocks the thread via Atomics.wait.  In a route handler
+// that stalls every other request this worker is serving, so we wait far less
+// than the library's 5s default: the critical section is two small synchronous
+// fs calls, so real contention clears in single-digit milliseconds.  Anything
+// slower is a stuck holder, and failing fast beats freezing the dashboard.
+const REGISTRY_LOCK_TIMEOUT_MS = 250;
+
+/**
+ * Read-modify-write `enabled-agents.json` while holding the framework's
+ * inter-process lock on its directory.
+ *
+ * `mutate` MUST stay synchronous, and so must every fs call inside it.
+ * `withFileLockSync` releases the lock in a `finally` the moment the callback
+ * RETURNS — an `async` callback returns a pending Promise immediately, so the
+ * lock would be dropped before the write ever ran.  That failure is silent:
+ * the code still looks locked and protects nothing.  Hence `readFileSync` /
+ * `writeFileSync` here rather than the `fs/promises` used elsewhere in this file.
+ *
+ * The read happens INSIDE the lock, so callers must not pass state they read
+ * earlier — `mutate` receives the freshly-read registry.
+ *
+ * Locking here excludes other dashboard requests and the agent processes that
+ * take this same lock.  It does NOT exclude the CLI writers of this file
+ * (`enable-agent.ts`, `start.ts`, `import-agent.ts`, `install.ts`), which
+ * currently take no lock at all — that half is tracked separately.
+ */
+function mutateEnabledAgents(mutate: (agents: Record<string, any>) => void): void {
+  const dir = path.join(getCTXRoot(), 'config');
+  const file = path.join(dir, 'enabled-agents.json');
+  mkdirSync(dir, { recursive: true });
+
+  withFileLockSync(dir, () => {
+    let raw: string;
+    try {
+      raw = readFileSync(file, 'utf-8');
+    } catch (err) {
+      // Only "not there yet" is recoverable.  A permissions or I/O error must
+      // propagate rather than be treated as an empty registry.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      raw = '{}';
+    }
+    // Deliberately NOT caught: a malformed registry means we cannot know what
+    // the other entries were, and writing our mutation on top of `{}` would
+    // deregister every other agent.  Fail loudly and leave the file intact.
+    const agents: Record<string, any> = JSON.parse(raw);
+    mutate(agents);
+    writeFileSync(file, JSON.stringify(agents, null, 2) + '\n', 'utf-8');
+  }, { timeoutMs: REGISTRY_LOCK_TIMEOUT_MS });
 }
 
 const VALID_ACTIONS = ['enable', 'disable', 'restart', 'start', 'stop', 'restart_continue', 'restart_fresh'];
@@ -88,22 +140,15 @@ export async function POST(
 
     switch (action) {
       case 'enable': {
-        const ctxRoot = getCTXRoot();
-        const enabledAgentsPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
-        let enabledAgents: Record<string, unknown> = {};
-        try {
-          const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-          enabledAgents = JSON.parse(raw);
-        } catch { /* file may not exist yet */ }
-        enabledAgents[decoded] = {
-          ...(typeof enabledAgents[decoded] === 'object' && enabledAgents[decoded] !== null
-            ? (enabledAgents[decoded] as object)
-            : {}),
-          enabled: true,
-          ...(safeOrg ? { org: safeOrg } : {}),
-        };
-        await fs.mkdir(path.dirname(enabledAgentsPath), { recursive: true });
-        await fs.writeFile(enabledAgentsPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+        mutateEnabledAgents((enabledAgents) => {
+          enabledAgents[decoded] = {
+            ...(typeof enabledAgents[decoded] === 'object' && enabledAgents[decoded] !== null
+              ? (enabledAgents[decoded] as object)
+              : {}),
+            enabled: true,
+            ...(safeOrg ? { org: safeOrg } : {}),
+          };
+        });
         registryMessage = 'enabled in registry';
         ipcResult = await ipc.send({ type: 'start-agent', agent: decoded });
         break;
@@ -111,15 +156,12 @@ export async function POST(
 
       case 'disable': {
         ipcResult = await ipc.send({ type: 'stop-agent', agent: decoded });
-        const ctxRoot = getCTXRoot();
-        const enabledAgentsPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
         try {
-          const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-          const enabledAgents = JSON.parse(raw) as Record<string, unknown>;
-          if (enabledAgents[decoded] && typeof enabledAgents[decoded] === 'object') {
-            (enabledAgents[decoded] as Record<string, unknown>).enabled = false;
-          }
-          await fs.writeFile(enabledAgentsPath, JSON.stringify(enabledAgents, null, 2) + '\n', 'utf-8');
+          mutateEnabledAgents((enabledAgents) => {
+            if (enabledAgents[decoded] && typeof enabledAgents[decoded] === 'object') {
+              (enabledAgents[decoded] as Record<string, unknown>).enabled = false;
+            }
+          });
           registryMessage = 'disabled in registry';
         } catch {
           registryMessage = 'registry update failed (non-fatal)';
@@ -222,14 +264,16 @@ export async function DELETE(
     }
   }
 
-  // 2. Remove from enabled-agents.json
+  // 2. Remove from enabled-agents.json.
+  //
+  // The read above (for the org lookup) is deliberately NOT reused here: an IPC
+  // round-trip has happened since, so that snapshot is stale, and writing it
+  // back would silently revert anything the CLI or another request changed in
+  // the meantime.  `mutateEnabledAgents` re-reads inside the lock.
   try {
-    delete enabledAgents[decoded];
-    await fs.writeFile(
-      enabledAgentsPath,
-      JSON.stringify(enabledAgents, null, 2) + '\n',
-      'utf-8',
-    );
+    mutateEnabledAgents((agents) => {
+      delete agents[decoded];
+    });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`[api/agents/${decoded}/lifecycle] failed to update enabled-agents.json:`, message);

--- a/dashboard/src/app/api/agents/__tests__/create-race.test.ts
+++ b/dashboard/src/app/api/agents/__tests__/create-race.test.ts
@@ -1,0 +1,212 @@
+/**
+ * dashboard/src/app/api/agents/__tests__/create-race.test.ts
+ *
+ * The race that `POST /api/agents` was restructured to close: two creates of the
+ * SAME agent name arriving together must produce exactly one 201 and one 409,
+ * and leave exactly one coherent registry entry.
+ *
+ * Why an in-process test is the right shape here, and what it does NOT prove:
+ *
+ * The window being closed is not a multi-process one.  Both requests are served
+ * by one Next worker on one thread, and every step of the registry mutation is
+ * synchronous, so two requests can never be *inside* `mutateEnabledAgents` at
+ * once regardless of locking.  They interleave at the handler's `await` points —
+ * the template copy and the state-dir mkdirs.  The old code checked for a
+ * duplicate, awaited all of that, and only then wrote the registry, so both
+ * requests passed the check before either had claimed the name.  Reserving the
+ * name in the same synchronous block as the check is what closes it, and that is
+ * exactly what these tests exercise.
+ *
+ * The file lock is therefore NOT what makes these tests pass, and they must not
+ * be read as evidence that it works: single-threaded, it is uncontended every
+ * time.  The lock exists for the cross-process case (CLI and agents), and today
+ * the CLI writers of this registry take no lock at all, so the cross-process
+ * race remains open.  Nothing here speaks to it.
+ *
+ * The fs is real (temp dirs, a real template tree, real copies) because the
+ * awaits inside the copy are the interleaving points; mocking them away would
+ * remove the very thing under test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { NextRequest } from 'next/server';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync, existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+
+// ---------------------------------------------------------------------------
+// Roots are per-test temp dirs.  `vi.mock` factories are hoisted above the file
+// body, so they read through this holder rather than capturing a value.
+// ---------------------------------------------------------------------------
+
+const roots = vi.hoisted(() => ({ ctx: '', framework: '' }));
+
+vi.mock('@/lib/config', () => ({
+  getCTXRoot: () => roots.ctx,
+  getFrameworkRoot: () => roots.framework,
+  getAllAgents: () => [],
+}));
+
+// No daemon in tests.  `isDaemonRunning` false takes the create path's
+// short-circuit, so no IPC socket is ever opened.
+vi.mock('@/lib/ipc-client', () => {
+  function IPCClient() {}
+  IPCClient.prototype.isDaemonRunning = async () => false;
+  IPCClient.prototype.send = async () => ({ success: true });
+  return { IPCClient };
+});
+
+type AgentsRouteModule = typeof import('../route');
+let route: AgentsRouteModule;
+let tmpRoot: string;
+
+const ORG = 'testorg';
+const TEMPLATE = 'agent';
+
+beforeEach(async () => {
+  tmpRoot = mkdtempSync(path.join(os.tmpdir(), 'agents-race-'));
+  roots.ctx = path.join(tmpRoot, 'ctx');
+  roots.framework = path.join(tmpRoot, 'framework');
+
+  // A real (tiny) template tree, so `copyDir` does real async work.
+  const templateDir = path.join(roots.framework, 'templates', TEMPLATE);
+  mkdirSync(path.join(templateDir, 'nested'), { recursive: true });
+  writeFileSync(path.join(templateDir, 'AGENTS.md'), '# template\n', 'utf-8');
+  writeFileSync(path.join(templateDir, 'nested', 'SOUL.md'), '# soul\n', 'utf-8');
+
+  mkdirSync(path.join(roots.ctx, 'config'), { recursive: true });
+
+  vi.resetModules();
+  route = await import('../route');
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createRequest(name: string, overrides: Record<string, unknown> = {}) {
+  return new NextRequest('http://localhost/api/agents', {
+    method: 'POST',
+    body: JSON.stringify({
+      name,
+      org: ORG,
+      template: TEMPLATE,
+      botToken: 'test-token',
+      chatId: '12345',
+      ...overrides,
+    }),
+  });
+}
+
+function readRegistry(): Record<string, any> {
+  const file = path.join(roots.ctx, 'config', 'enabled-agents.json');
+  if (!existsSync(file)) return {};
+  return JSON.parse(readFileSync(file, 'utf-8'));
+}
+
+function agentDirFor(name: string): string {
+  return path.join(roots.framework, 'orgs', ORG, 'agents', name);
+}
+
+// ---------------------------------------------------------------------------
+// The race
+// ---------------------------------------------------------------------------
+
+describe('POST /api/agents — concurrent creates of the same name', () => {
+  it('returns exactly one 201 and one 409', async () => {
+    const [a, b] = await Promise.all([
+      route.POST(createRequest('racer')),
+      route.POST(createRequest('racer')),
+    ]);
+
+    // Sorted, because which request wins is a scheduling detail and asserting a
+    // particular winner would make this flaky for no gain.
+    expect([a.status, b.status].sort()).toEqual([201, 409]);
+  });
+
+  it('leaves exactly one committed registry entry, with no reservation residue', async () => {
+    await Promise.all([
+      route.POST(createRequest('racer')),
+      route.POST(createRequest('racer')),
+    ]);
+
+    const registry = readRegistry();
+    expect(Object.keys(registry)).toEqual(['racer']);
+
+    const entry = registry.racer;
+    // The committed shape — not the reservation.  A surviving `status:'creating'`
+    // or `reservationToken` would mean the winner never finished its commit, and
+    // `enabled:false` would leave the agent invisible to the daemon.
+    expect(entry.enabled).toBe(true);
+    expect(entry.org).toBe(ORG);
+    expect(entry.template).toBe(TEMPLATE);
+    expect(entry.status).toBeUndefined();
+    expect(entry.reservationToken).toBeUndefined();
+  });
+
+  it('the winner is fully built on disk', async () => {
+    await Promise.all([
+      route.POST(createRequest('racer')),
+      route.POST(createRequest('racer')),
+    ]);
+
+    // The loser must not have left the winner's directory half-written: the
+    // template contents and the .env both have to be there.
+    const dir = agentDirFor('racer');
+    expect(readFileSync(path.join(dir, 'AGENTS.md'), 'utf-8')).toBe('# template\n');
+    expect(readFileSync(path.join(dir, 'nested', 'SOUL.md'), 'utf-8')).toBe('# soul\n');
+    expect(readFileSync(path.join(dir, '.env'), 'utf-8')).toContain('BOT_TOKEN=test-token');
+  });
+
+  it('a third concurrent create of the same name also loses', async () => {
+    const results = await Promise.all([
+      route.POST(createRequest('racer')),
+      route.POST(createRequest('racer')),
+      route.POST(createRequest('racer')),
+    ]);
+
+    expect(results.map((r) => r.status).sort()).toEqual([201, 409, 409]);
+    expect(Object.keys(readRegistry())).toEqual(['racer']);
+  });
+
+  it('concurrent creates of DIFFERENT names both succeed', async () => {
+    // The control on the other side: the reservation must not serialise
+    // unrelated creates into a spurious 409.
+    const [a, b] = await Promise.all([
+      route.POST(createRequest('alpha')),
+      route.POST(createRequest('beta')),
+    ]);
+
+    expect([a.status, b.status]).toEqual([201, 201]);
+    expect(Object.keys(readRegistry()).sort()).toEqual(['alpha', 'beta']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Sequential duplicate — the case that already worked, kept so a regression
+// that made *everything* 409 would be distinguishable from the fix working.
+// ---------------------------------------------------------------------------
+
+describe('POST /api/agents — sequential duplicate', () => {
+  it('rejects a create for a name already committed', async () => {
+    const first = await route.POST(createRequest('solo'));
+    expect(first.status).toBe(201);
+
+    const second = await route.POST(createRequest('solo'));
+    expect(second.status).toBe(409);
+    expect(Object.keys(readRegistry())).toEqual(['solo']);
+  });
+
+  it('rejects a create for a name present on disk but absent from the registry', async () => {
+    // Registry-absent + directory-present is a live agent: absent entries
+    // default to ENABLED, so this must not be treated as a free name.
+    mkdirSync(agentDirFor('ondisk'), { recursive: true });
+
+    const res = await route.POST(createRequest('ondisk'));
+    expect(res.status).toBe(409);
+  });
+});

--- a/dashboard/src/app/api/agents/route.ts
+++ b/dashboard/src/app/api/agents/route.ts
@@ -1,9 +1,12 @@
 import { NextRequest } from 'next/server';
 import fs from 'fs/promises';
+import { existsSync } from 'fs';
+import { randomUUID } from 'crypto';
 import path from 'path';
 import { getFrameworkRoot, getCTXRoot, getAllAgents } from '@/lib/config';
 import { IPCClient } from '@/lib/ipc-client';
 import { getHeartbeat, getHealthStatus } from '@/lib/data/heartbeats';
+import { mutateEnabledAgents } from '@/lib/enabled-agents';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,6 +16,21 @@ export const dynamic = 'force-dynamic';
 
 const VALID_NAME = /^[a-z0-9_-]+$/;
 const VALID_TEMPLATES = ['agent', 'agent-codex', 'orchestrator', 'analyst'];
+
+/** Thrown inside the reservation's locked section; mapped to HTTP 409. */
+class DuplicateAgentError extends Error {}
+
+/**
+ * How long a `status: 'creating'` reservation may sit before another create is
+ * allowed to reclaim the name.
+ *
+ * Without reclaim, a worker killed mid-create would claim a name permanently:
+ * the reservation blocks every retry and nothing ever clears it, so the only
+ * recovery would be hand-editing the registry.  That would be worse than the
+ * unlocked behaviour this replaces.  The window only has to exceed a genuine
+ * create (a template copy and a handful of mkdirs — well under a second).
+ */
+const RESERVATION_STALE_MS = 10 * 60 * 1000;
 
 
 // ---------------------------------------------------------------------------
@@ -101,31 +119,75 @@ export async function POST(request: NextRequest) {
 
   const frameworkRoot = getFrameworkRoot();
   const ctxRoot = getCTXRoot();
-  const enabledAgentsPath = path.join(ctxRoot, 'config', 'enabled-agents.json');
+  const templateDir = path.join(frameworkRoot, 'templates', template);
+  const agentDir = path.join(frameworkRoot, 'orgs', org, 'agents', name);
 
-  // Check for duplicate name in enabled-agents.json
+  // Creating an agent is a reserve -> build -> commit sequence.  The registry
+  // lock is deliberately NOT held across the template copy or the IPC hop: it
+  // blocks the thread via Atomics.wait, so holding it there would stall every
+  // other request this worker is serving.  Instead the name is claimed up front
+  // in one short critical section and confirmed in another.
+  const createdAt = new Date().toISOString();
+  const reservationToken = randomUUID();
+
+  // --- 1. RESERVE the name -------------------------------------------------
+  //
+  // The duplicate check and the write that makes the name taken must happen in
+  // the SAME critical section.  They used to be separated by the template copy,
+  // six mkdirs and an IPC round-trip, so two concurrent creates of one name
+  // both passed the check, both copied a template into the same directory, and
+  // the second registry write silently won.
+  //
+  // The reservation is written `enabled: false` on purpose: an agent ABSENT
+  // from the registry defaults to enabled (see
+  // `agent-manager.ts#readInstanceEnableList`), so a daemon restart during the
+  // copy below would otherwise discover and start a half-copied agent.
   try {
-    const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-    const existing = JSON.parse(raw);
-    if (existing[name]) {
+    mutateEnabledAgents((agents) => {
+      const existing = agents[name];
+      const reservedAt =
+        existing && typeof existing === 'object' && existing.status === 'creating'
+          ? Date.parse(existing.createdAt ?? '')
+          : NaN;
+      const reclaimable =
+        Number.isFinite(reservedAt) && Date.now() - reservedAt > RESERVATION_STALE_MS;
+
+      if (existing && !reclaimable) throw new DuplicateAgentError();
+
+      // Registry-absent but present on disk is the other way a name is already
+      // taken — such an agent defaults to enabled and may be running.  Skipped
+      // when reclaiming, where the directory is leftover from the abandoned
+      // attempt this reservation is replacing.
+      if (!existing && existsSync(agentDir)) throw new DuplicateAgentError();
+
+      agents[name] = {
+        enabled: false,
+        status: 'creating',
+        org,
+        template,
+        createdAt,
+        reservationToken,
+      };
+    });
+  } catch (err: unknown) {
+    if (err instanceof DuplicateAgentError) {
       return Response.json(
         { error: `Agent "${name}" already exists` },
         { status: 409 },
       );
     }
-  } catch {
-    // File doesn't exist yet - that's fine, we'll create it
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[api/agents] POST: failed to reserve agent name:', message);
+    return Response.json({ error: 'Failed to create agent' }, { status: 500 });
   }
 
+  // --- 2. BUILD ------------------------------------------------------------
   try {
-    // 1. Copy template dir to orgs/{org}/agents/{name}/
-    const templateDir = path.join(frameworkRoot, 'templates', template);
-    const agentDir = path.join(frameworkRoot, 'orgs', org, 'agents', name);
-
+    // 2a. Copy template dir to orgs/{org}/agents/{name}/
     await fs.mkdir(agentDir, { recursive: true });
     await copyDir(templateDir, agentDir);
 
-    // 2. Write .env file
+    // 2b. Write .env file
     const envLines = [
       `BOT_TOKEN=${botToken}`,
       `CHAT_ID=${chatId}`,
@@ -135,61 +197,84 @@ export async function POST(request: NextRequest) {
     }
     await fs.writeFile(path.join(agentDir, '.env'), envLines.join('\n') + '\n', 'utf-8');
 
-    // 3. Create state dirs under CTX_ROOT
+    // 2c. Create state dirs under CTX_ROOT
     const stateDirs = ['inbox', 'outbox', 'processed', 'inflight', 'logs', 'state'];
     for (const dir of stateDirs) {
       await fs.mkdir(path.join(ctxRoot, dir, name), { recursive: true });
     }
-
-    // 4. Register with daemon via IPC (replaces Mac-only generate-launchd.sh + launchctl)
-    const instanceId = process.env.CTX_INSTANCE_ID ?? 'default';
-    const ipc = new IPCClient(instanceId);
-    const daemonRunning = await ipc.isDaemonRunning();
-    if (daemonRunning) {
-      const ipcResult = await ipc.send({
-        type: 'start-agent',
-        agent: name,
-        data: { dir: agentDir },
-      });
-      if (!ipcResult.success) {
-        console.warn(`[api/agents] POST: daemon start-agent returned error for "${name}":`, ipcResult.error);
-      }
-    } else {
-      console.info(`[api/agents] POST: daemon not running; "${name}" registered and will start with daemon.`);
-    }
-
-    // 5. Update enabled-agents.json
-    let enabledAgents: Record<string, unknown> = {};
-    try {
-      const raw = await fs.readFile(enabledAgentsPath, 'utf-8');
-      enabledAgents = JSON.parse(raw);
-    } catch {
-      // Start fresh
-    }
-
-    enabledAgents[name] = {
-      enabled: true,
-      org,
-      template,
-      createdAt: new Date().toISOString(),
-    };
-
-    await fs.mkdir(path.dirname(enabledAgentsPath), { recursive: true });
-    await fs.writeFile(
-      enabledAgentsPath,
-      JSON.stringify(enabledAgents, null, 2) + '\n',
-      'utf-8',
-    );
-
-    return Response.json({ success: true, agent: { name, org } }, { status: 201 });
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     console.error('[api/agents] POST error:', message);
-    return Response.json(
-      { error: 'Failed to create agent' },
-      { status: 500 },
-    );
+
+    // Release the reservation so the name can be retried immediately, but only
+    // if it is still ours — an unlocked CLI writer may have replaced it.  The
+    // partially-created directory is left in place: removing a path that might
+    // have pre-existed with real content is destructive, and dir-without-entry
+    // is the same state a failed create left behind before this change.
+    try {
+      mutateEnabledAgents((agents) => {
+        const cur = agents[name];
+        if (cur && typeof cur === 'object' && cur.reservationToken === reservationToken) {
+          delete agents[name];
+        }
+      });
+    } catch (rollbackErr: unknown) {
+      console.error(
+        `[api/agents] POST: could not release reservation for "${name}"; it will be reclaimable in ${RESERVATION_STALE_MS}ms:`,
+        rollbackErr instanceof Error ? rollbackErr.message : String(rollbackErr),
+      );
+    }
+
+    return Response.json({ error: 'Failed to create agent' }, { status: 500 });
   }
+
+  // --- 3. COMMIT -----------------------------------------------------------
+  //
+  // NOT rolled back on failure.  The common failure here is the 250ms lock
+  // timeout, which is transient — deleting the reservation would throw away a
+  // fully-built agent because the registry was momentarily busy.  Leaving the
+  // reservation keeps the work, and it becomes reclaimable on its own.
+  try {
+    mutateEnabledAgents((agents) => {
+      const cur = agents[name];
+      // Ownership check: sound against writers that take this lock, which the
+      // CLI ones do not.  If the entry is no longer ours, someone else now owns
+      // this name and overwriting them would be the very clobber being fixed.
+      if (!cur || typeof cur !== 'object' || cur.reservationToken !== reservationToken) return;
+      agents[name] = { enabled: true, org, template, createdAt };
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(
+      `[api/agents] POST: "${name}" was created on disk but the registry commit failed:`,
+      message,
+    );
+    return Response.json({ error: 'Failed to create agent' }, { status: 500 });
+  }
+
+  // --- 4. Register with daemon via IPC -------------------------------------
+  //
+  // Runs AFTER the registry says enabled, matching the ordering the lifecycle
+  // route's `enable` path uses.  Previously this ran before the registry write,
+  // so a failed write left the agent running but unregistered; now a failed IPC
+  // leaves it registered but not running, which the next daemon start heals.
+  // Non-fatal either way — the agent exists and is registered.
+  const instanceId = process.env.CTX_INSTANCE_ID ?? 'default';
+  const ipc = new IPCClient(instanceId);
+  if (await ipc.isDaemonRunning()) {
+    const ipcResult = await ipc.send({
+      type: 'start-agent',
+      agent: name,
+      data: { dir: agentDir },
+    });
+    if (!ipcResult.success) {
+      console.warn(`[api/agents] POST: daemon start-agent returned error for "${name}":`, ipcResult.error);
+    }
+  } else {
+    console.info(`[api/agents] POST: daemon not running; "${name}" registered and will start with daemon.`);
+  }
+
+  return Response.json({ success: true, agent: { name, org } }, { status: 201 });
 }
 
 // ---------------------------------------------------------------------------

--- a/dashboard/src/lib/atomic-write.ts
+++ b/dashboard/src/lib/atomic-write.ts
@@ -1,0 +1,23 @@
+/**
+ * The dashboard's single point of coupling to the framework's atomic file write.
+ *
+ * Follows `file-lock.ts`, and for the same reason: this RE-EXPORTS
+ * `src/utils/atomic.ts` rather than reimplementing temp-file-plus-rename.  A
+ * dashboard-local copy would drift from the CLI's copy in exactly the details
+ * that matter — the temp file's directory (a rename is only atomic within one
+ * filesystem), its mode, and whether the payload gets a trailing newline.
+ *
+ * WHAT THE GUARANTEE ACTUALLY IS.  `atomicWriteSync` writes a temp file in the
+ * target's own directory and renames it over the target.  A reader therefore
+ * never observes a partially-written file: it sees either the whole old
+ * contents or the whole new contents.  It does NOT fsync the file or the
+ * directory, so this is NOT durability against power loss — post-crash the
+ * rename may not have reached disk.  The claim is "no torn read", nothing
+ * stronger.  Say it that way.
+ *
+ * Two behaviours callers get wrong, both silent:
+ *   - it appends its own trailing "\n", so callers must NOT add one;
+ *   - the temp file is created mode 0o600 and rename preserves that, so a file
+ *     that was 0644 becomes 0600 the first time it is written this way.
+ */
+export { atomicWriteSync, ensureDir } from '../../../src/utils/atomic';

--- a/dashboard/src/lib/enabled-agents.ts
+++ b/dashboard/src/lib/enabled-agents.ts
@@ -1,0 +1,89 @@
+/**
+ * Locked read-modify-write for the instance agent registry
+ * (`<ctxRoot>/config/enabled-agents.json`).
+ *
+ * Lives here rather than in a route because more than one route mutates the
+ * registry, and the protocol below is easy to get subtly, silently wrong.
+ */
+import { mkdirSync, readFileSync, writeFileSync, renameSync, unlinkSync } from 'fs';
+import path from 'path';
+import { getCTXRoot } from '@/lib/config';
+import { withFileLockSync } from '@/lib/file-lock';
+
+// The framework's lock blocks the thread via Atomics.wait.  In a route handler
+// that stalls every other request this worker is serving, so we wait far less
+// than the library's 5s default: the critical section is two small synchronous
+// fs calls, so real contention clears in single-digit milliseconds.  Anything
+// slower is a stuck holder, and failing fast beats freezing the dashboard.
+const REGISTRY_LOCK_TIMEOUT_MS = 250;
+
+export function enabledAgentsPath(): string {
+  return path.join(getCTXRoot(), 'config', 'enabled-agents.json');
+}
+
+/**
+ * Read-modify-write `enabled-agents.json` while holding the framework's
+ * inter-process lock on its directory.
+ *
+ * `mutate` MUST stay synchronous, and so must every fs call inside it.
+ * `withFileLockSync` releases the lock in a `finally` the moment the callback
+ * RETURNS — an `async` callback returns a pending Promise immediately, so the
+ * lock would be dropped before the write ever ran.  That failure is silent:
+ * the code still looks locked and protects nothing, and it type-checks clean
+ * (`T` simply infers `Promise<void>`), so the compiler will never catch it.
+ * Hence `readFileSync` / `writeFileSync` here rather than the `fs/promises`
+ * used elsewhere in the routes.
+ *
+ * The read happens INSIDE the lock, so callers must not pass state they read
+ * earlier — `mutate` receives the freshly-read registry.
+ *
+ * SCOPE OF THE EXCLUSION — do not overstate this.  Locking here excludes other
+ * dashboard requests and the agent processes that take this same lock.  It does
+ * NOT exclude the CLI writers of this file (`enable-agent.ts`, `start.ts`,
+ * `import-agent.ts`, `install.ts`, `add-agent.ts`), none of which take any lock
+ * today.  Against those, a lost update is still possible and no amount of care
+ * on this side prevents it; that half is tracked separately.  Any ownership
+ * check a caller does inside `mutate` is therefore sound against locked writers
+ * only.
+ */
+export function mutateEnabledAgents(mutate: (agents: Record<string, any>) => void): void {
+  const file = enabledAgentsPath();
+  const dir = path.dirname(file);
+  mkdirSync(dir, { recursive: true });
+
+  withFileLockSync(dir, () => {
+    let raw: string;
+    try {
+      raw = readFileSync(file, 'utf-8');
+    } catch (err) {
+      // Only "not there yet" is recoverable.  A permissions or I/O error must
+      // propagate rather than be treated as an empty registry.
+      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      raw = '{}';
+    }
+    // Deliberately NOT caught: a malformed registry means we cannot know what
+    // the other entries were, and writing our mutation on top of `{}` would
+    // deregister every other agent.  Fail loudly and leave the file intact.
+    const agents: Record<string, any> = JSON.parse(raw);
+    mutate(agents);
+
+    // Write via a temp file + rename rather than in place.  Because we throw on
+    // malformed JSON above, a crash partway through an in-place write would
+    // leave truncated JSON that makes every later registry call fail — one
+    // unlucky moment would take out create and lifecycle until someone repaired
+    // the file by hand.  `renameSync` within the same directory is atomic, so a
+    // reader sees either the old registry or the new one.
+    const tmp = `${file}.tmp-${process.pid}`;
+    try {
+      writeFileSync(tmp, JSON.stringify(agents, null, 2) + '\n', 'utf-8');
+      renameSync(tmp, file);
+    } catch (err) {
+      try {
+        unlinkSync(tmp);
+      } catch {
+        // temp file may not exist; the original write error is what matters
+      }
+      throw err;
+    }
+  }, { timeoutMs: REGISTRY_LOCK_TIMEOUT_MS });
+}

--- a/dashboard/src/lib/file-lock.ts
+++ b/dashboard/src/lib/file-lock.ts
@@ -1,0 +1,20 @@
+/**
+ * The dashboard's single point of coupling to the framework's inter-process lock.
+ *
+ * This deliberately RE-EXPORTS `src/utils/lock.ts` rather than reimplementing the
+ * protocol.  The whole reason to lock these JSON stores is to exclude a *different
+ * process* — the CLI and the agents — from a read-modify-write window.  Mutual
+ * exclusion only holds if both sides create the same `.lock.d` marker, in the same
+ * directory, with the same stale-owner semantics.  A dashboard-local copy would be
+ * a lock that excludes nothing the moment either copy is changed, and it would fail
+ * silently: both sides would take "a lock" and still clobber each other.
+ *
+ * The import reaches outside `dashboard/` — the only runtime import that does.  That
+ * is the point: one crossing, in one file, instead of the protocol being duplicated.
+ *
+ * It imports the TypeScript source, not `dist/`, so the dashboard build does not
+ * depend on the framework having been compiled first.  `lock.ts` imports nothing but
+ * `fs` and `path`, so nothing else is pulled across the boundary.
+ */
+export { withFileLockSync, acquireLock, releaseLock } from '../../../src/utils/lock';
+export type { FileLockOptions } from '../../../src/utils/lock';

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2017",
+    "target": "ES2020",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,

--- a/src/utils/package.json
+++ b/src/utils/package.json
@@ -1,0 +1,1 @@
+{"type":"module"}


### PR DESCRIPTION
**Scope:** the dashboard's config PATCH ended its read-modify-write in a bare `writeFileSync`. Swap it for `atomicWriteSync` (temp file + rename), via a re-export shim, and cover it with a test that fails on the reverse mutation. Two commits: the shim, then the route + test.

Why it matters: `writeFileSync` truncates and then refills, so a concurrent reader can observe config.json half-written — and every reader parses it inside a `try/catch` that falls back to defaults. A torn read therefore does not surface as an error, it surfaces as an agent silently running with **default settings**.

**Verified:**
- `dashboard/src/app/api/agents/[name]/__tests__/config-atomic-write.test.ts` — 4 tests, green. Full dashboard suite: 123 passed / 10 files. `tsc -p dashboard/tsconfig.json --noEmit` clean.
- **Mutation-tested, both directions.** Reverting the route to `writeFileSync(... + '\n')` turns the inode test and the mode test red (`2 failed | 2 passed`). Keeping `atomicWriteSync` but letting the caller append its own `'\n'` turns the trailing-newline test red (`1 failed | 3 passed`).
- The decisive test hard-links config.json before the PATCH. A hard link is a second name for the same inode, so an in-place rewrite is visible through it and a whole-file replacement is not — which is exactly the property "no reader observes a torn file" rests on. It carries a control arm (the new value must actually have landed), or "the old inode is untouched" would be trivially true of a handler that wrote nothing.

**Honest caveats:**
- **This PR used to include a lock, and it was cut on review.** The earlier version wrapped the RMW in `withFileLockSync`, justified as making the dashboard's *two* config.json writers mutually exclusive. Tracing it through what #837 actually removes, that justification does not survive: (a) the lock does **not** close an in-process race — this RMW is synchronous and after the handler's last `await`, and Node is single-threaded, so it was already safe; the crons PUT was the genuine in-process hazard precisely because it read *before* its `await request.json()`, and #837 deletes it; (b) it would only exclude other **processes** locking the same directory, and that set is empty today — `src/cli/add-agent.ts:176,193,299` and `src/cli/import-agent.ts:132` are plain `writeFileSync`, and the CLI's crons lock keys on the **state** dir, not `orgs/<org>/agents/<agent>/`. It made config.json lock**ABLE**, not locked. If a real second writer appears, the lock is one `withFileLockSync` wrap away and belongs in that change.
- **config.json goes 0644 → 0600** on its first write through this path: `atomicWriteSync` creates its temp file `0o600` and rename preserves the mode. Nothing in the fleet reads config.json as another user, so this is safe today — it is asserted in the test so it is a recorded decision rather than a surprise, and that test is where it surfaces if that ever changes.
- The guarantee is "no torn read", **not durability**. `atomicWriteSync` does not fsync the file or the directory, so post-crash the rename may not have reached disk. The shim's header says so explicitly.
- The leftover-`.tmp.*` assertion is **vacuously green** under a plain `writeFileSync` — it guards the atomic path's own failure mode, it does not distinguish the two writers. The test file says that inline so nobody counts it as evidence.
- Pre-existing, not touched here: `src/utils/atomic.ts:35` uses `require('fs')` for temp-file cleanup, which is `undefined` under the `{"type":"module"}` marker this crossing relies on. It sits in a swallowing `try/catch` and the original error is rethrown, so the only consequence is a leaked `.tmp.*` on an already-failing write. Worth a separate one-line fix, not this PR.

**Ordering:** branch is based on `fix/dashboard-unlocked-rmw` (#830) — it needs that PR's `src/utils/package.json` (`{"type":"module"}`) and `dashboard/tsconfig.json` target bump for the cross-boundary import. **Land #830 first.** No conflict with #837.

**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.
