### PR TITLE
fix(lock): releaseLock only ever touches an acquisition we currently hold

### DIFF
--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,21 +1,397 @@
-import { mkdirSync, rmdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, rmSync, renameSync, statSync } from 'fs';
 import { join } from 'path';
+
+/**
+ * How long a lock directory may sit with NO pid file before we treat it as
+ * abandoned.  The window between `mkdirSync` and `writeFileSync` in
+ * `claimLock` is sub-millisecond, so 30s is ~30,000x the exposure: for this to
+ * steal from a live holder, that holder must freeze *precisely* inside the gap,
+ * stay frozen past the threshold, and then resume.
+ */
+const PIDLESS_STEAL_AFTER_MS = 30_000;
+
+/**
+ * How long a lock may be held by a PID we can see but cannot *identify* before
+ * we treat it as abandoned (no /proc, or a legacy pid-only record).  Longer
+ * than PIDLESS_STEAL_AFTER_MS because we have no corroborating evidence at all
+ * here — only the passage of time.  Every caller holds this lock for a
+ * synchronous JSON read-modify-write measured in milliseconds, so a five-minute
+ * tenure is already pathological.
+ */
+const UNVERIFIABLE_STEAL_AFTER_MS = 300_000;
+
+/**
+ * Read a process's start time (field 22 of /proc/<pid>/stat, in clock ticks
+ * since boot).  Together with the PID this forms an identity that survives PID
+ * reuse: the OS can recycle the number, but not the number *and* the start
+ * tick.
+ *
+ * Returns null when unavailable (non-Linux, or the process is gone), which
+ * callers must treat as "cannot identify" — never as "dead".
+ */
+function readStartTime(pid: number): string | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    // Field 2 (comm) is parenthesised and may itself contain spaces AND
+    // parens — e.g. "((sd-pam))".  Split after the LAST ')', never by naive
+    // whitespace splitting of the whole line.
+    const close = stat.lastIndexOf(')');
+    if (close === -1) return null;
+    const start = stat.slice(close + 2).split(' ')[19];
+    return start !== undefined && /^\d+$/.test(start) ? start : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The identity we stamp into the pid file: "<pid> <starttime>", or "<pid>". */
+function ownerRecord(): string {
+  const startTime = readStartTime(process.pid);
+  return startTime === null ? String(process.pid) : `${process.pid} ${startTime}`;
+}
+
+type Verdict =
+  | 'alive'         // holder provably exists and is provably the original owner
+  | 'dead'          // holder provably gone (ESRCH, or the PID was recycled)
+  | 'unverifiable'; // something answers to the PID but we cannot identify it
+
+/**
+ * Decide the fate of the recorded lock holder.
+ *
+ * The critical correctness rule: **only ESRCH proves death.**  EPERM means the
+ * process exists and merely is not signalable by us (a different UID) —
+ * treating it as dead lets a contender delete a live owner's lock so that both
+ * enter the critical section.
+ */
+function holderVerdict(pid: number, recordedStart: string | null): Verdict {
+  try {
+    process.kill(pid, 0);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ESRCH') return 'dead';
+    if (code !== 'EPERM') return 'unverifiable';
+    // EPERM: alive, just not signalable by us.  Fall through to identity.
+  }
+
+  // Something answers to this PID.  Is it still *our* holder?
+  if (recordedStart === null) return 'unverifiable'; // legacy pid-only record
+  const currentStart = readStartTime(pid);
+  if (currentStart === null) return 'unverifiable';  // no /proc to corroborate
+  // A mismatch is positive proof that the original holder exited and the OS
+  // reused the number — so this steal is *proven* safe, not a gamble.
+  return currentStart === recordedStart ? 'alive' : 'dead';
+}
+
+/**
+ * Age of the lock dir in ms; 0 if it vanished or the clock went backwards.
+ *
+ * Both terms are wall-clock, so a forward clock step (an NTP correction, a VM
+ * resume) inflates every lock's apparent age and can bring a live lock over a
+ * steal threshold early.  There is no monotonic equivalent for a file
+ * timestamp, so this is inherent to age-based recovery rather than a bug to
+ * fix here — it is bounded by the loud log on every steal, and by the
+ * thresholds being far longer than any real critical section.  Note this is
+ * why the *timeout* in `withFileLockSync` uses hrtime instead: that one has a
+ * monotonic option, and this one does not.
+ */
+function lockAgeMs(lockDir: string): number {
+  try {
+    return Math.max(0, Date.now() - statSync(lockDir).mtimeMs);
+  } catch {
+    return 0;
+  }
+}
+
+/**
+ * The exact record we wrote for each lock this process currently holds, keyed
+ * by lock directory.
+ *
+ * `releaseLock` compares against THIS, not against a freshly computed
+ * `ownerRecord()`.  Recomputing is not idempotent: `readStartTime` can fail
+ * transiently (fd exhaustion, a /proc hiccup), and a claim-time record of
+ * "<pid> <start>" then compares unequal to a release-time record of "<pid>",
+ * so a process refuses to release its own intact lock — permanently, because
+ * the holder it declines to remove is itself, and a live holder is judged
+ * 'alive' forever by `holderVerdict` (no age threshold is ever consulted).
+ * The record we actually wrote is ground truth; nothing else is.
+ */
+const heldRecords = new Map<string, string>();
+
+/**
+ * Take exclusive custody of `lockDir` by renaming it aside, then delete it only
+ * if what is inside satisfies `accept`.
+ *
+ * This is the same pattern `stealLock` implements inline, and it exists for the
+ * same reason: a verdict about a lock is a statement about the record we
+ * *read*, but a delete-by-pathname acts on whatever occupies the path *now*.
+ * Between those two moments the lock can turn over, and an unguarded delete
+ * then removes a live holder's directory — the exact silent cascade the
+ * ownership check in `releaseLock` was added to prevent, reintroduced by the
+ * very next statement.  `renameSync` is atomic, so exactly one contender wins
+ * the right to remove the directory; the contents are then re-read under the
+ * temporary name, where nobody else can reach them, which is what makes the
+ * second look authoritative rather than another guess.
+ *
+ * A useful consequence: the rename IS the release.  Once it succeeds the
+ * canonical path is free and the lock is acquirable again, so a later `rmSync`
+ * failure leaks a temp directory rather than wedging the lock.
+ *
+ * RESIDUAL, stated rather than glossed — identical to the one in `stealLock`,
+ * and not closable from here: between the rename and a declining restore the
+ * canonical path is vacant, so a third acquirer can `mkdirSync` it.  If it has
+ * already written its pid, the restore fails with ENOTEMPTY; if it is still
+ * inside its sub-millisecond mkdir-to-pid-write window, rename onto an empty
+ * directory SUCCEEDS on Linux and silently replaces it.  Node exposes no
+ * RENAME_NOREPLACE, so there is no atomic "restore only if absent" available.
+ * Both outcomes now log — see `declined` below.
+ */
+type Custody = 'removed' | 'declined' | 'lost';
+
+function removeWithCustody(
+  lockDir: string,
+  accept: (actual: string | null) => boolean,
+  describe: (actual: string | null) => string,
+): Custody {
+  const tmp = `${lockDir}.release.${process.pid}.${process.hrtime.bigint()}`;
+  try {
+    renameSync(lockDir, tmp);
+  } catch (err) {
+    // ENOENT means the directory is simply not there any more — our lock was
+    // removed under us.  Anything else (EACCES, EIO, EBUSY) means the lock is
+    // still sitting there and we could not free it, which wedges every future
+    // acquirer for as long as this process lives.  Neither may be swallowed:
+    // callers that fail to acquire a lock frequently degrade to a silent no-op
+    // (checkInbox returns an empty list), so a wedged lock reads as "nothing to
+    // do" rather than as an outage.
+    const code = (err as NodeJS.ErrnoException).code;
+    console.error(
+      code === 'ENOENT'
+        ? `[lock] lock "${lockDir}" was already gone when we tried to release it — ` +
+          `it was stolen or removed while we were inside the critical section; ` +
+          `data guarded by it may be torn. Investigate.`
+        : `[lock] FAILED to release "${lockDir}" (${code ?? 'unknown error'}). ` +
+          `The lock directory is still present and this process is still alive, so ` +
+          `every future acquirer will judge it 'alive' and block indefinitely. Investigate.`,
+    );
+    return 'lost';
+  }
+
+  let actual: string | null;
+  try {
+    actual = readFileSync(join(tmp, 'pid'), 'utf-8').trim();
+  } catch {
+    // Cannot distinguish "no pid file" from a transient read failure here, and
+    // the safe direction is to decline: putting a lock back is recoverable,
+    // deleting someone else's is not.
+    actual = null;
+  }
+
+  if (!accept(actual)) {
+    try {
+      renameSync(tmp, lockDir);
+      // Logged even when the restore SUCCEEDS: success here does not mean no
+      // harm was done.  The restore can land on a third acquirer's empty
+      // directory (see RESIDUAL above), which destroys its claim while it still
+      // believes it holds the lock.  That case is invisible from this side, so
+      // the window being entered at all is the only thing we can report.
+      console.error(
+        `[lock] declined to remove "${lockDir}": ${describe(actual)}. Restored it.`,
+      );
+    } catch {
+      console.error(
+        `[lock] could not restore "${lockDir}" after declining to remove it ` +
+        `(${describe(actual)}). A live holder may have lost its lock directory — investigate.`,
+      );
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        // Best effort.
+      }
+    }
+    return 'declined';
+  }
+
+  try {
+    rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    // The rename already freed the lock path, so the lock is released; this
+    // only leaks a temp directory. Not worth failing the release over.
+  }
+  return 'removed';
+}
+
+/**
+ * mkdir the lock dir and stamp our identity into it.
+ *
+ * If the mkdir succeeds but the pid write does not, the directory MUST be
+ * removed before the error propagates — otherwise it leaks as a lock nobody
+ * holds and nobody can attribute, wedging every future acquirer.
+ *
+ * That cleanup goes through `removeWithCustody` for the reason spelled out
+ * there.  A plain `rmSync(lockDir)` here is unsafe: if our pid write fails
+ * slowly — or we freeze between the mkdir and the throw — the pidless directory
+ * we left behind is exactly what `acquireLock` steals after
+ * PIDLESS_STEAL_AFTER_MS, so by the time we run the cleanup the path can name a
+ * *different, live* lock, and removing it by pathname deletes a holder that has
+ * done nothing wrong.
+ *
+ * We accept only a directory with NO pid file, because that is the state we
+ * left ours in — we are here precisely because the write did not succeed.  A
+ * partially written record therefore reads as "not ours" and is left alone; the
+ * corrupt-record path in `acquireLock` recovers it after PIDLESS_STEAL_AFTER_MS.
+ * Leaving a lock behind is recoverable; deleting a live one is not.
+ */
+function claimLock(lockDir: string, pidFile: string): boolean {
+  mkdirSync(lockDir); // throws EEXIST to the caller if someone beat us to it
+  const record = ownerRecord();
+  try {
+    writeFileSync(pidFile, record);
+  } catch (err) {
+    removeWithCustody(
+      lockDir,
+      actual => actual === null,
+      actual =>
+        `our pid write failed, but the directory now holds "${actual}" — ` +
+        `it is no longer the one we created`,
+    );
+    throw err;
+  }
+  heldRecords.set(lockDir, record);
+  return true;
+}
+
+/**
+ * Remove a lock we have judged abandoned and take it, atomically.
+ *
+ * The naive steal (rmSync then mkdirSync) is itself a mutual-exclusion bug: two
+ * contenders can interleave as rm(A), mkdir(A), rm(B) — which deletes A's fresh
+ * directory — then mkdir(B), leaving BOTH believing they hold the lock.
+ * `renameSync` is atomic, so exactly one contender wins the right to remove it.
+ *
+ * But atomic removal is NOT enough on its own.  The staleness verdict is about
+ * the record we *read*; the rename acts on whatever occupies the path *now*:
+ *
+ *   - A and B both read holder X and both correctly judge it dead.
+ *   - A renames X away, removes it, and claims a fresh lock.  A legitimately holds it.
+ *   - B's rename now runs.  The path exists again — it is A's LIVE lock — so B's
+ *     rename SUCCEEDS, and B steals a lock it never examined.  Both proceed.
+ *
+ * So the rename is only the first half: it wins us exclusive custody of the
+ * directory, and `expected` is then re-checked *inside* that custody.  Nobody
+ * else can reach the dir under its new name, so what we read there is
+ * authoritative.  Mismatch means the lock turned over between our verdict and
+ * our rename — we put it back and lose the race rather than steal a live lock.
+ *
+ * `expected` is the exact trimmed pid-file content the verdict was based on, or
+ * null when the verdict was "there is no readable pid file".
+ */
+function stealLock(
+  lockDir: string,
+  pidFile: string,
+  expected: string | null,
+  reason: string,
+): boolean {
+  const tmp = `${lockDir}.stale.${process.pid}.${process.hrtime.bigint()}`;
+  try {
+    renameSync(lockDir, tmp);
+  } catch {
+    return false; // another contender got there first — let the caller retry
+  }
+
+  // Exclusive custody: re-read under the new name and confirm this is the same
+  // lock we judged, not a live one that replaced it.
+  let actual: string | null;
+  try {
+    actual = readFileSync(join(tmp, 'pid'), 'utf-8').trim();
+  } catch {
+    actual = null;
+  }
+  if (actual !== expected) {
+    try {
+      // Put it back; the holder we renamed aside is unharmed.
+      //
+      // RESIDUAL, stated rather than glossed: rename onto an existing EMPTY
+      // directory SUCCEEDS on Linux (verified — a non-empty target gives
+      // ENOTEMPTY). So if a third acquirer is inside its own sub-millisecond
+      // mkdir-to-pid-write window right now, this replaces its fresh dir. It
+      // then writes its pid into the restored one and holds the lock, while the
+      // holder we restored believes it still does. Node exposes no
+      // RENAME_NOREPLACE, so there is no atomic "rename only if absent" to use
+      // instead.
+      //
+      // An earlier version of this comment called ownership-checked releaseLock
+      // "the backstop that check exists for". That overstated it, and the
+      // correction matters more than the original claim did. Ownership-checked
+      // release does two things: it stops the loser from deleting the winner's
+      // live lock on its way out, and it reports the loss. It does NOT prevent
+      // the two of them from being inside the critical section at the same time
+      // — that violation happens, completes, and can tear the guarded data
+      // BEFORE either party reaches a release. "Not silent" is therefore true
+      // only after the fact; while the window is open it is entirely silent.
+      // The residual is bounded and eventually observable, not neutralised.
+      renameSync(tmp, lockDir);
+      // Logged on SUCCESS too: a successful restore is not evidence of no harm,
+      // because the empty-directory case above is invisible from this side.
+      console.error(
+        `[lock] aborted a steal of "${lockDir}": holder changed from ` +
+        `${expected ?? '<no pid file>'} to ${actual ?? '<no pid file>'} before we could ` +
+        `take it. Restored it; a third acquirer racing this window may have lost its claim.`,
+      );
+    } catch {
+      // We could not restore it — a new acquirer already occupies the path, so
+      // some other holder's lock directory is now gone. This is the one hole we
+      // cannot close from here; ownership-checked releaseLock is its backstop.
+      console.error(
+        `[lock] could not restore lock "${lockDir}" after aborting a steal ` +
+        `(holder changed from ${expected ?? '<no pid file>'} to ${actual ?? '<no pid file>'}). ` +
+        `A live holder may have lost its lock directory — investigate.`,
+      );
+      try {
+        rmSync(tmp, { recursive: true, force: true });
+      } catch {
+        // Best effort.
+      }
+    }
+    return false;
+  }
+
+  // We removed a lock on the strength of an inference, not a certainty. Say so
+  // loudly: if the rare bad case ever happens (a holder resuming after we
+  // judged it abandoned) this line is the only thing that makes it visible.
+  console.error(
+    `[lock] STOLE apparently-stale lock "${lockDir}" (${reason}). ` +
+    `If a live holder was still using it, this is a mutual-exclusion violation — investigate.`,
+  );
+
+  try {
+    rmSync(tmp, { recursive: true, force: true });
+  } catch {
+    // Best effort — the rename already freed the lock path.
+  }
+
+  try {
+    return claimLock(lockDir, pidFile);
+  } catch (err) {
+    // A brand-new acquirer legitimately beat us to the freed path.
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw err;
+  }
+}
 
 /**
  * Acquire a mutex lock using mkdir (atomic on all filesystems).
  * Matches the bash pattern: mkdir .lock.d with PID tracking.
  *
  * Returns true if lock acquired, false if another process holds it.
- * Automatically recovers stale locks (dead process).
+ * Recovers abandoned locks — see `holderVerdict` for how "abandoned" is decided,
+ * and the module constants for the thresholds used where it cannot be proven.
  */
 export function acquireLock(dir: string): boolean {
   const lockDir = join(dir, '.lock.d');
   const pidFile = join(lockDir, 'pid');
 
   try {
-    mkdirSync(lockDir);
-    writeFileSync(pidFile, String(process.pid));
-    return true;
+    return claimLock(lockDir, pidFile);
   } catch (err) {
     // Only EEXIST means contention. EACCES / ENOSPC / EROFS / etc. are real
     // filesystem failures — propagate so the caller (withFileLockSync) does
@@ -28,54 +404,117 @@ export function acquireLock(dir: string): boolean {
     // of) the lock.  We must NOT treat the gap between mkdirSync and
     // writeFileSync as "stale" — doing so allows two acquirers to interleave
     // and BOTH believe they hold the lock (the actual race that broke iter
-    // 12).  When the PID file is missing, the holder is mid-acquire; the
-    // caller should retry.
-    let storedPidRaw: string;
+    // 12).  When the PID file is missing the holder is mid-acquire and the
+    // caller should retry — until the directory is old enough that no
+    // mid-acquire explanation is credible any more.
+    let storedRaw: string;
     try {
-      storedPidRaw = readFileSync(pidFile, 'utf-8').trim();
+      storedRaw = readFileSync(pidFile, 'utf-8').trim();
     } catch {
-      // PID file not yet written.  Holder is between mkdir and writeFileSync.
-      // Refuse the lock — the caller's retry loop will try again.
+      const age = lockAgeMs(lockDir);
+      if (age >= PIDLESS_STEAL_AFTER_MS) {
+        return stealLock(
+          lockDir, pidFile, null,
+          `no pid file after ${Math.round(age / 1000)}s — holder died between mkdir and pid write`,
+        );
+      }
       return false;
     }
 
-    const storedPid = parseInt(storedPidRaw, 10);
-    if (isNaN(storedPid) || storedPidRaw === '') {
-      // Corrupt PID file.  Don't steal — let caller retry; if it persists
-      // the holder is broken and a future stale-detection pass (process.kill
-      // check below, after the PID is written cleanly) will recover.
+    // Parse the WHOLE record with an anchored pattern.  A bare parseInt would
+    // accept "123abc" as pid 123 and half-parse partial corruption into a
+    // valid-looking identity; here anything we did not write is simply corrupt.
+    const parsed = /^(\d+)(?: (\d+))?$/.exec(storedRaw);
+    const storedPid = parsed ? parseInt(parsed[1], 10) : NaN;
+    // Reject non-positive PIDs explicitly: process.kill(0, 0) signals our OWN
+    // process group and would succeed, making a corrupt "0" pid file read as a
+    // permanently live holder.  Negative values address a process group too.
+    if (isNaN(storedPid) || storedPid <= 0) {
+      // Corrupt PID file.  Don't steal on sight — let the caller retry, and let
+      // the age threshold recover it if it never becomes readable.
+      const age = lockAgeMs(lockDir);
+      if (age >= PIDLESS_STEAL_AFTER_MS) {
+        return stealLock(
+          lockDir, pidFile, storedRaw,
+          `unusable pid record "${storedRaw}" after ${Math.round(age / 1000)}s`,
+        );
+      }
       return false;
     }
 
-    // Check if process is still alive
-    try {
-      process.kill(storedPid, 0);
-      // Process is alive - lock is held
-      return false;
-    } catch {
-      // Process is dead - stale lock, remove and re-acquire atomically.
-      try {
-        rmSync(lockDir, { recursive: true, force: true });
-        mkdirSync(lockDir);
-        writeFileSync(pidFile, String(process.pid));
-        return true;
-      } catch {
-        // Another process beat us to the steal — let caller retry.
+    const recordedStart = parsed![2] ?? null;
+
+    switch (holderVerdict(storedPid, recordedStart)) {
+      case 'dead':
+        return stealLock(lockDir, pidFile, storedRaw, `holder pid ${storedPid} is gone`);
+      case 'unverifiable': {
+        const age = lockAgeMs(lockDir);
+        if (age >= UNVERIFIABLE_STEAL_AFTER_MS) {
+          return stealLock(
+            lockDir, pidFile, storedRaw,
+            `pid ${storedPid} answers but cannot be identified as the original holder ` +
+            `(no /proc corroboration) and the lock is ${Math.round(age / 1000)}s old`,
+          );
+        }
         return false;
       }
+      default:
+        return false; // 'alive' — genuinely held
     }
   }
 }
 
 /**
- * Release a mutex lock.
+ * Release a mutex lock — but only if it is still OURS.
+ *
+ * An unconditional remove here turns a single accepted steal into an unbounded
+ * silent cascade.  Because a lock may be stolen from a holder that was merely
+ * frozen (see the age thresholds above), that holder can wake up and finish:
+ *
+ *   1. A freezes past the threshold.  B steals — loudly, as designed.
+ *   2. A resumes, completes, and releases — deleting B's lock while B is still
+ *      inside its critical section.
+ *   3. C now acquires cleanly.  B and C overlap, with no steal and no log
+ *      anywhere: the loud line in `stealLock` never fires for step 3.
+ *
+ * So the steal is visible but the damage it seeds is not.  Checking ownership
+ * before removing bounds the blast radius at the one overlap we knowingly
+ * accepted, and converts every later one into a logged event instead of
+ * silence.
+ *
+ * The check alone is NOT sufficient, and getting this wrong once already is why
+ * the note is here.  Reading the record, deciding, and then removing by
+ * pathname is a check-then-act race: the lock can be stolen from us in the gap
+ * (the same freeze that got us stolen from in step 1 can recur), and `rmSync`
+ * with `force` would then delete the *new* holder's live directory — recreating
+ * exactly the cascade above, one statement below the check meant to stop it.
+ * So the removal goes through `removeWithCustody`, which re-checks under a name
+ * only we can reach.
+ *
+ * Failing to remove is the safe direction, but it is NOT free, and the earlier
+ * claim here that "the age thresholds recover it" was wrong: those thresholds
+ * are only consulted for pidless, corrupt, or unidentifiable records.  A lock
+ * left holding the record of *this* live process is judged 'alive' on every
+ * future acquisition and is never recovered while we run.  That is why every
+ * path out of `removeWithCustody` that does not remove the lock logs.
  */
 export function releaseLock(dir: string): void {
   const lockDir = join(dir, '.lock.d');
-  try {
-    rmSync(lockDir, { recursive: true, force: true });
-  } catch {
-    // Ignore errors on release
+
+  // The record we WROTE, not one recomputed now — see `heldRecords`.
+  const mine = heldRecords.get(lockDir) ?? ownerRecord();
+
+  const result = removeWithCustody(
+    lockDir,
+    actual => actual === mine,
+    actual =>
+      `it is held by ${actual ?? '<no pid file>'}, not us (${mine}); our lock was ` +
+      `stolen or removed while we were still inside the critical section, so data ` +
+      `guarded by it may be torn`,
+  );
+
+  if (result === 'removed') {
+    heldRecords.delete(lockDir);
   }
 }
 
@@ -107,6 +546,17 @@ const SLEEP_VIEW = new Int32Array(SLEEP_SAB);
  * mutations between the read and the write (the atomic rename in
  * writeCrons is per-write only — it does NOT make the surrounding
  * read-modify-write transactional).
+ *
+ * `fn` MUST be synchronous. This is a synchronous mutex: anything deferred past
+ * `fn`'s return (an await, a callback, a Promise) runs with the lock ALREADY
+ * RELEASED by the `finally` below.
+ *
+ * Stated property, so it is not a surprise in an incident: the recovery
+ * thresholds are deliberately much longer than this timeout. A lock left in an
+ * unprovable state therefore makes callers throw here — loudly, for up to
+ * PIDLESS_STEAL_AFTER_MS (or UNVERIFIABLE_STEAL_AFTER_MS) — before anyone is
+ * allowed to recover it. That is the intended order: fail visibly first, steal
+ * only once no benign explanation survives.
  *
  * @throws if the lock cannot be acquired within `timeoutMs`.
  */

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -145,7 +145,20 @@ const heldRecords = new Map<string, string>();
  * RENAME_NOREPLACE, so there is no atomic "restore only if absent" available.
  * Both outcomes now log — see `declined` below.
  */
-type Custody = 'removed' | 'declined' | 'lost';
+/**
+ * `lost` is split because the two failures mean OPPOSITE things about whether we
+ * still hold the lock, and `releaseLock` has to act differently on each.
+ *
+ *   - `vanished` (ENOENT): the directory is not there.  We no longer hold it,
+ *     and the path is free for anyone — including us — to acquire again.
+ *   - `stuck` (any other errno): the directory is still sitting there, still
+ *     carrying our record.  We DO still hold it, and nothing but this process
+ *     can free it: every future acquirer will judge the holder alive.
+ *
+ * Collapsing these into one outcome is what makes "just forget the record on a
+ * failed release" wrong — see `releaseLock`.
+ */
+type Custody = 'removed' | 'declined' | 'vanished' | 'stuck';
 
 function removeWithCustody(
   lockDir: string,
@@ -173,7 +186,7 @@ function removeWithCustody(
           `The lock directory is still present and this process is still alive, so ` +
           `every future acquirer will judge it 'alive' and block indefinitely. Investigate.`,
     );
-    return 'lost';
+    return code === 'ENOENT' ? 'vanished' : 'stuck';
   }
 
   let actual: string | null;
@@ -501,8 +514,20 @@ export function acquireLock(dir: string): boolean {
 export function releaseLock(dir: string): void {
   const lockDir = join(dir, '.lock.d');
 
-  // The record we WROTE, not one recomputed now — see `heldRecords`.
-  const mine = heldRecords.get(lockDir) ?? ownerRecord();
+  // The record we WROTE, not one recomputed now — see `heldRecords`.  No entry
+  // means we do not hold this lock, and the only correct action on a lock we do
+  // not hold is NOTHING.  The previous `?? ownerRecord()` fallback made a stray
+  // release take custody of a healthy foreign lock — renaming it aside, reading
+  // it, and renaming it back — which enters the restore window documented on
+  // `removeWithCustody` (where it can destroy a third acquirer's fresh claim)
+  // and logs "our lock was stolen ... data may be torn. Investigate", sending
+  // someone after an incident that never happened.  Recomputing was never even
+  // sound as identity: `readStartTime` can fail transiently, so the recomputed
+  // record can differ from the one we wrote.
+  const mine = heldRecords.get(lockDir);
+  if (mine === undefined) {
+    return;
+  }
 
   const result = removeWithCustody(
     lockDir,
@@ -513,7 +538,23 @@ export function releaseLock(dir: string): void {
       `guarded by it may be torn`,
   );
 
-  if (result === 'removed') {
+  // The entry must mean "we hold this ACQUISITION", but the record identifies a
+  // PROCESS — there is no generation nonce, and adding one is a format migration
+  // (the record is parsed by a fixed regex further down).  So a surviving entry
+  // is not inert: this process can re-acquire the same path later and write a
+  // byte-identical record, and a delayed or duplicated release would then match
+  // on it and remove an acquisition it never owned.  Classic ABA.  Clearing the
+  // entry the moment the acquisition ends is what keeps that unreachable
+  // without the migration.
+  //
+  // `stuck` is the one outcome that must KEEP it: there the directory is still
+  // present and still ours, so we are still the holder, and the entry is the
+  // only surviving copy of the record needed to release it.  Dropping it would
+  // turn every later release attempt into the no-op above and wedge the lock
+  // permanently — the exact outcome the entry exists to prevent.  There is no
+  // ABA risk in that state either: nobody, including us, can re-acquire a path
+  // whose live holder is this process.
+  if (result !== 'stuck') {
     heldRecords.delete(lockDir);
   }
 }

--- a/tests/unit/utils/lock-release-ownership.test.ts
+++ b/tests/unit/utils/lock-release-ownership.test.ts
@@ -1,0 +1,165 @@
+/**
+ * `releaseLock` must touch a lock directory ONLY while this process actually
+ * holds that acquisition.
+ *
+ * Both halves of that live in the `heldRecords` map, and both were broken in
+ * ways the existing suite is blind to — every test in `lock.test.ts` passes
+ * before and after this change, so none of them is evidence for it.
+ *
+ *   - No entry meant "recompute the record and try anyway", so a stray release
+ *     took custody of a healthy FOREIGN lock: renamed it aside, read it, renamed
+ *     it back.  That is not a read-only mistake — the restore window is the one
+ *     documented on `removeWithCustody`, where a third acquirer's fresh claim can
+ *     be destroyed — and it logs "data guarded by it may be torn. Investigate",
+ *     which is a false alarm someone has to chase.
+ *   - An entry that survived a failed release meant the map named a PROCESS
+ *     rather than an ACQUISITION.
+ *
+ * WHAT THE SECOND FIX DOES AND DOES NOT CLOSE.  Clearing the entry makes a
+ * duplicate release after a failed one a no-op instead of an operation on
+ * whatever occupies the path now.  It does NOT make double-release safe in
+ * general: if this process RE-ACQUIRES the same path, `claimLock` writes a
+ * byte-identical record and repopulates the map, so a delayed release still
+ * matches and removes the new acquisition.  Closing that needs a generation
+ * nonce in the record, which is a format migration (the record is parsed by a
+ * fixed regex) and is deliberately not attempted here.  The invariant these
+ * tests establish is the narrower one in the first line, and no more.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { acquireLock, releaseLock } from '../../../src/utils/lock';
+
+let root: string;
+let dir: string;
+let lockDir: string;
+let errs: string[];
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'lockown-'));
+  dir = join(root, 'target');
+  mkdirSync(dir);
+  lockDir = join(dir, '.lock.d');
+  errs = [];
+  vi.spyOn(console, 'error').mockImplementation(msg => { errs.push(String(msg)); });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  try { chmodSync(dir, 0o755); } catch { /* ignore */ }
+  rmSync(root, { recursive: true, force: true });
+});
+
+/** Every sibling `.lock.d.release.*` custody directory left behind. */
+const custodyTemps = () => readdirSync(dir).filter(f => f.startsWith('.lock.d.release.'));
+
+/** A live lock belonging to someone else. pid 1 exists and is not us. */
+function plantForeignLock(): void {
+  mkdirSync(lockDir);
+  writeFileSync(join(lockDir, 'pid'), '1');
+}
+
+describe('releaseLock on a lock this process does not hold', () => {
+  it('does nothing — no custody, no restore window, no false alarm', () => {
+    plantForeignLock();
+
+    releaseLock(dir);
+
+    // The claim: not merely "the lock survived" — the code never went near it.
+    // Under the old `?? ownerRecord()` fallback this logs `declined to remove
+    // ... data guarded by it may be torn`, having renamed the directory aside
+    // and back to find that out.
+    expect(errs).toEqual([]);
+    expect(custodyTemps()).toEqual([]);
+
+    // Control arm: the lock we planted has to still be a real, intact, foreign
+    // lock, or "nothing happened to it" would be true of an empty directory.
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe('1');
+  });
+
+  it('stays a no-op after our own acquisition ends, so a duplicate release cannot reach a stranger', () => {
+    expect(acquireLock(dir)).toBe(true);
+
+    // Our lock is stolen and replaced while we are still inside the critical
+    // section: the path now holds someone else's record, not ours.
+    writeFileSync(join(lockDir, 'pid'), '1');
+
+    // First release: correctly declines and restores. This one SHOULD log — it
+    // is the genuine "we were stolen from" case, and the control arm for the
+    // assertion below (an implementation that logs nothing at all would satisfy
+    // that assertion vacuously).
+    releaseLock(dir);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toMatch(/declined to remove/);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe('1');
+
+    // The acquisition is over, so the record must be gone with it. A second,
+    // delayed or duplicated, release must not custody the stranger's lock.
+    errs.length = 0;
+    releaseLock(dir);
+    expect(errs).toEqual([]);
+    expect(custodyTemps()).toEqual([]);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe('1');
+  });
+});
+
+describe('releaseLock when the release itself fails', () => {
+  it('forgets the acquisition when the lock VANISHED, so a later release cannot reach whoever took the path', () => {
+    // The observable consequence of forgetting has to be measured against a
+    // path that someone ELSE now holds. Re-acquiring it ourselves proves
+    // nothing: `claimLock` writes a byte-identical record and repopulates the
+    // map, so the retry succeeds whether or not the entry was ever cleared.
+    expect(acquireLock(dir)).toBe(true);
+
+    // Somebody removed our lock directory outright.
+    rmSync(lockDir, { recursive: true, force: true });
+
+    releaseLock(dir);
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toMatch(/already gone/);
+
+    // The path really is free — and a stranger takes it. (`plantForeignLock`
+    // mkdirs, so it would throw were the path still occupied.)
+    expect(existsSync(lockDir)).toBe(false);
+    plantForeignLock();
+
+    // A delayed or duplicated release must not touch it. Keeping the record
+    // here — treating a vanished lock as still ours — is what would make this
+    // custody a stranger's healthy lock and raise a false torn-data alarm.
+    errs.length = 0;
+    releaseLock(dir);
+    expect(errs).toEqual([]);
+    expect(custodyTemps()).toEqual([]);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe('1');
+  });
+
+  it('KEEPS the acquisition when the lock is STUCK, so a retry can still release it', () => {
+    // This is the case that makes "clear the record on any failed release"
+    // wrong. The directory is still there and still ours, so we are still the
+    // holder — and the cached record is the only copy of what we wrote. Forget
+    // it and every later release becomes the no-op above, wedging the lock for
+    // the life of the process: a live holder is judged 'alive' forever.
+    expect(acquireLock(dir)).toBe(true);
+
+    // A rename out of a directory needs write permission on that directory, so
+    // this makes the custody rename fail EACCES rather than ENOENT.
+    chmodSync(dir, 0o555);
+    releaseLock(dir);
+    chmodSync(dir, 0o755);
+
+    // Assert we actually hit the stuck path. Without this the test would pass
+    // vacuously anywhere the chmod does not bite — as root, for instance.
+    expect(errs).toHaveLength(1);
+    expect(errs[0]).toMatch(/FAILED to release/);
+    expect(existsSync(lockDir)).toBe(true);
+
+    // The retry: it must still know the record, and must actually remove it.
+    errs.length = 0;
+    releaseLock(dir);
+    expect(errs).toEqual([]);
+    expect(existsSync(lockDir)).toBe(false);
+  });
+});

--- a/tests/unit/utils/lock.test.ts
+++ b/tests/unit/utils/lock.test.ts
@@ -1,19 +1,120 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+// The mid-release takeover test has to run code at the instant lock.ts reads a
+// pid file — the one hook that exists in ANY implementation of an
+// ownership-checked release, however it is structured. `vi.spyOn(fs, ...)` is
+// not available (ESM module namespaces are not configurable), so the module is
+// wrapped once here and left as a pure passthrough unless a test arms the hook.
+const hooks = vi.hoisted(() => ({
+  /** Runs immediately AFTER a successful read — the check-then-act window. */
+  afterPidRead: null as ((path: string) => void) | null,
+  /** Runs BEFORE a read, so it may throw to simulate a transient failure. */
+  beforeRead: null as ((path: string) => void) | null,
+  /** Runs BEFORE a write, so it may throw to simulate a failing pid write. */
+  beforeWrite: null as ((path: string) => void) | null,
+}));
+
+vi.mock('fs', async importOriginal => {
+  const real = await importOriginal<typeof import('fs')>();
+  return {
+    ...real,
+    default: real,
+    readFileSync: (p: unknown, ...rest: unknown[]) => {
+      hooks.beforeRead?.(String(p));
+      const out = (real.readFileSync as (...a: unknown[]) => unknown)(p, ...rest);
+      hooks.afterPidRead?.(String(p));
+      return out;
+    },
+    writeFileSync: (p: unknown, ...rest: unknown[]) => {
+      hooks.beforeWrite?.(String(p));
+      return (real.writeFileSync as (...a: unknown[]) => unknown)(p, ...rest);
+    },
+  };
+});
+
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync, utimesSync, chmodSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { acquireLock, releaseLock } from '../../../src/utils/lock';
 
+// Thresholds mirrored from src/utils/lock.ts. Kept as literals so a silent
+// change to the source constants shows up here as a failure rather than
+// being followed automatically.
+const PIDLESS_STEAL_AFTER_MS = 30_000;
+const UNVERIFIABLE_STEAL_AFTER_MS = 300_000;
+
+/** Real start time of a pid, the same way lock.ts reads it. */
+function startTimeOf(pid: number): string | null {
+  try {
+    const stat = readFileSync(`/proc/${pid}/stat`, 'utf-8');
+    const close = stat.lastIndexOf(')');
+    if (close === -1) return null;
+    const f = stat.slice(close + 2).split(' ')[19];
+    return f !== undefined && /^\d+$/.test(f) ? f : null;
+  } catch {
+    return null;
+  }
+}
+
+const HAVE_PROC = startTimeOf(process.pid) !== null;
+
+/**
+ * A pid that is valid to signal but certainly not in use, so process.kill
+ * answers ESRCH ("provably dead") rather than an argument error. Scanning down
+ * from pid_max keeps this correct on any host instead of hard-coding a number.
+ */
+function deadPid(): number {
+  const max = parseInt(readFileSync('/proc/sys/kernel/pid_max', 'utf-8').trim(), 10);
+  for (let p = max - 1; p > max - 500; p--) {
+    try {
+      process.kill(p, 0);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'ESRCH') return p;
+    }
+  }
+  throw new Error('could not find an unused pid');
+}
+
+/** Does pid 1 exist but refuse our signals? That is the real EPERM case. */
+function pid1IsUnsignalable(): boolean {
+  try {
+    process.kill(1, 0);
+    return false; // signalable (e.g. running as root) — not the case we want
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
 describe('mkdir-based locking', () => {
   let testDir: string;
+  let lockDir: string;
+  let pidFile: string;
+  let errSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
     testDir = mkdtempSync(join(tmpdir(), 'cortextos-lock-test-'));
+    lockDir = join(testDir, '.lock.d');
+    pidFile = join(lockDir, 'pid');
+    errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {
+    errSpy.mockRestore();
     rmSync(testDir, { recursive: true, force: true });
   });
+
+  /** Plant a held lock with an exact pid-file body. */
+  function plantLock(body: string): void {
+    mkdirSync(lockDir);
+    writeFileSync(pidFile, body);
+  }
+
+  /** Backdate the lock dir so age-based recovery sees it as old. */
+  function ageLock(ms: number): void {
+    const when = (Date.now() - ms) / 1000;
+    utimesSync(lockDir, when, when);
+  }
+
+  // ---------------------------------------------------------------- baseline
 
   it('acquires lock on empty directory', () => {
     expect(acquireLock(testDir)).toBe(true);
@@ -22,10 +123,8 @@ describe('mkdir-based locking', () => {
 
   it('prevents double acquire', () => {
     expect(acquireLock(testDir)).toBe(true);
-    // Same process, same PID - should fail since lock.d already exists
-    // (but our PID check will see it's our own process and succeed)
-    // Actually, mkdir will fail because it already exists, then we check PID
-    // Since it's our own PID, it sees process alive and returns false
+    // Same process: the holder is provably alive and provably us, so the
+    // second acquire must be refused.
     expect(acquireLock(testDir)).toBe(false);
     releaseLock(testDir);
   });
@@ -35,5 +134,386 @@ describe('mkdir-based locking', () => {
     releaseLock(testDir);
     expect(acquireLock(testDir)).toBe(true);
     releaseLock(testDir);
+  });
+
+  // ------------------------------------------- only ESRCH may prove death
+
+  // Mutation: revert holderVerdict to a bare `catch { /* dead */ }`.
+  // Uses no mocking — pid 1 genuinely exists and genuinely refuses our
+  // signals with EPERM when we are not root.
+  it.skipIf(!pid1IsUnsignalable() || !HAVE_PROC)(
+    'refuses a lock held by a live process we are not allowed to signal (EPERM, pid 1)',
+    () => {
+      plantLock(`1 ${startTimeOf(1)}`);
+      expect(acquireLock(testDir)).toBe(false);
+      expect(existsSync(pidFile)).toBe(true);
+    },
+  );
+
+  // The same rule, forced rather than observed, so it is covered even where
+  // pid 1 happens to be signalable (container running as root).
+  it('treats an EPERM liveness probe as alive, not dead', () => {
+    plantLock('424242 12345');
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const e = new Error('EPERM') as NodeJS.ErrnoException;
+      e.code = 'EPERM';
+      throw e;
+    });
+    try {
+      // EPERM proves existence; the recorded start time cannot be corroborated
+      // for a pid that is not really there, so this is 'unverifiable' — and a
+      // fresh lock must still be refused rather than stolen.
+      expect(acquireLock(testDir)).toBe(false);
+    } finally {
+      killSpy.mockRestore();
+    }
+  });
+
+  it.skipIf(!HAVE_PROC)('steals a lock whose holder is provably gone (ESRCH)', () => {
+    plantLock(`${deadPid()} 12345`);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  // A pid outside the signalable range is an argument error, not ESRCH, so it
+  // is NOT proof of death. It must fall to the conservative 'unverifiable'
+  // path — refused while fresh, recovered only on the longer threshold.
+  it('treats an out-of-range pid record as unverifiable, not as a dead holder', () => {
+    plantLock('4294967290 12345');
+    expect(acquireLock(testDir)).toBe(false);
+    ageLock(PIDLESS_STEAL_AFTER_MS + 1_000);
+    expect(acquireLock(testDir)).toBe(false); // still not the right threshold
+    ageLock(UNVERIFIABLE_STEAL_AFTER_MS + 1_000);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  // --------------------------------------------------- PID reuse detection
+
+  // Mutation: drop the start-time comparison in holderVerdict.
+  // Our own pid is unquestionably alive, so only the start-time mismatch can
+  // justify the steal — no mocking, no timing.
+  it.skipIf(!HAVE_PROC)(
+    'steals a lock whose recorded start time does not match the live pid (PID reuse)',
+    () => {
+      plantLock(`${process.pid} 1`); // real live pid, impossible start tick
+      expect(acquireLock(testDir)).toBe(true);
+      expect(readFileSync(pidFile, 'utf-8')).toBe(`${process.pid} ${startTimeOf(process.pid)}`);
+      releaseLock(testDir);
+    },
+  );
+
+  it.skipIf(!HAVE_PROC)('refuses a lock whose recorded start time matches the live pid', () => {
+    plantLock(`${process.pid} ${startTimeOf(process.pid)}`);
+    expect(acquireLock(testDir)).toBe(false);
+  });
+
+  // ------------------------------------------------- non-positive pid guard
+
+  // Mutation: drop the `storedPid <= 0` guard. Without it process.kill(0, 0)
+  // signals our OWN process group, succeeds, and reads as a live holder —
+  // which then needs the much longer unverifiable threshold, so a lock aged
+  // just past the pidless threshold stays stuck.
+  it('recovers a lock whose pid record is 0 instead of signalling our own process group', () => {
+    plantLock('0');
+    expect(acquireLock(testDir)).toBe(false); // fresh: still refused
+    ageLock(PIDLESS_STEAL_AFTER_MS + 1_000);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  it('recovers a lock whose pid record is corrupt once it is old enough', () => {
+    plantLock('not-a-pid');
+    expect(acquireLock(testDir)).toBe(false);
+    ageLock(PIDLESS_STEAL_AFTER_MS + 1_000);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  // ------------------------------------------------------ pid-less lock dir
+
+  it('refuses a pid-less lock dir that may still be mid-acquire', () => {
+    mkdirSync(lockDir); // holder is between mkdir and the pid write
+    expect(acquireLock(testDir)).toBe(false);
+    expect(existsSync(lockDir)).toBe(true);
+  });
+
+  // Mutation: drop the pidless age branch -> permanent silent outage.
+  it('recovers a pid-less lock dir older than the threshold', () => {
+    mkdirSync(lockDir);
+    ageLock(PIDLESS_STEAL_AFTER_MS + 1_000);
+    expect(acquireLock(testDir)).toBe(true);
+    expect(existsSync(pidFile)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  // ------------------------------------------ legacy pid-only compatibility
+
+  it('honours a lock written in the legacy pid-only format', () => {
+    plantLock(String(process.pid)); // live pid, no start time to corroborate
+    expect(acquireLock(testDir)).toBe(false);
+  });
+
+  // Mutation: drop the unverifiable age branch.
+  it('recovers a legacy pid-only lock once it passes the unverifiable threshold', () => {
+    plantLock(String(process.pid));
+    ageLock(UNVERIFIABLE_STEAL_AFTER_MS + 1_000);
+    expect(acquireLock(testDir)).toBe(true);
+    releaseLock(testDir);
+  });
+
+  it('does not steal an unverifiable lock before the threshold', () => {
+    plantLock(String(process.pid));
+    ageLock(UNVERIFIABLE_STEAL_AFTER_MS - 60_000);
+    expect(acquireLock(testDir)).toBe(false);
+  });
+
+  // ------------------------------------------------ pid write failure clean-up
+
+  // Mutation: drop the rmSync in claimLock's catch. A umask of 0o555 makes the
+  // new directory mode 0o222 — writable but not searchable — so creating the
+  // pid file inside it fails with EACCES for real. Skipped as root, where
+  // permission checks are bypassed.
+  it.skipIf(process.getuid?.() === 0)(
+    'removes the lock directory when the pid file cannot be written',
+    () => {
+      const prev = process.umask(0o555);
+      try {
+        expect(() => acquireLock(testDir)).toThrow();
+        expect(existsSync(lockDir)).toBe(false);
+      } finally {
+        process.umask(prev);
+      }
+      // The path is not wedged: a normal acquire still works afterwards.
+      expect(acquireLock(testDir)).toBe(true);
+      releaseLock(testDir);
+    },
+  );
+
+  // ------------------------------------------------------------ loud signal
+
+  // Mutation: delete the console.error in stealLock. The orchestrator's
+  // decision to allow age-based stealing was explicitly conditional on the
+  // steal being observable, so silence here is a policy violation, not a
+  // cosmetic one.
+  it('logs loudly when it steals a lock on inference rather than proof', () => {
+    mkdirSync(lockDir);
+    ageLock(PIDLESS_STEAL_AFTER_MS + 1_000);
+    expect(acquireLock(testDir)).toBe(true);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0]![0])).toContain('STOLE');
+    releaseLock(testDir);
+  });
+
+  it('does not log when it acquires a free lock', () => {
+    expect(acquireLock(testDir)).toBe(true);
+    expect(errSpy).not.toHaveBeenCalled();
+    releaseLock(testDir);
+  });
+
+  // ------------------------------------------------------------ steal race
+  //
+  // HONESTY BOUNDARY: this asserts the *outcome* after a steal, not the
+  // interleaving itself. The real race the renameSync fixes — rm(A), mkdir(A),
+  // rm(B), mkdir(B) with both winning — needs two OS processes scheduled
+  // against each other and is NOT reproducible in a single-process test. Do
+  // not rename this test to claim it covers the race; it does not.
+  it.skipIf(!HAVE_PROC)('leaves exactly one holder after a steal', () => {
+    plantLock(`${deadPid()} 12345`); // provably dead holder
+    expect(acquireLock(testDir)).toBe(true);
+    expect(acquireLock(testDir)).toBe(false); // we now hold it; nobody else may
+    releaseLock(testDir);
+  });
+
+  // The rename wins us exclusive custody of the directory, but the staleness
+  // verdict was formed BEFORE it. If the lock turns over in between, renaming
+  // "the stale lock" actually renames a live one — so custody is where the
+  // identity has to be re-checked.
+  it('aborts a steal when the lock turns over between the verdict and the rename', () => {
+    plantLock(`${deadPid()}`); // verdict will be 'dead' → steal
+
+    const newHolder = '999999 12345';
+    // Fires at the instant stealLock builds its temp name: after the verdict,
+    // before the rename. That is exactly the window a competing process would
+    // use to free the dead lock and claim it. Everything else is real fs.
+    const hrSpy = vi.spyOn(process.hrtime, 'bigint').mockImplementationOnce(() => {
+      writeFileSync(pidFile, newHolder);
+      return 1n;
+    });
+
+    try {
+      expect(acquireLock(testDir)).toBe(false); // must not steal a live lock
+      expect(existsSync(lockDir)).toBe(true);   // must have put it back
+      expect(readFileSync(pidFile, 'utf-8')).toBe(newHolder); // holder unharmed
+      // A SUCCESSFUL restore is not evidence of no harm: it can land on a third
+      // acquirer's empty directory and destroy its claim invisibly. Entering the
+      // window at all is the only thing observable from this side, so it is
+      // reported. Silence here would hide the residual entirely.
+      expect(errSpy).toHaveBeenCalledTimes(1);
+      expect(String(errSpy.mock.calls[0]![0])).toContain('aborted a steal')
+    } finally {
+      hrSpy.mockRestore();
+    }
+  });
+
+  // ------------------------------------------------- ownership-checked release
+  //
+  // Without this, one accepted steal cascades: the stolen-from holder wakes,
+  // finishes, and releases — deleting the NEW holder's lock, letting a third
+  // acquirer in with no steal and no log anywhere. The steal is loud; the
+  // overlap it seeds would be silent.
+  it('refuses to release a lock that has been taken over by another holder', () => {
+    expect(acquireLock(testDir)).toBe(true);
+
+    const newHolder = '999999 12345';
+    writeFileSync(pidFile, newHolder); // we were stolen from while frozen
+
+    releaseLock(testDir);
+
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(pidFile, 'utf-8')).toBe(newHolder);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0]![0])).toContain('declined to remove');
+  });
+
+  // The test above is necessary but NOT sufficient, and believing otherwise is
+  // what this one exists to correct. It rewrites the pid file BEFORE the
+  // release, so the ownership check simply sees a stranger and declines — which
+  // a naive check-then-delete implementation also does, correctly. It therefore
+  // passes whether or not the gap between the check and the delete is guarded,
+  // while being named for exactly that invariant.
+  //
+  // The defect lives entirely in that gap: read the record, judge it ours, and
+  // the lock can still turn over before the rmSync lands. `force: true` then
+  // deletes the NEW holder's live directory, and a third acquirer walks in with
+  // no steal logged anywhere — the same silent cascade the ownership check was
+  // added to prevent, reintroduced one statement below it.
+  it('does not delete the new holder\'s lock when the takeover lands mid-release', () => {
+    expect(acquireLock(testDir)).toBe(true);
+
+    const newHolder = '999999 12345';
+    let taken = false;
+
+    // Fires on the pid read that forms the ownership verdict: the instant an
+    // implementation has decided "this is mine" but has not yet removed
+    // anything. A competing process frees our lock and claims the path right
+    // here. Whatever we do next must not destroy what it created.
+    hooks.afterPidRead = (p: string) => {
+      if (taken || !p.endsWith('pid')) return;
+      taken = true;
+      rmSync(lockDir, { recursive: true, force: true });
+      mkdirSync(lockDir);
+      writeFileSync(pidFile, newHolder);
+    };
+
+    try {
+      releaseLock(testDir);
+    } finally {
+      hooks.afterPidRead = null;
+    }
+
+    expect(taken).toBe(true); // the window was actually entered
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(pidFile, 'utf-8')).toBe(newHolder);
+  });
+
+  // A bare parseInt reads "1234abc" as pid 1234. If that pid happens to be
+  // dead, partial corruption would license an immediate steal on an identity
+  // nobody ever wrote — so the record is parsed all-or-nothing.
+  it('does not steal on a half-parsable pid record naming a dead process', () => {
+    plantLock(`${deadPid()}abc`);
+    // Corrupt, and far younger than the recovery threshold: refuse and retry.
+    expect(acquireLock(testDir)).toBe(false);
+    expect(existsSync(lockDir)).toBe(true);
+  });
+
+  it('refuses to release a lock whose pid file has vanished', () => {
+    expect(acquireLock(testDir)).toBe(true);
+    rmSync(pidFile);
+
+    releaseLock(testDir);
+
+    // Cannot prove the dir is ours, so leave it: the age thresholds in
+    // acquireLock recover a pidless dir, and deleting a stranger's is worse.
+    expect(existsSync(lockDir)).toBe(true);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+
+  // ------------------------------------------- failed-claim cleanup is custody
+  //
+  // The cleanup after a failed pid write is a delete-by-pathname on a directory
+  // we created — and between our mkdir and our cleanup, that pathname can come
+  // to name someone else's lock. The pid-less directory we left behind is
+  // precisely what acquireLock steals after PIDLESS_STEAL_AFTER_MS, so a slow
+  // failing write is enough. Same defect class as the mid-release takeover.
+  it('does not delete a lock that replaced ours when our pid write fails', () => {
+    const foreign = '999999 12345';
+    hooks.beforeWrite = (p: string) => {
+      if (!p.endsWith('pid')) return;
+      hooks.beforeWrite = null;
+      // A competing acquirer judged our pid-less dir stale and now holds it.
+      rmSync(lockDir, { recursive: true, force: true });
+      mkdirSync(lockDir);
+      writeFileSync(pidFile, foreign);
+      const err: NodeJS.ErrnoException = new Error('simulated pid write failure');
+      err.code = 'EACCES';
+      throw err;
+    };
+
+    try {
+      expect(() => acquireLock(testDir)).toThrow();
+    } finally {
+      hooks.beforeWrite = null;
+    }
+
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(pidFile, 'utf-8')).toBe(foreign); // holder unharmed
+  });
+
+  // ------------------------------------------ identity is what we WROTE
+  //
+  // Recomputing the owner record at release time is not idempotent: if
+  // readStartTime fails transiently we compute "<pid>" where we stored
+  // "<pid> <start>", mismatch against our own lock, and decline to release it.
+  // That leak is permanent, not transient — the record names this live process,
+  // so every future acquirer judges it 'alive' and no age threshold ever runs.
+  it.skipIf(!HAVE_PROC)('releases its own lock even if its identity cannot be recomputed', () => {
+    expect(acquireLock(testDir)).toBe(true);
+
+    hooks.beforeRead = (p: string) => {
+      if (!p.startsWith('/proc/')) return;
+      const err: NodeJS.ErrnoException = new Error('simulated /proc failure');
+      err.code = 'EMFILE';
+      throw err;
+    };
+
+    try {
+      releaseLock(testDir);
+    } finally {
+      hooks.beforeRead = null;
+    }
+
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  // ------------------------------------------------ a failed release is loud
+  //
+  // Swallowing this is what makes it dangerous. Callers degrade to silence when
+  // they cannot acquire (checkInbox returns an empty list), so a wedged lock
+  // reads as "nothing to do" rather than as an outage — for as long as this
+  // process lives.
+  it.skipIf(process.getuid?.() === 0)('shouts when it cannot release the lock at all', () => {
+    expect(acquireLock(testDir)).toBe(true);
+    chmodSync(testDir, 0o555); // nothing inside can be renamed or unlinked
+
+    try {
+      releaseLock(testDir);
+    } finally {
+      chmodSync(testDir, 0o755);
+    }
+
+    expect(existsSync(lockDir)).toBe(true);
+    expect(errSpy).toHaveBeenCalledTimes(1);
+    expect(String(errSpy.mock.calls[0]![0])).toContain('FAILED to release');
   });
 });


### PR DESCRIPTION
**Based on #826** (`fix/lock-stale-detection` @ `e571bf1`) — that commit introduces `heldRecords`, which this one fixes. Review #826 first; against `main` this PR shows both commits, only `3631b22` is new.

## Scope

`heldRecords` is meant to answer "do we hold this lock, and with what record". Both halves were broken.

**1. A map miss fell back to `?? ownerRecord()`.** Releasing a lock we never took recomputed an identity and proceeded anyway — taking custody of a healthy *foreign* lock: renamed it aside, read it, renamed it back. That enters the restore window documented on `removeWithCustody`, where a third acquirer's fresh claim can be destroyed, and it logs `data guarded by it may be torn. Investigate` — a false alarm someone has to chase. Recomputing was never sound as identity either: `readStartTime` can fail transiently, so the recomputed record need not match the one we wrote. A miss is now a no-op.

**2. The entry survived a failed release**, so the map named a *process* rather than an *acquisition*. The entry is now cleared as soon as the acquisition ends.

Clearing it on *every* failure would be a new bug, so `Custody`'s `lost` is split:

| outcome | condition | do we still hold it? | entry |
|---|---|---|---|
| `vanished` | ENOENT | no — path is free | cleared |
| `stuck` | any other errno | **yes** — dir still there, still carrying our record | **kept** |

`stuck` must keep the entry. Dropping it would make every later release the no-op from (1) and **wedge the lock for the life of the process**, since a live holder is judged alive forever.

## Verified

`tsc --noEmit` clean. 32/32 (`lock.test.ts` 28 + 4 new).

**By mutation.** The 28 existing tests in `lock.test.ts` pass both before and after this change and went red on **none** of the five mutations — they are not evidence for it. Each mutation is caught only by the new file:

| mutation | tests that go red |
|---|---|
| restore `?? ownerRecord()` | 3 — no-op / duplicate / vanished |
| clear on every outcome (`if (true)`) | 1 — **STUCK** |
| clear only on `'removed'` (old behaviour) | 2 — duplicate / vanished |
| split collapsed to always `'stuck'` | 1 — **VANISHED** |
| split collapsed to always `'vanished'` | 1 — **STUCK** |

The last two pin each direction of the split independently.

An earlier draft of the vanished test re-acquired the lock to show the path was free. It **passed even when the record was wrongly kept** — re-acquiring repopulates the map with a byte-identical record, so cleared-or-not was unobservable. It now hands the freed path to a foreign holder instead, so the entry's absence is what the assertion rests on. That draft is why the "always `'stuck'`" row above exists.

The STUCK test forces EACCES by `chmod 0o555` on the parent dir, and asserts it actually hit that path — as root the chmod would not bite and the test would otherwise pass vacuously.

## Caveats — what this does NOT close

**Double-release is not safe in general.** If the process **re-acquires** the same path, `claimLock` writes a byte-identical record and repopulates the map, so a delayed release still matches and removes the new acquisition. Closing that needs a **generation nonce** in the record — a format migration, since the record is parsed by a fixed regex (`/^(\d+)(?: (\d+))?$/`, ~line 427). Deliberately not attempted here; worth its own issue.

The invariant actually established is the narrower **"`releaseLock` only ever touches an acquisition this process currently holds"**, and no more.

**A note on the filed task text.** The task this came from prescribed "clear `heldRecords` on declined/lost release". Taken literally that is *harmful*: `lost` covered two opposite situations, and clearing on a non-ENOENT failure is exactly the wedge described above. Hence the split. Flagging it because the prescription, not just the bug, needed correcting.

`removeWithCustody`'s decline path still does an unverified `renameSync(tmp, lockDir)` restore — pre-existing, untested, out of scope here.

---

**Pre-existing CI note:** the pre-push hook runs `npm run build && npm test`. On a clean detached worktree of `upstream/main` @ `a15baad` the suite already fails **33 tests across 4 files** (`upgrade-cron-teaching-cli`, `bus/hooks`, `cli/bus-crons`, `hooks/hook-crash-alert`) — verified as a control arm, identical count and files. Unrelated to this branch.
