### PR TITLE
daemon: record cron fires daemon-side (offload agent bus-write turns)

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -6,6 +6,7 @@ import { WorkerProcess } from './worker-process.js';
 import { FastChecker } from './fast-checker.js';
 import { CronScheduler } from './cron-scheduler.js';
 import { migrateCronsForAgent } from './cron-migration.js';
+import { updateCronFire } from '../bus/cron-state.js';
 import type { CronDefinition } from '../types/index.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
@@ -1149,6 +1150,16 @@ export class AgentManager {
       const injected = this.injectAgent(agentName, injection);
       if (!injected) {
         throw new Error(`injectAgent returned false for agent "${agentName}" — agent may not be running`);
+      }
+      // Record the fire daemon-side (best-effort) so the agent no longer has to
+      // spend an LLM turn running `cortextos bus update-cron-fire`. Writes the same
+      // cron-state.json record (upsert by name), so daemon + any residual agent-side
+      // write converge. Failures here must NEVER break cron dispatch — swallow and log.
+      try {
+        const stateDir = join(this.ctxRoot, 'state', agentName);
+        updateCronFire(stateDir, cron.name, cron.schedule);
+      } catch (err) {
+        console.error(`[daemon] Failed to record cron fire for "${agentName}/${cron.name}" (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
       }
     };
 


### PR DESCRIPTION
## What
The daemon now records each cron fire itself in `onFire` (best-effort `updateCronFire`), so agents no longer need to run `cortextos bus update-cron-fire` at the end of every cron — an extra per-cron agent round-trip.

## Why
On a large persistent-agent fleet this trims a recurring bookkeeping call from every cron execution. Recording daemon-side is also more accurate (dispatch time, not "whenever the agent remembered").

## Safety
- Additive + defensively wrapped (try/catch → log & continue) — cannot break cron dispatch.
- Upserts `cron-state.json` by name, so daemon + any residual agent-side write converge (no duplicates).
- `update-heartbeat` left agent-authored on purpose (daemon-authored liveness is intentionally distrusted).
- `cron.schedule` passed through as the record interval; that field is currently write-only.

## Validation
Verified on a downstream fork carrying the identical change: `typecheck`, `build` + `--help` smoke, and `test:codex` **48/48** (incl. `multi-agent-crons-codex`, `codex-bus-roundtrip`), plus cron-state / cron-scheduler / agent-manager suites. `this.ctxRoot`/`join(...,'state',agent)` matches the existing stateDir pattern in this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)