### PR TITLE
feat(community): claude-to-codex agent migration skill

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,10 @@ WINDOWS_INSTALL_REPORT.md
 *INSTALL_REPORT.md
 /PHASE*-REPORT.md
 docs/phase-reports/
+
+# claude-to-codex-migration leakage-guard fixture (author-specific ban tokens: fleet
+# roster + specific chat-ids). CI/local ONLY, pointed at by CTX_LEAKAGE_FIXTURE. NEVER
+# public — glob'd broadly so it can never be accidentally committed into the tree.
+leakage-fixture.json
+**/leakage-fixture.json
+*.leakage-fixture.json

--- a/community/skills/claude-to-codex-migration/SKILL.md
+++ b/community/skills/claude-to-codex-migration/SKILL.md
@@ -1,0 +1,751 @@
+---
+name: claude-to-codex-migration
+description: >-
+  Migrate ANY cortextOS agent from the claude-code runtime to the live
+  codex-app-server runtime. Use this whenever a user wants to convert,
+  port, move, or switch a Claude-cortextOS agent to Codex / gpt-5-codex /
+  gpt-5.5, "make agent X run on codex", "turn this claude agent into a codex
+  agent", or asks how a Claude agent's CLAUDE.md / .claude/skills / .mcp.json /
+  hooks map onto the codex-app-server adapter. Takes a source agent name and
+  produces a SEPARATE codex-shaped agent (non-destructive, dry-run by default).
+  Trigger even if they only say "migrate <agent> to codex" without naming the
+  artifacts. Do NOT use for creating a brand-new codex agent from scratch
+  (use `cortextos add-agent`) or for hermes/orchestrator/analyst runtimes.
+---
+
+# Claude -> Codex Agent Migration
+
+Convert a `runtime: claude-code` cortextOS agent into a `runtime: codex-app-server`
+agent that the live `CodexAppServerPTY` adapter can boot and loop. The migration is
+mostly a transform of the agent's in-repo directory plus a `config.json` runtime/model
+flip; the bus, crons, heartbeat, dashboard, and Telegram surfaces are already
+runtime-agnostic and carry over unchanged.
+
+This skill is GENERAL: it takes any source agent name/path as input. It is
+NON-DESTRUCTIVE: the source agent is never modified or deleted; you produce a
+separate codex-form agent. It is DRY-RUN BY DEFAULT: nothing is written until you
+pass `--apply`.
+
+## The promise and the contract
+
+The codex adapter (`src/pty/codex-app-server-pty.ts`) re-implements most of what
+Claude's `.claude/settings.json` hooks did, natively in code. So the migration is
+NOT "everything Claude-specific is lost." The honest decomposition is:
+
+- **1:1** -> copy verbatim (identity/soul/goals/memory/.env/workspaces/crons).
+- **TRANSFORM** -> rewrite into codex shape (config.json, CLAUDE.md, skills, MCP, refs).
+- **DROPPED (no equivalent)** -> exactly THREE in-turn Telegram behaviors lose their
+  hook: plan-mode->Telegram, AskUserQuestion->Telegram, PreCompact->Telegram. Re-home
+  them to the out-of-band bus `approvals` flow.
+- **NEEDS-HUMAN** -> items that cannot be mechanically converted and block enable.
+
+The cardinal rule: **never silently drop an artifact.** Every file the source agent
+owns lands in a bucket and appears in the report, including files this skill has no
+specific rule for (they go to a `port-verbatim` catch-all). If the tree-walk finds
+something with no rule, it is surfaced, not skipped.
+
+## How to run this: walk the USER through it (interactive, 5 steps)
+
+You (the implementing agent) do NOT run this silently. Migration changes a live
+agent's runtime and can take over a Telegram bot — the user must steer the
+irreversible choices. Run a conversation in exactly these five steps. The scripts
+below do the work; THIS section is the script YOU follow with the user.
+
+The whole flow maps onto the engine flags like this: STEP 1-2 gather the user's
+answers; STEP 3 is the deterministic convert; the bot/boot choices from STEP 2
+become `--bot-mode` / `--boot` / `--new-bot-token` on `convert.py`; STEP 5 reads
+the engine's `end_state`. With NO flags the engine is fully non-destructive
+(dry-run, source untouched, codex disabled) — so always do the STEP 1 detect as a
+dry-run first, ask, THEN apply with the user-confirmed flags.
+
+### STEP 1 — DETECT + plain-language SUMMARY (no changes yet)
+Run Step 0 + Step 1 (DETECT) below, read the manifest, then tell the user, in
+plain language (not JSON):
+- the agent name and its current runtime,
+- N skills (X custom / Y bundled-for-free),
+- M crons, the MCP servers (or "none"),
+- the Telegram bot it runs on,
+- what migrates CLEAN (1:1), what is LOSSY (the 3 dropped Telegram behaviors,
+  any leaky skills), and what will NEED THEM (the needs-human set).
+Make NO changes. This is the orientation read.
+
+### STEP 2 — ASK the user these 3 decisions, then WAIT for answers
+Present all three with their defaults; do not proceed until answered.
+
+- **Q1 TARGET.** Create a new agent `<name>-codex` ALONGSIDE the original
+  (DEFAULT — safe, fully rollbackable), OR replace the original in place?
+  Default is new-alongside. "Replace" is advanced/destructive — warn explicitly
+  that it removes the rollback path.
+- **Q2 BOT TOKEN (the key one).**
+  - **(a) REUSE the existing Telegram bot** -> the skill performs a CUTOVER: it
+    DISABLES the source Claude agent, copies its bot token into the codex agent,
+    and boots the codex agent on the SAME token. Telegram allows only ONE poller
+    per bot, so reuse REQUIRES disabling the source — this is intended and
+    seamless. End state: "X is now codex, same bot." (Sets `--bot-mode reuse`,
+    which implies boot.)
+  - **(b) NEW bot** -> the user pastes a new bot token (from @BotFather); it goes
+    in the codex agent's env, and BOTH source and codex can run side by side.
+    (Sets `--bot-mode new --new-bot-token <token>`.)
+- **Q3 BOOT.** After migrating, boot the codex agent now, or leave it DISABLED
+  for the user to inspect first? (If Q2=reuse-cutover, booting is implied — still
+  confirm with the user.) (Sets `--boot now` or `--boot no`, default `no`.)
+
+### STEP 2b — WRITE-SIDE HANDOFF GATE (HARD, cutover only — block before any teardown)
+This is a NON-NEGOTIABLE pre-cutover gate. A clean cutover requires real session
+continuity, not a synthesized handoff. Before any `--bot-mode reuse`:
+1. Record the migration-start timestamp and pass it as `--migration-start-ts`.
+2. **AUTHORIZE the migration — the gate depends on REVERSIBILITY.** A
+   security-hardened source agent will (CORRECTLY) REFUSE a cold bus demand to run a
+   handoff — it reads "produce a handoff now, urgent, via bus" as a prompt-injection
+   pattern and escalates instead of complying (good behavior; clean-room test runs
+   proved it). How you authorize depends on what the migration DOES:
+
+   **2a. OWNER-DIRECT-CONFIRM — REQUIRED for an irreversible / external-surface /
+   shared-system cutover (defect 9).** `--bot-mode reuse` is a BOT-HANDOVER: the
+   target takes over the source's live Telegram surface — irreversible and
+   externally visible. Per the approval doctrine, an irreversible external-surface
+   action requires the OWNER (the user) to confirm DIRECTLY, OUT-OF-BAND, over the
+   TARGET agent's own trusted surface (e.g. the principal sends the SOURCE agent a
+   direct Telegram: "migration to <target> is authorized, comply with the next
+   handoff request"). This is the AUTHORIZATION gate. An orchestrator-minted in-band token is
+   NOT sufficient for it: a transmitted token is itself an attack surface (any agent
+   that sees the bus can quote it), and request-authenticity is not owner-authorization
+   for an irreversible action. The source complies because its OWNER told it to,
+   directly. Do NOT substitute a delegated/relayed approval for the owner's direct
+   confirm on an irreversible cutover.
+
+   **The owner confirm must be EXPLICIT, UNAMBIGUOUS, and verified at the RECIPIENT
+   (defect 10).** Three hard sub-rules, all proven by a clean-room test run where a
+   relayer inflated a bare owner "Authorized" into the full gate phrase:
+   - SPECIFIC: the owner's confirm must NAME the target AND the action ("migration to
+     `<target>` authorized, comply with the next handoff request"). A bare affirmation
+     ("Authorized", "ok", "go", "bet") is ACK, NOT approval — it does not satisfy the
+     gate, especially if it answers nothing specific or leaves a target's clarifying
+     question unanswered.
+   - VERBATIM RELAY ONLY: anyone relaying the owner's authorization must quote the
+     owner's LITERAL words — NEVER a characterization or upgraded interpretation. An
+     owner saying "I sent it" to a relayer is an action-CLAIM, not verification of
+     CONTENT. If the owner's words are ambiguous, the gate is NOT met and you HOLD —
+     you do NOT fill the gap. (Pairs with the fleet provenance-travels-verbatim rule.)
+   - GATE-SIGNAL = RECIPIENT CONFIRMS RECEIPT: the gate is satisfied ONLY when the
+     TARGET agent confirms, in ITS OWN channel, that it received the owner's specific
+     unambiguous confirm — NOT when a relayer claims the owner "sent it." The recipient
+     is always the source of truth for what was actually received. Fire the cutover
+     only after the target confirms receipt. (The architecture must not depend on the
+     relayer being perfect; the target verifying is the safety, which is why it exists.)
+   - STRONGEST / CANONICAL FORM (preferred): TARGET-INITIATED — the target itself asks
+     its owner, IN ITS OWN CHANNEL, to authorize the migration; the owner approves
+     THERE verbatim; the target confirms receipt. This keeps the entire authorization
+     path inside the target's own trusted channel with ZERO relayer, structurally
+     closing the inflation gap rather than relying on relay discipline. (You may still
+     paste the owner the exact phrase to send — but the GATE is the target's
+     receipt-confirmation, never your claim.)
+
+   **2b. ONE-TIME TOKEN — defense-in-depth for REQUEST AUTHENTICITY (defect 8ii),
+   optional layer / sufficient alone only for REVERSIBLE migrations.** The
+   orchestrator mints a short ONE-TIME TOKEN, pre-arms the source ("comply when the
+   migration agent requests handoff:create AND quotes token `<TOKEN>`"), and the
+   migration agent ECHOES that exact token INLINE with the provenance. This proves the
+   handoff request is the authentic migration agent (defeats an attacker riding the
+   window) and is appropriate for low-stakes/reversible migrations — but for an
+   irreversible cutover it is a SUPPLEMENT to 2a, never a replacement.
+
+   In all cases: NEVER a bare urgent demand, and NEVER bypass a refusal — if the
+   source refuses, the authorization gate was not satisfied; fix it (get the owner
+   confirm), do not force past it.
+3. **FLUSH IN-SESSION CORRECTIONS FIRST (defect 13 — HARD pre-handoff step).**
+   Before the source runs `handoff:create`, tell it to FLUSH any recent in-session
+   behavioral corrections to PERSISTED state (memory/ + GUARDRAILS.md): routing
+   rules, suppression rules ("never surface X"), triage-only rules, per-recipient
+   overrides — anything a human told it THIS session that it has not yet written
+   down. **The migration carries only PERSISTED artifacts + the handoff; unpersisted
+   in-session context does NOT exist as migratable state and will be LOST at
+   cutover.** It is also not enough for the correction to change behavior while
+   leaving a stale config/cron in place — e.g. if the operator said "stop sending
+   pending-items direct to the principal" but the cron prompt still says so, the migrated
+   cron inherits the WRONG behavior. So the source must, in this flush: (a) write
+   the correction to memory/GUARDRAILS.md, AND (b) fix any config/cron whose text
+   still encodes the pre-correction behavior. This is a KNOWN HARD LIMITATION of
+   migration, not a bug to engineer around: the handoff is a summary, not a
+   substitute for persisted guardrails. (Observed failure mode: a migrated agent
+   inherited several same-day behavioral corrections that were never persisted — it
+   resumed sending items directly to the principal, surfaced messages it had been
+   told to suppress, and re-surfaced a suppressed item — because the source agent
+   never wrote those corrections down before cutover.)
+4. Tell the (now pre-armed) LIVE source agent to run its NORMAL handoff procedure
+   (the same `handoff:create` it runs at its context-handoff threshold). Do NOT
+   synthesize a handoff yourself.
+5. convert.py BLOCKS and polls the SOURCE WORKSPACE `<src-dir>/memory/handoffs/` —
+   where agents ACTUALLY write handoffs (defect 8i: NOT `state/<source>/handoffs/`,
+   which usually does not exist) — for a handoff whose mtime is AFTER the
+   migration-start timestamp. A pre-existing stale handoff does NOT satisfy the gate.
+   If no fresh handoff appears within `--handoff-wait` seconds (default 300), the
+   cutover ABORTS: the source is NOT disabled, the target is NOT enabled (end_state
+   `cutover-aborted`).
+That fresh handoff is then carried into a DETERMINISTIC location in the new agent's
+dir so it is ALWAYS reliably read on boot (not a "newest file" guess): into BOTH the
+daemon boot-state dir `state/<target>/handoffs/` AND the new agent's WORKSPACE
+`memory/handoffs/` (its native handoff:resume dir), as the NEWEST file in each, and a
+deterministic boot directive (`state/<target>/.handoff-doc-path`) is written so the
+daemon points the new agent at the exact file as its FIRST action on boot (the same
+CONTEXT HANDOFF injection mechanism the daemon uses for restarts). The side-by-side
+(`--bot-mode new`) and disabled (default) paths do NOT take over the source and are
+NOT gated.
+
+### STEP 3 — AUTOMATE everything else SILENTLY (no questions)
+Run CONVERT (Step 3 below) with the flags from STEP 2. The script does, with no
+further questions: config flip, skill relayout + symlinks, CLAUDE.md->AGENTS.md
+fold, boot-state continuity carry (`.onboarded` + markers + handoffs/ so the agent
+does NOT cold-onboard), stale-session-transcript exclusion, the cron UNION
+migration (config.json + live registry, deduped, paths translated, direct-to-principal
+sends re-routed through the orchestrator by BOTH chat-id token AND prose intent — defect 14;
+one-shot crons carried as their daemon-loadable registry crontab form instead of
+the config `type:once`/`fire_at` form the daemon silently drops — defect 11b, with
+a loud per-cron flag), guardrail-into-template (routing + approval rules),
+memory, MCP TOML emit, registry-disable, plus (from the flags) the bot-token write,
+the write-side handoff gate, the cutover source-disable, **the cutover
+SOURCE-CRON-disable (defect 11a: disabling the source AGENT does NOT disable its
+CRONS — they stay enabled in the registry and re-fire on daemon restart/re-enable =
+durable dual-scheduler; the script disables every RECURRING source cron and HOLDS
+one-shots until the operator re-arms them on the target)**, and the boot. It also runs a
+SQLITE-INTEGRITY pass (defect 15): skill data is raw-copied, and copying a LIVE
+sqlite DB tears it (an agent's live signals DB came over malformed) — so every copied
+`*.db` is integrity-checked, any torn one is re-copied from source via the sqlite
+backup API (a consistent snapshot, even of a live DB) and re-asserted; a DB that
+still cannot be made sound is a HARD cutover-blocking failure (default-deny: abort
+before any source teardown, exit non-zero — a migration that cannot produce a valid
+DB copy must not report success). `os.walk` skips symlinks, so shared skills are
+untouched — only the agent's own copies. Two of these are guaranteed by `verify.py`
+OUTCOME-ASSERTIONS, not by trusting the step ran: (1) no RECURRING source cron
+stays enabled post-cutover (defect 11a), and (2) no migrated cron routes to the principal
+by token OR prose (defect 14); the sqlite pass is itself prevent-plus-assert. Verify by OUTCOME,
+never assume a step ran — a skilled operator hand-rescuing during a test masks a
+missing step completely (this exact class-bug hid behind manual rescue across two
+live migrations).
+
+### STEP 4 — PAUSE for the genuinely-human items only
+List the needs-human set from the manifest/convert log and let the user pick
+handle-now or skip for each:
+- the 3 dropped in-turn Telegram behaviors (re-home to the bus approvals flow),
+- leaky custom skills to rewrite (hand to skill-creator),
+- AGENTS.md de-dup after the fold,
+- TOOLS.md Claude-auth-env flag.
+These are the items no script can safely auto-do (Step 4 below has the detail).
+
+### STEP 5 — FINAL REPORT (end-state aware)
+Render the report (Step 6 below). Read the engine's `end_state` and lead with the
+matching line:
+- cutover: "**<X>-codex is live on the original bot; Claude <X> is disabled.**"
+- new-bot + boot: "**<X>-codex is live on its new bot; <X> is still running.**"
+- left disabled (default): "**Ready — run `cortextos enable <name>-codex` when
+  you're happy.**"
+
+## Instance-discovery (routing is parameterized, not baked to any fleet)
+
+cortextOS fleets often run a routing rule: **principal-facing sends route THROUGH an
+orchestrator agent** (the one that owns the principal's Telegram surface). This skill
+KEEPS that rule but discovers WHO the principal and orchestrator are for YOUR
+deployment — nothing is hardcoded. Three values, each discovered-then-safe-degraded:
+
+| Value | `convert.py` param | Discovery precedence | If unknown (safe-degrade) |
+|-------|--------------------|----------------------|---------------------------|
+| Principal chat id | `--principal-chat-id` | param -> source `.env` `CHAT_ID` -> `ALLOWED_USER` (if numeric) | literal-id reroute leg OFF (nothing hunted) |
+| Principal name | `--principal-name` | param -> source `.env` `ALLOWED_USER` (if non-numeric) | prose-intent reroute leg OFF (no false name match) |
+| Orchestrator (reroute target) | `--orchestrator <name>` | param -> auto-scan siblings for a POSITIVE role signal (config `role`/`template`==orchestrator OR an IDENTITY/SOUL self-declaration), exactly-one match only | **whole reroute OFF**; principal-facing crons FLAGGED needs-human |
+| Org | `--org <org>` | param (no default) | — |
+
+Key behaviors:
+- **The reroute is GATED on the orchestrator being known.** A known principal chat id
+  with an UNKNOWN orchestrator does NOT rewrite anything (no send-into-the-void). Pass
+  `--orchestrator <name>` to enable routing, or the crons are surfaced for manual review.
+- **Auto-scan never guesses.** It requires a positive role declaration; it will NOT
+  pick the lone sibling in a 2-agent fleet. A single positive hit is SURFACED in the
+  report for you to confirm before trusting the reroute. In most fleets it finds
+  nothing and you simply pass `--orchestrator` — that is the expected, honest path.
+- **Guardrails split.** The APPROVAL guardrail ("no external action without an explicit
+  per-item go") is always injected. The ROUTING guardrail (naming the orchestrator) is
+  injected ONLY when both orchestrator and principal are known.
+- **Double-unknown** (no orchestrator AND no principal) emits ONE loud needs-human line
+  in the report — routing reroute disabled; review crons manually.
+
+## The flow: DETECT -> MAP -> CONVERT -> VERIFY -> REPORT
+
+```
+/migrate-agent-to-codex <source-agent> [--org <org>] [--target-name <name>]
+    [--dry-run | --apply]      # default: --dry-run
+    [--instance <id>]          # default: default
+    [--orchestrator <name>]    # reroute target; else auto-scan -> safe-degrade
+    [--principal-chat-id <id>] [--principal-name <name>]  # else from source .env
+```
+
+Run the bundled scripts in order. They do the deterministic work; YOU do the
+judgment work (the fold review, the leakage adjudication, the needs-human decisions).
+Read `references/` files when a step points you there.
+
+### Step 0 — Resolve paths and orient
+
+```bash
+# SKILL_DIR is the directory holding THIS SKILL.md and its scripts/. This file is
+# READ by you, not executed, so there is no $0 — set it to the absolute path of the
+# skill dir you are reading from (or `cd` into it and use `SKILL_DIR="$(pwd)"`).
+SKILL_DIR="<absolute path to the dir containing this SKILL.md>"
+SRC_AGENT="<source-agent>"
+ORG="<org>"                          # your org (no default — pass it explicitly)
+INSTANCE="default"
+# CTX_ROOT comes from the source agent's .cortextos-env, NOT a guess:
+CTX_ROOT="$(grep -E '^CTX_ROOT=' orgs/$ORG/agents/$SRC_AGENT/.cortextos-env | cut -d= -f2-)"
+SRC_DIR="orgs/$ORG/agents/$SRC_AGENT"
+# Migration-start cutoff for the write-side handoff gate: only a source handoff
+# produced AFTER this timestamp satisfies the gate. Capture it ONCE, before the
+# source is told to run handoff:create, and reuse it for convert.py + verify.py.
+MIGRATION_START_TS="$(date +%s)"
+```
+
+Confirm the source is a Claude agent. Refuse if `config.json.runtime` is already
+`codex-app-server` (nothing to migrate) or `hermes` (out of scope).
+
+### Step 1 — DETECT (always runs, even in dry-run)
+
+```bash
+python3 "$SKILL_DIR/scripts/detect.py" \
+  --src-dir "$SRC_DIR" --ctx-root "$CTX_ROOT" --agent "$SRC_AGENT" \
+  > /tmp/migrate-$SRC_AGENT-manifest.json
+```
+
+`detect.py` walks the whole agent dir and the relevant `$CTX_ROOT` state, classifies
+every artifact into a bucket (`one_to_one`, `transform`, `dropped`, `needs_human`,
+`port_verbatim`), greps custom skills for Claude-only leakage, and emits a JSON
+manifest. The catch-all `port_verbatim` bucket guarantees no file is dropped just
+because there is no rule for it.
+
+Read the manifest. It is the heart of the dry-run. Pay attention to:
+- `hard_stops` — non-empty means STOP and report before any convert (see Step 2).
+- `needs_human` — the blocking set; the migrated agent stays disabled until resolved.
+- `skills.custom` with `leakage_hits` — these need your adjudication (Step 4).
+- `mcp.servers` — each populated server is real host-config + secrets work.
+
+### Step 2 — Pre-flight hard stops (block before convert)
+
+Surface these BEFORE writing anything. They are non-negotiable:
+
+1. **Non-codex template — HUMAN pre-check (not automated).** If the source was
+   scaffolded from `orchestrator`, `analyst`, or `m2c1-worker`, there is no codex
+   variant — do NOT migrate it (`add-agent` rejects the combo; hand-building a
+   degraded agent is wrong). The `hermes` runtime IS caught automatically (it shows
+   up as `config.json.runtime == hermes` and detect.py hard-stops on it). The other
+   three are NOT reliably auto-detectable: no template field is persisted in
+   config.json, the runtime is plain `claude-code`, and identity files diverge from
+   the template after customization, so by migration time they look like an ordinary
+   `agent` scaffold. detect.py emits a best-effort ADVISORY note when source files
+   resemble one of these templates, but YOU must confirm the source's lineage before
+   proceeding — this skill does not (and cannot) mechanically enforce it.
+2. **Target name collision.** If `--target-name` resolves to an existing dir,
+   `add-agent` refuses. Same-name reuse requires disabling/renaming the source FIRST
+   — ask, never auto-clobber. Safe default: `--target-name <source>-codex`.
+3. **MCP host-global name collision.** Codex MCP server names are host-wide (NOT
+   `<agent>__`-namespaced like skills). If the source's `.mcp.json` declares a server
+   whose name already exists in `~/.codex/config.toml` for a DIFFERENT definition,
+   that is a collision a human must resolve. HARD STOP until decided.
+4. **BOT_TOKEN reuse.** The source `.env` BOT_TOKEN cannot be shared by two live
+   agents (Telegram `getUpdates` conflict). The target needs EITHER a new bot token
+   OR the source disabled first. Decide before enable. Do not copy a live BOT_TOKEN
+   into a second agent that will run concurrently.
+
+### Step 3 — CONVERT (only on --apply)
+
+**MANDATORY, ORDERED prerequisite:** lay the codex skeleton with `add-agent`
+FIRST, then run convert. This is not optional and not reversible in order: convert
+overlays onto the skeleton and hard-refuses (exit 1) if
+`.agents/plugins/marketplace.json` is absent in the target. Reusing `add-agent`
+gets you the marketplace.json, the 23-skill codex stdlib, symlink wiring, config
+defaults, a correct per-agent `.cortextos-env`, org-context seeding, and
+enabled-agents registration for free.
+
+```bash
+TARGET="${TARGET_NAME:-${SRC_AGENT}-codex}"
+cortextos add-agent "$TARGET" --template agent-codex --runtime codex-app-server --org "$ORG"
+# add-agent MUST have created orgs/$ORG/agents/$TARGET/.agents/plugins/marketplace.json
+# before convert will proceed.
+```
+
+Then run the converter, which overlays everything the skeleton does not provide:
+
+```bash
+python3 "$SKILL_DIR/scripts/convert.py" \
+  --manifest /tmp/migrate-$SRC_AGENT-manifest.json \
+  --src-dir "$SRC_DIR" \
+  --target-dir "orgs/$ORG/agents/$TARGET" \
+  --target-agent "$TARGET" \
+  --ctx-root "$CTX_ROOT" \
+  --source-agent "$SRC_AGENT" --migration-start-ts "$MIGRATION_START_TS" \
+  --apply
+  # --migration-start-ts is the write-side handoff-gate cutoff (STEP 2b); on a
+  # cutover convert.py BLOCKS up to --handoff-wait (default 300s) for a source
+  # handoff newer than it, and ABORTS the cutover if none appears.
+  # Interactive-flow flags from STEP 2 (omit all for the SAFE default:
+  # source untouched, codex disabled, no boot — exactly the legacy behavior):
+  #   --bot-mode reuse                 # CUTOVER: disable source, copy its bot
+  #                                    # token to codex, IMPLY boot (one bot)
+  #   --bot-mode new --new-bot-token T # write a fresh token; both run side-by-side
+  #   --boot now                       # enable+start codex (implied by reuse)
+  #   --source-agent "$SRC_AGENT" --org "$ORG" --instance "$INSTANCE"
+  #                                    # required for reuse-cutover + boot
+```
+
+**Flag semantics (engine):** all four flags default to the SAFE path. `--bot-mode
+none` (default) and `--boot no` (default) = source untouched, codex disabled, no
+token change — byte-identical to running with no flags at all. The destructive
+parts ONLY happen when the user-confirmed flags are present:
+- `--bot-mode reuse` -> (i) source `config.json` enabled:false AND source registry
+  entry enabled:false (the cutover source-disable), (ii) source BOT_TOKEN copied
+  into the codex `.env` (0600), (iii) boot implied.
+- `--bot-mode new` -> writes `--new-bot-token` into the codex `.env`; if the token
+  is omitted it writes a `REPLACE_ME_WITH_NEW_BOT_TOKEN` placeholder and emits a
+  needs-human line. Source is NOT touched.
+- `--boot now` (or implied by reuse) -> flips codex `config.json` + registry to
+  enabled:true and runs `cortextos enable <target> --org <org>` to start it.
+The engine prints an `end_state` (`disabled` | `live` | `cutover-live`) on stdout;
+STEP 5 of the report keys off it.
+
+`convert.py` performs the deterministic transforms (detailed per-artifact in the next
+section). It does NOT make judgment calls: it stages the CLAUDE.md fold for your
+review, copies leakage-clean custom skills, rewrites mechanical refs, transforms
+`.mcp.json` into TOML it prints for you to merge, and drops the `.force-fresh` marker.
+After it runs, do the human steps it flags (fold review, leakage rewrites, MCP merge,
+symlink install).
+
+**By default it leaves the agent DISABLED in BOTH places.** `add-agent` registers the
+new agent in the instance registry `$CTX_ROOT/config/enabled-agents.json` as
+`enabled:true`, and the daemon reads THAT registry (not the agent-dir config.json) for
+live enable state. So setting only config.json `enabled:false` would leave a migrated
+agent LIVE. With no interactive flags, convert.py flips the target's registry entry to
+`enabled:false` too (merge-only, touching no other agent's key), and verify.py asserts
+both — enabling is then a separate explicit step. **The ONLY way the target boots (or the
+source gets disabled) is when the user-confirmed STEP 2 flags are passed:** `--boot now`
+re-enables the target in both places and starts it via `cortextos enable`; `--bot-mode
+reuse` additionally disables the SOURCE in both places (the cutover). Absent those flags,
+nothing is enabled and the source is never touched.
+
+### Step 4 — Human judgment steps (the parts no script can do)
+
+1. **Review the folded AGENTS.md.** `convert.py` appends the source CLAUDE.md's
+   substantive content under a clearly-labeled section. A blind concat can put
+   contradictory instructions into the ONE file codex auto-reads. Read the merged
+   AGENTS.md end to end, de-duplicate overlapping sections (session-start protocol,
+   etc.), and resolve conflicts in favor of the codex-tuned wording. This is mandatory.
+2. **Adjudicate leakage-flagged custom skills.** For each custom skill with
+   `leakage_hits`: if the hits are mechanically rewritable (a `.claude/skills/x` path,
+   an `ANTHROPIC_API_KEY` mention) `convert.py` already rewrote them — confirm. If the
+   skill embeds Claude-Code-only BEHAVIOR (relies on `ExitPlanMode`, the Claude `Agent`
+   tool's subagent types, or `mcp__<x>__*` tool calls), it is NEEDS-HUMAN: hand it to
+   the `skill-creator` skill for a codex rewrite. Do not ship a broken skill — it
+   degrades the codex agent on first boot. Note: grep-clean is necessary, not
+   sufficient; a skill can pass the grep and still depend on Claude tool semantics, so
+   a boot-probe (Step 5 Tier 2) is the real confirmation.
+3. **Install the symlinks.** After custom skills are in
+   `plugins/cortextos-agent-skills/skills/`, ensure every one has a host symlink:
+   `~/.codex/skills/<target>__<skill>`. Re-running `cortextos add-agent`'s symlink path
+   is the cleanest way; `convert.py --apply` also creates them directly. The installer
+   ONLY walks `plugins/cortextos-agent-skills/skills/*` — so put ALL custom skills
+   there, never in `.agents/skills/` (which gets no symlink). Symlinks are REQUIRED,
+   not optional; do not rely on cwd-relative discovery masking a miss.
+4. **Merge MCP servers + provision secrets.** For each populated MCP server,
+   `convert.py` printed a `[mcp_servers.<name>]` TOML block. MERGE it into the
+   host-global `~/.codex/config.toml` (never overwrite the file — it is shared by all
+   codex agents). The secret is NOT in the block: it is referenced via
+   `bearer_token_env_var`. Add that env var to `orgs/<org>/secrets.env` (or the shell
+   profile). Codex resolves it at app-server startup.
+5. **Verify host model auth exists.** Codex model auth is host-global
+   (`~/.codex/auth.json`), selected as `model` in `~/.codex/config.toml`. VERIFY it
+   exists (`codex` is logged in); NEVER mint or copy model credentials per agent. The
+   agent `.env` stays Telegram/bus/tool secrets only — no gpt-5.5 auth in `.env`.
+   `cortextos doctor` covers host-level auth/binary checks; reuse it.
+
+### Step 5 — VERIFY
+
+**THE GATE (NON-NEGOTIABLE).** The migration is NOT "done" until `verify.py` exits
+`0`. Every step before this is best-effort; `verify.py` is the OUTCOME-ASSERTION that
+the agent actually WORKS after cutover, not merely that files COPIED. A non-zero exit
+is a HARD STOP: do NOT report success, do NOT enable the target, do NOT tell the user
+"migrated" — fix the failing assertion (or surface it as a blocking needs-human) and
+re-run until it passes. Verify is mandatory and runs on BOTH the dry-run and the
+`--apply` pass; the `--apply` run's green is the one that authorizes "done".
+
+```bash
+python3 "$SKILL_DIR/scripts/verify.py" \
+  --target-dir "orgs/$ORG/agents/$TARGET" --target-agent "$TARGET" --ctx-root "$CTX_ROOT" \
+  --source-dir "$SRC_DIR" --source-agent "$SRC_AGENT" \
+  --migration-start-ts "$MIGRATION_START_TS"
+  # --source-dir/--source-agent enable the cron-UNION assertion (and the cutover
+  # source-disable check); --migration-start-ts enables the fresh-handoff assertion.
+  # Match the assertion to the end state the user chose in STEP 2:
+  #   (no flag)         default -> assert codex DISABLED in config.json + registry
+  #   --expect-boot     user chose --boot now (new-bot path) -> assert codex ENABLED
+  #   --expect-cutover  user chose bot reuse -> assert codex ENABLED *and* the
+  #                     SOURCE disabled in both config.json + registry
+```
+
+- **Tier 1 (static, always).** Asserts the codex tree is well-formed:
+  `config.json.runtime == codex-app-server`, `model` present, the codex
+  enabled-state matches the chosen end state (DEFAULT: `enabled:false` in
+  config.json AND in the registry `$CTX_ROOT/config/enabled-agents.json` — the
+  daemon reads the registry, so it is the load-bearing assertion; with
+  `--expect-boot`/`--expect-cutover` it instead asserts `enabled:true` in both, and
+  `--expect-cutover` additionally asserts the SOURCE is `enabled:false` in both),
+  NO `CLAUDE.md`, NO `.claude/settings.json`,
+  AGENTS.md present, every custom skill present under `plugins/.../skills/` AND
+  symlinked, `.env` present and 0600, no stale `codex-app-server-thread.json` (and
+  no `*thread.json`), `.force-fresh` marker present. ALSO asserts the migration
+  invariants: `state/<target>/.onboarded` present (no cold-onboard); the
+  source-generated fresh handoff is the NEWEST file in `state/<target>/handoffs/`
+  and `.handoff-doc-path` references it; the target cron set matches the source
+  union (no drops) and every cron's cd/skills path resolves in the target workspace;
+  no migrated cron sends direct to the principal; the routing+approval guardrails are
+  present in the target bootstrap (`GUARDRAILS.md` + `approval_rules`).
+  ALSO the does-it-WORK assertions: every custom skill symlink RESOLVES (not just
+  exists — a dangling/mis-targeted link FAILS, since Codex can't load it); every
+  MCP server the source declared is installed as `[mcp_servers.<name>]` in
+  `~/.codex/config.toml` with its bearer token in `secrets.env` (else a live 401);
+  every migrated `*.db` passes a sqlite `integrity_check` (no torn live-copy);
+  and on `--expect-cutover`: the recurring source crons are disabled in the source
+  `config.json` too (not just the registry — the config==registry drift guard), and
+  NO sibling agent strands a hardcoded ref to the retired `agents/<source>` path
+  (it would read stale/empty post-cutover — repoint it to `agents/<target>`).
+- **Tier 2 (live boot probe, only on explicit go).** This enables the agent for a
+  bounded probe, watches the log, then disables it. It costs codex tokens and briefly
+  puts the agent live — never run it in dry-run, never without explicit user go.
+  Signals (from the adapter):
+  - boot OK: log contains `[codex-app-server] ready thread=<id>` (BOOTSTRAP_PATTERN).
+  - boot FAIL: log contains `[codex-app-server] degraded:`.
+  - loop OK: a `turn/completed` fires and `last_idle.flag` is written after a trivial
+    probe turn.
+  - skills wired: `skills/list` returns the expected custom-skill names.
+  This is a boot probe, not a soak. Label it as such; do not claim a soak passed.
+
+### Step 6 — REPORT
+
+Render `references/report-template.md`, filled from the manifest + convert log +
+verify results. Rules:
+- **Lossy / dropped items are NEVER silent.** Every dropped or transformed artifact
+  gets a line with a reason and the codex-native alternative (or an honest "lost").
+- **Order by severity:** hard-stops first, then dropped (no-equivalent), then
+  needs-human, then transformed, then the clean 1:1 list last. Do not bury a dropped
+  behavior under green checkmarks.
+- **Separate "done" from "needs you."** The needs-human section is the blocking set;
+  the agent stays disabled until those are resolved.
+- The dry-run report IS the approval artifact: the user reads it, then re-runs
+  `--apply` with the STEP 2 flags. LEAD with the END STATE line matching the
+  engine's `end_state` (cutover-live / live / disabled — see report-template.md).
+- For the DISABLED end state, end with the exact enable command, gated on review:
+  `cortextos enable <target> --org <org>`. For LIVE / CUTOVER-LIVE, the agent is
+  already booting — give the boot-probe + rollback commands from the template
+  instead.
+
+## Per-artifact handling (the mapping)
+
+This is the lookup the scripts implement. Use it to read the manifest and the report.
+
+### config.json — TRANSFORM (mechanical)
+Flip `runtime` `"claude-code"` -> `"codex-app-server"` (this is the ONLY field the
+daemon branches on to select the codex PTY — setting it wrong silently keeps the
+claude PTY). Set `model` to a codex model (`gpt-5-codex` template default; `gpt-5.5`
+also valid). DROP `dangerously_skip_permissions` (meaningless — codex hardcodes
+`approvalPolicy:'never'` / `danger-full-access`). DROP the `ecosystem` block (the
+codex template does not carry it). ADD `codex_context_cap` (default 256000) so codex
+has a context-window fallback when the app-server reports null `modelContextWindow`.
+CARRY all runtime-agnostic knobs from the source: `timezone`, `day_mode_*`,
+`communication_style`, `approval_rules`, `startup_delay`,
+`max_session_seconds`, `max_crashes_per_day`, `crash_window`, `telegram_polling`.
+`crons[]` is NOT carried here — it is migrated separately (see Crons below)
+because config.json can DIVERGE from the live registry.
+`agent_name` is set to the TARGET name (not the source). `working_directory` is
+NOT carried verbatim: if the source pins a launch path INSIDE its own agent dir,
+the target would inherit the same `~/.claude/projects/<dashed-path>/` JSONL key
+and share the source's stale session state (defeating the `.force-fresh` guard) —
+that case is a HARD STOP, and the target is left with `working_directory=""` (its
+own dir). A working_directory pointing OUTSIDE the source agent dir (a genuine
+external repo) is carried.
+
+Cost note: `dashboard/src/lib/cost-parser.ts` maps any model containing `gpt-5` to
+`gpt-5-codex` PRICING. So a `gpt-5.5` agent is costed at gpt-5-codex rates. If gpt-5.5
+has different real pricing, flag it as needs-human (cost rows will be wrong until a
+dedicated `gpt-5.5` pricing entry is added) — the migration does not block on it but
+the report must name it.
+
+### CLAUDE.md -> AGENTS.md fold — TRANSFORM + NEEDS-HUMAN review
+Codex has NO `CLAUDE.md`; `AGENTS.md` is the only file codex auto-reads. If the source
+CLAUDE.md is a thin `@AGENTS.md` wrapper, just drop it. If it has real per-agent
+content (inbox routing, graphify rules, etc.), fold that content into AGENTS.md under a
+labeled heading, rewrite Claude-isms during the fold (`.claude/skills/x` paths,
+`~/.claude/` mentions, CLAUDE.md-cascade phrasing), then DELETE CLAUDE.md from the
+target. The concat is automatic; the semantic de-dup is a mandatory human review.
+
+### Skills relayout — TRANSFORM
+`.claude/skills/<skill>/` -> `plugins/cortextos-agent-skills/skills/<skill>/SKILL.md`.
+Diff the source skill set against the 23-skill codex stdlib (see
+`references/codex-bundled-skills.txt`): skills already in the bundle come for free via
+`add-agent` — do NOT re-copy. RE-EXAMINE any skill that is a Claude-STANDARD/bundled
+skill but absent from the codex 23 (e.g. `one-big-feature`, `skill-creator`, `docx`,
+`code-review`): the grep treats it as plain custom, but it can carry Claude-specific
+orchestration semantics (subagent types, plan-mode loops, ExitPlanMode) that a token
+grep misses. detect.py flags these as needs-human; confirm a codex equivalent exists
+or rewrite via skill-creator before shipping. For each CUSTOM skill (not in the bundle):
+leakage-grep first (`references/leakage-tokens.txt`); if clean, copy the whole dir verbatim
+(SKILL.md + resources/ + templates/); if it has mechanically-rewritable refs, copy +
+rewrite; if it embeds non-portable Claude behavior, NEEDS-HUMAN -> skill-creator.
+Then `convert.py` re-runs the FULL symlink install over EVERY dir in
+`plugins/cortextos-agent-skills/skills/*` (bundled + custom), creating/refreshing
+`~/.codex/skills/<target>__<skill>` for each — idempotent, and it never clobbers a
+real (non-symlink) file at the link path. This is deliberate: verify.py asserts a
+symlink for every skill dir incl the 23 bundled ones, and add-agent's installer
+silently no-ops on a pre-existing non-symlink, so the scripted path must guarantee
+the links itself rather than assume them. The marketplace.json registration ships
+with the codex skeleton from `add-agent`.
+
+### Hooks (.claude/settings.json) — mostly RE-EXPRESSED, three DROPPED
+DELETE `.claude/settings.json`; no codex file replaces it. See
+`references/hooks-disposition.md` for the per-hook table. Summary: the allowlist and
+auto-allow are SUPERSEDED by codex's hardcoded autonomy; idle-flag, context-status,
+crash-alert, typing, and boot-notify are RE-EXPRESSED natively by the adapter/daemon
+(NOT lost); only three behaviors genuinely DROP — plan-mode->Telegram,
+AskUserQuestion->Telegram, PreCompact->Telegram. Re-home those to the bus `approvals`
+flow and report them as needs-human. NEVER emit a blanket "hooks lost."
+
+### MCP (.mcp.json) -> ~/.codex/config.toml [mcp_servers.<id>] — TRANSFORM + NEEDS-HUMAN
+Empty `.mcp.json` -> no-op (report "no MCP servers"). Populated -> for each server emit
+a `[mcp_servers.<name>]` TOML table into the HOST-GLOBAL `~/.codex/config.toml` (MERGE,
+never overwrite). Each server sets EITHER `command` (stdio) OR `url` (HTTP). HTTP:
+`url` + `bearer_token_env_var` (the token is referenced, never inlined). stdio:
+`command`, `args`, `env` (canonical sub-table `[mcp_servers.<id>.env]` with `KEY = "VALUE"` lines, per OpenAI docs), `cwd`, `enabled`, `startup_timeout_sec` (alias
+`startup_timeout_ms`), `tool_timeout_sec`, `required`, `enabled_tools`,
+`disabled_tools`, `default_tools_approval_mode` (auto|prompt|approve).
+`bearer_token_env_var` is HTTP-only. Secrets move to env vars (not auto-carried).
+See `references/mcp-toml-keys.md`. Host-global name collisions are a hard stop (Step 2).
+
+### Slash commands -> /goal + slash->$skill rewrite — mostly NO-EQUIVALENT
+Codex handles only `/goal` locally; every other `/foo` is auto-rewritten to `$foo` and
+resolved as a skill. So a slash command whose name matches a present skill works for
+free. A Claude-CLI macro with NO backing skill (`commit`, `pr`, `worktree`) becomes
+`$macro` and fails skill lookup — author a skill (skill-creator) or report needs-human.
+Per-agent `~/.claude/commands/` is usually absent (machine-wide Plane C, out of scope).
+
+### Subagents (.claude/agents/*.md) -> in-session multi-agent — NO-EQUIVALENT on disk
+No codex per-agent subagent file exists. If the source defines none (common), report
+"no on-disk subagents." If it defines some, do NOT silently drop: list each subagent
+name + purpose and re-express as a codex skill or a bus worker-agent (worker-agents
+skill). NEEDS-HUMAN.
+
+### Auth env + instruction cross-refs — mixed (one FLAG, one mechanical)
+TOOLS.md references to `ANTHROPIC_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN` are FLAGGED
+for human review, NOT auto-stripped: codex model auth is host `~/.codex/auth.json`,
+but TOOLS.md is prose and auto-editing it can mangle surrounding instructions, so
+`convert.py` emits a needs-human REPORT line and leaves the text in place for you to
+edit. (Script and mapping agree: flag-only, not a mechanical transform.) The agent
+`.env` (BOT_TOKEN/CHAT_ID/ALLOWED_USER) ports 1:1. The `.claude/skills` ->
+`plugins/cortextos-agent-skills/skills` ref-rewrite IS mechanical and automatic:
+`convert.py` greps the whole target dir and rewrites every hit in instruction files
+and scripts.
+
+### Crons — TRANSFORM (UNION + path-translate + reroute)
+Migrate ALL crons, not just config.json's. The source config.json `crons[]` can
+DIVERGE from the live cron registry (`$CTX_ROOT/.cortextOS/state/agents/<source>/
+crons.json` — the file the daemon actually fires from). convert.py takes the UNION
+of both, deduped by name (config.json wins on conflict since it carries the
+canonical schedule TYPE), so a cron present in config.json but absent from the live
+registry (or vice versa) is still migrated. For each cron prompt it translates BOTH
+legs together so the command resolves in the TARGET workspace: the skills path
+(`.claude/skills/<x>` -> `plugins/cortextos-agent-skills/skills/<x>`) AND the
+workspace path (`agents/<source>` -> `agents/<target>`, matched as a complete path
+segment so it never touches a prefix or prose), plus any hardcoded absolute
+source-workspace path. Translating only one leg (the prod defect) yields a
+`cd agents/<source>` referencing a plugins path that only resolves under
+`agents/<target>`. Finally, any cron that sends DIRECT to the principal
+(`send-telegram <principal-chat-id>`) is re-routed through the orchestrator (`send-message <orchestrator>`)
+per the fleet routing guardrail. verify.py asserts the target cron set matches the
+source union, every path resolves in the target, and no cron sends direct to the principal.
+
+### Skill-depth delta — COMPAT SYMLINK (defect 7)
+Path translation in the cron PROMPT is not enough: the cron prompts only fix where
+the command `cd`s and which script it calls. The SCRIPTS THEMSELVES compute their
+workspace-relative output paths from `__file__` at a FIXED depth — e.g.
+`OUTPUT_BASE = dirname(__file__)/../../../docs` or `ROOT = Path(__file__).parents[3];
+ROOT/"docs"`. Those were correct at claude's depth-3 layout (`.claude/skills/<x>`)
+but codex skills sit ONE directory deeper (`plugins/cortextos-agent-skills/skills/<x>`),
+so the same anchor resolves to `<ws>/plugins/docs` — one level short — and the script
+silently mis-writes output there instead of `<ws>/docs`. (Observed in a real
+migration: several skills with depth-pinned output anchors all hit this; a cron can
+FIRE yet its command write to the wrong place — scheduler-fire and command-success
+are distinct.) `create_skill_depth_compat_symlink` lays a single
+`<ws>/plugins/docs -> ../docs` symlink so every depth-short `docs` anchor resolves back
+to the real workspace docs (idempotent; merges any mis-written contents first, never
+clobbers). verify.py asserts the symlink resolves. CAVEAT: this covers the workspace
+DOCS anchor (the observed output class); scripts that anchor NON-docs workspace paths
+via the same fixed depth (e.g. `ROOT/".env"`) need manual review.
+
+### Guardrails — ENSURED IN TEMPLATE (routing + approval)
+The fleet routing+approval guardrails must land in the migration so EVERY migrated
+agent inherits them, not as a per-workspace patch. convert.py's `ensure_guardrails`
+guarantees the target bootstrap carries (a) "all principal-facing sends route through
+the orchestrator" and (b) "no external action without an explicit per-item go + approval":
+it appends both as red-flag rows to the target `GUARDRAILS.md` (idempotent — skipped
+if already present) and ensures `config.json.approval_rules.always_ask` gates
+`external-comms`. verify.py asserts both the prose markers and the config gate.
+
+### Stale Claude session state — EXCLUDE NARROWLY (the crash-loop footgun)
+NEVER carry the stale SESSION TRANSCRIPTS, but DO carry the boot-state continuity
+markers. Claude JSONL session state lives in Plane C
+(`~/.claude/projects/<dashed-launch-path>/*.jsonl`); codex ignores it for
+`shouldContinue` (it keys on `codex-app-server-thread.json` existence), but a stale
+`codex-app-server-thread.json` (or any `*thread.json`) would make codex attempt a
+`thread/resume` against a thread that never existed for it -> resume timeout ->
+crash loop. So convert.py: (1) CARRIES the boot-state continuity markers
+source->target so the agent does NOT cold-onboard — `.onboarded` (the daemon
+onboarding gate, agent-process.ts ~699-713, runs ONBOARDING.md when this is absent),
+`heartbeat.json`, `.telegram-offset`, `cron-state.json`, `.message-dedup-hashes`,
+`.crash_alert_dedup.json`, `.ctx-circuit.json`, `pending-reminders.json`, and the
+`handoffs/` directory; (2) EXCLUDES ONLY the stale session transcript(s)
+(`codex-app-server-thread.json` / `*thread.json`); (3) drops a `.force-fresh` marker
+at `$CTX_ROOT/state/<target>/.force-fresh`. It NEVER wipes the whole state dir (the
+over-broad wipe dropped `.onboarded` and forced a cold onboard). verify.py asserts
+`.onboarded` is present and no `*thread.json` was carried.
+
+### Everything else — 1:1 / port-verbatim
+IDENTITY/SOUL/GUARDRAILS/HEARTBEAT/USER/SYSTEM/MEMORY .md (bodies, after ref-rewrite),
+goals.json/GOALS.md, memory/, workspaces (repos/work/staging/projects/experiments/
+docs/etc.), skills/drafts/, in-repo state/, and all Plane-B runtime state (crons
+registry, heartbeat, flags, daily memory, handoffs, bus inbox/outbox) port 1:1 or are
+daemon/bus-regenerated. The catch-all in detect.py ensures any unlisted file lands in
+`port_verbatim` and shows up in the report rather than being dropped.
+
+EXCEPTION — identity/path-pinned dot-state is NEVER carried (it goes to `dropped`,
+not `port_verbatim`): `.cortextos-env` pins `CTX_AGENT_NAME`/`CTX_AGENT_DIR`/etc to
+the SOURCE — copying it makes the target boot AS the source and share the live
+source's inbox/state/heartbeat. add-agent regenerates a correct per-agent one.
+`.playwright-mcp` is host/session-pinned MCP state. convert.py skips both even if
+they somehow reach port_verbatim.
+
+CREDENTIAL DIRS — `auth/`-class dirs are copied but get an explicit REPORT line
+("carried — review for stale/agent-specific tokens"), never a silent bulk copy.
+Review them before enable; the copied tokens may be source-specific or stale.
+
+## Safety invariants (do not violate)
+
+- Source agent is NEVER modified or deleted, EXCEPT the one explicit cutover case:
+  `--bot-mode reuse` disables the source (config.json + registry) so the codex agent
+  can take over the single Telegram bot. No other flag, and no default run, touches
+  the source. Output is otherwise always a separate codex agent.
+- Dry-run is the default. Nothing writes without `--apply`.
+- With NO interactive flags the target is left scaffolded + DISABLED in BOTH
+  config.json AND the instance registry (enabled-agents.json — the file the daemon
+  actually reads). convert.py flips the registry entry merge-only (no other agent
+  touched); verify.py asserts it. Enabling is then a separate explicit user step.
+  The target ONLY boots when the user passes `--boot now` (or `--bot-mode reuse`,
+  which implies boot) — both are user-confirmed STEP 2 choices, never automatic.
+- No artifact is silently dropped — catch-all bucket + severity-ordered report.
+- Never copy `.claude/settings.json`, Claude JSONL state, or model-auth credentials.
+- Never copy `.cortextos-env` or `.playwright-mcp` — they pin the SOURCE's identity/
+  session; the target keeps its add-agent-generated `.cortextos-env`.
+- Never carry `working_directory` that points inside the source agent dir (shared
+  JSONL session key) — that is a hard stop.
+- `auth/`-class credential dirs are copied with a loud REPORT line, never silently.
+- Merge `~/.codex/config.toml`, never overwrite it (host-shared).

--- a/community/skills/claude-to-codex-migration/references/codex-bundled-skills.txt
+++ b/community/skills/claude-to-codex-migration/references/codex-bundled-skills.txt
@@ -1,0 +1,28 @@
+# The codex "stdlib" — 23 skills bundled by `templates/agent-codex/`
+# Source: templates/agent-codex/plugins/cortextos-agent-skills/skills/ (verified count 23).
+# Any source-agent skill whose name is in this list ships for free via
+# `cortextos add-agent --template agent-codex` — do NOT re-copy it. Only skills
+# NOT in this list are "custom" and must be ported + leakage-grepped + symlinked.
+activity-channel
+agent-browser
+agent-management
+approvals
+auto-skill
+autoresearch
+bus-reference
+comms
+cron-management
+env-management
+event-logging
+guardrails-reference
+heartbeat
+human-tasks
+knowledge-base
+m2c1-worker
+memory
+onboarding
+soul-philosophy
+system-diagnostics
+tasks
+tool-registration
+worker-agents

--- a/community/skills/claude-to-codex-migration/references/hooks-disposition.md
+++ b/community/skills/claude-to-codex-migration/references/hooks-disposition.md
@@ -1,0 +1,48 @@
+# Hooks disposition — `.claude/settings.json` -> codex
+
+Codex has NO `settings.json` and NO Claude-Code hook event model. DELETE the file;
+no codex file replaces it. The capability does not vanish — it splits three ways.
+This table is the canonical source for the migration report's hook lines. Derive
+report logic from THIS table (verified against `src/pty/codex-app-server-pty.ts`),
+NOT from any per-agent settings.json guess.
+
+Three buckets:
+- **SUPERSEDED** — codex's hardcoded autonomy makes the hook unnecessary.
+- **RE-EXPRESSED** — the adapter/daemon already does this natively; capability survives,
+  just not as a configurable hook. NOT a loss.
+- **DROPPED** — genuinely no codex equivalent. There are exactly THREE.
+
+| Claude hook (settings.json) | What it did | Codex disposition | Where it lives on codex |
+|---|---|---|---|
+| `permissions.allow` / `defaultMode: bypassPermissions` | tool allowlist | **SUPERSEDED** | `approvalPolicy:'never'` + `sandbox:'danger-full-access'` (adapter `:70-78`; host `~/.codex/config.toml`) |
+| `PermissionRequest` catch-all (auto-allow `echo`) | auto-approves perms | **SUPERSEDED** | same autonomous policy |
+| `Stop` -> `hook-idle-flag` | writes idle flag on stop | **RE-EXPRESSED** | adapter `writeIdleFlag()` on idle/turn-completed -> same `last_idle.flag` |
+| `statusLine` -> `hook-context-status` | polls, writes context_status.json | **RE-EXPRESSED** (event-driven) | adapter `writeContextStatus()` on `thread/tokenUsage/updated` -> same-shape `context_status.json` (note: `cache_creation_input_tokens` is hardcoded 0 under codex — small lossy field) |
+| `SessionEnd` -> `cortextos crash-alert` | crash alert on exit | **RE-EXPRESSED** (daemon) | daemon `handleExit` (counter, backoff, crash-loop pauser, restarts.log) |
+| (implicit) typing indicator | — | **RE-EXPRESSED (bonus)** | adapter `maybeFireTyping()` on turn activity |
+| (implicit) "back online" telegram | inline boot instruction | **RE-EXPRESSED (daemon)** | `maybeSendCodexBootNotification` (codex doesn't reliably run the inline instruction, Issue #392) |
+| `PermissionRequest` matcher `ExitPlanMode` -> `hook-planmode-telegram` | plan -> Telegram approval gate | **DROPPED** | none — codex has no ExitPlanMode lifecycle event |
+| `PreToolUse` matcher `AskUserQuestion` -> `hook-ask-telegram` | interactive question -> Telegram | **DROPPED** | none — no AskUserQuestion tool / PreToolUse interception |
+| `PreCompact` -> `hook-compact-telegram` | compaction Telegram notice | **DROPPED** | none — codex has no Claude-style compaction event; session pressure handled by `max_session_seconds` session-refresh |
+
+## The three DROPPED behaviors (the real functional loss)
+
+All three are "in-turn human-in-the-loop over Telegram." A codex agent runs fully
+autonomous (`approvalPolicy:'never'`), so the conceptual replacement is the
+**out-of-band bus `approvals` flow** (create approval object -> notify -> block), NOT an
+in-turn hook. Report them as needs-human:
+
+1. plan-mode -> Telegram approval gate (`hook-planmode-telegram`)
+2. interactive AskUserQuestion -> Telegram (`hook-ask-telegram`)
+3. compaction -> Telegram notice (`hook-compact-telegram`)
+
+The migration verifies the target AGENTS.md carries the approval-via-bus contract
+(the codex template's AGENTS.md already mandates the `approvals` skill +
+`cortextos bus create-approval`).
+
+## NOTE on phantom hooks
+
+Do NOT report `hook-loop-detector` or a catch-all `hook-permission-telegram` as lost.
+Those were fabricated in an earlier mapping draft and are not present in real agent
+settings.json files. Only report hooks the source's ACTUAL `.claude/settings.json`
+wires (detect.py reads the real file).

--- a/community/skills/claude-to-codex-migration/references/leakage-tokens.txt
+++ b/community/skills/claude-to-codex-migration/references/leakage-tokens.txt
@@ -1,0 +1,19 @@
+# Claude-only leakage tokens — grep custom skills + instruction files + scripts.
+# A hit means the artifact references Claude-Code-only machinery. Some hits are
+# mechanically rewritable (paths, env-var names); some signal non-portable
+# BEHAVIOR that needs a human/skill-creator rewrite. Grep-clean is NECESSARY but
+# NOT SUFFICIENT — a clean skill can still depend on Claude tool semantics that
+# don't appear as a literal string (confirm with a boot probe).
+#
+# == Mechanically rewritable (convert.py rewrites these) ==
+.claude/skills        # -> plugins/cortextos-agent-skills/skills
+.claude/              # path ref; rewrite or drop
+ANTHROPIC_API_KEY     # codex model auth is host ~/.codex/auth.json; drop the mention
+CLAUDE_CODE_OAUTH_TOKEN  # same; drop
+#
+# == Behavioral leakage (NEEDS-HUMAN -> skill-creator if load-bearing) ==
+ExitPlanMode          # Claude plan-mode hook; codex has no plan-mode lifecycle event
+bypassPermissions     # Claude permission mode; codex is hardcoded autonomous
+hook-                 # any cortextos bus hook-* call relied on by the skill
+mcp__                 # Claude MCP tool-name namespace (e.g. mcp__playwright__*)
+/loop                 # Claude-CLI /loop macro, no codex equivalent

--- a/community/skills/claude-to-codex-migration/references/mcp-toml-keys.md
+++ b/community/skills/claude-to-codex-migration/references/mcp-toml-keys.md
@@ -1,0 +1,72 @@
+# MCP: `.mcp.json` -> `~/.codex/config.toml [mcp_servers.<id>]`
+
+Codex MCP servers are declared as TOML tables in the **host-global** `~/.codex/config.toml`,
+NOT in any per-agent file. This is a SCOPE change (per-agent repo file -> host-shared
+config) as well as a format change. MERGE the tables; NEVER overwrite the file (it is
+shared by all codex agents on the host).
+
+Example (placeholder host/token — substitute your own):
+```toml
+[mcp_servers.example-remote]
+url = "https://your-mcp-server.example.com/mcp"
+bearer_token_env_var = "EXAMPLE_MCP_TOKEN"
+```
+
+## Each server is EITHER stdio OR HTTP
+
+A server sets EITHER `command` (stdio) OR `url` (streamable HTTP). Never both.
+
+### HTTP / remote server
+| key | meaning |
+|---|---|
+| `url` | the MCP endpoint (presence of `url` implies HTTP transport) |
+| `bearer_token_env_var` | **HTTP-only.** Name of the env var holding the bearer token. The token is REFERENCED, never inlined. |
+
+### stdio / local server
+| key | meaning |
+|---|---|
+| `command` | the binary to spawn |
+| `args` | array of CLI args |
+| `env` | env vars for the process. Canonical TOML form is a sub-table `[mcp_servers.<id>.env]` with `KEY = "VALUE"` lines (per OpenAI docs). Inline `env = { KEY = "VALUE" }` is valid TOML too, but prefer the sub-table to match the docs. |
+| `cwd` | working directory |
+| `enabled` | bool |
+| `startup_timeout_sec` | startup timeout in seconds (alias: `startup_timeout_ms`) |
+| `tool_timeout_sec` | per-tool timeout in seconds |
+| `required` | bool — fail startup if this server can't start |
+| `enabled_tools` | array — allowlist of tool names |
+| `disabled_tools` | array — denylist of tool names |
+| `default_tools_approval_mode` | `auto` \| `prompt` \| `approve` |
+
+## Translating a Claude `.mcp.json` entry
+
+Claude form (per-agent JSON):
+```json
+{ "mcpServers": {
+  "supabase": { "type":"http", "url":"https://mcp.supabase.com/mcp?...", "headers":{"Authorization":"Bearer sbp_..."} }
+}}
+```
+becomes:
+```toml
+[mcp_servers.supabase]
+url = "https://mcp.supabase.com/mcp?..."
+bearer_token_env_var = "SUPABASE_MCP_TOKEN"
+```
+and a NEEDS-HUMAN task: add `SUPABASE_MCP_TOKEN=<secret>` to `orgs/<org>/secrets.env`
+(or shell profile). The secret value cannot be auto-migrated into config.toml by design.
+
+For a Claude stdio entry `{ "command": "...", "args": [...], "env": {...} }`, write (env as a sub-table, per OpenAI docs):
+```toml
+[mcp_servers.<id>]
+command = "..."
+args = ["..."]
+
+[mcp_servers.<id>.env]
+KEY = "VALUE"
+```
+
+## Hard constraints
+- **Host-global name collision is a HARD STOP.** Codex MCP names are host-wide, NOT
+  `<agent>__`-namespaced like skills. Two agents with a `supabase` server collide in
+  one config.toml. A human must resolve before convert.
+- **Secrets never land in config.toml.** Always `bearer_token_env_var` indirection.
+- **Empty `.mcp.json` is a no-op** — report "no MCP servers to migrate."

--- a/community/skills/claude-to-codex-migration/references/report-template.md
+++ b/community/skills/claude-to-codex-migration/references/report-template.md
@@ -1,0 +1,81 @@
+# Migration Report: <source> (claude-code) -> <target> (codex-app-server)
+
+Mode: DRY-RUN | APPLIED          Date: <iso>
+
+## END STATE  (lead with the ONE line that matches the engine's `end_state`)
+- cutover-live: **<target> is live on the ORIGINAL bot; Claude <source> is disabled.**
+- live:         **<target> is live on its NEW bot; <source> is still running.**
+- disabled:     **Ready — run `cortextos enable <target> --org <org>` when you're happy.**
+
+## Summary
+- Portable 1:1:    N artifacts
+- Transformed:     M artifacts
+- Dropped (no eq): K artifacts
+- Needs human:     J items
+- Verify:          BOOT <pass|fail|not-run> · LOOP <...> · SKILLS <n/n wired>
+- Bot strategy:    REUSE (cutover) | NEW (side-by-side) | unchanged
+- End state:       <disabled | live | cutover-live>
+                   disabled  -> codex enabled:false in config.json AND registry
+                   live      -> codex enabled:true in both; source untouched
+                   cutover-live -> codex enabled:true in both; SOURCE disabled in both
+
+## HARD STOPS  (must resolve before --apply; none = good)
+- <e.g. MCP server "supabase" name-collision in ~/.codex/config.toml — resolve first>
+- <e.g. target name collides with existing dir — disable/rename source or use -codex suffix>
+
+## NOT migrated — no codex equivalent (DROPPED, with reason)
+- Hooks: plan-mode -> Telegram approval gate (hook-planmode-telegram) — codex has no
+  ExitPlanMode event. Replacement: bus approvals flow.
+- Hooks: AskUserQuestion -> Telegram (hook-ask-telegram) — no codex AskUserQuestion
+  tool. Replacement: normal Telegram message via cortextos bus send-telegram.
+- Hooks: PreCompact -> Telegram notice (hook-compact-telegram) — codex has no
+  compaction event. Continuity rides max_session_seconds session-refresh.
+- Claude JSONL session state — intentionally excluded (stale resume = crash loop).
+- <any custom skill / subagent that could not be ported>
+
+## NEEDS HUMAN INPUT (blocking — agent left DISABLED)
+- Review folded AGENTS.md for duplication/conflict (CLAUDE.md content merged in).
+- MCP secrets: add <ENV_VAR> to orgs/<org>/secrets.env for each migrated server.
+- Telegram creds: confirm target uses a NEW bot OR source is disabled (BOT_TOKEN reuse).
+- Custom skill "<x>" failed leakage adjudication (INVOCATION hit) -> hand to skill-creator.
+- Custom skill "<x>" is a Claude-STANDARD skill absent from the codex 23
+  (one-big-feature/skill-creator/docx/...) -> re-examine for Claude orchestration
+  semantics the grep misses; verify codex equivalent or rewrite.
+- TOOLS.md references Claude auth env (ANTHROPIC_API_KEY/CLAUDE_CODE_OAUTH_TOKEN) ->
+  flagged for human strip (prose not auto-edited).
+- Slash macro "<y>" has no backing skill -> author a skill or drop.
+- gpt-5.5 cost: priced as gpt-5-codex in cost-parser; confirm pricing if on gpt-5.5.
+- Verify host codex login exists (~/.codex/auth.json) — do NOT mint per-agent.
+
+## Transformed (artifact -> change applied)
+- config.json -> runtime flipped, model=<codex model>, dangerously_skip_permissions +
+  ecosystem dropped, codex_context_cap added, knobs carried.
+- CLAUDE.md -> folded into AGENTS.md (review required), source CLAUDE.md deleted.
+- .claude/settings.json -> deleted (idle/context/crash RE-EXPRESSED natively; 3 dropped above).
+- skill "<custom>" -> moved to plugins/.../skills + symlinked; <leakage result>.
+- .mcp.json -> N servers -> [mcp_servers.*] TOML printed for config.toml merge.
+- instruction refs -> .claude/skills paths rewritten to plugins/.../skills.
+- .force-fresh marker dropped; stale codex-app-server-thread.json removed.
+- registry enabled-agents.json[<target>].enabled -> false (merge-only; daemon-read disable).
+- nested .claude/ + CLAUDE.md inside copied content removed (recursive sweep).
+
+## Carried items to confirm (large / binary / scratch — not silently bulk-copied)
+- <e.g. example-image.png (519 KB) — confirm it belongs in the codex agent>
+- <large/binary/scratch carried items each get a line; review before enable>
+
+## Migrated 1:1
+- IDENTITY/SOUL/GUARDRAILS/HEARTBEAT/USER/SYSTEM/MEMORY .md, goals.json, GOALS.md,
+  memory/, .env (BOT_TOKEN/CHAT_ID/ALLOWED_USER), crons[], workspaces, skills/drafts/,
+  in-repo state/, <any port_verbatim catch-all files>.
+
+## How to finish
+    # DISABLED end state (default): after reviewing everything above and
+    # resolving needs-human items, boot it when ready:
+    cortextos enable <target> --org <org>
+
+    # LIVE / CUTOVER-LIVE end state: the agent is already booting. Confirm health
+    # with the boot probe (verify.py Tier 2) and watch the bot. For a CUTOVER,
+    # the source is disabled — to roll back, re-enable the source and disable the
+    # codex agent:
+    #   cortextos enable <source> --org <org>
+    #   cortextos disable <target> --org <org>

--- a/community/skills/claude-to-codex-migration/scripts/convert.py
+++ b/community/skills/claude-to-codex-migration/scripts/convert.py
@@ -1,0 +1,2196 @@
+#!/usr/bin/env python3
+"""
+convert.py — CONVERT stage of the Claude->Codex agent migration.
+
+Overlays the source agent's customizations onto a codex skeleton that was already
+laid down by `cortextos add-agent --template agent-codex`. Performs ONLY the
+deterministic transforms; flags every judgment step for the human (fold review,
+leakage adjudication, MCP merge, secrets).
+
+NON-DESTRUCTIVE on the source: it reads the source and writes the TARGET only.
+Dry-run by default; pass --apply to write.
+
+Prereq (caller runs first):
+  cortextos add-agent <target> --template agent-codex --runtime codex-app-server --org <org>
+
+Usage:
+  convert.py --manifest <manifest.json> --src-dir <src> --target-dir <tgt>
+             --target-agent <name> --ctx-root <CTX_ROOT> [--apply]
+             [--bot-mode reuse|new|none] [--new-bot-token <token>]
+             [--boot now|no] [--source-agent <name>] [--org <org>]
+
+Interactive-flow flags (the implementing agent sets these from the user's
+answers to Step 2 of SKILL.md). ALL default to the SAFE, non-destructive path:
+  --bot-mode  reuse : CUTOVER. Disable the source (config.json + registry),
+                      copy the source BOT_TOKEN into the codex .env, imply boot.
+              new   : write --new-bot-token into the codex .env (both can run).
+              none  : (DEFAULT) no token change, source untouched, codex disabled.
+  --boot      now   : enable the codex agent (config.json + registry) and start it
+                      via `cortextos enable`.
+              no    : (DEFAULT) leave the codex agent disabled.
+With NO flags this script behaves EXACTLY as before: source untouched, codex
+disabled, no boot. The destructive cutover/boot ONLY happen on explicit flags.
+"""
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+REWRITE = (".claude/skills", "plugins/cortextos-agent-skills/skills")
+CLAUDE_AUTH_ENV = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
+
+# Codex skills live under a different host path than claude's `.claude/skills`.
+# A cron prompt that `cd`s into the source workspace and invokes a skill must have
+# BOTH legs translated together or the command resolves a non-existent path:
+#   - `.claude/skills/<x>` -> `plugins/cortextos-agent-skills/skills/<x>` (skills leg)
+#   - `cd .../agents/<source>` -> `cd .../agents/<target>` (workspace leg)
+# Translating only one (the prod defect) leaves `cd agents/<source>` referencing a
+# plugins/ path that only resolves under agents/<target>.
+CRON_SKILLS_REWRITE = REWRITE  # same skills-path rewrite the rest of the tree uses
+
+# INSTANCE-DISCOVERY (public skill: no principal/orchestrator identity is baked in).
+# The routing guardrail — "principal-facing sends route THROUGH the orchestrator" —
+# is a real cortextOS pattern, but WHO the principal and orchestrator are is
+# instance-specific and must be DISCOVERED from the target deployment or passed
+# explicitly. When a value is unknown the feature SAFE-DEGRADES (no reroute, flag
+# for human) rather than inventing one — a hardcoded chat id / orchestrator name is
+# both a leak AND a functional bug for any other user (it would hunt a foreign id
+# and rewrite crons to an agent they do not have).
+
+
+def _looks_numeric_id(v):
+    return bool(v) and str(v).strip().isdigit()
+
+
+def _read_env_value(env_path, *keys):
+    """First present non-empty value among keys in an .env file, else None."""
+    if not os.path.isfile(env_path):
+        return None
+    pairs, _ = _read_env(env_path)
+    lut = {k: v for k, v in pairs}
+    for k in keys:
+        if lut.get(k):
+            return lut[k].strip()
+    return None
+
+
+def resolve_principal_chat_id(src_dir, param=None):
+    """The principal's Telegram chat id, for the literal-reroute leg. Precedence:
+    explicit param -> source .env CHAT_ID -> source .env ALLOWED_USER (if numeric)
+    -> None. None disables the literal leg (nothing to match — no hunting a foreign
+    id). No hardcoded literal anywhere."""
+    if param:
+        return str(param).strip()
+    env = os.path.join(src_dir, ".env")
+    v = _read_env_value(env, "CHAT_ID")
+    if v:
+        return v
+    au = _read_env_value(env, "ALLOWED_USER")
+    return au if _looks_numeric_id(au) else None
+
+
+def resolve_principal_name(src_dir, param=None):
+    """The principal's NAME, for prose-intent detection/guard text. Precedence:
+    explicit param -> source .env ALLOWED_USER (only if NON-numeric, i.e. a name)
+    -> None. None disables the prose leg (no name to match — avoids false hits)."""
+    if param:
+        return str(param).strip()
+    au = _read_env_value(os.path.join(src_dir, ".env"), "ALLOWED_USER")
+    return au if (au and not _looks_numeric_id(au)) else None
+
+
+# A migrated cron whose prompt directs a send at the principal in prose (no literal
+# chat id) slips the token rewrite; detect it so a routing guard can be injected.
+# Built PER-INSTANCE from the discovered principal name (never a baked-in name).
+def principal_prose_send_res(principal_name):
+    """Two compiled regexes catching '<verb> ... <principal>' and the reversed
+    '<principal> ... a reminder/directly/...' phrasings. Returns [] when the
+    principal name is unknown (prose leg disabled)."""
+    if not principal_name:
+        return []
+    p = re.escape(principal_name)
+    return [
+        re.compile(
+            r"\b(send|sends|sending|tell|telling|notify|notifying|message|messaging|"
+            r"ping|pinging|remind|reminding|reminder\s+to|alert|alerting|dm|email|"
+            r"emailing|text|texting)\b[^.\n]{0,40}\b" + p + r"\b", re.IGNORECASE),
+        re.compile(
+            r"\b" + p + r"\b[^.\n]{0,30}\b(a\s+reminder|directly|right away|immediately|"
+            r"a\s+summary|a\s+message|a\s+ping|a\s+heads.?up)\b", re.IGNORECASE),
+    ]
+
+
+def orchestrator_route_re(orchestrator):
+    """Recognize a prompt that ALREADY routes through the orchestrator (do not
+    double-route). Built per-instance from the discovered orchestrator name."""
+    if not orchestrator:
+        return None
+    o = re.escape(orchestrator)
+    return re.compile(
+        r"(send-message\s+" + o + r"|through\s+" + o + r"|via\s+" + o +
+        r"|route\s+(it\s+)?through\s+" + o + r"|to\s+" + o + r"\b|" + o +
+        r"\s+\(route|MIGRATION ROUTING GUARD)", re.IGNORECASE)
+
+
+# Positive orchestrator signal for auto-discovery (GAP D): a sibling agent must
+# ACTIVELY declare the orchestrator role — mere existence (e.g. the lone sibling in
+# a 2-agent instance) is NOT enough. config.json persists no role today, so the
+# signal is a role/template field IF present OR an explicit self-declaration in the
+# agent's identity files. Absent/ambiguous => param-only safe-degrade.
+_ORCH_IDENTITY_RE = re.compile(
+    r"(?im)^\s*(?:#+\s*)?role\s*[:=]\s*orchestrator\b"
+    r"|(?i)\b(?:you are|i am)\s+(?:the\s+|an\s+)?orchestrator\b"
+    r"|(?i)\borchestrator\s+(?:agent|role)\s+for\s+(?:the\s+)?(?:org|fleet)\b")
+
+
+def _agent_declares_orchestrator(agent_dir):
+    cfgp = os.path.join(agent_dir, "config.json")
+    if os.path.isfile(cfgp):
+        try:
+            with open(cfgp) as f:
+                cfg = json.load(f)
+            for field in ("role", "template", "agentType", "agent_type"):
+                if str(cfg.get(field, "")).strip().lower() == "orchestrator":
+                    return True
+        except Exception:
+            pass
+    for fn in ("IDENTITY.md", "SOUL.md"):
+        fp = os.path.join(agent_dir, fn)
+        if os.path.isfile(fp):
+            try:
+                with open(fp, errors="ignore") as f:
+                    if _ORCH_IDENTITY_RE.search(f.read()):
+                        return True
+            except Exception:
+                pass
+    return False
+
+
+def discover_orchestrator(src_dir, source_agent, target_agent, param, actions):
+    """Resolve the orchestrator (reroute target). Precedence: explicit --orchestrator
+    param -> best-effort auto-scan of sibling agents for a POSITIVE role signal
+    (exactly one candidate) -> None (safe-degrade). Returns (name_or_None, source_str).
+    NEVER picks a sibling on existence alone; a single auto-scan hit is SURFACED for
+    operator confirmation, not trusted silently."""
+    if param:
+        return str(param).strip(), "param"
+    agents_root = os.path.dirname(os.path.normpath(src_dir))
+    if not os.path.isdir(agents_root):
+        return None, "no-agents-root"
+    candidates = []
+    for name in sorted(os.listdir(agents_root)):
+        if name in (source_agent, target_agent):
+            continue
+        d = os.path.join(agents_root, name)
+        if os.path.isdir(d) and _agent_declares_orchestrator(d):
+            candidates.append(name)
+    if len(candidates) == 1:
+        log(actions, f"★ ORCHESTRATOR AUTO-DISCOVERED: '{candidates[0]}' (positive role "
+                     f"signal in its config/identity). CONFIRM this is your orchestrator "
+                     f"before trusting the cron reroute; pass --orchestrator to override.")
+        return candidates[0], "auto-scan"
+    if len(candidates) > 1:
+        log(actions, f"orchestrator auto-scan AMBIGUOUS ({candidates}) — pass "
+                     f"--orchestrator <name> to disambiguate; reroute SAFE-DEGRADED.")
+    return None, ("ambiguous" if candidates else "no-signal")
+
+# Boot-state continuity markers carried source->target so the migrated agent does
+# NOT cold-onboard (the daemon onboarding gate, agent-process.ts ~699-713, runs
+# ONBOARDING.md when state/<name>/.onboarded is absent). The stale session
+# transcripts are EXCLUDED narrowly (the legitimate reason force_fresh existed):
+# a stale codex thread file makes codex attempt a thread/resume that crash-loops.
+STATE_CONTINUITY_FILES = (
+    ".onboarded", "heartbeat.json", ".telegram-offset", "cron-state.json",
+    ".message-dedup-hashes", ".crash_alert_dedup.json", ".ctx-circuit.json",
+    "pending-reminders.json",
+)
+STATE_CONTINUITY_DIRS = ("handoffs",)
+# Never carry these from the source state dir: stale session transcripts that
+# would cause a stale-session resume crash on the target's first boot.
+STATE_EXCLUDE_SUFFIXES = ("thread.json",)  # codex-app-server-thread.json, *thread.json
+STATE_EXCLUDE_EXACT = ("codex-app-server-thread.json",)
+
+# Carried items above this size (or with a binary/scratch extension) are surfaced
+# in the report rather than silently bulk-copied.
+LARGE_ITEM_BYTES = 256 * 1024  # 256 KB
+BINARY_SCRATCH_EXT = (
+    ".png", ".jpg", ".jpeg", ".gif", ".webp", ".mp4", ".mov", ".webm",
+    ".zip", ".tar", ".gz", ".tgz", ".log", ".bin", ".pdf", ".sqlite", ".db",
+)
+
+
+def _tree_size(path):
+    if os.path.isfile(path):
+        try:
+            return os.path.getsize(path)
+        except OSError:
+            return 0
+    total = 0
+    for dp, dn, fns in os.walk(path):
+        dn[:] = [d for d in dn if d not in ("node_modules", ".git")]
+        for fn in fns:
+            try:
+                total += os.path.getsize(os.path.join(dp, fn))
+            except OSError:
+                pass
+    return total
+
+
+def surface_large_or_binary(name, src, actions):
+    """Emit a REPORT line for a carried item that is large or binary/scratch, so
+    big PNGs/logs/zips never slip through in a silent bulk copy."""
+    size = _tree_size(src)
+    ext = os.path.splitext(name)[1].lower()
+    is_binary = os.path.isfile(src) and ext in BINARY_SCRATCH_EXT
+    if size >= LARGE_ITEM_BYTES or is_binary:
+        kb = size / 1024.0
+        kind = "binary/scratch" if is_binary else "large"
+        log(actions, f"REPORT: carried {kind} item '{name}' ({kb:.0f} KB) — "
+                     f"confirm it belongs in the codex agent (not stale scratch)")
+
+
+def log(actions, msg):
+    actions.append(msg)
+    print(f"  {msg}", file=sys.stderr)
+
+
+def rewrite_refs_in_file(path, apply, actions):
+    """Rewrite .claude/skills -> plugins path in a single file. Returns hit count."""
+    try:
+        with open(path, errors="ignore") as f:
+            content = f.read()
+    except Exception:
+        return 0
+    if REWRITE[0] not in content:
+        return 0
+    n = content.count(REWRITE[0])
+    if apply:
+        with open(path, "w") as f:
+            f.write(content.replace(REWRITE[0], REWRITE[1]))
+    log(actions, f"rewrote {n} '.claude/skills' ref(s) in {os.path.basename(path)}")
+    return n
+
+
+def copy_tree(src, dst, apply, actions, label):
+    if apply:
+        os.makedirs(os.path.dirname(dst), exist_ok=True)
+        if os.path.isdir(src):
+            if os.path.exists(dst):
+                shutil.rmtree(dst)
+            shutil.copytree(src, dst, symlinks=False)
+        else:
+            shutil.copy2(src, dst)
+    log(actions, f"{label}: {os.path.relpath(src)} -> {os.path.relpath(dst)}")
+
+
+def transform_config(src_dir, target_dir, target_agent, manifest, apply, actions):
+    src_cfg_path = os.path.join(src_dir, "config.json")
+    tgt_cfg_path = os.path.join(target_dir, "config.json")
+    with open(src_cfg_path) as f:
+        src_cfg = json.load(f)
+    # base on the codex skeleton's config if it exists (keeps codex defaults)
+    tgt_cfg = {}
+    if os.path.isfile(tgt_cfg_path):
+        with open(tgt_cfg_path) as f:
+            tgt_cfg = json.load(f)
+    # carry runtime-agnostic knobs from source (working_directory handled below)
+    # NOTE: `enabled` is deliberately NOT carried here — the source's value is
+    # irrelevant; the target is forced enabled=false below (config.json) and in
+    # the registry (disable_in_registry). Carrying it would be dead code.
+    # NOTE: `crons` is deliberately NOT carried here. The source config.json crons[]
+    # can DIVERGE from the live registry (crons.json) — the prod migration dropped
+    # 7 of 11 by reading only one source. migrate_crons() (called after this) takes
+    # the UNION of config.json + the live registry, translates paths, and re-routes
+    # direct-to-principal sends, then writes the result into tgt_cfg["crons"].
+    for k in ("timezone", "day_mode_start", "day_mode_end", "communication_style",
+              "approval_rules", "startup_delay", "max_session_seconds",
+              "max_crashes_per_day", "crash_window",
+              "telegram_polling"):
+        if k in src_cfg:
+            tgt_cfg[k] = src_cfg[k]
+    # working_directory: do NOT carry verbatim. If the source pins a launch path,
+    # the target inherits it AND the source's ~/.claude/projects/<dashed>/ JSONL
+    # key — sharing stale session state and defeating the .force-fresh guard. Only
+    # carry it if it points OUTSIDE the source agent dir (a genuine external repo).
+    # Default the target to its own dir (empty string => daemon uses the agent dir).
+    src_wd = (src_cfg.get("working_directory") or "").strip()
+    src_abs = os.path.abspath(src_dir)
+    if not src_wd:
+        tgt_cfg["working_directory"] = ""
+        log(actions, "working_directory: source unset -> target defaults to its own dir")
+    else:
+        wd_abs = os.path.abspath(src_wd)
+        inside_src = wd_abs == src_abs or wd_abs.startswith(src_abs + os.sep)
+        if inside_src:
+            # collides with the source's JSONL key — refuse to carry it.
+            manifest.setdefault("hard_stops", []).append(
+                f"source pins working_directory='{src_wd}' inside its own agent dir "
+                f"-> would share the source's JSONL session key. Resolve manually "
+                f"(repoint to an external path or clear it) before enabling.")
+            tgt_cfg["working_directory"] = ""
+            log(actions, f"HARD-STOP: source working_directory='{src_wd}' is INSIDE "
+                         f"the source agent dir (JSONL-key collision) — NOT carried, "
+                         f"target left empty, flagged for human")
+        else:
+            tgt_cfg["working_directory"] = src_wd
+            log(actions, f"working_directory='{src_wd}' carried (external to source dir)")
+    # codex-mandatory edits
+    tgt_cfg["agent_name"] = target_agent
+    tgt_cfg["runtime"] = "codex-app-server"
+    tgt_cfg["model"] = tgt_cfg.get("model") or "gpt-5-codex"
+    tgt_cfg.pop("dangerously_skip_permissions", None)
+    tgt_cfg.pop("ecosystem", None)
+    tgt_cfg.setdefault("codex_context_cap", 256000)
+    # safety: target starts disabled regardless of source
+    tgt_cfg["enabled"] = False
+    if apply:
+        with open(tgt_cfg_path, "w") as f:
+            json.dump(tgt_cfg, f, indent=2)
+            f.write("\n")
+    log(actions, "config.json: runtime->codex-app-server, model set, "
+                 "dangerously_skip_permissions+ecosystem dropped, codex_context_cap added, "
+                 "knobs carried, enabled=false")
+
+
+def _translate_cron_prompt(prompt, source_agent, target_agent, actions, cron_name):
+    """Translate a cron prompt so it resolves in the TARGET workspace. Three legs,
+    applied together (the prod defect translated only the skills leg, leaving a
+    `cd agents/<source>` that referenced a plugins/ path only resolving under
+    <target>):
+      1. skills path: `.claude/skills/<x>` -> `plugins/cortextos-agent-skills/skills/<x>`
+      2. workspace cd: `orgs/<org>/agents/<source>` -> `.../agents/<target>`
+      3. hardcoded absolute source-workspace paths (e.g. /…/agents/<source>/…).
+    Returns (new_prompt, list_of_change_notes)."""
+    notes = []
+    new = prompt
+    # 1. skills leg
+    if CRON_SKILLS_REWRITE[0] in new:
+        n = new.count(CRON_SKILLS_REWRITE[0])
+        new = new.replace(CRON_SKILLS_REWRITE[0], CRON_SKILLS_REWRITE[1])
+        notes.append(f"skills path x{n}")
+    # 2 + 3. any `agents/<source>` PATH SEGMENT (covers both the relative `cd
+    # orgs/.../agents/<source>` and any hardcoded absolute path ending in
+    # /agents/<source>). Bounded to a complete segment via a negative-lookahead on
+    # the next name char so `agents/data` does NOT match `agents/database` and a
+    # second pass does NOT re-translate the already-rewritten `agents/<src>-codex`.
+    seg_re = re.compile(r"agents/" + re.escape(source_agent) + r"(?![\w-])")
+    matches = seg_re.findall(new)
+    if matches:
+        new = seg_re.sub(f"agents/{target_agent}", new)
+        notes.append(f"workspace path agents/{source_agent}->agents/{target_agent} x{len(matches)}")
+    return new, notes
+
+
+def _reroute_principal_sends(prompt, cron_name, actions, principal_chat_id,
+                             orchestrator, principal_name):
+    """Guardrail (defect 6c + 14): a migrated cron that sends DIRECT to the principal
+    violates the routing rule (principal-facing sends route THROUGH the orchestrator).
+
+    GATED (GAP C): the ENTIRE reroute is skipped unless an orchestrator is known —
+    there is nothing safe to rewrite TO otherwise (a known chat id with an unknown
+    orchestrator must NOT be rewritten into a send-into-the-void). WHO the principal
+    and orchestrator are is discovered per-instance; nothing is baked in.
+
+    Two detection layers (each additionally gated on its own instance value):
+      (a) LITERAL (6c): `send-telegram <principal_chat_id>` / bare id -> rewritten to
+          `send-message <orchestrator> normal`. Requires principal_chat_id known.
+      (b) PROSE (14): a principal-directed send verb in prose (keyed on the discovered
+          principal NAME) with no literal id -> NON-DESTRUCTIVELY append a routing
+          guard. Requires principal_name known.
+    Returns (new_prompt, rerouted_bool)."""
+    new = prompt
+    rerouted = False
+    if not orchestrator:
+        # SAFE-DEGRADE: no orchestrator -> no reroute (never invent one). The caller
+        # surfaces principal-facing crons as needs-human instead.
+        return new, False
+    # (a) LITERAL chat-id rewrite (deterministic, safe) — only if we know the id.
+    if principal_chat_id and principal_chat_id in new:
+        new = re.sub(
+            r"cortextos bus send-telegram\s+" + re.escape(principal_chat_id),
+            f"cortextos bus send-message {orchestrator} normal",
+            new,
+        )
+        if principal_chat_id in new:
+            new = new.replace(
+                principal_chat_id,
+                f"{orchestrator} (route through {orchestrator}, do NOT send direct to the principal)")
+        log(actions, f"GUARDRAIL: cron '{cron_name}' sent DIRECT to the principal "
+                     f"(send-telegram <principal-chat-id>) -> re-routed through "
+                     f"'{orchestrator}' per the routing rule")
+        rerouted = True
+    # (b) PROSE intent (only if not already routing through the orchestrator).
+    prose_res = principal_prose_send_res(principal_name)
+    route_re = orchestrator_route_re(orchestrator)
+    has_prose = any(rx.search(new) for rx in prose_res)
+    if has_prose and not (route_re and route_re.search(new)):
+        guard = (f"\n\n[MIGRATION ROUTING GUARD]: This cron is principal-facing. Per the "
+                 f"routing rule, route every principal-facing send THROUGH the "
+                 f"orchestrator '{orchestrator}' "
+                 f"(`cortextos bus send-message {orchestrator} normal '<msg>'`) — do NOT "
+                 f"send direct to the principal. The orchestrator owns the principal's "
+                 f"surface and delivers.")
+        new = new + guard
+        log(actions, f"GUARDRAIL (defect 14 prose): cron '{cron_name}' has prose "
+                     f"direct-to-principal send intent with no orchestrator routing -> "
+                     f"appended a routing-guard directive (non-destructive); verify.py "
+                     f"asserts the outcome")
+        rerouted = True
+    return new, rerouted
+
+
+def _load_registry_crons(ctx_root, source_agent, actions):
+    """Read the source's LIVE cron registry. cortextos stores it at
+    $CTX_ROOT/.cortextOS/state/agents/<agent>/crons.json (the daemon-loaded
+    registry) — the file the daemon actually fires from. Returns a list of cron
+    dicts (possibly empty)."""
+    reg_path = os.path.join(ctx_root, ".cortextOS", "state", "agents",
+                            source_agent, "crons.json")
+    if not os.path.isfile(reg_path):
+        log(actions, f"note: no live cron registry at {reg_path} — "
+                     f"using config.json crons only")
+        return []
+    try:
+        with open(reg_path) as f:
+            data = json.load(f)
+    except Exception as e:
+        log(actions, f"WARNING: could not parse live cron registry {reg_path} ({e}) — "
+                     f"using config.json crons only")
+        return []
+    return data.get("crons", []) or []
+
+
+def migrate_crons(src_dir, target_dir, source_agent, target_agent, ctx_root,
+                  apply, actions, principal_chat_id=None, orchestrator=None,
+                  principal_name=None):
+    """Migrate ALL crons (defect 5): the UNION of the source config.json crons[]
+    AND the source live registry crons.json, deduped by name. Crons present in
+    config.json but absent from the live registry (and vice versa) are BOTH kept —
+    the prod migration dropped 7 of 11 by reading only the registry. For each cron:
+    translate cd/skills/absolute paths to the target workspace (defect 4), and
+    re-route any direct-to-principal send through the orchestrator (defect 6c). Writes the union into
+    the target config.json crons[]."""
+    src_cfg_path = os.path.join(src_dir, "config.json")
+    with open(src_cfg_path) as f:
+        src_cfg = json.load(f)
+    config_crons = src_cfg.get("crons", []) or []
+    registry_crons = _load_registry_crons(ctx_root, source_agent, actions)
+
+    # enabled-state must SURVIVE the union. The daemon fires from the registry, so a
+    # cron disabled in the LIVE registry (or in config) must NOT come back enabled at
+    # the target. The old union dropped `enabled` in registry normalization and let
+    # config win, silently re-enabling a live-disabled recurring cron. Capture both
+    # sides; the effective enabled is computed per cron in the emit loop below.
+    reg_enabled = {c.get("name"): c.get("enabled") for c in registry_crons if c.get("name")}
+    cfg_enabled = {c.get("name"): c.get("enabled") for c in config_crons if c.get("name")}
+
+    # defect 11b: one-shot crons. The source stores a once-cron in TWO shapes:
+    # config.json carries {type:"once", fire_at:<ISO>} which the daemon SKIPS (no
+    # native once/fire_at support => silent drop), while the LIVE registry carries
+    # the SAME cron as a dated crontab (e.g. '0 13 16 6 *') which the daemon LOADS
+    # and fires (TZ-correct in the agent's tz). So for a once-cron we must PREFER
+    # the registry crontab form over the config once-form, else the cron silently
+    # vanishes at the target. Identify once-crons from config up front.
+    once_names = set()
+    for c in config_crons:
+        nm = c.get("name")
+        if nm and (c.get("type") == "once" or c.get("fire_at") or c.get("fireAt")):
+            once_names.add(nm)
+
+    # UNION deduped by name; config.json is the canonical shape (type/interval/
+    # crontab), but a registry-only cron is still carried (normalized to a config
+    # cron). config.json wins on conflict (it carries the schedule TYPE) — EXCEPT
+    # for once-crons that have a daemon-loadable registry form (defect 11b).
+    merged = {}
+    order = []
+    registry_form = {}
+    for c in registry_crons:
+        nm = c.get("name")
+        if not nm:
+            continue
+        # normalize registry shape (schedule) to config shape; carry `enabled` through
+        # so a registry-only cron keeps its live enabled-state (was dropped here).
+        norm = {"name": nm, "prompt": c.get("prompt", "")}
+        if c.get("enabled") is not None:
+            norm["enabled"] = c.get("enabled")
+        sched = c.get("schedule")
+        if isinstance(sched, str) and (" " in sched or "*" in sched):
+            norm["type"] = "crontab"
+            norm["crontab"] = sched
+        elif sched:
+            norm["type"] = "recurring"
+            norm["interval"] = sched
+        merged[nm] = norm
+        order.append(nm)
+        registry_form[nm] = norm
+    for c in config_crons:
+        nm = c.get("name")
+        if not nm:
+            continue
+        if nm not in merged:
+            order.append(nm)
+            merged[nm] = dict(c)
+        elif nm in once_names and registry_form.get(nm, {}).get("type") in ("crontab", "recurring"):
+            # defect 11b: KEEP the registry's daemon-loadable form for this
+            # once-cron — do NOT let the config once-form override and get dropped.
+            merged[nm] = dict(registry_form[nm])
+        else:
+            merged[nm] = dict(c)  # config.json wins (carries the canonical schedule type)
+
+    out = []
+    rerouted = 0
+    once_flags = []  # (name, schedule_or_fire_at, kind)
+    for nm in order:
+        c = dict(merged[nm])
+        # defect 11b: a once-cron must end up daemon-loadable, never silently
+        # dropped. If it still carries the once-form (no registry crontab existed),
+        # it CANNOT be auto-converted safely (deriving a crontab from fire_at would
+        # guess the timezone and could fire at the wrong time) — keep it as a record
+        # and emit a HARD re-arm flag for the operator instead.
+        if nm in once_names:
+            if c.get("type") == "once" or c.get("fire_at") or c.get("fireAt"):
+                once_flags.append((nm, c.get("fire_at") or c.get("fireAt"), "needs-rearm"))
+            else:
+                once_flags.append((nm, c.get("crontab") or c.get("interval"), "registry-crontab"))
+        prompt = c.get("prompt", "")
+        prompt, notes = _translate_cron_prompt(prompt, source_agent, target_agent,
+                                               actions, nm)
+        prompt, was_rerouted = _reroute_principal_sends(
+            prompt, nm, actions, principal_chat_id, orchestrator, principal_name)
+        if was_rerouted:
+            rerouted += 1
+        c["prompt"] = prompt
+        # effective enabled: DISABLED if disabled in EITHER source (registry or config),
+        # else enabled. Never silently resurrect a live-disabled cron via config-wins.
+        eff_enabled = not (reg_enabled.get(nm) is False or cfg_enabled.get(nm) is False)
+        c["enabled"] = eff_enabled
+        if not eff_enabled:
+            log(actions, f"cron '{nm}': carried DISABLED (live-disabled in source; "
+                         f"not resurrected at target)")
+        out.append(c)
+        if notes:
+            log(actions, f"cron '{nm}': translated {', '.join(notes)}")
+
+    # defect 11b: flag every once-cron LOUDLY — converted ones carry a re-fire
+    # caveat, unconvertible ones get an explicit re-arm instruction. NEVER silent.
+    for (nm, sched, kind) in once_flags:
+        if kind == "registry-crontab":
+            log(actions, f"ONCE-CRON FLAG (defect 11b): '{nm}' was a one-shot; carried "
+                         f"as the registry's dated crontab '{sched}' so the daemon "
+                         f"LOADS+FIRES it (daemon has no native once/fire_at). CAVEAT: a "
+                         f"dated crontab RE-FIRES on the same date each year — confirm the "
+                         f"prompt self-destructs after firing, or remove it post-fire. "
+                         f"Verify with `cortextos bus list-crons {target_agent}`.")
+        else:
+            log(actions, f"ONCE-CRON FLAG (defect 11b) NEEDS-REARM: '{nm}' is a one-shot "
+                         f"(fire_at '{sched}') with NO daemon-loadable registry form — the "
+                         f"daemon will SKIP it (silent drop). It is carried in target "
+                         f"config.json as a record only. RE-ARM manually on the target "
+                         f"after boot: have '{target_agent}' create a one-shot reminder for "
+                         f"'{nm}' at {sched} (orchestrator-routed if principal-facing).")
+
+    # write into the target config.json crons[]
+    tgt_cfg_path = os.path.join(target_dir, "config.json")
+    if os.path.isfile(tgt_cfg_path):
+        with open(tgt_cfg_path) as f:
+            tcfg = json.load(f)
+        tcfg["crons"] = out
+        if apply:
+            with open(tgt_cfg_path, "w") as f:
+                json.dump(tcfg, f, indent=2)
+                f.write("\n")
+    log(actions, f"crons migrated: {len(out)} (UNION of {len(config_crons)} config "
+                 f"+ {len(registry_crons)} registry, deduped); {rerouted} direct-to-principal "
+                 f"send(s) re-routed through the orchestrator; cd/skills paths translated to target")
+    return out
+
+
+def carry_state_continuity(src_dir, ctx_root, source_agent, target_agent, apply, actions):
+    """Boot-state continuity (defect 1). The daemon cold-onboards an agent whose
+    state/<name>/.onboarded marker is absent. The old force_fresh dropped a marker
+    but never carried .onboarded, so a migrated agent re-ran ONBOARDING.md. CARRY
+    the boot-state continuity markers source->target (.onboarded, heartbeat.json,
+    .telegram-offset, cron-state.json, dedup/circuit files, pending-reminders.json,
+    handoffs/). EXCLUDE ONLY the stale session transcript(s) (codex thread file) —
+    the narrow, legitimate reason force_fresh existed. NEVER wipe the whole state
+    dir."""
+    src_state = os.path.join(ctx_root, "state", source_agent)
+    tgt_state = os.path.join(ctx_root, "state", target_agent)
+    if not os.path.isdir(src_state):
+        log(actions, f"note: source state dir {src_state} absent — nothing to carry "
+                     f"(target will cold-onboard unless .onboarded is created)")
+        return
+    if apply:
+        os.makedirs(tgt_state, exist_ok=True)
+    carried = []
+    for fn in STATE_CONTINUITY_FILES:
+        sp = os.path.join(src_state, fn)
+        if os.path.isfile(sp):
+            if apply:
+                shutil.copy2(sp, os.path.join(tgt_state, fn))
+            carried.append(fn)
+    for dn in STATE_CONTINUITY_DIRS:
+        sp = os.path.join(src_state, dn)
+        if os.path.isdir(sp):
+            dp = os.path.join(tgt_state, dn)
+            if apply:
+                if os.path.exists(dp):
+                    shutil.rmtree(dp)
+                shutil.copytree(sp, dp, symlinks=False)
+            carried.append(dn + "/")
+    log(actions, f"state continuity carried into state/{target_agent}/: "
+                 f"{', '.join(carried) if carried else '(none present)'} — "
+                 f".onboarded carried so the daemon does NOT cold-onboard the target")
+
+
+def carry_handoff_and_boot_directive(src_dir, target_dir, ctx_root, source_agent,
+                                     target_agent, migration_start_ts, apply, actions):
+    """Read-side handoff enforcement (defect 3) + DETERMINISTIC carry. The FRESH
+    source-generated handoff (produced AFTER migration start by the source's normal
+    handoff:create — gated by await_fresh_handoff) is carried into a DETERMINISTIC
+    location in the new agent's dir so it is ALWAYS reliably read on boot, not a
+    'newest file' guess. 8i FIX: the source handoff is read from the source WORKSPACE
+    memory/handoffs/ (not state/<source>/handoffs/). It is then carried into BOTH
+    boot-read locations: (1) the daemon boot-state dir state/<target>/handoffs/ and
+    (2) the new agent's WORKSPACE memory/handoffs/ (its native handoff:resume dir) —
+    so whichever path boot uses, the doc is there. A deterministic boot directive
+    (.handoff-doc-path) points the daemon at the exact carried file; the daemon
+    (agent-process.ts consumeHandoffBlock) reads it and injects 'read the handoff at
+    <path>' as the agent's first action. Returns the carried boot-state path (or None)."""
+    src_handoffs = os.path.join(src_dir, "memory", "handoffs")
+    fresh = _find_fresh_handoff(src_handoffs, migration_start_ts)
+    if not fresh:
+        log(actions, "WARNING: no fresh source handoff found in source memory/handoffs/ "
+                     "to carry — the read-side boot directive was NOT written "
+                     "(await_fresh_handoff should have blocked the cutover before this)")
+        return None
+    base = os.path.basename(fresh)
+    tgt_state = os.path.join(ctx_root, "state", target_agent)
+    tgt_state_handoffs = os.path.join(tgt_state, "handoffs")
+    tgt_ws_handoffs = os.path.join(target_dir, "memory", "handoffs")
+    state_dst = os.path.join(tgt_state_handoffs, base)
+    ws_dst = os.path.join(tgt_ws_handoffs, base)
+    if apply:
+        now = time.time()
+        # DETERMINISTIC dual-location carry: land it in BOTH boot-read dirs as NEWEST
+        # (copy2 preserves source mtime, which may predate carried older handoffs —
+        # bump to now so it sorts newest in each dir; verify.py asserts newest).
+        for dst_dir, dst in ((tgt_state_handoffs, state_dst), (tgt_ws_handoffs, ws_dst)):
+            os.makedirs(dst_dir, exist_ok=True)
+            shutil.copy2(fresh, dst)
+            os.utime(dst, (now, now))
+        # deterministic boot directive: the daemon reads this marker and injects CONTEXT HANDOFF.
+        marker = os.path.join(tgt_state, ".handoff-doc-path")
+        with open(marker, "w") as f:
+            f.write(os.path.abspath(state_dst) + "\n")
+    log(actions, f"read-side: carried fresh handoff '{base}' (from source memory/handoffs/) "
+                 f"into BOTH state/{target_agent}/handoffs/ AND target memory/handoffs/ as "
+                 f"NEWEST; wrote deterministic .handoff-doc-path boot directive -> daemon "
+                 f"injects 'read this handoff first' on the target's first boot")
+    return state_dst
+
+
+def ensure_guardrails(target_dir, apply, actions, orchestrator=None,
+                      principal_name=None):
+    """Guardrail-into-template (defect 6a/6b), SPLIT into two independent rows:
+
+      - APPROVAL row ('no external action without an explicit per-item go') is
+        instance-GENERAL cortextOS safety and is ALWAYS injected.
+      - ROUTING row ('principal-facing sends route THROUGH the orchestrator') is
+        injected whenever the ORCHESTRATOR is known (F1). The orchestrator is the
+        thing the rule routes TO, so it is the only value the row structurally needs.
+        The principal NAME is optional decoration: when known the row names the
+        principal, when unknown it uses a generic "the principal" — either way the
+        rule (route through the orchestrator) is well-defined and safe. This matters
+        because the COMMON live case has a numeric ALLOWED_USER, so principal_name is
+        None for most instances; gating the whole routing row on the name would drop
+        the guardrail for nearly everyone, and verify.py (orchestrator-gated, name-
+        independent) would then hard-fail. The reroute's PROSE leg stays name-gated
+        (principal_prose_send_res returns [] without a name — no false hits).
+        The routing row is omitted ONLY when no orchestrator is known (safe-degrade).
+
+    Idempotent: appends the block only if the marker is absent. Also ensures
+    config.json approval_rules gates external-comms (always — general)."""
+    ROUTE_MARKER = "MIGRATION GUARDRAILS (inherited via migration)"
+    inject_routing = bool(orchestrator)
+    principal_ref = (f"the principal ('{principal_name}')" if principal_name
+                     else "the principal")
+    rows = ""
+    if inject_routing:
+        rows += (
+            f"| Any principal-facing send | \"I'll just message the principal "
+            f"directly\" | Route every principal-facing send THROUGH the orchestrator "
+            f"'{orchestrator}'. Never send direct to {principal_ref}; send to "
+            f"'{orchestrator}' for delivery. |\n")
+    rows += (
+        "| About to take any external action | \"I have standing authorization\" | "
+        "NO external action (post, send, deploy, publish, purchase, delete) without "
+        "an EXPLICIT per-item go + approval. No inferred/standing authorization. |\n")
+    block = (
+        f"\n## MIGRATION GUARDRAILS (inherited via migration)\n\n"
+        "| Trigger | Red Flag Thought | Required Action |\n"
+        "|---------|-----------------|-----------------|\n"
+        + rows
+    )
+    gp = os.path.join(target_dir, "GUARDRAILS.md")
+    present = False
+    if os.path.isfile(gp):
+        with open(gp, errors="ignore") as f:
+            content = f.read()
+        present = ROUTE_MARKER in content
+        if not present and apply:
+            with open(gp, "a") as f:
+                f.write(block)
+    else:
+        content = "# Guardrails\n"
+        if apply:
+            with open(gp, "w") as f:
+                f.write(content + block)
+    if present:
+        log(actions, "guardrails: migration guardrails already present in target "
+                     "GUARDRAILS.md (idempotent no-op)")
+    else:
+        routing_note = (f"ROUTING (principal-facing sends via '{orchestrator}') + "
+                        if inject_routing else
+                        "ROUTING row OMITTED (no orchestrator known — "
+                        "safe-degrade) + ")
+        log(actions, f"guardrails: appended {routing_note}APPROVAL (no external action "
+                     f"without explicit per-item go) to target GUARDRAILS.md")
+    # config approval_rules: ensure external-comms is gated (always_ask).
+    cfg_path = os.path.join(target_dir, "config.json")
+    if os.path.isfile(cfg_path):
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+        rules = cfg.setdefault("approval_rules", {})
+        always = rules.setdefault("always_ask", [])
+        changed = False
+        for need in ("external-comms",):
+            if need not in always:
+                always.append(need)
+                changed = True
+        if changed and apply:
+            with open(cfg_path, "w") as f:
+                json.dump(cfg, f, indent=2)
+                f.write("\n")
+        log(actions, f"guardrails: config approval_rules.always_ask ensures external-comms "
+                     f"gated ({'added' if changed else 'already present'})")
+
+
+def fold_claude_md(src_dir, target_dir, manifest, apply, actions):
+    cm = manifest.get("claude_md", {})
+    if not cm.get("present"):
+        log(actions, "no CLAUDE.md in source")
+        return
+    src_cm = os.path.join(src_dir, "CLAUDE.md")
+    with open(src_cm, errors="ignore") as f:
+        body = f.read()
+    if cm.get("thin_wrapper"):
+        log(actions, "CLAUDE.md is a thin @AGENTS.md wrapper — dropped, no fold needed")
+        return
+    body = body.replace(REWRITE[0], REWRITE[1])
+    tgt_agents = os.path.join(target_dir, "AGENTS.md")
+    section = (
+        "\n\n<!-- ============================================================ -->\n"
+        "<!-- FOLDED FROM SOURCE CLAUDE.md — REVIEW FOR DUPLICATION/CONFLICT -->\n"
+        "<!-- ============================================================ -->\n"
+        "## Folded from CLAUDE.md (review and de-duplicate)\n\n"
+        + body + "\n"
+    )
+    if apply and os.path.isfile(tgt_agents):
+        with open(tgt_agents, "a") as f:
+            f.write(section)
+    log(actions, "CLAUDE.md content appended to target AGENTS.md under a labeled "
+                 "section — HUMAN REVIEW REQUIRED for de-duplication")
+
+
+def strip_tools_auth(target_dir, apply, actions):
+    tp = os.path.join(target_dir, "TOOLS.md")
+    if not os.path.isfile(tp):
+        return
+    with open(tp, errors="ignore") as f:
+        content = f.read()
+    hit = any(e in content for e in CLAUDE_AUTH_ENV)
+    if hit:
+        log(actions, "NEEDS-HUMAN: TOOLS.md references Claude auth env (ANTHROPIC_API_KEY/"
+                     "CLAUDE_CODE_OAUTH_TOKEN) — codex model auth is host ~/.codex/auth.json; "
+                     "FLAGGED for human review/strip (prose not auto-edited)")
+
+
+def copy_custom_skills(src_dir, target_dir, target_agent, manifest, apply, actions):
+    skills = manifest.get("skills", {}).get("custom", [])
+    tgt_skills_root = os.path.join(target_dir, "plugins", "cortextos-agent-skills", "skills")
+    for s in skills:
+        name = s["name"]
+        src = os.path.join(src_dir, ".claude", "skills", name)
+        dst = os.path.join(tgt_skills_root, name)
+        if s["disposition"] == "needs_human":
+            log(actions, f"custom skill '{name}' has behavioral leakage "
+                         f"{list(s['leakage_behavioral'].keys())} — NOT auto-copied; "
+                         f"hand to skill-creator")
+            continue
+        copy_tree(src, dst, apply, actions, f"custom skill '{name}'")
+        # rewrite mechanical refs inside the copied skill
+        if apply and os.path.isdir(dst):
+            for dp, dn, fns in os.walk(dst):
+                dn[:] = [d for d in dn if d != "node_modules"]
+                for fn in fns:
+                    rewrite_refs_in_file(os.path.join(dp, fn), apply, actions)
+    # Symlinks for ALL skills (bundled + custom) are installed by
+    # install_all_symlinks(), called separately after this — verify.py asserts a
+    # symlink for EVERY skill dir, not just the customs copied here.
+
+
+def install_all_symlinks(target_dir, target_agent, apply, actions):
+    """Replicate add-agent's installCodexSkillSymlinks over EVERY skill dir in
+    plugins/cortextos-agent-skills/skills/* (bundled + custom). Idempotent:
+    replaces an existing symlink, leaves a real file/dir in place. This guarantees
+    the scripted path produces exactly what verify.py checks (which asserts a
+    ~/.codex/skills/<agent>__<skill> link for every skill dir, including the 23
+    bundled ones whose symlinks would otherwise be an implicit add-agent
+    prerequisite that silently no-ops if a non-symlink pre-exists)."""
+    skills_root = os.path.join(target_dir, "plugins", "cortextos-agent-skills", "skills")
+    codex_skills_dir = os.path.join(os.path.expanduser("~"), ".codex", "skills")
+    if not os.path.isdir(skills_root):
+        log(actions, "no plugins/.../skills dir in target — no symlinks to install")
+        return
+    linked = 0
+    for name in sorted(os.listdir(skills_root)):
+        sp = os.path.join(skills_root, name)
+        if not os.path.isdir(sp):
+            continue
+        link = os.path.join(codex_skills_dir, f"{target_agent}__{name}")
+        if apply:
+            os.makedirs(codex_skills_dir, exist_ok=True)
+            # Replace an existing symlink; never clobber a real file/dir.
+            if os.path.islink(link):
+                # idempotent: only re-link if it points elsewhere
+                if os.path.realpath(link) == os.path.realpath(sp):
+                    linked += 1
+                    continue
+                os.unlink(link)
+            elif os.path.exists(link):
+                log(actions, f"WARNING: {link} exists and is not a symlink — left untouched")
+                continue
+            os.symlink(sp, link, target_is_directory=True)
+        linked += 1
+    log(actions, f"symlink install (bundled+custom): {linked} skill(s) linked into "
+                 f"~/.codex/skills/{target_agent}__*")
+
+
+def create_skill_depth_compat_symlink(target_dir, apply, actions):
+    """Defect 7 (skill-depth-delta): codex skills live at
+    plugins/cortextos-agent-skills/skills/<x> -- ONE directory deeper than claude's
+    .claude/skills/<x>. Skill scripts that anchor workspace output relative to
+    __file__ with a FIXED depth -- e.g. OUTPUT_BASE = dirname(__file__)/../../../docs
+    or ROOT = Path(__file__).resolve().parents[3]; ROOT/"docs" -- were correct at
+    claude depth 3 but resolve to <ws>/plugins/docs at codex depth 4, silently
+    mis-writing output one level short of the workspace. (github-trending-feed,
+    daily-signal-pipeline, and nightly-topic-briefing all hit this in the
+    an observed migration: digests landed in plugins/docs/, not docs/.)
+    A single compatibility symlink <ws>/plugins/docs -> ../docs makes every such
+    depth-short 'docs' anchor resolve back to the real <ws>/docs. Idempotent; never
+    silently clobbers a real dir -- it merges any mis-written contents into <ws>/docs
+    first, and refuses (warns) if a name collides so nothing is lost.
+    NOTE: this covers the common workspace-DOCS anchor (the observed output class).
+    Scripts that anchor NON-docs workspace paths via the same fixed depth (e.g.
+    ROOT/".env") are flagged by verify.py's depth-anchor scan for manual review."""
+    plugins_dir = os.path.join(target_dir, "plugins")
+    if not os.path.isdir(plugins_dir):
+        return
+    link = os.path.join(plugins_dir, "docs")
+    real_docs = os.path.join(target_dir, "docs")
+    if os.path.islink(link) and os.path.realpath(link) == os.path.realpath(real_docs):
+        log(actions, "skill-depth-compat: plugins/docs -> ../docs already correct")
+        return
+    if apply:
+        os.makedirs(real_docs, exist_ok=True)
+        if os.path.isdir(link) and not os.path.islink(link):
+            for sub in sorted(os.listdir(link)):
+                s = os.path.join(link, sub)
+                d = os.path.join(real_docs, sub)
+                if not os.path.exists(d):
+                    shutil.move(s, d)
+                else:
+                    log(actions, f"WARNING: docs/{sub} exists in target — left "
+                                 f"plugins/docs/{sub} for manual merge")
+            try:
+                os.rmdir(link)
+            except OSError:
+                log(actions, f"WARNING: {link} not empty after merge — symlink NOT "
+                             f"created, resolve the collision manually")
+                return
+        elif os.path.islink(link):
+            os.unlink(link)
+        os.symlink("../docs", link)
+    log(actions, "skill-depth-compat: plugins/docs -> ../docs (depth-short __file__ "
+                 "anchors now resolve workspace output into <ws>/docs)")
+
+
+def _sqlite_ok(path):
+    """True if `path` is a sound sqlite DB (or a 0-byte placeholder, which carries
+    no data to corrupt). False if it fails PRAGMA integrity_check or cannot be
+    opened. Read-only open so it never mutates the file it is checking."""
+    try:
+        if not os.path.isfile(path) or os.path.getsize(path) == 0:
+            return True
+        import sqlite3
+        c = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            row = c.execute("PRAGMA integrity_check;").fetchone()
+        finally:
+            c.close()
+        return bool(row) and row[0] == "ok"
+    except Exception:
+        return False
+
+
+def ensure_sqlite_integrity(src_dir, target_dir, apply, actions):
+    """Defect 15: skill data is raw file-copied (copy_tree). Copying a LIVE sqlite
+    DB while the source daemon holds it open mid-write produces a TORN copy
+    (malformed, usually SMALLER than the source) — an agent's daily-signal
+    signals.db came over malformed and failed its first nightly run. A raw cp gives
+    no consistency guarantee for a live DB.
+
+    PREVENT + ASSERT (self-catching, same class as the cron/routing outcome-
+    assertions): walk the TARGET tree for *.db; for each malformed copy, re-copy
+    from the corresponding SOURCE via the sqlite backup API (a CONSISTENT snapshot
+    even of a live DB), then re-run integrity_check. os.walk does NOT follow
+    symlinks, so SHARED symlinked skills are skipped — only the agent's OWN real
+    copies are touched. Returns (repaired, ok_list, unrepairable). A non-empty
+    `unrepairable` is a HARD migration failure for the caller (default-deny: a
+    migration that cannot produce a valid DB copy must NOT report success or tear
+    down the source)."""
+    import sqlite3
+    repaired, ok_list, unrepairable = [], [], []
+    for root, _dirs, files in os.walk(target_dir):  # walk does not follow symlinks
+        for fn in files:
+            if not fn.endswith(".db"):
+                continue
+            tdb = os.path.join(root, fn)
+            rel = os.path.relpath(tdb, target_dir)
+            if _sqlite_ok(tdb):
+                ok_list.append(rel)
+                continue
+            # malformed target copy. Map back to the SOURCE db: reverse the
+            # skills-path rewrite (plugins/cortextos-agent-skills/skills ->
+            # .claude/skills) so the source path resolves under <src_dir>.
+            srel = rel.replace(REWRITE[1], REWRITE[0])
+            sdb = os.path.join(src_dir, srel)
+            if not (os.path.isfile(sdb) and _sqlite_ok(sdb)):
+                unrepairable.append(rel)
+                log(actions, f"DB-INTEGRITY (defect 15) UNREPAIRABLE: target '{rel}' is "
+                             f"malformed AND its source '{sdb}' is missing or also "
+                             f"malformed — cannot restore. HARD FAIL.")
+                continue
+            if apply:
+                try:
+                    # Remove the torn copy first: the backup API opens the DEST as a
+                    # db, and a torn non-db dest fails ("file is not a database").
+                    # A fresh dest file lets backup() populate a clean snapshot.
+                    try:
+                        os.remove(tdb)
+                    except OSError:
+                        pass
+                    s = sqlite3.connect(f"file:{sdb}?mode=ro", uri=True)
+                    d = sqlite3.connect(tdb)
+                    try:
+                        s.backup(d)
+                    finally:
+                        d.close()
+                        s.close()
+                except Exception as e:
+                    unrepairable.append(rel)
+                    log(actions, f"DB-INTEGRITY (defect 15) UNREPAIRABLE: backup-API "
+                                 f"re-copy of '{rel}' from source failed ({e}). HARD FAIL.")
+                    continue
+                if _sqlite_ok(tdb):
+                    repaired.append(rel)
+                    log(actions, f"DB-INTEGRITY (defect 15): '{rel}' was a torn raw-copy "
+                                 f"(malformed); re-copied from source via the sqlite backup "
+                                 f"API; integrity_check now ok.")
+                else:
+                    unrepairable.append(rel)
+                    log(actions, f"DB-INTEGRITY (defect 15) UNREPAIRABLE: '{rel}' still "
+                                 f"malformed AFTER backup-API re-copy. HARD FAIL.")
+            else:
+                # dry-run: cannot write, but REPORT what would be repaired (no abort).
+                repaired.append(rel)
+                log(actions, f"DB-INTEGRITY (defect 15, dry-run): '{rel}' is a torn copy; "
+                             f"would re-copy from source '{sdb}' via the backup API on --apply.")
+    log(actions, f"DB-INTEGRITY (defect 15): {len(ok_list)} db(s) ok, {len(repaired)} "
+                 f"repaired via backup API, {len(unrepairable)} UNREPAIRABLE {unrepairable}. "
+                 f"Non-empty unrepairable = HARD cutover-blocking failure.")
+    return repaired, ok_list, unrepairable
+
+
+def rewrite_all_refs(target_dir, apply, actions):
+    """Grep the whole target dir for .claude/skills and rewrite (instruction files + scripts)."""
+    total = 0
+    for dp, dn, fns in os.walk(target_dir):
+        dn[:] = [d for d in dn if d not in ("node_modules", ".git")]
+        for fn in fns:
+            if fn.endswith((".md", ".sh", ".txt", ".json", ".py", ".js", ".ts")):
+                total += rewrite_refs_in_file(os.path.join(dp, fn), apply, actions)
+    log(actions, f"ref-rewrite sweep: {total} total '.claude/skills' hit(s) across target")
+
+
+def scan_cross_agent_strands(src_dir, source_agent, target_agent, actions):
+    """CUTOVER best-effort SURFACE (the migration-strands class). On cutover the
+    source agent is retired and its workspace renamed agents/<source> ->
+    agents/<target>; any SIBLING agent that hardcodes `agents/<source>/...` then
+    reads a path the producer no longer feeds (a stale cross-agent read (agents/<src>
+    class). The migration must NOT silently rewrite siblings (surgical scope) — so
+    this only REPORTS the stranded refs for the operator to repoint, and
+    verify.py --expect-cutover is the hard gate that FAILS until they are.
+    Returns [(sibling_agent, relpath), ...]."""
+    hits = []
+    agents_root = os.path.dirname(os.path.normpath(src_dir))
+    if not os.path.isdir(agents_root):
+        return hits
+    seg = re.compile(r"agents/" + re.escape(source_agent) + r"(?![\w-])")
+    skip = {os.path.basename(os.path.normpath(src_dir)), source_agent, target_agent}
+    for sib in sorted(os.listdir(agents_root)):
+        sib_dir = os.path.join(agents_root, sib)
+        if sib in skip or not os.path.isdir(sib_dir):
+            continue
+        for dp, dn, fns in os.walk(sib_dir):
+            dn[:] = [d for d in dn if d not in ("node_modules", ".git", "state", "logs")]
+            for fn in fns:
+                if not fn.endswith((".md", ".sh", ".txt", ".json", ".py", ".js", ".ts")):
+                    continue
+                fp = os.path.join(dp, fn)
+                try:
+                    with open(fp, errors="ignore") as f:
+                        if seg.search(f.read()):
+                            hits.append((sib, os.path.relpath(fp, agents_root)))
+                except Exception:
+                    pass
+    if hits:
+        log(actions, f"CUTOVER cross-agent strands: {len(hits)} sibling ref(s) to retired "
+                     f"agents/{source_agent} — REPOINT to agents/{target_agent} before enabling "
+                     f"(verify.py --expect-cutover hard-fails until clean): {hits}")
+    else:
+        log(actions, f"CUTOVER cross-agent strands: no sibling refs to agents/{source_agent} (clean)")
+    return hits
+
+
+def _toml_basic_str(s):
+    """Escape a Python value as the body of a TOML basic string (no surrounding quotes)."""
+    return (str(s).replace("\\", "\\\\").replace('"', '\\"')
+            .replace("\n", "\\n").replace("\t", "\\t"))
+
+
+def _existing_mcp_server_names(config_text):
+    """Server names already declared as [mcp_servers.<name>] in a config.toml text."""
+    return set(re.findall(r'(?m)^\s*\[mcp_servers\.([^\].]+)\]\s*$', config_text))
+
+
+_MCP_MIGRATION_HEADER_RE = re.compile(
+    r"^# === migrated MCP servers for agent '([^']*)' "
+    r"\(claude-to-codex-migration\) ===\s*$")
+
+
+def _split_self_owned_mcp_region(config_text, target_agent):
+    """Partition config.toml text into (foreign_text, self_owned_names).
+
+    A block THIS skill previously wrote for target_agent begins at its
+    `# === migrated MCP servers for agent '<target_agent>' (claude-to-codex-migration) ===`
+    header and runs to the next such header (any agent) or EOF. Its
+    [mcp_servers.<name>] names are SELF-OWNED: a re-run must idempotently OVERWRITE
+    them, NOT treat them as a host-global collision (fix for the re-run self-abort —
+    the header was written but never parsed back, so a second --apply on an
+    MCP-bearing agent hard-stopped on its OWN prior write). Everything else (hand
+    config + OTHER agents' migrated blocks) is foreign and returned untouched, so the
+    caller can strip only its own stale region before re-appending."""
+    lines = config_text.splitlines(keepends=True)
+    foreign, owned_names = [], set()
+    i, n = 0, len(lines)
+    while i < n:
+        m = _MCP_MIGRATION_HEADER_RE.match(lines[i].rstrip("\n"))
+        if m:
+            region = [lines[i]]
+            j = i + 1
+            while j < n and not _MCP_MIGRATION_HEADER_RE.match(lines[j].rstrip("\n")):
+                region.append(lines[j])
+                j += 1
+            if m.group(1) == target_agent:
+                owned_names |= _existing_mcp_server_names("".join(region))
+            else:
+                foreign.extend(region)
+            i = j
+        else:
+            foreign.append(lines[i])
+            i += 1
+    return "".join(foreign), owned_names
+
+
+def _bearer_from_headers(headers):
+    """Pull the raw token from a Claude .mcp.json 'Authorization: Bearer <tok>' header."""
+    for k, v in (headers or {}).items():
+        if k.lower() == "authorization":
+            m = re.match(r"\s*Bearer\s+(.+?)\s*$", str(v), re.I)
+            if m:
+                return m.group(1).strip()
+    return None
+
+
+def _mcp_env_var_name(name):
+    return re.sub(r"[^A-Z0-9]", "_", name.upper()) + "_MCP_TOKEN"
+
+
+def emit_mcp_toml(manifest, target_agent, target_dir, apply, actions):
+    """Migrate each source MCP server into the host-global ~/.codex/config.toml as a
+    [mcp_servers.<name>] table, MERGING — never overwriting (the file is shared by
+    every codex agent on the host). Returns (written, needs_secret, collisions).
+
+    fix #16: this was a print-only STUB (placeholder args/env, no token, never wrote
+    config), so Codex started ZERO migrated servers (a migrated agent's Notion server was dead until
+    hand-fixed). Now it actually writes the tables, carries the http bearer token from
+    the source headers into org secrets.env (env-var indirection — the secret never
+    lands in config.toml), and treats a host-global name COLLISION as a HARD-STOP:
+    a colliding server cannot be installed = a broken agent, so we write NOTHING and
+    the caller aborts the cutover (mirrors the sqlite-integrity gate). verify.py
+    asserts every server is present in config.toml AND, live, that Codex starts it."""
+    servers = manifest.get("mcp", {}).get("servers", [])
+    if not servers:
+        log(actions, "no MCP servers to migrate")
+        return [], [], []
+
+    codex_cfg = os.path.join(os.path.expanduser("~"), ".codex", "config.toml")
+    existing_text = ""
+    if os.path.isfile(codex_cfg):
+        with open(codex_cfg, errors="ignore") as f:
+            existing_text = f.read()
+    # A re-run must OVERWRITE this agent's own prior migrated block, not self-collide
+    # on it. Split off self-owned names so only FOREIGN [mcp_servers.<name>] entries
+    # (hand config + other agents' blocks) count as host-global collisions.
+    foreign_text, self_owned = _split_self_owned_mcp_region(existing_text, target_agent)
+    existing_names = _existing_mcp_server_names(foreign_text)
+
+    # org secrets.env: target_dir is <...>/orgs/<org>/agents/<agent> -> two up + secrets.env
+    secrets_path = os.path.join(
+        os.path.dirname(os.path.dirname(os.path.normpath(target_dir))), "secrets.env")
+    spairs, sseen = _read_env(secrets_path)
+
+    blocks, written, needs_secret, collisions = [], [], [], []
+    for s in servers:
+        name = s["name"]
+        if name in existing_names:
+            collisions.append(name)
+            log(actions, f"MCP HARD-STOP: server '{name}' already declared in {codex_cfg} "
+                         f"(host-global name collision; a human must rename before convert)")
+            continue
+        if name in self_owned:
+            log(actions, f"MCP '{name}': overwriting this agent's own prior migrated "
+                         f"table (idempotent re-run, not a collision)")
+        lines = [f"[mcp_servers.{name}]"]
+        if s.get("transport") == "http":
+            env_var = _mcp_env_var_name(name)
+            lines.append(f'url = "{_toml_basic_str(s.get("url") or "")}"')
+            lines.append(f'bearer_token_env_var = "{env_var}"')
+            tok = _bearer_from_headers(s.get("headers"))
+            if tok:
+                _set_env_key(spairs, sseen, env_var, tok)
+                log(actions, f"MCP '{name}' (http): carried {env_var} into "
+                             f"{os.path.basename(secrets_path)} from source headers")
+            else:
+                needs_secret.append(env_var)
+                log(actions, f"MCP '{name}' (http): NO token in source headers -> provision "
+                             f"{env_var} in secrets.env (verify FAILS until set)")
+        else:
+            lines.append(f'command = "{_toml_basic_str(s.get("command") or "")}"')
+            a = s.get("args") or []
+            if a:
+                lines.append("args = [" + ", ".join(f'"{_toml_basic_str(x)}"' for x in a) + "]")
+            if s.get("cwd"):
+                lines.append(f'cwd = "{_toml_basic_str(s.get("cwd"))}"')
+            env = s.get("env") or {}
+            if env:
+                lines.append("")
+                lines.append(f"[mcp_servers.{name}.env]")
+                for k, v in env.items():
+                    lines.append(f'{k} = "{_toml_basic_str(v)}"')
+            log(actions, f"MCP '{name}' (stdio): {len(a)} arg(s), {len(env)} env key(s) "
+                         f"-> [mcp_servers.{name}]")
+        blocks.append("\n".join(lines))
+        written.append(name)
+
+    # Host-global collision = HARD-STOP: write NOTHING, signal the caller to abort the
+    # cutover (a partial MCP install on an aborted cutover would be inconsistent state).
+    if collisions:
+        return [], needs_secret, collisions
+
+    if apply and blocks:
+        os.makedirs(os.path.dirname(codex_cfg), exist_ok=True)
+        region = (f"# === migrated MCP servers for agent '{target_agent}' "
+                  f"(claude-to-codex-migration) ===\n" + "\n\n".join(blocks) + "\n")
+        # Idempotent: rewrite foreign content (own prior region already stripped) + the
+        # fresh block, so a re-run replaces its own block instead of appending a second
+        # (duplicate [mcp_servers.<name>] tables). Foreign hand config + other agents'
+        # blocks are preserved verbatim.
+        base = foreign_text.rstrip("\n")
+        new_text = (base + "\n\n" + region) if base else region
+        with open(codex_cfg, "w") as f:
+            f.write(new_text)
+        _write_env(secrets_path, spairs, apply)
+        log(actions, f"MCP: wrote {len(written)} server table(s) into {codex_cfg} "
+                     f"(idempotent: own prior block replaced)")
+
+    return written, needs_secret, collisions
+
+
+def _find_fresh_handoff(handoffs_dir, after_ts):
+    """Return the path of the NEWEST handoff file in handoffs_dir whose mtime is
+    STRICTLY AFTER after_ts (the migration-start timestamp), or None. A
+    pre-existing stale handoff (mtime <= after_ts) does NOT satisfy this — the
+    write-side gate requires the source to have produced a FRESH handoff."""
+    if not os.path.isdir(handoffs_dir):
+        return None
+    candidates = []
+    for fn in os.listdir(handoffs_dir):
+        fp = os.path.join(handoffs_dir, fn)
+        if not os.path.isfile(fp):
+            continue
+        try:
+            mt = os.path.getmtime(fp)
+        except OSError:
+            continue
+        if mt > after_ts:
+            candidates.append((mt, fp))
+    if not candidates:
+        return None
+    candidates.sort()
+    return candidates[-1][1]  # newest fresh handoff
+
+
+def await_fresh_handoff(src_dir, source_agent, migration_start_ts, wait_seconds,
+                        poll_seconds, apply, actions):
+    """Write-side handoff enforcement (defect 2). BLOCK and poll the SOURCE agent's
+    REAL handoff output dir for a handoff produced AFTER migration start (the live
+    source runs its normal handoff:create at cutover — NOT a synthesized handoff).
+    8i FIX: agents write handoffs to their WORKSPACE memory/handoffs/, NOT
+    state/<source>/handoffs/ (that dir does not even exist for most agents), so the
+    gate polls <src_dir>/memory/handoffs/. A pre-existing stale handoff does NOT
+    satisfy the gate. If no fresh handoff appears within wait_seconds, return None —
+    the caller MUST ABORT the cutover (do NOT disable source, do NOT enable target).
+    Returns the fresh handoff path on success."""
+    handoffs_dir = os.path.join(src_dir, "memory", "handoffs")
+    fresh = _find_fresh_handoff(handoffs_dir, migration_start_ts)
+    if fresh:
+        log(actions, f"write-side gate: fresh source handoff found at "
+                     f"{os.path.relpath(fresh, src_dir)} (mtime > migration start)")
+        return fresh
+    if not apply:
+        # Dry-run: do not block. Report what WOULD be required.
+        log(actions, f"write-side gate (dry-run): would BLOCK up to {wait_seconds}s "
+                     f"polling {source_agent} workspace memory/handoffs/ for a handoff "
+                     f"produced AFTER migration start; abort cutover if none appears")
+        return None
+    deadline = time.time() + wait_seconds
+    log(actions, f"write-side gate: BLOCKING up to {wait_seconds}s for the live source "
+                 f"'{source_agent}' to produce a FRESH handoff (run handoff:create now)")
+    while time.time() < deadline:
+        time.sleep(poll_seconds)
+        fresh = _find_fresh_handoff(handoffs_dir, migration_start_ts)
+        if fresh:
+            log(actions, f"write-side gate: fresh handoff produced -> "
+                         f"{os.path.relpath(fresh, src_dir)}")
+            return fresh
+    log(actions, f"FAIL: write-side gate TIMED OUT after {wait_seconds}s — source "
+                 f"produced no fresh handoff. ABORTING cutover: source NOT disabled, "
+                 f"target NOT enabled.")
+    return None
+
+
+def force_fresh(ctx_root, target_agent, apply, actions):
+    """Drop the .force-fresh marker and EXCLUDE ONLY the stale session transcript(s)
+    — the narrow, legitimate reason this step exists. Carries the rest of the boot
+    state via carry_state_continuity(); this function NEVER wipes the whole state
+    dir (the old over-broad behavior dropped .onboarded -> cold onboard)."""
+    state_dir = os.path.join(ctx_root, "state", target_agent)
+    marker = os.path.join(state_dir, ".force-fresh")
+    if apply:
+        os.makedirs(state_dir, exist_ok=True)
+        with open(marker, "w") as f:
+            f.write("")
+        # Exclude ONLY the stale session transcripts (codex thread file / *thread.json)
+        # that would cause a stale-session resume crash. Everything else was carried.
+        removed = []
+        for fn in os.listdir(state_dir):
+            fp = os.path.join(state_dir, fn)
+            if not os.path.isfile(fp):
+                continue
+            if fn in STATE_EXCLUDE_EXACT or fn.endswith(STATE_EXCLUDE_SUFFIXES):
+                os.remove(fp)
+                removed.append(fn)
+        if removed:
+            log(actions, f"excluded stale session transcript(s): {', '.join(removed)}")
+    log(actions, f".force-fresh marker dropped at state/{target_agent}/; stale session "
+                 f"transcript(s) (*thread.json) excluded; boot-state continuity preserved")
+
+
+def delete_claude_artifacts(target_dir, apply, actions):
+    """If add-agent or a verbatim copy left .claude/ in the target, remove it.
+
+    Recursively removes NESTED .claude/ dirs and CLAUDE.md files anywhere inside
+    the target too (a copied workspace can carry its own .claude/CLAUDE.md, which
+    a top-level-only delete would leave live)."""
+    # Recursive sweep first: any nested .claude dir or CLAUDE.md inside copied content.
+    nested = 0
+    for dp, dn, fns in os.walk(target_dir, topdown=True):
+        dn[:] = [d for d in dn if d != "node_modules"]
+        if ".claude" in dn:
+            cdir = os.path.join(dp, ".claude")
+            if apply:
+                shutil.rmtree(cdir)
+            dn.remove(".claude")  # don't descend into a dir we just (logically) removed
+            nested += 1
+            log(actions, f"removed nested .claude/ at {os.path.relpath(cdir, target_dir)}")
+        for fn in fns:
+            if fn == "CLAUDE.md":
+                cm = os.path.join(dp, fn)
+                if apply:
+                    os.remove(cm)
+                nested += 1
+                log(actions, f"removed CLAUDE.md at {os.path.relpath(cm, target_dir)}")
+    if nested:
+        log(actions, f"recursive claude-artifact sweep: {nested} nested .claude/ or CLAUDE.md removed")
+    # Belt-and-braces: ensure top-level .claude/ and CLAUDE.md are gone (the sweep
+    # above already covers them, but keep an explicit assertion line for the report).
+    if os.path.isdir(os.path.join(target_dir, ".claude")):
+        if apply:
+            shutil.rmtree(os.path.join(target_dir, ".claude"))
+        log(actions, "removed top-level .claude/ from target — codex cruft")
+    if os.path.isfile(os.path.join(target_dir, "CLAUDE.md")):
+        if apply:
+            os.remove(os.path.join(target_dir, "CLAUDE.md"))
+        log(actions, "deleted top-level CLAUDE.md from target (codex auto-reads AGENTS.md only)")
+
+
+def disable_in_registry(ctx_root, target_agent, apply, actions):
+    """CRITICAL safety: `cortextos add-agent` registers the new agent in
+    $CTX_ROOT/config/enabled-agents.json as {"enabled": true, ...}. The
+    agent-dir config.json enabled=false is NOT enough — the daemon reads the
+    REGISTRY. So a migrated agent can be left LIVE in the registry while
+    config.json reports disabled. Flip ONLY the target's key to enabled:false,
+    MERGE (never overwrite) the json, and touch NO other agent's entry."""
+    reg_path = os.path.join(ctx_root, "config", "enabled-agents.json")
+    if not os.path.isfile(reg_path):
+        log(actions, f"WARNING: enabled-agents.json not found at {reg_path} — "
+                     f"cannot assert registry-disabled; verify add-agent ran")
+        return
+    try:
+        with open(reg_path) as f:
+            reg = json.load(f)
+    except Exception as e:
+        log(actions, f"WARNING: could not parse {reg_path} ({e}) — registry NOT modified")
+        return
+    if not isinstance(reg, dict):
+        log(actions, f"WARNING: {reg_path} is not a JSON object — registry NOT modified")
+        return
+    entry = reg.get(target_agent)
+    if entry is None:
+        log(actions, f"WARNING: target '{target_agent}' absent from enabled-agents.json — "
+                     f"add-agent registration may not have run; nothing to disable")
+        return
+    was = entry.get("enabled")
+    if isinstance(entry, dict):
+        entry["enabled"] = False  # mutate only the target's sub-object
+    else:
+        reg[target_agent] = {"enabled": False}
+    if apply:
+        with open(reg_path, "w") as f:
+            json.dump(reg, f, indent=2)
+            f.write("\n")
+    log(actions, f"registry: enabled-agents.json['{target_agent}'].enabled "
+                 f"{was} -> False (merge, other agents untouched)")
+
+
+# ---------------------------------------------------------------------------
+# Interactive-flow helpers: bot-token modes, source cutover, codex boot.
+# All are NO-OPs unless the implementing agent passes the user-confirmed flags.
+# ---------------------------------------------------------------------------
+
+def _read_env(path):
+    """Parse a KEY=VALUE .env into an ordered dict (preserves order, ignores
+    comments/blanks)."""
+    pairs = []
+    seen = {}
+    if not os.path.isfile(path):
+        return pairs, seen
+    with open(path, errors="ignore") as f:
+        for line in f:
+            raw = line.rstrip("\n")
+            t = raw.strip()
+            if not t or t.startswith("#") or "=" not in t:
+                pairs.append((None, raw))  # passthrough line
+                continue
+            k = t[:t.index("=")].strip()
+            v = t[t.index("=") + 1:]
+            pairs.append((k, v))
+            seen[k] = len(pairs) - 1
+    return pairs, seen
+
+
+def _write_env(path, pairs, apply):
+    if not apply:
+        return
+    out = []
+    for k, v in pairs:
+        out.append(v if k is None else f"{k}={v}")
+    with open(path, "w") as f:
+        f.write("\n".join(out).rstrip("\n") + "\n")
+    os.chmod(path, 0o600)
+
+
+def _set_env_key(pairs, seen, key, value):
+    """Set key=value in the parsed env list, in place, appending if absent."""
+    if key in seen:
+        pairs[seen[key]] = (key, value)
+    else:
+        pairs.append((key, value))
+        seen[key] = len(pairs) - 1
+
+
+def _get_src_bot_token(src_dir):
+    pairs, seen = _read_env(os.path.join(src_dir, ".env"))
+    if "BOT_TOKEN" in seen:
+        return pairs[seen["BOT_TOKEN"]][1]
+    return None
+
+
+def disable_source(src_dir, ctx_root, source_agent, instance, apply, actions):
+    """CUTOVER source-disable (reuse mode ONLY): set the SOURCE Claude agent's
+    config.json enabled=false AND its registry entry enabled=false, THEN actually
+    STOP the running source poller via `cortextos disable`. Telegram allows ONE
+    poller per bot, so reusing the source's bot REQUIRES the source to STOP
+    polling. The JSON flips alone do NOT stop a live poller — the daemon reads
+    enabled-agents.json only at startup (no fs.watch), so a flipped JSON leaves
+    the source poller running; booting codex on the same token would then create
+    TWO getUpdates pollers = Telegram 409 conflict = outage. So this function
+    returns True ONLY when the live source is CONFIRMED stopped; the caller MUST
+    NOT boot codex if it returns False. This is the ONLY path that ever touches
+    the source, and it only runs on explicit --bot-mode reuse."""
+    # source config.json
+    src_cfg_path = os.path.join(src_dir, "config.json")
+    if os.path.isfile(src_cfg_path):
+        with open(src_cfg_path) as f:
+            scfg = json.load(f)
+        was = scfg.get("enabled")
+        scfg["enabled"] = False
+        if apply:
+            with open(src_cfg_path, "w") as f:
+                json.dump(scfg, f, indent=2)
+                f.write("\n")
+        log(actions, f"CUTOVER: source '{source_agent}' config.json enabled "
+                     f"{was} -> False")
+    else:
+        log(actions, f"WARNING: source config.json not found at {src_cfg_path} — "
+                     f"cannot disable source config")
+    # source registry entry (the daemon-read disable)
+    reg_path = os.path.join(ctx_root, "config", "enabled-agents.json")
+    if not os.path.isfile(reg_path):
+        log(actions, f"WARNING: enabled-agents.json not found at {reg_path} — "
+                     f"cannot disable source in registry")
+    else:
+        try:
+            with open(reg_path) as f:
+                reg = json.load(f)
+        except Exception as e:
+            log(actions, f"WARNING: could not parse {reg_path} ({e}) — source registry NOT modified")
+            reg = None
+        if reg is not None and not isinstance(reg, dict):
+            log(actions, f"WARNING: {reg_path} is not a JSON object — source registry NOT modified")
+        elif reg is not None:
+            entry = reg.get(source_agent)
+            if entry is None:
+                log(actions, f"WARNING: source '{source_agent}' absent from enabled-agents.json — "
+                             f"nothing to disable in registry")
+            else:
+                was = entry.get("enabled") if isinstance(entry, dict) else entry
+                if isinstance(entry, dict):
+                    entry["enabled"] = False
+                else:
+                    reg[source_agent] = {"enabled": False}
+                if apply:
+                    with open(reg_path, "w") as f:
+                        json.dump(reg, f, indent=2)
+                        f.write("\n")
+                log(actions, f"CUTOVER: registry enabled-agents.json['{source_agent}'].enabled "
+                             f"{was} -> False (merge, other agents untouched)")
+
+    # P0-1: the JSON flips above do NOT stop the running source poller (the daemon
+    # reads enabled-agents.json only at startup — no fs.watch). We MUST issue the
+    # real daemon stop via `cortextos disable`, which sends IPC stop-agent AND
+    # writes the source's .user-disable marker. If this does not confirm a stop,
+    # the caller MUST NOT boot codex (two pollers on one bot = Telegram 409).
+    if not apply:
+        log(actions, f"CUTOVER (dry-run): would run `cortextos disable {source_agent} "
+                     f"--instance {instance}` to STOP the live source poller")
+        return True  # dry-run: pretend the stop succeeded so flow logging proceeds
+    cmd = ["cortextos", "disable", source_agent, "--instance", instance]
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        log(actions, f"CUTOVER: ran `{' '.join(cmd)}` -> exit {r.returncode}")
+        if r.returncode != 0:
+            log(actions, f"FAIL: `cortextos disable` returned {r.returncode}: "
+                         f"{r.stderr.strip()[:300]} — source poller NOT confirmed stopped; "
+                         f"REFUSING to boot codex (would create a double-poller 409 outage)")
+            return False
+    except Exception as e:
+        log(actions, f"FAIL: `cortextos disable` could not run ({e}) — source poller "
+                     f"NOT confirmed stopped; REFUSING to boot codex (double-poller risk)")
+        return False
+    log(actions, f"CUTOVER: source '{source_agent}' poller CONFIRMED stopped via daemon")
+    return True
+
+
+def disable_source_crons(src_dir, ctx_root, source_agent, apply, actions):
+    """CUTOVER (defect 11a): disable the RETIRED source agent's crons.
+
+    disable_source() stops the source AGENT (config.json + registry + `cortextos
+    disable`), which halts its live cron-scheduler — BUT the source crons stay
+    enabled:true in BOTH the live registry (crons.json) and config.json. Those
+    persisted enabled flags re-fire on any daemon restart / re-enable, and the
+    daemon has been observed firing retired-agent crons from the registry — a
+    durable dual-scheduler hazard once the target carries the same crons. There was
+    NEVER a step that disabled the source CRONS (only the agent); both live
+    migrations were hand-rescued, masking the gap (now baked + asserted by
+    verify.py so it is self-catching).
+
+    Disables RECURRING source crons (set enabled:false) in crons.json AND
+    config.json. HOLDS one-shot crons (config type:once / fire_at) ENABLED — they
+    have no daemon-loadable twin until the operator re-arms them on the target, so
+    disabling them here would leave the reminder armed NOWHERE. Returns
+    (disabled_recurring, held_once)."""
+    # identify once-crons from config (the same rule migrate_crons uses)
+    once_names = set()
+    src_cfg_path = os.path.join(src_dir, "config.json")
+    cfg = None
+    if os.path.isfile(src_cfg_path):
+        try:
+            with open(src_cfg_path) as f:
+                cfg = json.load(f)
+            for c in (cfg.get("crons") or []):
+                nm = c.get("name")
+                if nm and (c.get("type") == "once" or c.get("fire_at") or c.get("fireAt")):
+                    once_names.add(nm)
+        except Exception as e:
+            log(actions, f"WARNING: could not parse source config.json ({e}) — "
+                         f"cannot classify once-crons; treating all as recurring")
+
+    disabled, held = [], []
+
+    # (1) live registry crons.json — the file the daemon actually fires from.
+    reg_path = os.path.join(ctx_root, ".cortextOS", "state", "agents",
+                            source_agent, "crons.json")
+    if os.path.isfile(reg_path):
+        try:
+            with open(reg_path) as f:
+                reg = json.load(f)
+        except Exception as e:
+            log(actions, f"WARNING: could not parse source registry {reg_path} ({e}) — "
+                         f"source registry crons NOT disabled")
+            reg = None
+        if isinstance(reg, dict) and isinstance(reg.get("crons"), list):
+            for c in reg["crons"]:
+                nm = c.get("name")
+                if not nm:
+                    continue
+                if nm in once_names:
+                    held.append(nm)
+                    continue
+                if c.get("enabled") is not False:
+                    c["enabled"] = False
+                    disabled.append(nm)
+            if apply:
+                with open(reg_path, "w") as f:
+                    json.dump(reg, f, indent=2)
+                    f.write("\n")
+    else:
+        log(actions, f"note: no source registry at {reg_path} — nothing to disable there")
+
+    # (2) source config.json crons[] — keep the persisted copy consistent so a
+    # later daemon read of config does not re-enable a disabled cron.
+    if cfg is not None and isinstance(cfg.get("crons"), list):
+        changed = False
+        for c in cfg["crons"]:
+            nm = c.get("name")
+            if not nm or nm in once_names:
+                continue
+            if c.get("enabled") is not False:
+                c["enabled"] = False
+                changed = True
+        if changed and apply:
+            with open(src_cfg_path, "w") as f:
+                json.dump(cfg, f, indent=2)
+                f.write("\n")
+
+    # dedupe for the log
+    disabled = sorted(set(disabled))
+    held = sorted(set(held))
+    log(actions, f"CUTOVER (defect 11a): disabled {len(disabled)} RECURRING source cron(s) "
+                 f"in registry+config: {disabled}. HELD {len(held)} one-shot(s) ENABLED "
+                 f"(no daemon-loadable twin until re-armed on target): {held} — the operator "
+                 f"must re-arm these on the target, THEN disable them on the source. "
+                 f"verify.py --expect-cutover asserts no RECURRING source cron stays enabled.")
+    return disabled, held
+
+
+def apply_bot_mode(bot_mode, new_bot_token, src_dir, target_dir, ctx_root,
+                   source_agent, instance, apply, actions):
+    """Apply the user-chosen bot-token strategy to the codex .env. Returns
+    True if a cutover (source-disable, source CONFIRMED stopped) was performed
+    (which implies boot). Returns False otherwise (no boot)."""
+    env_path = os.path.join(target_dir, ".env")
+    pairs, seen = _read_env(env_path)
+    if bot_mode == "reuse":
+        token = _get_src_bot_token(src_dir)
+        if not token:
+            # P1-2: reuse means "take over the SOURCE bot". With no source
+            # BOT_TOKEN there is nothing to reuse — booting on a stale carried
+            # token while tearing down the source is an outage. HARD STOP:
+            # do NOT disable the source, do NOT boot.
+            log(actions, "FAIL: --bot-mode reuse but source .env has NO BOT_TOKEN — "
+                         "nothing to reuse. HARD STOP: source NOT disabled, codex NOT "
+                         "booted. Use --bot-mode new with a fresh token instead.")
+            return False
+        _set_env_key(pairs, seen, "BOT_TOKEN", token)
+        _write_env(env_path, pairs, apply)
+        log(actions, "bot-mode reuse: copied source BOT_TOKEN into codex .env (0600)")
+        # the cutover: disable AND confirm-stop the source so only ONE poller
+        # runs the bot. If the source is NOT confirmed stopped, do NOT boot.
+        stopped = disable_source(src_dir, ctx_root, source_agent, instance, apply, actions)
+        if not stopped:
+            log(actions, "FAIL: cutover source-disable did not confirm a stop — "
+                         "codex will NOT boot (double-poller 409 prevention)")
+            return False
+        log(actions, "bot-mode reuse implies boot — codex takes over the original bot")
+        return True
+    if bot_mode == "new":
+        if new_bot_token:
+            _set_env_key(pairs, seen, "BOT_TOKEN", new_bot_token)
+            _write_env(env_path, pairs, apply)
+            log(actions, "bot-mode new: wrote user-provided BOT_TOKEN into codex .env (0600)")
+        else:
+            placeholder = "REPLACE_ME_WITH_NEW_BOT_TOKEN"
+            _set_env_key(pairs, seen, "BOT_TOKEN", placeholder)
+            _write_env(env_path, pairs, apply)
+            log(actions, f"NEEDS-HUMAN: --bot-mode new with no --new-bot-token — wrote "
+                         f"placeholder BOT_TOKEN='{placeholder}' into codex .env; user must "
+                         f"paste a real token from @BotFather before boot")
+        return False
+    # none / default: source untouched, no token change
+    log(actions, "bot-mode none (default): source untouched, codex BOT_TOKEN unchanged")
+    return False
+
+
+def boot_codex(target_dir, target_agent, ctx_root, org, instance, apply, actions):
+    """Enable the codex agent: flip config.json + registry to enabled:true, then
+    start it with `cortextos enable` (the daemon-driven start). ONLY on --boot now
+    (or implied by bot-mode reuse). Default path never calls this.
+
+    Returns the `cortextos enable` exit code (0 = started). Returns 0 in dry-run
+    (nothing ran) and None if apply but the command could not run at all — the
+    caller treats non-zero/None as a boot failure and (in a cutover) rolls back."""
+    # config.json enabled = true
+    cfg_path = os.path.join(target_dir, "config.json")
+    if os.path.isfile(cfg_path):
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+        cfg["enabled"] = True
+        if apply:
+            with open(cfg_path, "w") as f:
+                json.dump(cfg, f, indent=2)
+                f.write("\n")
+        log(actions, "boot: codex config.json enabled -> True")
+    # registry enabled = true (merge-only)
+    reg_path = os.path.join(ctx_root, "config", "enabled-agents.json")
+    if not os.path.isfile(reg_path):
+        # P2-2: parity with disable_in_registry — surface a missing registry.
+        log(actions, f"WARNING: enabled-agents.json not found at {reg_path} — "
+                     f"cannot set boot enabled:true in registry (the daemon-read "
+                     f"state); verify add-agent ran")
+    else:
+        try:
+            with open(reg_path) as f:
+                reg = json.load(f)
+        except Exception as e:
+            log(actions, f"WARNING: could not parse {reg_path} ({e}) — boot registry NOT modified")
+            reg = None
+        if reg is not None and not isinstance(reg, dict):
+            log(actions, f"WARNING: {reg_path} is not a JSON object — boot registry NOT modified")
+        elif isinstance(reg, dict):
+            entry = reg.get(target_agent)
+            if isinstance(entry, dict):
+                entry["enabled"] = True
+            else:
+                reg[target_agent] = {"enabled": True}
+            if apply:
+                with open(reg_path, "w") as f:
+                    json.dump(reg, f, indent=2)
+                    f.write("\n")
+            log(actions, f"boot: registry enabled-agents.json['{target_agent}'].enabled -> True")
+    # daemon start via cortextos enable
+    cmd = ["cortextos", "enable", target_agent, "--instance", instance]
+    if org:
+        cmd += ["--org", org]
+    if not apply:
+        log(actions, f"boot (dry-run): would run `{' '.join(cmd)}`")
+        return 0
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        log(actions, f"boot: ran `{' '.join(cmd)}` -> exit {r.returncode}")
+        if r.returncode != 0:
+            log(actions, f"WARNING: `cortextos enable` failed: {r.stderr.strip()[:300]}")
+        return r.returncode
+    except Exception as e:
+        log(actions, f"WARNING: `cortextos enable` could not run ({e})")
+        return None
+
+
+def rollback_source(src_dir, ctx_root, source_agent, org, instance, apply, actions):
+    """P0-3: a cutover boot FAILED after the source was already disabled+stopped.
+    The bot is now orphaned (source down, codex never started) = OUTAGE. Restore
+    the source: flip its config.json + registry back to enabled:true and restart
+    it via `cortextos enable`. Returns True if the source restart was confirmed."""
+    log(actions, f"ROLLBACK: cutover boot failed AFTER source was disabled — "
+                 f"restoring source '{source_agent}' to undo the outage")
+    # source config.json enabled = true
+    src_cfg_path = os.path.join(src_dir, "config.json")
+    if os.path.isfile(src_cfg_path):
+        with open(src_cfg_path) as f:
+            scfg = json.load(f)
+        scfg["enabled"] = True
+        if apply:
+            with open(src_cfg_path, "w") as f:
+                json.dump(scfg, f, indent=2)
+                f.write("\n")
+        log(actions, f"ROLLBACK: source config.json enabled -> True")
+    # source registry enabled = true (merge-only)
+    reg_path = os.path.join(ctx_root, "config", "enabled-agents.json")
+    if os.path.isfile(reg_path):
+        try:
+            with open(reg_path) as f:
+                reg = json.load(f)
+        except Exception:
+            reg = None
+        if isinstance(reg, dict):
+            entry = reg.get(source_agent)
+            if isinstance(entry, dict):
+                entry["enabled"] = True
+            else:
+                reg[source_agent] = {"enabled": True}
+            if apply:
+                with open(reg_path, "w") as f:
+                    json.dump(reg, f, indent=2)
+                    f.write("\n")
+            log(actions, f"ROLLBACK: registry['{source_agent}'].enabled -> True")
+    # restart the source poller
+    cmd = ["cortextos", "enable", source_agent, "--instance", instance]
+    if org:
+        cmd += ["--org", org]
+    if not apply:
+        log(actions, f"ROLLBACK (dry-run): would run `{' '.join(cmd)}`")
+        return True
+    try:
+        r = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
+        log(actions, f"ROLLBACK: ran `{' '.join(cmd)}` -> exit {r.returncode}")
+        if r.returncode != 0:
+            log(actions, f"ROLLBACK FAILED: `cortextos enable {source_agent}` returned "
+                         f"{r.returncode}: {r.stderr.strip()[:300]} — SOURCE STILL DOWN, "
+                         f"MANUAL INTERVENTION REQUIRED")
+            return False
+        log(actions, f"ROLLBACK: source '{source_agent}' restarted — outage averted")
+        return True
+    except Exception as e:
+        log(actions, f"ROLLBACK FAILED: could not restart source ({e}) — SOURCE STILL "
+                     f"DOWN, MANUAL INTERVENTION REQUIRED")
+        return False
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--manifest", required=True)
+    ap.add_argument("--src-dir", required=True)
+    ap.add_argument("--target-dir", required=True)
+    ap.add_argument("--target-agent", required=True)
+    ap.add_argument("--ctx-root", required=True)
+    ap.add_argument("--apply", action="store_true")
+    # Interactive-flow flags (Step 2 of SKILL.md). Safe defaults: no token
+    # change, source untouched, codex disabled — i.e. today's behavior.
+    ap.add_argument("--bot-mode", choices=["reuse", "new", "none"], default="none",
+                    help="reuse=cutover (disable source, copy its bot token, imply boot); "
+                         "new=write --new-bot-token; none=no token change (default)")
+    ap.add_argument("--new-bot-token", default=None,
+                    help="token to write into the codex .env when --bot-mode new")
+    ap.add_argument("--boot", choices=["now", "no"], default="no",
+                    help="now=enable+start the codex agent; no=leave disabled (default)")
+    ap.add_argument("--source-agent", default=None,
+                    help="source agent name (for reuse-cutover source-disable); "
+                         "defaults to manifest source_agent")
+    ap.add_argument("--org", default=None, help="org (for `cortextos enable` on boot)")
+    ap.add_argument("--instance", default="default", help="instance id (for boot enable)")
+    # Write-side handoff gate (defect 2). The migration-start timestamp is the cutoff:
+    # only a handoff produced AFTER it satisfies the gate (a stale pre-existing one
+    # does not). Defaults to now-at-parse-time if unset.
+    ap.add_argument("--migration-start-ts", type=float, default=None,
+                    help="epoch seconds marking migration start; only a source handoff "
+                         "with mtime AFTER this satisfies the write-side gate "
+                         "(default: now)")
+    ap.add_argument("--handoff-wait", type=int, default=300,
+                    help="max seconds to BLOCK polling for a fresh source handoff "
+                         "before ABORTING the cutover (default 300)")
+    ap.add_argument("--handoff-poll", type=int, default=5,
+                    help="seconds between handoff polls (default 5)")
+    # INSTANCE-DISCOVERY params (public generality). All optional; each degrades to
+    # discovery-from-source then safe-degrade when absent.
+    ap.add_argument("--orchestrator", default=None,
+                    help="orchestrator agent that principal-facing sends route THROUGH "
+                         "(the reroute target). If omitted, best-effort auto-scan of "
+                         "sibling agents for a positive role signal; if none, the cron "
+                         "reroute SAFE-DEGRADES (crons flagged for human review).")
+    ap.add_argument("--principal-chat-id", default=None,
+                    help="principal's Telegram chat id (literal-reroute match). If "
+                         "omitted, discovered from source .env CHAT_ID/ALLOWED_USER.")
+    ap.add_argument("--principal-name", default=None,
+                    help="principal's name (prose-intent detection + guard text). If "
+                         "omitted, discovered from source .env ALLOWED_USER if non-numeric.")
+    args = ap.parse_args()
+    migration_start_ts = args.migration_start_ts if args.migration_start_ts is not None else time.time()
+
+    with open(args.manifest) as f:
+        manifest = json.load(f)
+
+    # P1-1: reuse INHERENTLY means cutover+boot (take over the source's bot, which
+    # requires stopping the source and starting codex). `--bot-mode reuse --boot no`
+    # is a self-contradiction the old code silently resolved as "cutover anyway".
+    # Reject it loudly so the operator picks a coherent combination.
+    if args.bot_mode == "reuse" and args.boot == "no":
+        print("ERROR: --bot-mode reuse --boot no is contradictory. Reuse takes over "
+              "the source's bot, which REQUIRES disabling the source and booting "
+              "codex. If you don't want to boot, don't reuse (use --bot-mode none, "
+              "or --bot-mode new for a side-by-side codex agent).", file=sys.stderr)
+        sys.exit(2)
+
+    # P0-2: host model auth preflight. Codex model auth is host-global
+    # (~/.codex/auth.json). A codex agent with no host login crash-loops on first
+    # turn — and in a cutover the source is already down, so the bot is orphaned =
+    # OUTAGE. Gate the ENTIRE destructive path (source-disable AND boot) on host
+    # auth existing. Only enforced on --apply with a boot/cutover requested; the
+    # non-destructive default + dry-run are unaffected.
+    will_boot = args.apply and ((args.boot == "now") or (args.bot_mode == "reuse"))
+    if will_boot:
+        auth_path = os.path.expanduser("~/.codex/auth.json")
+        if not os.path.isfile(auth_path):
+            print(f"ERROR: host codex auth missing at {auth_path}. A codex agent with "
+                  f"no host login crash-loops on first turn; in a cutover the source "
+                  f"is already down, so this would be an OUTAGE. Run `codex login` "
+                  f"(host-global model auth) and re-run. ABORTING the cutover/boot — "
+                  f"source left UNTOUCHED.", file=sys.stderr)
+            sys.exit(2)
+
+    if manifest.get("hard_stops"):
+        print("REFUSING: hard stops present:", file=sys.stderr)
+        for h in manifest["hard_stops"]:
+            print(f"  - {h}", file=sys.stderr)
+        sys.exit(2)
+
+    if not os.path.isdir(args.target_dir):
+        print(f"ERROR: target dir {args.target_dir} not found. Run "
+              f"`cortextos add-agent {args.target_agent} --template agent-codex "
+              f"--runtime codex-app-server` first.", file=sys.stderr)
+        sys.exit(1)
+
+    # The codex skeleton (add-agent --template agent-codex) is a MANDATORY,
+    # ordered prerequisite. An empty/hand-made target dir lacks the
+    # marketplace.json + bundled-skill layout the overlay assumes. Hard-check
+    # the marketplace file specifically (not just that the dir exists).
+    marketplace = os.path.join(args.target_dir, ".agents", "plugins", "marketplace.json")
+    if not os.path.isfile(marketplace):
+        print(f"ERROR: target {args.target_dir} is missing "
+              f".agents/plugins/marketplace.json — the codex skeleton was not laid "
+              f"down. Run `cortextos add-agent {args.target_agent} --template "
+              f"agent-codex --runtime codex-app-server --org <org>` FIRST, then "
+              f"re-run convert.", file=sys.stderr)
+        sys.exit(1)
+
+    mode = "APPLY" if args.apply else "DRY-RUN"
+    print(f"=== convert {manifest['source_agent']} -> {args.target_agent} [{mode}] ===",
+          file=sys.stderr)
+    actions = []
+
+    # 1:1 overlays (instruction family, memory, goals, workspaces, catch-all)
+    one_to_one = ["IDENTITY.md", "SOUL.md", "GUARDRAILS.md", "HEARTBEAT.md",
+                  "USER.md", "SYSTEM.md", "MEMORY.md", "GOALS.md", "goals.json",
+                  "TOOLS.md", "ONBOARDING.md", "AGENTS.md"]
+    for fn in one_to_one:
+        src = os.path.join(args.src_dir, fn)
+        if os.path.isfile(src):
+            copy_tree(src, os.path.join(args.target_dir, fn), args.apply, actions, f"overlay {fn}")
+    # Identity/path-pinning state is NEVER copied: it would overwrite the
+    # target's per-agent identity (.cortextos-env) or carry host/session-pinned
+    # MCP state (.playwright-mcp). detect.py already keeps these out of
+    # port_verbatim; this is a belt-and-braces guard.
+    NEVER_COPY = {".cortextos-env", ".playwright-mcp"}
+    # Credential-bearing dirs: copy but surface a REPORT line (review for stale/
+    # agent-specific tokens), never let them slip by in a silent bulk copy.
+    CREDENTIAL_DIRS = {"auth"}
+    # port_verbatim catch-all (memory/, workspaces, skills/drafts, in-repo state/, etc.)
+    for name in manifest["buckets"].get("port_verbatim", []):
+        if name in NEVER_COPY:
+            log(actions, f"SKIP {name}: identity/path-pinned — target keeps its "
+                         f"add-agent-generated one")
+            continue
+        src = os.path.join(args.src_dir, name)
+        if os.path.exists(src):
+            copy_tree(src, os.path.join(args.target_dir, name), args.apply, actions,
+                      f"port-verbatim {name}")
+            surface_large_or_binary(name, src, actions)
+            if name in CREDENTIAL_DIRS or name.endswith("auth"):
+                log(actions, f"REPORT: '{name}/' carried — credential-bearing; "
+                             f"REVIEW for stale/agent-specific tokens before enable")
+    # .env (carry, preserve 0600)
+    env_src = os.path.join(args.src_dir, ".env")
+    if os.path.isfile(env_src):
+        env_dst = os.path.join(args.target_dir, ".env")
+        copy_tree(env_src, env_dst, args.apply, actions, ".env")
+        if args.apply:
+            os.chmod(env_dst, 0o600)
+
+    source_agent = args.source_agent or manifest.get("source_agent")
+
+    # INSTANCE-DISCOVERY: resolve WHO the principal + orchestrator are for THIS
+    # deployment (never baked in). Each degrades to None -> the routing feature
+    # safe-degrades rather than inventing an identity.
+    principal_chat_id = resolve_principal_chat_id(args.src_dir, args.principal_chat_id)
+    principal_name = resolve_principal_name(args.src_dir, args.principal_name)
+    orchestrator, orch_src = discover_orchestrator(
+        args.src_dir, source_agent, args.target_agent, args.orchestrator, actions)
+    log(actions, f"instance-discovery: principal_chat_id="
+                 f"{'set' if principal_chat_id else 'UNKNOWN'} "
+                 f"principal_name={'set' if principal_name else 'UNKNOWN'} "
+                 f"orchestrator={orchestrator or 'UNKNOWN'} (via {orch_src})")
+    # GAP E — DOUBLE-UNKNOWN: no orchestrator AND no principal id/name. The routing
+    # reroute is entirely off; surface ONE loud, un-buried needs-human line rather
+    # than silently shipping crons that may send direct to a principal.
+    if not orchestrator and not (principal_chat_id or principal_name):
+        log(actions, "★ NEEDS-HUMAN (routing): no orchestrator AND no principal "
+                     "discovered — the principal-facing-send reroute is DISABLED. "
+                     "Review this agent's crons manually for any direct-to-principal "
+                     "sends, or re-run with --orchestrator <name> (+ --principal-chat-id "
+                     "/ --principal-name) to auto-route. (Not silently applied.)")
+    elif not orchestrator:
+        log(actions, "★ NEEDS-HUMAN (routing): a principal was discovered but NO "
+                     "orchestrator — cron reroute SAFE-DEGRADED (no send-into-the-void). "
+                     "Re-run with --orchestrator <name> to auto-route principal-facing "
+                     "crons, or hand-route them.")
+
+    transform_config(args.src_dir, args.target_dir, args.target_agent, manifest, args.apply, actions)
+    # crons: UNION of config.json + live registry, deduped; paths translated;
+    # principal-facing sends re-routed through the discovered orchestrator when known
+    # (defects 4, 5, 6c) — safe-degraded otherwise.
+    migrate_crons(args.src_dir, args.target_dir, source_agent, args.target_agent,
+                  args.ctx_root, args.apply, actions,
+                  principal_chat_id=principal_chat_id, orchestrator=orchestrator,
+                  principal_name=principal_name)
+    fold_claude_md(args.src_dir, args.target_dir, manifest, args.apply, actions)
+    strip_tools_auth(args.target_dir, args.apply, actions)
+    # guardrails-into-template: APPROVAL row always; ROUTING row only when the
+    # orchestrator + principal are known (defect 6a/6b).
+    ensure_guardrails(args.target_dir, args.apply, actions,
+                      orchestrator=orchestrator, principal_name=principal_name)
+    copy_custom_skills(args.src_dir, args.target_dir, args.target_agent, manifest, args.apply, actions)
+    install_all_symlinks(args.target_dir, args.target_agent, args.apply, actions)
+    # skill-depth-delta (defect 7): codex skills sit one dir deeper than claude, so
+    # __file__-relative workspace anchors (../../../docs, parents[3]) land short;
+    # a plugins/docs -> ../docs compat symlink restores workspace doc writes.
+    create_skill_depth_compat_symlink(args.target_dir, args.apply, actions)
+    # defect 15: any skill sqlite DB raw-copied above may be a TORN copy (copying a
+    # live DB tears it). Re-copy malformed DBs from source via the backup API and
+    # assert integrity. A non-empty unrepairable set HARD-BLOCKS the cutover below.
+    _sqlite_repaired, _sqlite_ok_list, sqlite_unrepairable = ensure_sqlite_integrity(
+        args.src_dir, args.target_dir, args.apply, actions)
+    rewrite_all_refs(args.target_dir, args.apply, actions)
+    delete_claude_artifacts(args.target_dir, args.apply, actions)
+    mcp_written, mcp_needs_secret, mcp_collisions = emit_mcp_toml(
+        manifest, args.target_agent, args.target_dir, args.apply, actions)
+    # boot-state continuity: carry .onboarded + markers + handoffs/ so the target
+    # does NOT cold-onboard (defect 1). Runs BEFORE force_fresh, which then excludes
+    # ONLY the stale session transcript(s).
+    carry_state_continuity(args.src_dir, args.ctx_root, source_agent,
+                           args.target_agent, args.apply, actions)
+    force_fresh(args.ctx_root, args.target_agent, args.apply, actions)
+    disable_in_registry(args.ctx_root, args.target_agent, args.apply, actions)
+
+    # --- Interactive-flow tail: bot-token strategy, then boot. Defaults are
+    # fully non-destructive (bot-mode none + boot no) => identical to the
+    # original behavior. Only explicit flags trigger source-disable / start.
+    #
+    # ORDERING CONTRACT (P0-1): when reuse, apply_bot_mode -> disable_source MUST
+    # confirm the source poller is STOPPED before boot_codex runs. If the stop is
+    # not confirmed, apply_bot_mode returns cutover=False and we DO NOT boot.
+    # Codex is NEVER started before the source is confirmed stopped. ---
+    # P2-1: `cortextos disable`/`enable` resolve state under --instance, while the
+    # JSON writes here use the raw ctx_root path. They must agree: ctx_root should
+    # end in the instance segment (.../.cortextos/<instance>). Warn on mismatch so
+    # a disable that targets the wrong instance is caught, not silent.
+    if os.path.basename(os.path.normpath(args.ctx_root)) != args.instance:
+        log(actions, f"WARNING: ctx_root '{args.ctx_root}' does not end with the "
+                     f"instance segment '/{args.instance}'. `cortextos disable/enable "
+                     f"--instance {args.instance}` resolves a DIFFERENT path than the "
+                     f"JSON writes here — they must agree or the daemon stop/start "
+                     f"misses. Verify --instance matches the source's ctx_root.")
+
+    # WRITE-SIDE HANDOFF GATE (defect 2): before any cutover, the LIVE source must
+    # have produced a FRESH handoff (its normal handoff:create, NOT a synthesized
+    # one). Block-poll for a handoff with mtime AFTER migration start. If none
+    # appears in time, ABORT: do NOT disable the source, do NOT enable the target.
+    # Only gates the cutover path (--bot-mode reuse); side-by-side / disabled paths
+    # do not take over the source so they are not gated.
+    fresh_handoff = None
+    if args.bot_mode == "reuse":
+        fresh_handoff = await_fresh_handoff(args.src_dir, source_agent,
+                                            migration_start_ts, args.handoff_wait,
+                                            args.handoff_poll, args.apply, actions)
+        if args.apply and not fresh_handoff:
+            # Hard abort: no fresh handoff -> never tear down the source.
+            end_state = "cutover-aborted"
+            log(actions, "ABORT: write-side handoff gate failed (no fresh source "
+                         "handoff). Source NOT disabled, target NOT enabled.")
+            print(f"\n=== {len(actions)} actions ({mode}) ===", file=sys.stderr)
+            print(f"ABORTED: write-side handoff gate failed — source produced no fresh "
+                  f"handoff. Source untouched, target NOT booted.", file=sys.stderr)
+            json.dump({"mode": mode, "actions": actions, "end_state": end_state,
+                       "bot_mode": args.bot_mode, "boot": False, "cutover": False},
+                      sys.stdout, indent=2)
+            sys.stdout.write("\n")
+            return
+
+    # DB-INTEGRITY HARD GATE (defect 15, default-deny): if any copied sqlite DB
+    # could not be made sound (torn copy + source missing/also-malformed, or still
+    # malformed after a backup-API re-copy), the migration produced a corrupt
+    # artifact and MUST NOT proceed. Gate BEFORE apply_bot_mode so the source is
+    # never torn down and the target never boots — same safe shape as the handoff
+    # gate, but exits NON-ZERO so the failure cannot be mistaken for success.
+    if args.apply and sqlite_unrepairable:
+        end_state = "db-integrity-failed"
+        log(actions, f"ABORT: DB-integrity gate failed — unrepairable sqlite copy(ies) "
+                     f"{sqlite_unrepairable}. Source NOT disabled, target NOT enabled.")
+        print(f"\n=== {len(actions)} actions ({mode}) ===", file=sys.stderr)
+        print(f"ABORTED: DB-integrity gate failed — {len(sqlite_unrepairable)} sqlite "
+              f"copy(ies) could not be made sound ({sqlite_unrepairable}). Source "
+              f"untouched, target NOT booted. Fix the source DB or re-run.", file=sys.stderr)
+        json.dump({"mode": mode, "actions": actions, "end_state": end_state,
+                   "bot_mode": args.bot_mode, "boot": False, "cutover": False,
+                   "unrepairable_dbs": sqlite_unrepairable},
+                  sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(2)
+
+    # fix #16: a host-global MCP name collision means a migrated server cannot be
+    # installed into the shared ~/.codex/config.toml = the agent boots without that
+    # capability. Same gate class as DB-integrity: HARD-BLOCK the cutover, exit
+    # non-zero, leave the source untouched. emit_mcp_toml already wrote NOTHING on
+    # collision, so there is no partial state to unwind. A human renames the colliding
+    # server (host-wide) and re-runs.
+    if args.apply and mcp_collisions:
+        end_state = "mcp-collision-failed"
+        log(actions, f"ABORT: MCP gate failed — host-global name collision(s) "
+                     f"{mcp_collisions} already in ~/.codex/config.toml. Source NOT "
+                     f"disabled, target NOT enabled, no MCP tables written.")
+        print(f"\n=== {len(actions)} actions ({mode}) ===", file=sys.stderr)
+        print(f"ABORTED: MCP gate failed — {len(mcp_collisions)} server name(s) "
+              f"{mcp_collisions} collide with existing host-global config.toml entries. "
+              f"Rename the colliding server(s) host-wide and re-run. Source untouched, "
+              f"target NOT booted.", file=sys.stderr)
+        json.dump({"mode": mode, "actions": actions, "end_state": end_state,
+                   "bot_mode": args.bot_mode, "boot": False, "cutover": False,
+                   "mcp_collisions": mcp_collisions},
+                  sys.stdout, indent=2)
+        sys.stdout.write("\n")
+        sys.exit(2)
+
+    cutover = apply_bot_mode(args.bot_mode, args.new_bot_token, args.src_dir,
+                             args.target_dir, args.ctx_root, source_agent,
+                             args.instance, args.apply, actions)
+    # READ-SIDE handoff enforcement (defect 3): on a CONFIRMED cutover, carry the
+    # fresh source handoff into the target handoffs/ as the NEWEST file and write
+    # the boot directive (.handoff-doc-path) so the daemon points the target at it
+    # on first boot. Done before boot so the directive exists when the agent spawns.
+    if cutover:
+        carry_handoff_and_boot_directive(args.src_dir, args.target_dir, args.ctx_root,
+                                         source_agent, args.target_agent,
+                                         migration_start_ts, args.apply, actions)
+        # defect 11a: the source AGENT is now confirmed stopped, but its CRONS are
+        # still enabled:true in the registry+config (durable dual-scheduler hazard
+        # once the target carries the same crons). Disable the recurring source
+        # crons NOW, before the target boots, so there is no window where both fire.
+        # One-shots are HELD enabled (re-armed on target by the operator first).
+        disable_source_crons(args.src_dir, args.ctx_root, source_agent,
+                             args.apply, actions)
+        # Surface (don't auto-rewrite) any SIBLING agent still pointing at the
+        # retired source's agents/<source> path — the operator must repoint these
+        # to agents/<target> or verify.py --expect-cutover hard-fails on them.
+        scan_cross_agent_strands(args.src_dir, source_agent, args.target_agent, actions)
+    # do_boot only when reuse-cutover CONFIRMED the source stop, or new-bot --boot now.
+    do_boot = cutover or (args.bot_mode != "reuse" and args.boot == "now")
+    end_state = "disabled"
+    if do_boot:
+        rc = boot_codex(args.target_dir, args.target_agent, args.ctx_root, args.org,
+                        args.instance, args.apply, actions)
+        if rc == 0:
+            end_state = "cutover-live" if cutover else "live"
+        else:
+            # P0-3: enable failed. For a cutover the source is ALREADY down, so a
+            # failed boot is an OUTAGE — roll the source back and report failed,
+            # NEVER "live".
+            if cutover:
+                rolled = rollback_source(args.src_dir, args.ctx_root, source_agent,
+                                         args.org, args.instance, args.apply, actions)
+                end_state = "cutover-failed"
+                log(actions, f"end_state=cutover-failed (enable rc={rc}); source "
+                             f"rollback {'succeeded' if rolled else 'FAILED — manual fix needed'}")
+            else:
+                end_state = "boot-failed"
+                log(actions, f"end_state=boot-failed (enable rc={rc}); source was never "
+                             f"touched, codex left enabled-in-config but not started")
+    elif args.bot_mode == "reuse":
+        # reuse requested but cutover did NOT confirm (no token / stop unconfirmed).
+        # Nothing was booted and (per the hard stops) the source was not torn down.
+        end_state = "cutover-aborted"
+
+    print(f"\n=== {len(actions)} actions ({mode}) ===", file=sys.stderr)
+    if end_state == "cutover-live":
+        print(f"CUTOVER: source '{source_agent}' DISABLED, '{args.target_agent}' booting on "
+              f"the original bot. Do the human steps + run verify.py --expect-cutover.",
+              file=sys.stderr)
+    elif end_state == "live":
+        print(f"Target '{args.target_agent}' booting on its OWN bot; source still running. "
+              f"Do the human steps + run verify.py --expect-boot.", file=sys.stderr)
+    elif end_state == "cutover-failed":
+        print(f"OUTAGE/FAILED: codex enable failed during a cutover. Attempted to roll the "
+              f"source '{source_agent}' back up. Target is NOT live. Check the action log for "
+              f"the rollback result and intervene if it failed.", file=sys.stderr)
+    elif end_state == "boot-failed":
+        print(f"FAILED: codex enable failed (new-bot boot). Source untouched; target NOT live. "
+              f"Investigate the `cortextos enable` error in the action log.", file=sys.stderr)
+    elif end_state == "cutover-aborted":
+        print(f"ABORTED: reuse-cutover could not proceed (no source token, or the source stop "
+              f"was not confirmed). Source NOT torn down, target NOT booted. See the FAIL lines "
+              f"in the action log.", file=sys.stderr)
+    else:
+        print("Target left DISABLED. Do the human steps (fold review, MCP merge, secrets, "
+              "leakage adjudication), run verify.py, then `cortextos enable`.", file=sys.stderr)
+    json.dump({"mode": mode, "actions": actions, "end_state": end_state,
+               "bot_mode": args.bot_mode, "boot": do_boot, "cutover": cutover},
+              sys.stdout, indent=2)
+    sys.stdout.write("\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/community/skills/claude-to-codex-migration/scripts/detect.py
+++ b/community/skills/claude-to-codex-migration/scripts/detect.py
@@ -1,0 +1,431 @@
+#!/usr/bin/env python3
+"""
+detect.py — DETECT stage of the Claude->Codex agent migration.
+
+Walks a source Claude-cortextOS agent dir, classifies EVERY artifact into a
+bucket, greps custom skills for Claude-only leakage, and emits a JSON manifest on
+stdout. The catch-all `port_verbatim` bucket guarantees no file is silently
+dropped just because there is no specific rule for it.
+
+Read-only: never writes to or modifies the source agent.
+
+Usage:
+  detect.py --src-dir orgs/<org>/agents/<agent> --ctx-root <CTX_ROOT> --agent <name>
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+# 23-skill codex stdlib (templates/agent-codex/.../skills). Skills in this set
+# ship for free via add-agent; only skills NOT here are "custom".
+BUNDLED_SKILLS = {
+    "activity-channel", "agent-browser", "agent-management", "approvals",
+    "auto-skill", "autoresearch", "bus-reference", "comms", "cron-management",
+    "env-management", "event-logging", "guardrails-reference", "heartbeat",
+    "human-tasks", "knowledge-base", "m2c1-worker", "memory", "onboarding",
+    "soul-philosophy", "system-diagnostics", "tasks", "tool-registration",
+    "worker-agents",
+}
+
+# Leakage tokens. Split: rewritable (mechanical) vs behavioral (needs-human).
+LEAKAGE_REWRITABLE = [".claude/skills", "ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"]
+LEAKAGE_BEHAVIORAL = ["ExitPlanMode", "bypassPermissions", "hook-", "mcp__", "/loop"]
+
+NON_CODEX_TEMPLATES = {"orchestrator", "analyst", "m2c1-worker", "hermes"}
+
+# Claude-STANDARD / Claude-bundled skills that are NOT in the codex 23-skill
+# stdlib. If a source agent carries one of these, it is "custom" by our test
+# (absent from BUNDLED_SKILLS) so it gets ported + grepped — but it may embed
+# Claude-Code-specific orchestration semantics (subagent types, ExitPlanMode,
+# plan-mode loops) that a token grep does NOT catch. Surface for human re-exam.
+CLAUDE_STANDARD_NON_CODEX = {
+    "one-big-feature", "skill-creator", "docx", "pdf", "pptx", "xlsx",
+    "code-review", "security-review", "m2c1", "video-to-skill-pipeline",
+}
+
+# Top-level files that are part of the codex instruction family (port, possibly
+# with ref-rewrite). Bodies are runtime-agnostic.
+ONE_TO_ONE_MD = {
+    "IDENTITY.md", "SOUL.md", "GUARDRAILS.md", "HEARTBEAT.md", "USER.md",
+    "SYSTEM.md", "MEMORY.md", "GOALS.md",
+}
+
+
+def read_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+# A token appearing ONLY in a skill's NON-INVOCATION surface (its own prose/docs,
+# OR its scraped/generated data corpus) means the skill DOCUMENTS or STORES the
+# token, not that it DEPENDS on Claude semantics. Two classes:
+#  - NARRATIVE: the skill's own human docs (SKILL.md, README, references/docs).
+#  - DATA corpus: generated/scraped output the skill writes (transcripts of
+#    YouTube videos, digests, cached analysis) — a `/loop` inside a scraped
+#    transcript or a "hook-writing" phrase in a video analysis is content ABOUT
+#    the world, never a skill invocation.
+# An INVOCATION hit (anywhere else — scripts, config, the skill body proper) still
+# flags. This is conservative: a real Claude-tool call lives in scripts/SKILL body,
+# not in a transcripts/ JSON blob.
+NARRATIVE_BASENAMES = {"SKILL.md", "README.md", "README", "CHANGELOG.md"}
+NARRATIVE_DIRS = {"references", "docs", "reference", "examples"}
+# Data/output subtrees a monitor-style skill populates with scraped/generated content.
+DATA_DIRS = {
+    "data", "transcripts", "digests", "output", "outputs", "cache", "state",
+    "logs", "results", "downloads", "raw", "snapshots", "archive",
+}
+
+
+def _is_non_invocation(relpath):
+    """True if relpath is the skill's own prose/docs OR its scraped/generated data
+    corpus — i.e. NOT a Claude-tool invocation surface. A token found only in such
+    files is documented/stored, not depended on."""
+    parts = relpath.split(os.sep)
+    base = parts[-1]
+    if base in NARRATIVE_BASENAMES:
+        return True
+    dirparts = parts[:-1]
+    if any(p in NARRATIVE_DIRS for p in dirparts):
+        return True
+    if any(p in DATA_DIRS for p in dirparts):
+        return True
+    return False
+
+
+def grep_tokens(root, tokens, prose_aware=False):
+    """Return {token: [relpaths]} for any token found under root (text files).
+
+    When prose_aware=True, a token that appears ONLY in the skill's own
+    narrative/docs (SKILL.md, README, references/) is NOT reported as a hit:
+    documenting a token (e.g. a SKILL.md that explains `/loop`) is not the same
+    as depending on it. A token that appears in ANY non-narrative file (scripts,
+    config, invocation surfaces) is still reported, with the prose paths included
+    for context. This cuts the obvious prose false-positives while staying
+    conservative: a real invocation anywhere still flags."""
+    raw = {}  # token -> {"narrative": [...], "invocation": [...]}
+    for dirpath, dirnames, filenames in os.walk(root):
+        # don't descend into binary-ish / vendored trees
+        dirnames[:] = [d for d in dirnames if d not in ("node_modules", ".git")]
+        for fn in filenames:
+            fp = os.path.join(dirpath, fn)
+            try:
+                with open(fp, "r", errors="ignore") as f:
+                    content = f.read()
+            except Exception:
+                continue
+            rel = os.path.relpath(fp, root)
+            narrative = _is_non_invocation(rel)
+            for tok in tokens:
+                if tok in content:
+                    bucket = raw.setdefault(tok, {"narrative": [], "invocation": []})
+                    bucket["narrative" if narrative else "invocation"].append(rel)
+    if not prose_aware:
+        return {tok: b["narrative"] + b["invocation"] for tok, b in raw.items()}
+    # prose_aware: drop tokens that are narrative-only; keep ones with any
+    # invocation hit (report invocation paths first, then prose for context).
+    hits = {}
+    for tok, b in raw.items():
+        if b["invocation"]:
+            hits[tok] = b["invocation"] + b["narrative"]
+    return hits
+
+
+def grep_prose_only(root, tokens):
+    """Return {token: [relpaths]} for tokens that appear ONLY in narrative/docs
+    (no invocation hit). Used to note 'documents token (prose-only)' in the
+    report without firing a needs-human flag."""
+    raw = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in ("node_modules", ".git")]
+        for fn in filenames:
+            fp = os.path.join(dirpath, fn)
+            try:
+                with open(fp, "r", errors="ignore") as f:
+                    content = f.read()
+            except Exception:
+                continue
+            rel = os.path.relpath(fp, root)
+            narrative = _is_non_invocation(rel)
+            for tok in tokens:
+                if tok in content:
+                    b = raw.setdefault(tok, {"narrative": [], "invocation": []})
+                    b["narrative" if narrative else "invocation"].append(rel)
+    return {tok: b["narrative"] for tok, b in raw.items()
+            if b["narrative"] and not b["invocation"]}
+
+
+def detect(src_dir, ctx_root, agent):
+    m = {
+        "source_agent": agent,
+        "source_dir": src_dir,
+        "ctx_root": ctx_root,
+        "hard_stops": [],
+        "config": {},
+        "claude_md": {},
+        "hooks": {},
+        "skills": {"bundled_present": [], "custom": []},
+        "mcp": {"present": False, "servers": []},
+        "subagents": {"present": False, "names": []},
+        "buckets": {
+            "one_to_one": [],
+            "transform": [],
+            "dropped": [],
+            "needs_human": [],
+            "port_verbatim": [],
+        },
+        "notes": [],
+    }
+
+    if not os.path.isdir(src_dir):
+        m["hard_stops"].append(f"source dir not found: {src_dir}")
+        return m
+
+    # --- config.json ---
+    cfg_path = os.path.join(src_dir, "config.json")
+    cfg = read_json(cfg_path)
+    if cfg is None:
+        m["hard_stops"].append("config.json missing or unparseable")
+    else:
+        runtime = cfg.get("runtime", "claude-code")
+        m["config"] = {
+            "runtime": runtime,
+            "model": cfg.get("model"),
+            "has_ecosystem": "ecosystem" in cfg,
+            "has_dangerously_skip": "dangerously_skip_permissions" in cfg,
+            "has_codex_context_cap": "codex_context_cap" in cfg,
+            "carry_knobs": {k: cfg.get(k) for k in (
+                "timezone", "day_mode_start", "day_mode_end", "communication_style",
+                "approval_rules", "startup_delay", "max_session_seconds",
+                "max_crashes_per_day", "crash_window", "working_directory",
+                "telegram_polling") if k in cfg},
+            "cron_count": len(cfg.get("crons", []) or []),
+        }
+        if runtime == "codex-app-server":
+            m["hard_stops"].append("source is ALREADY codex-app-server — nothing to migrate")
+        elif runtime == "hermes":
+            m["hard_stops"].append("source runtime is hermes — out of scope")
+        # Best-effort, ADVISORY-only template-lineage check for the three
+        # non-codex templates that are NOT distinguishable by runtime
+        # (orchestrator/analyst/m2c1-worker all run as claude-code). No template
+        # field is persisted in config.json, so this is a heuristic on identity
+        # files — it NEVER hard-stops (would false-fire on customized agents);
+        # the operator must confirm lineage (SKILL.md Step 2 #1, a HUMAN pre-check).
+        for marker_file, phrases in (
+            ("IDENTITY.md", ("Analyst Identity", "Orchestrator Identity")),
+            ("SYSTEM.md", ("You are the orchestrator", "You are the analyst")),
+        ):
+            mp = os.path.join(src_dir, marker_file)
+            if os.path.isfile(mp):
+                try:
+                    with open(mp, errors="ignore") as f:
+                        head = f.read(2000)
+                except Exception:
+                    head = ""
+                for ph in phrases:
+                    if ph in head:
+                        m["notes"].append(
+                            f"ADVISORY (template lineage): {marker_file} contains "
+                            f"'{ph}' — source may be scaffolded from a NON-CODEX "
+                            f"template (orchestrator/analyst/m2c1-worker). Confirm "
+                            f"before migrating; no codex variant exists for these.")
+        m["buckets"]["transform"].append("config.json")
+        model = cfg.get("model", "")
+        if isinstance(model, str) and model.startswith("gpt-5.5"):
+            m["notes"].append("target model gpt-5.5 is costed as gpt-5-codex in cost-parser; confirm pricing")
+
+    # --- CLAUDE.md ---
+    claude_md = os.path.join(src_dir, "CLAUDE.md")
+    if os.path.isfile(claude_md):
+        with open(claude_md, errors="ignore") as f:
+            body = f.read()
+        # thin wrapper detection: body is essentially @AGENTS.md + boilerplate
+        stripped = re.sub(r"\s+", " ", body).strip()
+        thin = ("@AGENTS.md" in body and len(stripped) < 200)
+        m["claude_md"] = {"present": True, "thin_wrapper": thin, "bytes": len(body)}
+        m["buckets"]["transform"].append("CLAUDE.md (fold into AGENTS.md)")
+        m["buckets"]["needs_human"].append("review folded AGENTS.md for duplication/conflict")
+    else:
+        m["claude_md"] = {"present": False}
+
+    # --- AGENTS.md ---
+    if os.path.isfile(os.path.join(src_dir, "AGENTS.md")):
+        m["buckets"]["one_to_one"].append("AGENTS.md (becomes sole boot contract; ref-rewrite)")
+
+    # --- instruction family ---
+    for fn in sorted(ONE_TO_ONE_MD):
+        if os.path.isfile(os.path.join(src_dir, fn)):
+            m["buckets"]["one_to_one"].append(fn)
+    if os.path.isfile(os.path.join(src_dir, "TOOLS.md")):
+        # TOOLS.md ports 1:1 (the .claude/skills ref-rewrite is mechanical), but any
+        # Claude auth env names are FLAGGED for human review, not auto-stripped
+        # (editing prose is risky). convert.py is flag-only here; surfaced below if hit.
+        m["buckets"]["one_to_one"].append("TOOLS.md (ports 1:1; Claude auth env names flagged for human strip if present)")
+    if os.path.isfile(os.path.join(src_dir, "ONBOARDING.md")):
+        m["buckets"]["transform"].append("ONBOARDING.md (rewrite .claude/skills refs)")
+
+    # --- hooks (.claude/settings.json) ---
+    settings = read_json(os.path.join(src_dir, ".claude", "settings.json"))
+    if settings is not None:
+        events = list((settings.get("hooks") or {}).keys())
+        wired = []
+        for ev, arr in (settings.get("hooks") or {}).items():
+            for entry in (arr or []):
+                for h in (entry.get("hooks") or []):
+                    cmd = h.get("command", "")
+                    wired.append({"event": ev, "matcher": entry.get("matcher"), "command": cmd})
+        if "statusLine" in settings:
+            wired.append({"event": "statusLine", "matcher": None,
+                          "command": (settings["statusLine"] or {}).get("command", "")})
+        m["hooks"] = {"present": True, "events": events, "wired": wired}
+        m["buckets"]["dropped"].append(".claude/settings.json (delete; 3 in-turn behaviors lost — see hooks-disposition.md)")
+        m["buckets"]["needs_human"].append("re-home plan-mode/ask-user/compact Telegram prompts to bus approvals flow")
+    else:
+        m["hooks"] = {"present": False}
+
+    # --- skills ---
+    skills_root = os.path.join(src_dir, ".claude", "skills")
+    if os.path.isdir(skills_root):
+        for name in sorted(os.listdir(skills_root)):
+            sp = os.path.join(skills_root, name)
+            if not os.path.isdir(sp):
+                continue
+            if name in BUNDLED_SKILLS:
+                m["skills"]["bundled_present"].append(name)
+                continue
+            # custom skill — leakage grep.
+            # Rewritable tokens (paths/env names): match everywhere (they get
+            # mechanically rewritten regardless of where they sit).
+            rew = grep_tokens(sp, LEAKAGE_REWRITABLE)
+            # Behavioral tokens (Claude tool/runtime semantics): prose-aware, so a
+            # skill that merely DOCUMENTS `/loop` in its SKILL.md isn't false-flagged
+            # needs_human. Only an INVOCATION hit (a non-narrative file) flags.
+            beh = grep_tokens(sp, LEAKAGE_BEHAVIORAL, prose_aware=True)
+            # Behavioral tokens that appear ONLY in prose/docs — noted, not flagged.
+            beh_prose_only = grep_prose_only(sp, LEAKAGE_BEHAVIORAL)
+            entry = {
+                "name": name,
+                "path": os.path.relpath(sp, src_dir),
+                "leakage_rewritable": rew,
+                "leakage_behavioral": beh,
+                "behavioral_prose_only": beh_prose_only,
+                "disposition": "needs_human" if beh else "transform",
+            }
+            # Claude-standard-but-not-codex-bundled: re-exam even if grep is clean.
+            if name in CLAUDE_STANDARD_NON_CODEX:
+                entry["claude_standard_non_codex"] = True
+                m["buckets"]["needs_human"].append(
+                    f"custom skill '{name}' is a Claude-STANDARD skill absent from the "
+                    f"codex 23 — re-examine for Claude-specific orchestration semantics "
+                    f"the grep can miss (subagent types, plan-mode); verify a codex "
+                    f"equivalent or rewrite via skill-creator")
+            m["skills"]["custom"].append(entry)
+            if beh:
+                m["buckets"]["needs_human"].append(f"custom skill '{name}' has behavioral leakage {list(beh.keys())} (invocation) -> skill-creator")
+            else:
+                m["buckets"]["transform"].append(f"custom skill '{name}' -> plugins/.../skills + symlink")
+            if beh_prose_only:
+                m["notes"].append(
+                    f"custom skill '{name}' DOCUMENTS {list(beh_prose_only.keys())} "
+                    f"in prose only (no invocation) — NOT a leak, no needs_human flag")
+
+    # --- MCP ---
+    mcp = read_json(os.path.join(src_dir, ".mcp.json"))
+    if mcp is not None:
+        servers = mcp.get("mcpServers", {}) or {}
+        m["mcp"]["present"] = True
+        for name, spec in servers.items():
+            is_http = "url" in spec or spec.get("type") == "http"
+            # Capture the FULL server spec — emit_mcp_toml needs args/env/headers/cwd
+            # to write a WORKING config.toml table, not a placeholder. (fix #16: the
+            # old parse dropped everything but url/command, so even a non-stub emit
+            # had nothing to write for stdio args/env or the http bearer token.)
+            m["mcp"]["servers"].append({
+                "name": name,
+                "transport": "http" if is_http else "stdio",
+                "url": spec.get("url"),
+                "command": spec.get("command"),
+                "args": spec.get("args") or [],
+                "env": spec.get("env") or {},
+                "cwd": spec.get("cwd"),
+                "headers": spec.get("headers") or {},
+            })
+        if servers:
+            m["buckets"]["transform"].append(f".mcp.json -> {len(servers)} server(s) into ~/.codex/config.toml")
+            m["buckets"]["needs_human"].append("provision MCP bearer-token env vars + check host-global name collisions")
+        else:
+            m["notes"].append(".mcp.json present but empty — no MCP servers to migrate")
+    else:
+        m["notes"].append("no .mcp.json in source — no MCP servers to migrate")
+
+    # --- subagents ---
+    agents_dir = os.path.join(src_dir, ".claude", "agents")
+    if os.path.isdir(agents_dir):
+        names = [f[:-3] for f in os.listdir(agents_dir) if f.endswith(".md")]
+        if names:
+            m["subagents"] = {"present": True, "names": names}
+            m["buckets"]["needs_human"].append(f"on-disk subagents {names} -> re-express as skills/worker-agents")
+
+    # --- .env (secret-leak guard) ---
+    if os.path.isfile(os.path.join(src_dir, ".env")):
+        m["buckets"]["one_to_one"].append(".env (BOT_TOKEN/CHAT_ID/ALLOWED_USER)")
+        m["buckets"]["needs_human"].append("confirm target uses a NEW bot OR source disabled (BOT_TOKEN reuse conflict)")
+
+    # --- stale Claude session state footgun ---
+    work_dir = (cfg or {}).get("working_directory") or src_dir
+    launch = os.path.abspath(work_dir)
+    dashed = launch.replace(os.sep, "-")
+    home = os.path.expanduser("~")
+    jsonl_dir = os.path.join(home, ".claude", "projects", dashed)
+    m["stale_jsonl_dir"] = jsonl_dir
+    m["stale_jsonl_present"] = os.path.isdir(jsonl_dir)
+    m["buckets"]["dropped"].append("Claude JSONL session state (excluded; .force-fresh on target)")
+
+    # --- catch-all: every other top-level entry ports verbatim ---
+    # Identity/path-pinning dot-state is EXCLUDED from port_verbatim: copying the
+    # source's .cortextos-env would overwrite the target's per-agent identity
+    # (CTX_AGENT_NAME/CTX_AGENT_DIR/...), making it boot AS the source and share
+    # the source's live inbox/state/heartbeat. add-agent regenerates a correct
+    # per-agent one in the target. .playwright-mcp is host/session-pinned MCP
+    # state and must not carry either.
+    identity_pinning = {".cortextos-env", ".playwright-mcp"}
+    known_handled = {
+        "config.json", "CLAUDE.md", "AGENTS.md", "TOOLS.md", "ONBOARDING.md",
+        ".claude", ".mcp.json", ".env",
+    } | ONE_TO_ONE_MD | {"goals.json"} | identity_pinning
+    for name in sorted(os.listdir(src_dir)):
+        if name in known_handled:
+            continue
+        if name in (".git", "node_modules"):
+            continue
+        m["buckets"]["port_verbatim"].append(name)
+    for name in sorted(identity_pinning):
+        if os.path.exists(os.path.join(src_dir, name)):
+            m["buckets"]["dropped"].append(
+                f"{name} (identity/path-pinned; NOT carried — target's add-agent-generated one stands)")
+
+    if os.path.isfile(os.path.join(src_dir, "goals.json")):
+        m["buckets"]["one_to_one"].append("goals.json")
+
+    return m
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src-dir", required=True)
+    ap.add_argument("--ctx-root", required=True)
+    ap.add_argument("--agent", required=True)
+    args = ap.parse_args()
+    manifest = detect(args.src_dir, args.ctx_root, args.agent)
+    json.dump(manifest, sys.stdout, indent=2)
+    sys.stdout.write("\n")
+    # exit non-zero if hard stops, so a caller can gate on it
+    sys.exit(2 if manifest["hard_stops"] else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/community/skills/claude-to-codex-migration/scripts/verify.py
+++ b/community/skills/claude-to-codex-migration/scripts/verify.py
@@ -1,0 +1,723 @@
+#!/usr/bin/env python3
+"""
+verify.py — VERIFY stage (Tier 1 static) of the Claude->Codex migration.
+
+Asserts the converted codex tree is well-formed. Read-only. Exit non-zero if any
+check fails. Tier 2 (live boot probe) is NOT done here — it enables a live agent,
+costs tokens, and must be run by the operator with explicit go (see SKILL.md
+Step 5 / the boot/loop/skills signals).
+
+Usage:
+  verify.py --target-dir <tgt> --target-agent <name> --ctx-root <CTX_ROOT>
+            [--expect-boot] [--expect-cutover --source-dir <src> --source-agent <name>]
+
+End-state expectation flags (set by the implementing agent from the user's Step 2
+answers). Default = today's behavior (assert codex DISABLED in both places):
+  (none)           : assert codex enabled:false in config.json AND registry.
+  --expect-boot    : the user chose to boot -> assert codex enabled:true in BOTH.
+  --expect-cutover : the user chose bot reuse -> implies boot AND additionally
+                     asserts the SOURCE is enabled:false in BOTH config.json and
+                     the registry (the cutover source-disable). Needs --source-dir
+                     and --source-agent.
+"""
+import argparse
+import json
+import os
+import re
+import sys
+
+# Approval guardrail marker — instance-GENERAL cortextOS safety, always asserted.
+APPROVAL_MARKERS = ("explicit per-item go", "per-item go")
+# The routing guardrail is instance-SPECIFIC; its presence is asserted (and its
+# marker built) only when an orchestrator is known — see routing_guardrail_present().
+
+
+def _looks_numeric_id(v):
+    return bool(v) and str(v).strip().isdigit()
+
+
+def _read_env_value(env_path, *keys):
+    if not os.path.isfile(env_path):
+        return None
+    lut = {}
+    with open(env_path, errors="ignore") as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                k, v = line.split("=", 1)
+                lut[k.strip()] = v.strip()
+    for k in keys:
+        if lut.get(k):
+            return lut[k]
+    return None
+
+
+def resolve_principal_chat_id(target_dir, param=None):
+    """Principal chat id, derived the SAME way convert did but from the TARGET .env
+    (the target inherited the source .env). param -> CHAT_ID -> ALLOWED_USER(numeric)
+    -> None."""
+    if param:
+        return str(param).strip()
+    env = os.path.join(target_dir, ".env")
+    v = _read_env_value(env, "CHAT_ID")
+    if v:
+        return v
+    au = _read_env_value(env, "ALLOWED_USER")
+    return au if _looks_numeric_id(au) else None
+
+
+def resolve_principal_name(target_dir, param=None):
+    if param:
+        return str(param).strip()
+    au = _read_env_value(os.path.join(target_dir, ".env"), "ALLOWED_USER")
+    return au if (au and not _looks_numeric_id(au)) else None
+
+
+def _principal_prose_res(principal_name):
+    """Per-instance prose-intent regexes (mirror convert.principal_prose_send_res).
+    Empty when the principal name is unknown (prose leg disabled)."""
+    if not principal_name:
+        return []
+    p = re.escape(principal_name)
+    return [
+        re.compile(
+            r"\b(send|sends|sending|tell|telling|notify|notifying|message|messaging|"
+            r"ping|pinging|remind|reminding|reminder\s+to|alert|alerting|dm|email|"
+            r"emailing|text|texting)\b[^.\n]{0,40}\b" + p + r"\b", re.IGNORECASE),
+        re.compile(
+            r"\b" + p + r"\b[^.\n]{0,30}\b(a\s+reminder|directly|right away|immediately|"
+            r"a\s+summary|a\s+message|a\s+ping|a\s+heads.?up)\b", re.IGNORECASE),
+    ]
+
+
+def _orchestrator_route_re(orchestrator):
+    if not orchestrator:
+        return None
+    o = re.escape(orchestrator)
+    return re.compile(
+        r"(send-message\s+" + o + r"|through\s+" + o + r"|via\s+" + o +
+        r"|route\s+(it\s+)?through\s+" + o + r"|to\s+" + o + r"\b|" + o +
+        r"\s+\(route|MIGRATION ROUTING GUARD)", re.IGNORECASE)
+
+
+def _routes_to_principal(prompt, principal_chat_id, principal_name, orchestrator):
+    """True if a cron prompt sends to the principal by chat-id OR prose intent and
+    does NOT route through the orchestrator / carry a migration routing guard. Each
+    leg is gated on its instance value being known (unknown -> that leg is off)."""
+    if principal_chat_id and principal_chat_id in prompt:
+        route_re = _orchestrator_route_re(orchestrator)
+        if not (route_re and route_re.search(prompt)):
+            return True
+    prose_res = _principal_prose_res(principal_name)
+    if prose_res and any(rx.search(prompt) for rx in prose_res):
+        route_re = _orchestrator_route_re(orchestrator)
+        return not (route_re and route_re.search(prompt))
+    return False
+
+
+def _source_recurring_crons_still_enabled(source_dir, ctx_root, source_agent):
+    """defect 11a OUTCOME-ASSERTION: return the names of RECURRING source crons
+    that are STILL enabled in the live registry (crons.json) post-cutover. A clean
+    cutover disables every recurring source cron (one-shots are HELD until re-armed
+    on the target, so they are excluded). Verify by OUTCOME — re-read the artifact,
+    never assume disable_source_crons ran. Non-empty result = the disable step did
+    not effectively run (the exact class-bug that hid behind manual rescue)."""
+    once_names = set()
+    cfg = _load_json(os.path.join(source_dir, "config.json")) or {}
+    for c in (cfg.get("crons") or []):
+        nm = c.get("name")
+        if nm and (c.get("type") == "once" or c.get("fire_at") or c.get("fireAt")):
+            once_names.add(nm)
+    reg = _load_json(os.path.join(ctx_root, ".cortextOS", "state", "agents",
+                                  source_agent, "crons.json"))
+    still = []
+    if isinstance(reg, dict):
+        for c in (reg.get("crons") or []):
+            nm = c.get("name")
+            if nm and nm not in once_names and c.get("enabled") is not False:
+                still.append(nm)
+    return sorted(still)
+
+
+def _load_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except Exception:
+        return None
+
+
+def _source_cron_union_names(source_dir, ctx_root, source_agent):
+    """Names of the EXPECTED migrated cron set: UNION of the source config.json
+    crons[] and the source live registry crons.json, deduped by name."""
+    names = set()
+    cfg = _load_json(os.path.join(source_dir, "config.json")) or {}
+    for c in (cfg.get("crons") or []):
+        if c.get("name"):
+            names.add(c["name"])
+    reg = _load_json(os.path.join(ctx_root, ".cortextOS", "state", "agents",
+                                  source_agent, "crons.json"))
+    if isinstance(reg, dict):
+        for c in (reg.get("crons") or []):
+            if c.get("name"):
+                names.add(c["name"])
+    return names
+
+
+def _sqlite_ok(path):
+    """True if `path` is a sound sqlite DB (or a 0-byte placeholder). False if it
+    fails PRAGMA integrity_check or cannot be opened. Read-only open — never mutates
+    the file. Mirror of convert._sqlite_ok so verify is the INDEPENDENT outcome gate
+    for the torn-DB class (#15), not trusting that the convert-time repair ran."""
+    try:
+        if not os.path.isfile(path) or os.path.getsize(path) == 0:
+            return True
+        import sqlite3
+        c = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        try:
+            row = c.execute("PRAGMA integrity_check;").fetchone()
+        finally:
+            c.close()
+        return bool(row) and row[0] == "ok"
+    except Exception:
+        return False
+
+
+def _torn_target_dbs(target_dir):
+    """#15 OUTCOME-ASSERTION. Walk the TARGET tree for the agent's OWN *.db files
+    (os.walk does NOT follow symlinks, so shared symlinked skill DBs are skipped)
+    and return any that fail an integrity_check. A torn copy reads malformed and
+    dies on first use; the convert-time backup-API repair is best-effort — THIS is
+    the independent gate that FAILS if any migrated DB landed corrupt."""
+    torn = []
+    for root, dirs, files in os.walk(target_dir):
+        dirs[:] = [d for d in dirs if d not in ("node_modules", ".git")]
+        for fn in files:
+            if fn.endswith(".db"):
+                fp = os.path.join(root, fn)
+                # Skip symlinked DBs (a symlink = shared, not the agent's OWN copy).
+                # os.walk already won't recurse symlinked DIRS; this also skips a
+                # symlinked .db FILE, which os.walk does still list.
+                if os.path.islink(fp):
+                    continue
+                if not _sqlite_ok(fp):
+                    torn.append(os.path.relpath(fp, target_dir))
+    return sorted(torn)
+
+
+def _skill_link_resolves(link, skill_dir):
+    """A migrated skill symlink must FOLLOW THROUGH to its skill dir. os.path.islink
+    is True even for a DANGLING link (target gone) — Codex then fails to load the
+    skill while a links-exist check passes. Require the link to resolve AND point at
+    this skill dir (catches dangling, missing, and mis-targeted links)."""
+    return (os.path.islink(link) and os.path.exists(link)
+            and os.path.realpath(link) == os.path.realpath(skill_dir))
+
+
+def _cron_missing_skill_paths(prompt, target_dir):
+    """OUTCOME-ASSERTION (stronger than absence-only): every skills path a migrated
+    cron will actually execute must RESOLVE in the target. The cron translation
+    rewrites `.claude/skills/<x>` -> `plugins/cortextos-agent-skills/skills/<x>`, where
+    convert places BOTH bundled and custom skills. A NEEDS-HUMAN/leaky skill is NOT
+    copied (convert.copy_custom_skills skips it) yet its cron ref is still translated —
+    leaving a dangling `plugins/.../skills/<x>` the cron fires against nothing. The old
+    verify only asserted the source `.claude/skills` substring was ABSENT, which the
+    translated prompt satisfies while still pointing at a missing dir. Return the
+    referenced skill names whose target dir does NOT exist. Slash-command skill refs
+    (e.g. `/humanify`) are not filesystem paths and are intentionally not checked."""
+    missing = []
+    for rel in re.findall(r"plugins/cortextos-agent-skills/skills/([\w.-]+)", prompt or ""):
+        if not os.path.isdir(os.path.join(
+                target_dir, "plugins", "cortextos-agent-skills", "skills", rel)):
+            missing.append(rel)
+    return missing
+
+
+def _agent_seg_re(agent):
+    """Match `agents/<agent>` ONLY as a complete path segment — a trailing name
+    char means a DIFFERENT agent (agents/<src> must NOT match agents/<src>-codex).
+    The segment ends at /, whitespace, a quote, or end-of-string."""
+    return re.compile(r"agents/" + re.escape(agent) + r"(?![\w-])")
+
+
+def _source_config_recurring_still_enabled(source_dir):
+    """Phase-2 config-drift guard. Mirror of _source_recurring_crons_still_enabled
+    but for the source CONFIG.JSON (not the live registry).
+    convert.disable_source_crons flips the recurring source crons enabled:false in
+    BOTH the registry AND config.json; the registry half is asserted (defect 11a)
+    but the config.json half was not. A config that still says enabled:true can
+    re-enable a disabled cron on the next daemon config-read (the config==registry
+    drift class — no hot-reload means the two can diverge). Return recurring crons
+    still enabled in source config.json (one-shots excluded — held until re-armed)."""
+    cfg = _load_json(os.path.join(source_dir, "config.json")) or {}
+    crons = cfg.get("crons") or []
+    once_names = set()
+    for c in crons:
+        nm = c.get("name")
+        if nm and (c.get("type") == "once" or c.get("fire_at") or c.get("fireAt")):
+            once_names.add(nm)
+    still = []
+    for c in crons:
+        nm = c.get("name")
+        if nm and nm not in once_names and c.get("enabled") is not False:
+            still.append(nm)
+    return sorted(still)
+
+
+def _stranded_cross_agent_refs(source_dir, source_agent, target_agent):
+    """Phase-2 cross-agent OUTCOME-ASSERTION (the migration-strands class).
+
+    Migrating one agent renames its workspace (e.g. agents/<src> -> agents/<src>-
+    codex). On CUTOVER the source is retired, so any SIBLING agent that hardcodes
+    `agents/<source>/...` now reads a path the producer no longer feeds — an
+    empty/stale read that is indistinguishable from a true gap (a stale cross-agent read-
+    stale-agents/data class, 4+ confirmed instances). The migration must NOT
+    silently rewrite siblings (surgical scope), so verify FAILS LOUD and the
+    operator repoints them to agents/<target>.
+
+    Scan every sibling agent dir under the source's agents/ root for an
+    `agents/<source>` path SEGMENT ref. Return [(sibling_agent, relpath), ...].
+    Excludes the source and target agents themselves."""
+    hits = []
+    agents_root = os.path.dirname(os.path.normpath(source_dir))
+    if not os.path.isdir(agents_root):
+        return hits
+    seg = _agent_seg_re(source_agent)
+    skip = {os.path.basename(os.path.normpath(source_dir)), source_agent, target_agent}
+    for sib in sorted(os.listdir(agents_root)):
+        sib_dir = os.path.join(agents_root, sib)
+        if sib in skip or not os.path.isdir(sib_dir):
+            continue
+        for dp, dn, fns in os.walk(sib_dir):
+            dn[:] = [d for d in dn if d not in ("node_modules", ".git", "state", "logs")]
+            for fn in fns:
+                if not fn.endswith((".md", ".sh", ".txt", ".json", ".py", ".js", ".ts")):
+                    continue
+                fp = os.path.join(dp, fn)
+                try:
+                    with open(fp, errors="ignore") as f:
+                        if seg.search(f.read()):
+                            hits.append((sib, os.path.relpath(fp, agents_root)))
+                except Exception:
+                    pass
+    return hits
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--target-dir", required=True)
+    ap.add_argument("--target-agent", required=True)
+    ap.add_argument("--ctx-root", required=True)
+    ap.add_argument("--expect-boot", action="store_true",
+                    help="assert codex agent is ENABLED (config.json + registry)")
+    ap.add_argument("--expect-cutover", action="store_true",
+                    help="implies --expect-boot AND asserts the source is disabled")
+    ap.add_argument("--source-dir", default=None, help="source agent dir (for --expect-cutover + cron-union check)")
+    ap.add_argument("--source-agent", default=None, help="source agent name (for --expect-cutover + cron-union check)")
+    ap.add_argument("--orchestrator", default=None,
+                    help="orchestrator the reroute targets; the routing OUTCOME-ASSERTION "
+                         "fires ONLY when this is known (else safe-degrade no-op). Pass "
+                         "the same value convert used.")
+    ap.add_argument("--principal-name", default=None,
+                    help="principal name for prose-intent detection (else derived from "
+                         "target .env ALLOWED_USER if non-numeric).")
+    ap.add_argument("--migration-start-ts", type=float, default=None,
+                    help="epoch seconds of migration start; the carried handoff in the "
+                         "target must have mtime AFTER this (the fresh-handoff assertion)")
+    args = ap.parse_args()
+    expect_boot = args.expect_boot or args.expect_cutover
+
+    td = args.target_dir
+    # INSTANCE-DISCOVERY (mirror convert): who the principal + orchestrator are for
+    # THIS deployment. principal_chat_id/name derived from the TARGET .env; the
+    # orchestrator comes from --orchestrator (verify does not auto-scan). When the
+    # orchestrator is unknown the routing assertion safe-degrades to a no-op.
+    v_principal_chat_id = resolve_principal_chat_id(td, None)
+    v_principal_name = resolve_principal_name(td, args.principal_name)
+    v_orchestrator = args.orchestrator.strip() if args.orchestrator else None
+    checks = []  # (ok, label)
+
+    def chk(ok, label):
+        checks.append((bool(ok), label))
+
+    # config.json
+    cfg_path = os.path.join(td, "config.json")
+    cfg = {}
+    if os.path.isfile(cfg_path):
+        try:
+            with open(cfg_path) as f:
+                cfg = json.load(f)
+        except Exception:
+            pass
+    chk(cfg.get("runtime") == "codex-app-server", "config.runtime == codex-app-server")
+    chk(bool(cfg.get("model")), "config.model present")
+    chk("dangerously_skip_permissions" not in cfg, "dangerously_skip_permissions dropped")
+    chk("ecosystem" not in cfg, "ecosystem block dropped")
+
+    # Enabled-state assertion is expectation-aware. The daemon reads the REGISTRY
+    # ($CTX_ROOT/config/enabled-agents.json), not the agent-dir config.json, for
+    # live enable state — so we assert BOTH places against the expected end state.
+    reg_path = os.path.join(args.ctx_root, "config", "enabled-agents.json")
+    reg = _load_json(reg_path)
+    reg_entry = (reg or {}).get(args.target_agent) if isinstance(reg, dict) else None
+    chk(reg_entry is not None,
+        f"registry entry present for '{args.target_agent}' in enabled-agents.json")
+    if expect_boot:
+        # Booted path: codex must be ENABLED in both config.json and registry.
+        chk(cfg.get("enabled") is True, "target ENABLED (config.json) [--expect-boot]")
+        chk(isinstance(reg_entry, dict) and reg_entry.get("enabled") is True,
+            "registry entry enabled:true (target enabled in enabled-agents.json) [--expect-boot]")
+    else:
+        # Default path: codex must be DISABLED in both (the safe end state).
+        chk(cfg.get("enabled") is False, "target starts disabled (config.json)")
+        chk(isinstance(reg_entry, dict) and reg_entry.get("enabled") is False,
+            "registry entry enabled:false (target disabled in enabled-agents.json)")
+
+    # Cutover: the SOURCE must be DISABLED in both config.json AND the registry
+    # (the bot-reuse source-disable). Only checked with --expect-cutover.
+    if args.expect_cutover:
+        if not (args.source_dir and args.source_agent):
+            chk(False, "--expect-cutover requires --source-dir and --source-agent")
+        else:
+            src_cfg = _load_json(os.path.join(args.source_dir, "config.json")) or {}
+            chk(src_cfg.get("enabled") is False,
+                f"source '{args.source_agent}' config.json enabled:false [--expect-cutover]")
+            src_entry = (reg or {}).get(args.source_agent) if isinstance(reg, dict) else None
+            chk(isinstance(src_entry, dict) and src_entry.get("enabled") is False,
+                f"source '{args.source_agent}' registry enabled:false [--expect-cutover]")
+            # The JSON flips alone do NOT stop a live poller — the daemon reads the
+            # registry only at startup (no fs.watch). A real cutover must have run
+            # `cortextos disable <source>`, which writes a `.user-disable` marker at
+            # $CTX_ROOT/state/<source>/.user-disable. Assert it to prove the
+            # process-STOP path was taken (not just the JSON edited) — the
+            # discriminating signal between "config flipped" and "poller stopped".
+            src_marker = os.path.join(args.ctx_root, "state", args.source_agent,
+                                      ".user-disable")
+            chk(os.path.isfile(src_marker),
+                f"source '{args.source_agent}' .user-disable marker present "
+                f"(proves `cortextos disable` STOPPED the poller, not just JSON flipped) "
+                f"[--expect-cutover]")
+            # defect 11a OUTCOME-ASSERTION (the keystone): disabling the source
+            # AGENT does NOT disable its CRONS — those stay enabled:true in the live
+            # registry and re-fire on any daemon restart/re-enable = durable
+            # dual-scheduler. A clean cutover must have disabled every RECURRING
+            # source cron. Re-read the registry and FAIL if any is still enabled.
+            # This is what catches the "disable step never ran / was hand-rescued"
+            # class-bug automatically, instead of trusting the step ran.
+            still_enabled = _source_recurring_crons_still_enabled(
+                args.source_dir, args.ctx_root, args.source_agent)
+            chk(not still_enabled,
+                f"all RECURRING source crons disabled post-cutover; still-enabled="
+                f"{still_enabled} (one-shots excluded — held until re-armed on target) "
+                f"[defect 11a]")
+            # Phase 2 config-drift half: the SAME recurring crons must read
+            # enabled:false in the source config.json too, or a later daemon
+            # config-read re-enables them (config==registry drift; no hot-reload).
+            still_cfg = _source_config_recurring_still_enabled(args.source_dir)
+            chk(not still_cfg,
+                f"all RECURRING source crons disabled in source config.json too; "
+                f"still-enabled={still_cfg} (config==registry drift guard) "
+                f"[defect 11a / config-drift]")
+            # Phase 2 cross-agent strands: no SIBLING agent may keep a hardcoded
+            # ref to the retired source's agents/<source> path (it reads stale/empty
+            # post-cutover). FAIL LOUD; operator repoints to agents/<target>.
+            stranded = _stranded_cross_agent_refs(
+                args.source_dir, args.source_agent, args.target_agent)
+            chk(not stranded,
+                f"no SIBLING agent strands a ref to retired source "
+                f"agents/{args.source_agent} (repoint to agents/{args.target_agent}); "
+                f"stranded={stranded} [cross-agent strands]")
+
+    # no claude cruft
+    chk(not os.path.isfile(os.path.join(td, "CLAUDE.md")), "no CLAUDE.md in target")
+    chk(not os.path.isfile(os.path.join(td, ".claude", "settings.json")),
+        "no .claude/settings.json")
+    chk(not os.path.isdir(os.path.join(td, ".claude")), "no .claude/ dir")
+
+    # core files
+    chk(os.path.isfile(os.path.join(td, "AGENTS.md")), "AGENTS.md present")
+    chk(os.path.isfile(os.path.join(td, ".agents", "plugins", "marketplace.json")),
+        ".agents/plugins/marketplace.json present (codex skeleton)")
+
+    # .env perms
+    env_path = os.path.join(td, ".env")
+    if os.path.isfile(env_path):
+        mode = oct(os.stat(env_path).st_mode & 0o777)
+        chk(mode == "0o600", f".env is 0600 (got {mode})")
+
+    # custom skills present + symlinked
+    skills_root = os.path.join(td, "plugins", "cortextos-agent-skills", "skills")
+    codex_skills = os.path.join(os.path.expanduser("~"), ".codex", "skills")
+    if os.path.isdir(skills_root):
+        for name in os.listdir(skills_root):
+            sp = os.path.join(skills_root, name)
+            if not os.path.isdir(sp):
+                continue
+            link = os.path.join(codex_skills, f"{args.target_agent}__{name}")
+            # Phase 2: assert the skill RESOLVES, not merely that a symlink exists.
+            chk(_skill_link_resolves(link, sp),
+                f"skill '{name}' symlink RESOLVES to its skill dir "
+                f"(~/.codex/skills/{args.target_agent}__{name}; not dangling/mis-targeted)")
+
+    # no .claude/skills refs left anywhere
+    leaked = []
+    for dp, dn, fns in os.walk(td):
+        dn[:] = [d for d in dn if d not in ("node_modules", ".git")]
+        for fn in fns:
+            if fn.endswith((".md", ".sh", ".txt", ".json", ".py", ".js", ".ts")):
+                try:
+                    with open(os.path.join(dp, fn), errors="ignore") as f:
+                        if ".claude/skills" in f.read():
+                            leaked.append(os.path.relpath(os.path.join(dp, fn), td))
+                except Exception:
+                    pass
+    chk(not leaked, f"no '.claude/skills' refs left ({len(leaked)} found)" if leaked
+        else "no '.claude/skills' refs left")
+
+    # --- DEFECT 15: torn-sqlite outcome gate. Every migrated *.db in the target
+    # workspace must pass integrity_check (a live DB raw-copied mid-write tears).
+    # The convert-time backup-API repair is best-effort; this is the independent
+    # gate that FAILS LOUD if any landed corrupt. ---
+    torn_dbs = _torn_target_dbs(td)
+    chk(not torn_dbs, f"all migrated *.db pass integrity_check; torn={torn_dbs} [defect 15]")
+
+    # state: fresh boot guaranteed
+    state_dir = os.path.join(args.ctx_root, "state", args.target_agent)
+    chk(os.path.isfile(os.path.join(state_dir, ".force-fresh")),
+        ".force-fresh marker present")
+    chk(not os.path.isfile(os.path.join(state_dir, "codex-app-server-thread.json")),
+        "no stale codex-app-server-thread.json")
+
+    # --- DEFECT 1: boot-state continuity. .onboarded MUST be present so the daemon
+    # does NOT cold-onboard the migrated agent (agent-process.ts gate ~699-713). ---
+    chk(os.path.isfile(os.path.join(state_dir, ".onboarded")),
+        "target state/.onboarded present (no cold-onboard) [defect 1]")
+    # The stale session transcripts MUST be excluded (no *thread.json carried).
+    stale_threads = [fn for fn in (os.listdir(state_dir) if os.path.isdir(state_dir) else [])
+                     if fn.endswith("thread.json")]
+    chk(not stale_threads, f"no stale *thread.json in target state ({stale_threads}) [defect 1]")
+
+    # --- DEFECT 3: read-side handoff. The source-generated fresh handoff is the
+    # NEWEST file in the target handoffs/ AND the boot directive references it. ---
+    # The read-side handoff carry happens ONLY on a cutover. Its discriminating
+    # signal is the .handoff-doc-path boot directive. Only assert the handoff
+    # invariants when that directive exists (cutover) OR when --expect-cutover was
+    # requested — a non-cutover migration carries no boot directive (and may carry
+    # an empty source handoffs/ dir, which must NOT trip the assertion).
+    tgt_handoffs = os.path.join(state_dir, "handoffs")
+    marker_path = os.path.join(state_dir, ".handoff-doc-path")
+    if os.path.isfile(marker_path) or args.expect_cutover:
+        files = []
+        if os.path.isdir(tgt_handoffs):
+            for fn in os.listdir(tgt_handoffs):
+                fp = os.path.join(tgt_handoffs, fn)
+                if os.path.isfile(fp):
+                    files.append((os.path.getmtime(fp), fp))
+        newest = max(files)[1] if files else None
+        chk(newest is not None, "target handoffs/ contains a handoff file [defect 3]")
+        # newest handoff must be AFTER migration start (the FRESH source handoff)
+        if newest is not None and args.migration_start_ts is not None:
+            chk(os.path.getmtime(newest) > args.migration_start_ts,
+                "newest target handoff is FRESH (mtime > migration start) [defect 3]")
+        # boot directive references the newest handoff
+        directive = None
+        if os.path.isfile(marker_path):
+            try:
+                with open(marker_path) as f:
+                    directive = f.read().strip()
+            except Exception:
+                directive = None
+        chk(directive is not None, ".handoff-doc-path boot directive present [defect 3]")
+        if directive and newest:
+            chk(os.path.abspath(directive) == os.path.abspath(newest),
+                "boot directive points at the newest carried handoff [defect 3]")
+        # DETERMINISTIC dual-location (defect 3 + 8i): the fresh handoff is ALSO carried
+        # into the target WORKSPACE memory/handoffs/ so the agent's native boot/resume
+        # path reads it regardless of which location boot consults.
+        if newest is not None:
+            ws_copy = os.path.join(td, "memory", "handoffs", os.path.basename(newest))
+            chk(os.path.isfile(ws_copy),
+                "fresh handoff also carried into target workspace memory/handoffs/ "
+                "(deterministic dual-location boot read) [defect 3 / 8i]")
+
+    # --- DEFECT 4+5: cron migration. Target cron set MATCHES the source UNION (no
+    # drops) and every migrated cron's cd/skills path resolves in the TARGET
+    # workspace (no leftover agents/<source> or .claude/skills). DEFECT 6c: no
+    # migrated cron sends DIRECT to the principal. ---
+    tgt_crons = (cfg.get("crons") or [])
+    tgt_cron_names = {c.get("name") for c in tgt_crons if c.get("name")}
+    if args.source_dir and args.source_agent:
+        want = _source_cron_union_names(args.source_dir, args.ctx_root, args.source_agent)
+        missing = sorted(want - tgt_cron_names)
+        chk(not missing,
+            f"all source-union crons migrated (no drops); missing={missing} [defect 5]")
+        chk(len(tgt_cron_names) >= len(want),
+            f"target cron count {len(tgt_cron_names)} >= source union {len(want)} [defect 5]")
+    # path resolution + direct-to-principal across every migrated cron prompt
+    src_agent_for_path = args.source_agent
+    bad_path = []
+    direct_principal = []
+    leftover_skills = []
+    # Match `agents/<source>` ONLY as a complete path segment — a trailing name
+    # char means it is a DIFFERENT agent (e.g. the translated `agents/<src>-codex`
+    # legitimately contains the substring `agents/<src>`). The segment ends at /,
+    # whitespace, a quote, or end-of-string.
+    src_seg_re = _agent_seg_re(src_agent_for_path) if src_agent_for_path else None
+    for c in tgt_crons:
+        p = c.get("prompt", "")
+        if src_seg_re and src_seg_re.search(p):
+            bad_path.append(c.get("name"))
+        if ".claude/skills" in p:
+            leftover_skills.append(c.get("name"))
+        # defect 6c + 14 routing OUTCOME-ASSERTION: catch a send to the principal by
+        # EITHER the literal chat id OR prose intent that does not route through the
+        # orchestrator / carry a migration routing guard. Fires ONLY when the
+        # orchestrator is known (else the reroute was safe-degraded on purpose and
+        # asserting it would hard-fail a legitimate degraded migration).
+        if v_orchestrator and _routes_to_principal(
+                p, v_principal_chat_id, v_principal_name, v_orchestrator):
+            direct_principal.append(c.get("name"))
+    chk(not bad_path,
+        f"no cron retains an unresolvable agents/<source> cd path ({bad_path}) [defect 4]")
+    chk(not leftover_skills,
+        f"no cron retains a .claude/skills path ({leftover_skills}) [defect 4]")
+    chk(not direct_principal,
+        f"no migrated cron routes to the principal by chat-id OR prose intent "
+        f"({direct_principal}) [defect 6c + 14]"
+        + ("" if v_orchestrator else " [SAFE-DEGRADE: orchestrator unknown, assertion off]"))
+    # EXISTENCE (stronger than absence): the translated skills path a cron will run
+    # must resolve in the target. Catches a NEEDS-HUMAN skill that was cron-referenced
+    # but never copied (dangling plugins/.../skills/<x>) — which the absence-only checks
+    # above pass GREEN because the source `.claude/skills` substring is gone.
+    missing_skill_paths = []
+    for c in tgt_crons:
+        for rel in _cron_missing_skill_paths(c.get("prompt", ""), td):
+            missing_skill_paths.append((c.get("name"), rel))
+    chk(not missing_skill_paths,
+        f"every migrated-cron skills path resolves in target ({missing_skill_paths}) "
+        f"[defect 4 existence]")
+
+    # --- DEFECT 6a/6b: routing + approval guardrails present in target bootstrap. ---
+    guard_text = ""
+    for fn in ("GUARDRAILS.md", "SOUL.md", "USER.md", "AGENTS.md"):
+        gp = os.path.join(td, fn)
+        if os.path.isfile(gp):
+            try:
+                with open(gp, errors="ignore") as f:
+                    guard_text += f.read()
+            except Exception:
+                pass
+    gt_low = guard_text.lower()
+    has_approval = any(m in guard_text for m in APPROVAL_MARKERS)
+    # ROUTING guardrail is instance-specific: assert its presence ONLY when the
+    # orchestrator is known (convert injects it only then). Its stable marker phrase
+    # names the orchestrator. When unknown, the row is legitimately absent (safe-
+    # degrade) — asserting it would hard-fail a valid degraded migration.
+    if v_orchestrator:
+        has_routing = ("route every principal-facing send through" in gt_low
+                       and v_orchestrator.lower() in gt_low)
+        chk(has_routing,
+            f"routing guardrail present in target bootstrap (principal-facing sends via "
+            f"'{v_orchestrator}') [defect 6a]")
+    # APPROVAL guardrail is instance-GENERAL — ALWAYS required.
+    chk(has_approval,
+        "approval guardrail present in target bootstrap (no external action without go) [defect 6b]")
+    # config approval_rules gates external-comms
+    chk("external-comms" in ((cfg.get("approval_rules") or {}).get("always_ask") or []),
+        "config approval_rules.always_ask gates external-comms [defect 6b]")
+
+    # --- DEFECT 7: skill-depth-delta compat symlink. codex skills sit one dir deeper
+    # than claude, so scripts anchoring workspace output via __file__ at a fixed depth
+    # (../../../docs, parents[3]/"docs") resolve one level short to plugins/docs; a
+    # plugins/docs -> ../docs symlink restores writes into <ws>/docs. Asserted only
+    # when the target actually carries a plugins/ skill tree. ---
+    plugins_dir = os.path.join(td, "plugins")
+    if os.path.isdir(plugins_dir):
+        compat = os.path.join(plugins_dir, "docs")
+        real_docs = os.path.join(td, "docs")
+        ok_link = (os.path.islink(compat)
+                   and os.path.realpath(compat) == os.path.realpath(real_docs))
+        chk(ok_link,
+            "plugins/docs -> ../docs compat symlink resolves to <ws>/docs "
+            "(depth-short __file__ docs anchors write into workspace) [defect 7]")
+
+        # Informational (NOT a pass/fail gate): the docs compat symlink only covers
+        # the workspace-DOCS anchor. Flag any migrated script that anchors a NON-docs
+        # workspace path via a fixed __file__ depth (e.g. ROOT/".env", secrets) — those
+        # still resolve one level short under the deeper codex layout and need a manual
+        # review (per the documented defect-7 caveat).
+        skills_root = os.path.join(plugins_dir, "cortextos-agent-skills", "skills")
+        anchor_re = re.compile(r"parents\[\d\]|(?:\.\./){3,}")
+        nondocs_re = re.compile(r"\.env|secrets|/data\b", re.IGNORECASE)
+        flagged = []
+        if os.path.isdir(skills_root):
+            for dp, dn, fns in os.walk(skills_root):
+                dn[:] = [d for d in dn if d not in ("node_modules", ".git", "digests")]
+                for fn in fns:
+                    if not fn.endswith(".py"):
+                        continue
+                    fp = os.path.join(dp, fn)
+                    try:
+                        with open(fp, errors="ignore") as f:
+                            txt = f.read()
+                    except Exception:
+                        continue
+                    if "__file__" in txt and anchor_re.search(txt) and nondocs_re.search(txt):
+                        flagged.append(os.path.relpath(fp, td))
+        if flagged:
+            print("  [WARN] non-docs __file__ depth anchors need manual review "
+                  f"(not covered by the docs symlink) [defect 7 caveat]: {flagged}")
+
+    # fix #16 OUTCOME-ASSERTION: every MCP server the source declared in .mcp.json
+    # must be present as a [mcp_servers.<name>] table in the host-global
+    # ~/.codex/config.toml, and every http server's bearer-token env var must be SET
+    # in org secrets.env (else the server 401s the moment Codex calls it). This is
+    # the gate that FAILS when emit_mcp_toml didn't actually install — the old
+    # print-only stub wrote nothing and nothing caught it, so Codex started zero
+    # migrated servers undetected. (Live "Codex actually starts it" is the Tier-2
+    # boot probe below.) Only checked when --source-dir is given (the .mcp.json
+    # ground truth); a source with no MCP servers adds no checks.
+    if args.source_dir:
+        src_mcp = _load_json(os.path.join(args.source_dir, ".mcp.json"))
+        mcp_servers = (src_mcp or {}).get("mcpServers", {}) if isinstance(src_mcp, dict) else {}
+        if mcp_servers:
+            codex_cfg = os.path.join(os.path.expanduser("~"), ".codex", "config.toml")
+            cfg_text = ""
+            if os.path.isfile(codex_cfg):
+                with open(codex_cfg, errors="ignore") as f:
+                    cfg_text = f.read()
+            present = set(re.findall(r"(?m)^\s*\[mcp_servers\.([^\].]+)\]\s*$", cfg_text))
+            secrets_path = os.path.join(
+                os.path.dirname(os.path.dirname(os.path.normpath(td))), "secrets.env")
+            secrets_text = ""
+            if os.path.isfile(secrets_path):
+                with open(secrets_path, errors="ignore") as f:
+                    secrets_text = f.read()
+            for name, spec in mcp_servers.items():
+                chk(name in present,
+                    f"MCP '{name}' installed as [mcp_servers.{name}] in ~/.codex/config.toml")
+                is_http = "url" in spec or spec.get("type") == "http"
+                if is_http:
+                    env_var = re.sub(r"[^A-Z0-9]", "_", name.upper()) + "_MCP_TOKEN"
+                    has_tok = re.search(r"(?m)^\s*%s\s*=\s*\S" % re.escape(env_var), secrets_text)
+                    chk(bool(has_tok),
+                        f"MCP '{name}' bearer token {env_var} set in secrets.env (else live 401)")
+
+    # report
+    passed = sum(1 for ok, _ in checks if ok)
+    print(f"=== Tier 1 static verify: {passed}/{len(checks)} passed ===")
+    for ok, label in checks:
+        print(f"  [{'PASS' if ok else 'FAIL'}] {label}")
+    if leaked:
+        print("  leaked refs:", leaked)
+    print("\nTier 2 (live boot probe) NOT run — operator runs it with explicit go.")
+    print("Boot OK signal:  [codex-app-server] ready thread=<id>")
+    print("Boot FAIL signal: [codex-app-server] degraded:")
+    print("Loop OK: turn/completed + last_idle.flag written. Skills: skills/list returns set.")
+    print("MCP OK: [codex-app-server] mcp server <name> ready  (FAIL: 'failed to start'/'401'/"
+          "server absent from tools/list) — the live half of the #16 MCP gate.")
+    sys.exit(0 if passed == len(checks) else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/community/skills/claude-to-codex-migration/tests/test_migration_bakes.py
+++ b/community/skills/claude-to-codex-migration/tests/test_migration_bakes.py
@@ -1,0 +1,640 @@
+#!/usr/bin/env python3
+"""Targeted tests for the 4 bakes: 11a (disable_source_crons + outcome-assert),
+11b (once-cron registry-form preference), 14 (prose reroute + routing assert),
+13 is doc-only. Functional + negative + idempotency. Plus PR#849 review fixes:
+R1 (MCP re-run idempotent self-owned overwrite), R2 (cron skills-path existence),
+R3 (live-disabled cron survives the union). Each convicts old behavior AND acquits."""
+import importlib.util, json, os, sys, tempfile, shutil
+
+SCRIPTS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "scripts")
+
+def load(name):
+    spec = importlib.util.spec_from_file_location(name, os.path.join(SCRIPTS, f"{name}.py"))
+    m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m); return m
+
+convert = load("convert")
+verify = load("verify")
+
+P = F = 0
+def ok(cond, label):
+    global P, F
+    if cond: P += 1; print(f"  PASS {label}")
+    else: F += 1; print(f"  FAIL {label}")
+
+# ---------- defect 14 + instance-discovery: parameterized principal-send reroute ----------
+# FAKE discovered values only (synthetic names, no roster names/real-chatid anywhere).
+print("[14] principal-send reroute (discovered orchestrator/principal, nothing hardcoded)")
+CHAT, ORCH, PRIN = "1000000000", "hub", "Casey"
+acts = []
+new, rr = convert._reroute_principal_sends("Send Casey a reminder to respond to a post.", "c1", acts, CHAT, ORCH, PRIN)
+ok(rr and "MIGRATION ROUTING GUARD" in new and ORCH in new, "prose 'Send Casey a reminder' -> guard injected naming the orchestrator")
+
+acts = []
+new, rr = convert._reroute_principal_sends("Ask hub to send Casey a summary via hub.", "c2", acts, CHAT, ORCH, PRIN)
+ok(not rr, "already orchestrator-routed prose -> NOT double-routed")
+
+acts = []
+new, rr = convert._reroute_principal_sends("cortextos bus send-telegram 1000000000 'hi'", "c3", acts, CHAT, ORCH, PRIN)
+ok(rr and "send-message hub normal" in new and CHAT not in new, "literal chat-id -> rewritten to the discovered orchestrator")
+
+acts = []
+new, rr = convert._reroute_principal_sends("Run the daily metrics scan and log results.", "c4", acts, CHAT, ORCH, PRIN)
+ok(not rr, "no principal intent -> not flagged")
+
+# GAP C: known chat_id but UNKNOWN orchestrator -> NO rewrite (no send-into-the-void)
+acts = []
+new, rr = convert._reroute_principal_sends("cortextos bus send-telegram 1000000000 'hi'", "c5", acts, CHAT, None, PRIN)
+ok(not rr and CHAT in new, "GAP C: unknown orchestrator -> literal id left intact, NOT rerouted")
+
+# #10 cross-check: prose fires for the DISCOVERED name, and NOT for a synthetic non-principal 'Rowan'
+acts = []
+_, rr_casey = convert._reroute_principal_sends("notify Casey directly about the outage", "c6", acts, CHAT, ORCH, PRIN)
+_, rr_rowan = convert._reroute_principal_sends("notify Rowan directly about the outage", "c7", acts, CHAT, ORCH, PRIN)
+ok(rr_casey, "prose fires for the discovered principal 'Casey'")
+ok(not rr_rowan, "DISCRIMINATING: prose does NOT fire for 'Rowan' (proves no hardcoded principal name remains)")
+
+# verify side helper (parameterized, gated legs)
+ok(verify._routes_to_principal("Notify Casey directly about the outage.", CHAT, PRIN, ORCH), "verify catches prose to principal")
+ok(not verify._routes_to_principal("Send Casey a summary — route through hub.", CHAT, PRIN, ORCH), "verify: orchestrator-routed prose passes")
+ok(verify._routes_to_principal("ping 1000000000 now", CHAT, PRIN, ORCH), "verify catches the literal chat-id")
+ok(not verify._routes_to_principal("notify Rowan directly", CHAT, PRIN, ORCH), "verify: 'Rowan' is not the principal -> not flagged")
+
+# ---------- F1: routing guardrail on ORCHESTRATOR-KNOWN ALONE (principal_name=None) ----------
+# The COMMON live case has a NUMERIC ALLOWED_USER -> resolve_principal_name=None. The
+# routing guardrail must STILL inject (gated on the orchestrator, not the name), and
+# verify's routing assertion (orchestrator-gated, name-INDEPENDENT) must PASS on it —
+# else the ordinary migration hard-fails "routing guardrail present [6a]". Every OTHER
+# test sets both values, so this None-principal path was previously untested.
+print("[F1] routing guardrail injects + verify agrees when principal_name is None")
+_gd = tempfile.mkdtemp()
+try:
+    convert.ensure_guardrails(_gd, True, [], orchestrator="hub", principal_name=None)
+    _gt_low = open(os.path.join(_gd, "GUARDRAILS.md"), errors="ignore").read().lower()
+    ok("route every principal-facing send through" in _gt_low and "hub" in _gt_low,
+       "F1: routing row injected on orchestrator-known + principal_name=None")
+    ok("the principal" in _gt_low and "('none')" not in _gt_low,
+       "F1: generic 'the principal' used when name unknown (no literal None leaked into the row)")
+    # verify.py's routing assertion is EXACTLY this predicate (verify.py ~617, orchestrator-
+    # gated, name-independent). Asserting it True proves convert+verify AGREE — no false-fail.
+    ok(("route every principal-facing send through" in _gt_low) and ("hub" in _gt_low),
+       "F1: verify routing assertion AGREES (PASSES) on the None-principal migration")
+    # the always-injected approval row is present regardless
+    _gtext = open(os.path.join(_gd, "GUARDRAILS.md"), errors="ignore").read()
+    ok(any(_m in _gtext for _m in verify.APPROVAL_MARKERS),
+       "F1: approval guardrail (instance-general) still injected alongside routing")
+finally:
+    shutil.rmtree(_gd, ignore_errors=True)
+
+# ---------- defect 11b: once-cron registry-form preference (migrate_crons) ----------
+print("[11b] once-cron registry crontab preference")
+tmp = tempfile.mkdtemp()
+try:
+    src = os.path.join(tmp, "src"); tgt = os.path.join(tmp, "tgt")
+    ctx = os.path.join(tmp, "ctx", "default")
+    reg_dir = os.path.join(ctx, ".cortextOS", "state", "agents", "srcagent")
+    os.makedirs(src); os.makedirs(tgt); os.makedirs(reg_dir)
+    # source config.json: once-cron in type:once form + a recurring + a prose-to-principal cron
+    json.dump({"crons": [
+        {"name": "annual-task", "type": "once", "fire_at": "2026-06-16T13:00:00Z", "prompt": "cancel annual-task"},
+        {"name": "heartbeat", "type": "recurring", "interval": "4h", "prompt": "do heartbeat"},
+        {"name": "noregister-once", "type": "once", "fire_at": "2026-06-20T09:00:00Z", "prompt": "remind Casey a reminder"},
+    ]}, open(os.path.join(src, "config.json"), "w"))
+    # live registry: annual-task as a dated CRONTAB (daemon-loadable) + heartbeat; NOT noregister-once
+    json.dump({"crons": [
+        {"name": "annual-task", "schedule": "0 13 16 6 *", "enabled": True, "prompt": "cancel annual-task"},
+        {"name": "heartbeat", "schedule": "4h", "enabled": True, "prompt": "do heartbeat"},
+    ]}, open(os.path.join(reg_dir, "crons.json"), "w"))
+    json.dump({"crons": []}, open(os.path.join(tgt, "config.json"), "w"))
+
+    acts = []
+    out = convert.migrate_crons(src, tgt, "srcagent", "srcagent-codex", ctx, True, acts, orchestrator="hub", principal_name="Casey")
+    by = {c["name"]: c for c in out}
+    ok(by["annual-task"].get("type") == "crontab" and by["annual-task"].get("crontab") == "0 13 16 6 *",
+       "annual-task once-cron carried as registry crontab (not dropped)")
+    ok("type" not in by["annual-task"] or by["annual-task"]["type"] != "once", "annual-task no longer type:once")
+    # noregister-once has no registry form -> kept as record + needs-rearm flag
+    ok(by["noregister-once"].get("type") == "once", "noregister-once kept as record")
+    flagged_rearm = any("NEEDS-REARM" in a and "noregister-once" in a for a in acts)
+    ok(flagged_rearm, "noregister-once emitted a NEEDS-REARM flag (not silent)")
+    flagged_conv = any("registry's dated crontab" in a and "annual-task" in a for a in acts)
+    ok(flagged_conv, "annual-task emitted a converted-crontab flag with re-fire caveat")
+    # prose-to-principal (noregister-once prompt 'remind Casey a reminder') -> routing guard in output
+    ok("MIGRATION ROUTING GUARD" in by["noregister-once"]["prompt"], "prose-to-principal once-cron got routing guard (discovered orchestrator)")
+
+    # ---------- defect 11a: disable_source_crons ----------
+    print("[11a] disable_source_crons")
+    acts = []
+    disabled, held = convert.disable_source_crons(src, ctx, "srcagent", True, acts)
+    ok("heartbeat" in disabled, "recurring 'heartbeat' disabled")
+    ok("annual-task" in held, "once 'annual-task' HELD (not disabled)")
+    reg2 = json.load(open(os.path.join(reg_dir, "crons.json")))
+    rb = {c["name"]: c for c in reg2["crons"]}
+    ok(rb["heartbeat"]["enabled"] is False, "registry heartbeat enabled:false")
+    ok(rb["annual-task"]["enabled"] is True, "registry annual-task still enabled:true (held)")
+    cfg2 = json.load(open(os.path.join(src, "config.json")))
+    cb = {c["name"]: c for c in cfg2["crons"]}
+    ok(cb["heartbeat"].get("enabled") is False, "config heartbeat enabled:false")
+
+    # outcome-assertion helper: recurring all disabled -> empty
+    still = verify._source_recurring_crons_still_enabled(src, ctx, "srcagent")
+    ok(still == [], "outcome-assert: no recurring source cron still enabled")
+
+    # idempotency: run disable again -> still clean, no new disables
+    acts = []
+    d2, h2 = convert.disable_source_crons(src, ctx, "srcagent", True, acts)
+    ok(d2 == [], "idempotent: second disable finds nothing recurring to disable")
+    ok(verify._source_recurring_crons_still_enabled(src, ctx, "srcagent") == [], "idempotent: still 0 recurring enabled")
+
+    # ---------- 11a NEGATIVE: leave a recurring cron enabled -> assertion catches it ----------
+    print("[11a-neg] outcome-assertion catches a missed disable")
+    reg3 = json.load(open(os.path.join(reg_dir, "crons.json")))
+    for c in reg3["crons"]:
+        if c["name"] == "heartbeat": c["enabled"] = True  # simulate the step no-opping
+    json.dump(reg3, open(os.path.join(reg_dir, "crons.json"), "w"))
+    still_neg = verify._source_recurring_crons_still_enabled(src, ctx, "srcagent")
+    ok(still_neg == ["heartbeat"], "NEGATIVE: assertion flags the still-enabled recurring cron")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- defect 15: safe sqlite copy + integrity outcome-assertion ----------
+import sqlite3
+print("[15] _sqlite_ok unit")
+tmp = tempfile.mkdtemp()
+try:
+    good = os.path.join(tmp, "good.db")
+    c = sqlite3.connect(good); c.execute("CREATE TABLE t(x)"); c.executemany("INSERT INTO t VALUES(?)", [(i,) for i in range(50)]); c.commit(); c.close()
+    ok(convert._sqlite_ok(good), "_sqlite_ok: valid db -> True")
+    garbage = os.path.join(tmp, "torn.db")
+    open(garbage, "wb").write(b"SQLite format 3\x00" + os.urandom(4000))  # plausible header, junk body
+    ok(not convert._sqlite_ok(garbage), "_sqlite_ok: malformed db -> False")
+    empty = os.path.join(tmp, "empty.db"); open(empty, "wb").close()
+    ok(convert._sqlite_ok(empty), "_sqlite_ok: 0-byte placeholder -> True")
+
+    # functional: torn target restored from valid source via backup API
+    print("[15] ensure_sqlite_integrity restore")
+    src = os.path.join(tmp, "src"); tgt = os.path.join(tmp, "tgt")
+    srel = os.path.join(".claude", "skills", "dsp", "data")
+    trel = os.path.join("plugins", "cortextos-agent-skills", "skills", "dsp", "data")
+    os.makedirs(os.path.join(src, srel)); os.makedirs(os.path.join(tgt, trel))
+    sdb = os.path.join(src, srel, "signals.db")
+    cs = sqlite3.connect(sdb); cs.execute("CREATE TABLE items(id INTEGER, v TEXT)")
+    cs.executemany("INSERT INTO items VALUES(?,?)", [(i, f"r{i}") for i in range(200)]); cs.commit(); cs.close()
+    tdb = os.path.join(tgt, trel, "signals.db")
+    open(tdb, "wb").write(b"SQLite format 3\x00" + os.urandom(3000))  # torn copy
+    ok(not convert._sqlite_ok(tdb), "precondition: target db is torn/malformed")
+    acts = []
+    rep, okl, unrep = convert.ensure_sqlite_integrity(src, tgt, True, acts)
+    ok(os.path.join(trel, "signals.db") in rep, "torn target listed as repaired")
+    ok(unrep == [], "no unrepairable when source is intact")
+    ok(convert._sqlite_ok(tdb), "target db integrity_check ok AFTER restore")
+    n = sqlite3.connect(tdb).execute("SELECT COUNT(*) FROM items").fetchone()[0]
+    ok(n == 200, "restored target carries full source history (200 rows)")
+
+    # negative: torn target + NO source -> unrepairable (HARD fail, not silent)
+    print("[15-neg] unrepairable when source missing -> hard-fail signal")
+    tgt2 = os.path.join(tmp, "tgt2"); src2 = os.path.join(tmp, "src2")
+    os.makedirs(os.path.join(tgt2, trel)); os.makedirs(src2)
+    tdb2 = os.path.join(tgt2, trel, "signals.db")
+    open(tdb2, "wb").write(b"SQLite format 3\x00" + os.urandom(3000))
+    acts = []
+    rep2, okl2, unrep2 = convert.ensure_sqlite_integrity(src2, tgt2, True, acts)
+    ok(os.path.join(trel, "signals.db") in unrep2, "NEGATIVE: source-missing torn db -> unrepairable (default-deny gate fires)")
+    ok(not convert._sqlite_ok(tdb2), "NEGATIVE: unrepairable db left detectably-bad, not silently passed")
+    ok(rep2 == [], "NEGATIVE: nothing falsely reported repaired")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- defect 16: emit_mcp_toml actually installs servers (+ verify gate) ----------
+print("[16] MCP emit writes config.toml tables + carries token + collision hard-stop")
+import re as _re
+tmp = tempfile.mkdtemp()
+_orig_home = os.environ.get("HOME")
+try:
+    home = os.path.join(tmp, "home"); os.makedirs(os.path.join(home, ".codex"))
+    os.environ["HOME"] = home  # isolate ~/.codex/config.toml
+    tdir = os.path.join(tmp, "orgs", "testorg", "agents", "newagent"); os.makedirs(tdir)
+    manifest = {"mcp": {"servers": [
+        {"name": "notion", "transport": "http", "url": "https://mcp.notion.com/mcp",
+         "command": None, "args": [], "env": {},
+         "headers": {"Authorization": "Bearer ntn_SECRET123"}},
+        {"name": "local-fs", "transport": "stdio", "url": None, "command": "npx",
+         "args": ["-y", "fs-mcp"], "env": {"ROOT": "/data"}, "headers": {}},
+    ]}}
+    acts = []
+    written, needs, coll = convert.emit_mcp_toml(manifest, "newagent", tdir, True, acts)
+    cfg_text = open(os.path.join(home, ".codex", "config.toml")).read()
+    secrets_text = open(os.path.join(tmp, "orgs", "testorg", "secrets.env")).read()
+    # DISCRIMINATING: the old print-only stub wrote NOTHING to config.toml, so every
+    # "table present in config.toml" assertion FAILS on the stub and passes only on
+    # the real install (the #16 A/B — a same-stderr test would pass on broken code).
+    ok("[mcp_servers.notion]" in cfg_text, "http table written to config.toml (stub wrote nothing)")
+    ok('bearer_token_env_var = "NOTION_MCP_TOKEN"' in cfg_text, "http: bearer_token_env_var set")
+    ok("ntn_SECRET123" not in cfg_text, "http: raw token NOT inlined in config.toml")
+    ok("NOTION_MCP_TOKEN=ntn_SECRET123" in secrets_text, "http: token carried into secrets.env from source headers")
+    ok("[mcp_servers.local-fs]" in cfg_text and 'command = "npx"' in cfg_text, "stdio table + command written")
+    ok('args = ["-y", "fs-mcp"]' in cfg_text, "stdio: args written (stub left a placeholder comment)")
+    ok("[mcp_servers.local-fs.env]" in cfg_text and 'ROOT = "/data"' in cfg_text, "stdio: env sub-table written")
+    ok(coll == [] and set(written) == {"notion", "local-fs"}, "both servers written, no collision")
+
+    print("[16-neg] host-global name collision -> hard-stop, writes nothing")
+    open(os.path.join(home, ".codex", "config.toml"), "w").write('[mcp_servers.notion]\nurl = "x"\n')
+    before = open(os.path.join(home, ".codex", "config.toml")).read()
+    acts = []
+    w2, n2, c2 = convert.emit_mcp_toml(manifest, "newagent", tdir, True, acts)
+    after = open(os.path.join(home, ".codex", "config.toml")).read()
+    ok("notion" in c2, "NEGATIVE: collision detected and returned")
+    ok(w2 == [], "NEGATIVE: nothing reported written on collision")
+    ok(before == after, "NEGATIVE: config.toml UNCHANGED on collision (no partial install)")
+
+    print("[16-verify] verify MCP presence gate discriminates absent vs installed")
+    rgx = r"(?m)^\s*\[mcp_servers\.([^\].]+)\]\s*$"
+    ok("notion" not in set(_re.findall(rgx, "")), "verify: empty config.toml -> server absent (gate FAILS)")
+    ok("notion" in set(_re.findall(rgx, "[mcp_servers.notion]\n")), "verify: installed -> server present (gate PASSES)")
+finally:
+    if _orig_home is not None: os.environ["HOME"] = _orig_home
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- Phase 2A: skill symlink must RESOLVE, not just exist ----------
+print("[P2a] skill symlink resolution (dangling/mis-targeted caught)")
+tmp = tempfile.mkdtemp()
+try:
+    skill_dir = os.path.join(tmp, "skills", "myskill"); os.makedirs(skill_dir)
+    links = os.path.join(tmp, "links"); os.makedirs(links)
+    good = os.path.join(links, "agent__good"); os.symlink(skill_dir, good)
+    ok(verify._skill_link_resolves(good, skill_dir), "valid symlink -> resolves (PASS)")
+    # DISCRIMINATING: dangling link — os.path.islink is True, so the OLD islink-only
+    # check passed; the resolution check must FAIL it.
+    missing_target = os.path.join(tmp, "skills", "gone")
+    dangling = os.path.join(links, "agent__dangling"); os.symlink(missing_target, dangling)
+    ok(os.path.islink(dangling), "precondition: dangling link IS a symlink (old check passed)")
+    ok(not verify._skill_link_resolves(dangling, missing_target),
+       "DISCRIMINATING: dangling symlink -> does NOT resolve (gate FAILS, islink-only would PASS)")
+    # absent link
+    ok(not verify._skill_link_resolves(os.path.join(links, "agent__absent"), skill_dir),
+       "absent link -> does not resolve")
+    # mis-targeted: link exists + resolves but points at the WRONG skill dir
+    other = os.path.join(tmp, "skills", "other"); os.makedirs(other)
+    mis = os.path.join(links, "agent__mis"); os.symlink(other, mis)
+    ok(not verify._skill_link_resolves(mis, skill_dir),
+       "mis-targeted symlink (resolves but wrong dir) -> FAILS")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- Phase 2B: cross-agent strands (sibling refs to retired source) ----------
+print("[P2b] cross-agent strands scan + segment boundary")
+tmp = tempfile.mkdtemp()
+try:
+    agents = os.path.join(tmp, "orgs", "x", "agents"); os.makedirs(agents)
+    src = os.path.join(agents, "alpha"); os.makedirs(src)
+    tgt = os.path.join(agents, "alpha-codex"); os.makedirs(tgt)
+    sib = os.path.join(agents, "beta"); os.makedirs(os.path.join(sib, "scripts"))
+    # sibling hardcodes the retired source path
+    stray = os.path.join(sib, "scripts", "read.py")
+    open(stray, "w").write("PATH = 'orgs/x/agents/alpha/docs/brief.md'\n")
+    hits = verify._stranded_cross_agent_refs(src, "alpha", "alpha-codex")
+    ok(("beta", os.path.relpath(stray, agents)) in hits,
+       "sibling ref to agents/alpha flagged as stranded")
+    # DISCRIMINATING boundary: a sibling pointing at agents/alpha-codex (the TARGET,
+    # longer name) must NOT be a false positive when source is 'alpha'.
+    open(os.path.join(sib, "scripts", "read.py"), "w").write(
+        "PATH = 'orgs/x/agents/alpha-codex/docs/brief.md'\n")
+    hits2 = verify._stranded_cross_agent_refs(src, "alpha", "alpha-codex")
+    ok(hits2 == [], "DISCRIMINATING: repointed to agents/alpha-codex -> NOT flagged (segment boundary)")
+    # source's OWN files are excluded (only siblings count)
+    open(os.path.join(src, "self.md"), "w").write("see agents/alpha/x\n")
+    ok(verify._stranded_cross_agent_refs(src, "alpha", "alpha-codex") == [],
+       "source's own agents/alpha refs excluded (only siblings strand)")
+    # convert-side best-effort surface returns the same hits
+    open(os.path.join(sib, "scripts", "read.py"), "w").write(
+        "PATH = 'orgs/x/agents/alpha/docs/brief.md'\n")
+    acts = []
+    chits = convert.scan_cross_agent_strands(src, "alpha", "alpha-codex", acts)
+    ok(("beta", os.path.relpath(stray, agents)) in chits, "convert surface finds the same strand")
+    ok(any("REPOINT" in a for a in acts), "convert surface logs a REPOINT action (not silent)")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- Phase 2C: source crons disabled in config.json too (drift guard) ----------
+print("[P2c] source config.json recurring-disable drift guard")
+tmp = tempfile.mkdtemp()
+try:
+    src = os.path.join(tmp, "src"); os.makedirs(src)
+    ctx = os.path.join(tmp, "ctx", "default")
+    reg_dir = os.path.join(ctx, ".cortextOS", "state", "agents", "srcagent"); os.makedirs(reg_dir)
+    json.dump({"crons": [
+        {"name": "heartbeat", "type": "recurring", "interval": "4h", "enabled": True, "prompt": "hb"},
+        {"name": "annual-task", "type": "once", "fire_at": "2026-06-20T09:00:00Z", "enabled": True, "prompt": "once"},
+    ]}, open(os.path.join(src, "config.json"), "w"))
+    json.dump({"crons": [
+        {"name": "heartbeat", "schedule": "4h", "enabled": True, "prompt": "hb"},
+    ]}, open(os.path.join(reg_dir, "crons.json"), "w"))
+    # before disable: config helper flags the recurring cron
+    ok(verify._source_config_recurring_still_enabled(src) == ["heartbeat"],
+       "pre-disable: config.json recurring cron flagged")
+    # DISCRIMINATING: disable ONLY the registry (simulate config-half skipped) ->
+    # registry helper passes but config helper still catches the drift.
+    reg = json.load(open(os.path.join(reg_dir, "crons.json")))
+    for c in reg["crons"]:
+        if c["name"] == "heartbeat": c["enabled"] = False
+    json.dump(reg, open(os.path.join(reg_dir, "crons.json"), "w"))
+    ok(verify._source_recurring_crons_still_enabled(src, ctx, "srcagent") == [],
+       "registry-only disable: registry helper now passes")
+    ok(verify._source_config_recurring_still_enabled(src) == ["heartbeat"],
+       "DISCRIMINATING: config helper still flags drift (config half not disabled)")
+    # full disable_source_crons flips BOTH -> both helpers clean
+    acts = []
+    convert.disable_source_crons(src, ctx, "srcagent", True, acts)
+    ok(verify._source_config_recurring_still_enabled(src) == [],
+       "post full disable: config.json recurring all disabled")
+    # one-shot never flagged by the config helper
+    cfg = json.load(open(os.path.join(src, "config.json")))
+    pj = {c["name"]: c for c in cfg["crons"]}
+    ok(pj["annual-task"].get("enabled") is True, "one-shot annual-task left enabled (held), not flagged")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- Phase 3: verify is the INDEPENDENT torn-db gate (#15 verify side) ----------
+print("[P3-15v] verify._torn_target_dbs independent integrity gate")
+tmp = tempfile.mkdtemp()
+try:
+    td = os.path.join(tmp, "tgt")
+    good_dir = os.path.join(td, "plugins", "x", "skills", "a"); os.makedirs(good_dir)
+    gdb = os.path.join(good_dir, "ok.db")
+    cc = sqlite3.connect(gdb); cc.execute("CREATE TABLE t(x)"); cc.commit(); cc.close()
+    ok(verify._torn_target_dbs(td) == [], "clean target -> no torn dbs")
+    # DISCRIMINATING: a torn target DB is caught by verify even if convert's repair
+    # never ran (the independent outcome gate).
+    torn_dir = os.path.join(td, "plugins", "x", "skills", "b"); os.makedirs(torn_dir)
+    tdbp = os.path.join(torn_dir, "bad.db")
+    open(tdbp, "wb").write(b"SQLite format 3\x00" + os.urandom(3000))
+    ok(verify._torn_target_dbs(td) == [os.path.relpath(tdbp, td)],
+       "DISCRIMINATING: torn target db flagged by verify gate (convert repair independent)")
+    # symlinked shared DB is NOT walked (os.walk does not follow symlinks)
+    shared = os.path.join(tmp, "shared.db")
+    open(shared, "wb").write(b"SQLite format 3\x00" + os.urandom(3000))  # torn, but shared
+    link_dir = os.path.join(td, "plugins", "x", "skills", "c"); os.makedirs(link_dir)
+    os.symlink(shared, os.path.join(link_dir, "shared.db"))
+    ok(verify._torn_target_dbs(td) == [os.path.relpath(tdbp, td)],
+       "symlinked shared db skipped (only agent's OWN real dbs gated)")
+    # 0-byte placeholder is fine
+    os.remove(tdbp)
+    open(os.path.join(torn_dir, "bad.db"), "wb").close()
+    ok(verify._torn_target_dbs(td) == [], "0-byte placeholder db -> ok")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- review MED#1: MCP re-run is idempotent (self-owned overwrite, not self-collision) ----------
+print("[R1] MCP re-run: own prior block idempotently overwritten, not a false self-collision")
+tmp = tempfile.mkdtemp()
+_orig_home = os.environ.get("HOME")
+try:
+    home = os.path.join(tmp, "home"); os.makedirs(os.path.join(home, ".codex"))
+    os.environ["HOME"] = home  # isolate ~/.codex/config.toml
+    tdir = os.path.join(tmp, "orgs", "testorg", "agents", "newagent"); os.makedirs(tdir)
+    manifest = {"mcp": {"servers": [
+        {"name": "notion", "transport": "http", "url": "https://mcp.notion.com/mcp",
+         "command": None, "args": [], "env": {}, "headers": {"Authorization": "Bearer ntn_S"}},
+    ]}}
+    acts = []
+    w1, n1, c1 = convert.emit_mcp_toml(manifest, "newagent", tdir, True, acts)
+    ok(c1 == [] and w1 == ["notion"], "first run installs notion, no collision")
+    # DISCRIMINATING: the OLD code parsed its own written [mcp_servers.notion] back as a
+    # host-global name on a second --apply -> false collision hard-stop (exit path). The
+    # fix recognizes the self-owned block by the migration header agent-name and overwrites.
+    acts = []
+    w2, n2, c2 = convert.emit_mcp_toml(manifest, "newagent", tdir, True, acts)
+    ok(c2 == [], "DISCRIMINATING: re-run does NOT self-collide (old code returned ['notion'])")
+    ok(w2 == ["notion"], "re-run re-writes the self-owned server (idempotent)")
+    cfg_text = open(os.path.join(home, ".codex", "config.toml")).read()
+    ok(cfg_text.count("[mcp_servers.notion]") == 1, "exactly ONE notion table after re-run (no duplicate)")
+    # ACQUIT: a DIFFERENT agent's prior migrated block IS still a real host-global collision
+    open(os.path.join(home, ".codex", "config.toml"), "a").write(
+        "\n# === migrated MCP servers for agent 'otheragent' (claude-to-codex-migration) ===\n"
+        "[mcp_servers.notion]\nurl = \"x\"\n")
+    acts = []
+    w3, n3, c3 = convert.emit_mcp_toml(manifest, "newagent", tdir, True, acts)
+    ok("notion" in c3, "ACQUIT: a DIFFERENT agent's block is still a real collision (hard-stop preserved)")
+    # helper unit: self-owned name extracted + its region stripped from foreign text
+    fk, owned = convert._split_self_owned_mcp_region(
+        "[mcp_servers.keep]\n# === migrated MCP servers for agent 'a' (claude-to-codex-migration) ===\n[mcp_servers.x]\n", "a")
+    ok("x" in owned and "[mcp_servers.x]" not in fk and "[mcp_servers.keep]" in fk,
+       "helper: self-owned name extracted, own region stripped, foreign kept")
+finally:
+    if _orig_home is not None: os.environ["HOME"] = _orig_home
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- review MED#2: verify asserts the translated cron skills path EXISTS ----------
+print("[R2] cron skills-leg existence: dangling translated skill path is caught")
+tmp = tempfile.mkdtemp()
+try:
+    td = os.path.join(tmp, "tgt")
+    os.makedirs(os.path.join(td, "plugins", "cortextos-agent-skills", "skills", "humanify"))
+    ok(verify._cron_missing_skill_paths(
+        "cd agents/x && run plugins/cortextos-agent-skills/skills/humanify", td) == [],
+       "present skill path -> nothing missing")
+    # DISCRIMINATING: a NEEDS-HUMAN skill not copied but still cron-referenced. The old
+    # verify only checked absence of '.claude/skills' (satisfied by the translated prompt)
+    # and passed GREEN; the existence check flags the dangling target path.
+    prompt = "cd agents/x && run plugins/cortextos-agent-skills/skills/leaky-custom"
+    ok(".claude/skills" not in prompt, "precondition: translated prompt has NO source substring (old check GREEN)")
+    ok(verify._cron_missing_skill_paths(prompt, td) == ["leaky-custom"],
+       "DISCRIMINATING: dangling translated skill path flagged (absence-only check missed it)")
+    # ACQUIT: a slash-command skill ref is not a filesystem path -> not falsely flagged
+    ok(verify._cron_missing_skill_paths("run /humanify then /docx now", td) == [],
+       "ACQUIT: slash-command skill refs not path-checked (no false positive)")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- review LOW-MED#3: live-disabled cron stays disabled through the union ----------
+print("[R3] disabled-recurring cron enabled-state survives the config-wins union")
+tmp = tempfile.mkdtemp()
+try:
+    src = os.path.join(tmp, "src"); tgt = os.path.join(tmp, "tgt")
+    ctx = os.path.join(tmp, "ctx", "default")
+    reg_dir = os.path.join(ctx, ".cortextOS", "state", "agents", "srcagent")
+    os.makedirs(src); os.makedirs(tgt); os.makedirs(reg_dir)
+    # config says ENABLED, but the LIVE REGISTRY has it DISABLED (someone disabled the
+    # cron, which flips the registry). The old config-wins union would resurrect it.
+    json.dump({"crons": [
+        {"name": "nightly", "type": "recurring", "interval": "24h", "enabled": True, "prompt": "do nightly"},
+        {"name": "beat", "type": "recurring", "interval": "4h", "enabled": True, "prompt": "beat"},
+    ]}, open(os.path.join(src, "config.json"), "w"))
+    json.dump({"crons": [
+        {"name": "nightly", "schedule": "24h", "enabled": False, "prompt": "do nightly"},
+        {"name": "beat", "schedule": "4h", "enabled": True, "prompt": "beat"},
+    ]}, open(os.path.join(reg_dir, "crons.json"), "w"))
+    json.dump({"crons": []}, open(os.path.join(tgt, "config.json"), "w"))
+    acts = []
+    out = convert.migrate_crons(src, tgt, "srcagent", "srcagent-codex", ctx, True, acts, orchestrator="hub", principal_name="Casey")
+    by = {c["name"]: c for c in out}
+    # DISCRIMINATING: old union dropped registry enabled in normalization + let config
+    # (enabled:True) win -> nightly would be enabled:True at target (resurrected).
+    ok(by["nightly"].get("enabled") is False,
+       "DISCRIMINATING: registry-disabled 'nightly' stays disabled at target (old code resurrected it)")
+    ok(by["beat"].get("enabled") is True, "ACQUIT: a genuinely-enabled cron stays enabled")
+    # registry-only disabled cron: enabled carried through normalization too
+    json.dump({"crons": [{"name": "regonly", "schedule": "6h", "enabled": False, "prompt": "ro"}]},
+              open(os.path.join(reg_dir, "crons.json"), "w"))
+    json.dump({"crons": []}, open(os.path.join(src, "config.json"), "w"))
+    json.dump({"crons": []}, open(os.path.join(tgt, "config.json"), "w"))
+    acts = []
+    out2 = {c["name"]: c for c in convert.migrate_crons(src, tgt, "srcagent", "srcagent-codex", ctx, True, acts, orchestrator="hub", principal_name="Casey")}
+    ok(out2["regonly"].get("enabled") is False,
+       "registry-only disabled cron carries enabled:false through normalization")
+finally:
+    shutil.rmtree(tmp, ignore_errors=True)
+
+# ---------- GAP H (#9) + F2/F3 (R3): leakage guard = GENERIC detectors shipped + author-specific fixture external ----------
+# DESIGN (R3): the SHIPPED guard carries ZERO author-specific value in ANY form
+# (plaintext / base64 / split-assembly / hash are all recoverable and were rejected).
+#   - GENERIC, always-on, always-shipped: (1) a host/URL/IP allowlist detector — the
+#     positive allowlist is the SOLE infra gate, so it flags ANY non-allowlisted host
+#     (incl a reintroduced private prod host) WITHOUT the guard shipping/knowing the
+#     secret host names; (2) a hardcoded-chat-id-literal detector (send context) that
+#     needs no author value.
+#   - AUTHOR-SPECIFIC (fleet roster + the specific real chat-id) live ONLY in an
+#     EXTERNAL, CI/local-only fixture (CTX_LEAKAGE_FIXTURE -> JSON {roster:[],chat_ids:[]}),
+#     which is gitignored and NEVER shipped. When the fixture is absent (the DEFAULT
+#     public path — zero setup, no error) that leg SKIPS with a log; the generic
+#     detectors above still enforce.
+print("[GAP-H] leakage guard: generic host + chat-id-literal detectors + external author fixture")
+import re as _reH, json as _jsonH
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_THIS = os.path.abspath(__file__)
+
+# F2-GAP-A: scan EVERY shipped text file under the skill dir (the R1 leak was in
+# references/, and references/*.txt was previously UNSCANNED). Walk the tree; keep known
+# text extensions + extensionless. Invariant asserted below: references/*.txt covered.
+_TEXT_EXT = {".md", ".txt", ".py", ".json", ".toml", ".yaml", ".yml", ".cfg", ".ini", ".sh", ""}
+_scan = []
+for _dp, _dns, _fns in os.walk(_ROOT):
+    _dns[:] = [_d for _d in _dns if not _d.startswith(".")]  # prune hidden dirs RELATIVE to the walk
+    for _fn in _fns:
+        if os.path.splitext(_fn)[1].lower() in _TEXT_EXT:
+            _scan.append(os.path.abspath(os.path.join(_dp, _fn)))
+_scan = sorted(set(_scan))
+# The host + chat-id detectors necessarily flag adversarial fixtures. This test file is
+# the ONE file that must carry such fixtures (to prove the detectors fire), so the
+# host/chat-id FILE scans run over the runtime surface = every shipped file EXCEPT this
+# one; the detectors themselves are proven by inline convict/acquit unit tests. The
+# author-specific (roster/chat-id) scan below still covers ALL files incl this one.
+_runtime_surface = [_f for _f in _scan if _f != _THIS]
+def _ln(_txt, _pos):
+    return _txt[:_pos].count(chr(10)) + 1
+def _rel(_f):
+    return os.path.relpath(_f, _ROOT)
+ok(any(_p.endswith(os.path.join("references", "leakage-tokens.txt")) for _p in _scan)
+   and any(_p.endswith(os.path.join("references", "codex-bundled-skills.txt")) for _p in _scan),
+   "F2-GAP-A: scan set covers references/*.txt (the prior blind spot)")
+
+# --- GENERIC detector 1: host/URL/IP allowlist (F2-GAP-B: scheme-OPTIONAL + bare host + IPv4). ---
+_HOST_ALLOW = {"mcp.notion.com", "mcp.supabase.com"}  # public well-known endpoints; *.example.com always ok
+_HOST_RE = _reH.compile(
+    r"(?P<scheme>[a-z][a-z0-9+.-]*://)?"
+    r"(?P<host>(?:(?:\d{1,3}\.){3}\d{1,3})"                              # IPv4
+    r"|(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z]{2,24})", _reH.IGNORECASE)
+def _host_allowed(_h):
+    _h = _h.lower().rstrip(".")
+    return _h in _HOST_ALLOW or _h == "example.com" or _h.endswith(".example.com")
+# real public TLDs we care about for a host leak. Combined with the subdomain/hyphen
+# rule below, this keeps Python attr chains (os.path.join, subprocess.run, args.org)
+# and filenames (self.md, read.py) from reading as hosts, while still catching a
+# reintroduced managed/PaaS host (e.g. a "<svc>.up.<provider>.app" style deploy host).
+_REAL_TLD = {"com", "net", "org", "io", "app", "dev", "co", "ai", "cloud", "run", "sh",
+             "xyz", "us", "uk", "gg", "tv", "me", "info", "biz", "page", "site", "tech"}
+def _host_leak_hits(_text):
+    """Return non-allowlisted host/URL/IP tokens. CONVICTS scheme://host of ANY scheme
+    (ws/postgres/http...), IPv4 literals, and bare hosts with a real TLD that carry a
+    subdomain or a hyphenated label (a reintroduced managed/PaaS deploy host). ACQUITS
+    Python attr-access look-alikes (args.org, subprocess.run, os.path.join) and filenames."""
+    _out = []
+    for _m in _HOST_RE.finditer(_text):
+        _h, _scheme = _m.group("host"), _m.group("scheme")
+        if _host_allowed(_h):
+            continue
+        if _reH.fullmatch(r"(?:\d{1,3}\.){3}\d{1,3}", _h):
+            if _h not in ("127.0.0.1", "0.0.0.0"):
+                _out.append(("ip", _h, _m.start()))
+            continue
+        if _scheme:
+            _out.append(("host", _h, _m.start()))  # explicit scheme = a real URL, any TLD
+            continue
+        _labels = _h.split(".")
+        if _labels[-1].lower() in _REAL_TLD and (len(_labels) >= 3 or any("-" in _l for _l in _labels)):
+            _out.append(("host", _h, _m.start()))
+    return _out
+_host_hits = []
+for _f in _runtime_surface:
+    _txt = open(_f, errors="ignore").read()
+    for _kind, _h, _pos in _host_leak_hits(_txt):
+        _host_hits.append(f"{_rel(_f)}:{_ln(_txt,_pos)}:{_kind}:{_h}")
+ok(_host_hits == [], f"NO non-allowlisted host/URL/IP across the skill runtime surface (hits={_host_hits})")
+# discriminating unit test for the host detector: convict + acquit. The convict host is
+# FABRICATED (acme placeholder) — no real infra host name ships in this file.
+ok(_host_leak_hits("url = svc-prod.up.acmepaas.app/mcp") and
+   _host_leak_hits("dsn = postgres://db.internal.acme.net:5432/x") and
+   _host_leak_hits("ws://10.11.12.13:9000"),
+   "host detector CONVICTS bare PaaS host + non-http scheme + IPv4")
+ok(not _host_leak_hits("subprocess.run(args) and args.org and os.path.join") and
+   not _host_leak_hits("see https://mcp.notion.com/mcp and your-mcp-server.example.com") and
+   not _host_leak_hits("files self.md config.json read.py"),
+   "host detector ACQUITS attr-access / allowlisted host / filenames")
+
+# --- GENERIC detector 2: hardcoded-chat-id-literal in a telegram/message send. ---
+def _chatid_leak_hits(_text):
+    """Flag a plausibly-real hardcoded numeric chat-id passed to a send-telegram/
+    send-message call. CONVICTS a bare >=7-digit id in send context. ACQUITS env/param
+    refs ($VAR, {param}, an orchestrator name) and obvious placeholders (>=4 trailing
+    zeros or a repdigit) — which disclose nothing. Needs NO author value to ship."""
+    _out = []
+    for _m in _reH.finditer(r"send-(?:telegram|message)\s+(-?[^\s'\"]+)", _text):
+        _arg = _m.group(1)
+        if not _arg.lstrip("-").isdigit():
+            continue
+        _d = _arg.lstrip("-")
+        if len(_d) < 7 or _d.endswith("0000") or len(set(_d)) == 1:
+            continue
+        _out.append((_arg, _m.start()))
+    return _out
+# scanned over _runtime_surface (defined above) — every shipped file except this test,
+# whose adversarial fixtures intentionally contain synthetic send-telegram calls.
+_chatid_hits = []
+for _f in _runtime_surface:
+    _txt = open(_f, errors="ignore").read()
+    for _arg, _pos in _chatid_leak_hits(_txt):
+        _chatid_hits.append(f"{_rel(_f)}:{_ln(_txt,_pos)}:chat-id:{_arg}")
+ok(_chatid_hits == [], f"NO hardcoded chat-id literal in send context across the skill runtime surface (hits={_chatid_hits})")
+# discriminating unit test: 5551234987 is a FABRICATED non-round id (NOT any real chat-id)
+ok(_chatid_leak_hits("cortextos bus send-telegram 5551234987 'x'"),
+   "chat-id detector CONVICTS a plausibly-real hardcoded id in send context")
+ok(not _chatid_leak_hits("send-telegram 1000000000 'hi'") and
+   not _chatid_leak_hits("send-telegram $CTX_TELEGRAM_CHAT_ID 'x'") and
+   not _chatid_leak_hits("send-message hub normal 'x'") and
+   not _chatid_leak_hits("fire_at 2026-06-20T09:00:00Z ran 1785437536491"),
+   "chat-id detector ACQUITS placeholder / env / param / non-send numerics")
+
+# --- AUTHOR-SPECIFIC leg: roster + specific chat-id from the EXTERNAL fixture only. ---
+# Shape: CTX_LEAKAGE_FIXTURE -> JSON {"roster": ["..."], "chat_ids": ["..."]}. Gitignored,
+# never shipped. Absent -> SKIP (default public path); present (our CI/local) -> full scan.
+_fix_path = os.environ.get("CTX_LEAKAGE_FIXTURE")
+if _fix_path and os.path.isfile(_fix_path):
+    _fx = _jsonH.load(open(_fix_path))
+    _author_ban = {}
+    for _n in (_fx.get("roster") or []):
+        _author_ban[f"roster:{_n}"] = _reH.compile(r"(?i)\b" + _reH.escape(str(_n)) + r"\b")
+    for _c in (_fx.get("chat_ids") or []):
+        _author_ban[f"chat-id:{_c}"] = _reH.compile(_reH.escape(str(_c)))
+    _author_hits = []
+    for _f in _scan:
+        _txt = open(_f, errors="ignore").read()
+        for _label, _rx in _author_ban.items():
+            for _m in _rx.finditer(_txt):
+                _author_hits.append(f"{_rel(_f)}:{_ln(_txt,_m.start())}:{_label}")
+    ok(_author_hits == [],
+       f"NO author-specific tokens (roster/chat-id from CTX_LEAKAGE_FIXTURE) in ANY shipped file (hits={_author_hits})")
+else:
+    print("  SKIP author-specific fixture scan: CTX_LEAKAGE_FIXTURE not set/found "
+          "(default public path — generic detectors above still enforce)")
+
+print(f"\n=== {P} passed, {F} failed ===")
+sys.exit(1 if F else 0)


### PR DESCRIPTION
## Summary

Adds the `claude-to-codex-migration` community skill: migrates ANY cortextOS agent from the `claude-code` runtime to the live `codex-app-server` runtime. Non-destructive and dry-run by default — takes a source agent name and produces a **separate** codex-shaped agent, never modifying the source except an explicit opt-in bot-cutover.

Covers every artifact type with an honest 1:1 / TRANSFORM / DROPPED / NEEDS-HUMAN decomposition: config runtime+model flip, `CLAUDE.md`->`AGENTS.md` fold, skills relayout + host symlinks, hooks disposition (3 in-turn Telegram behaviors re-homed to the bus approvals flow — never a blanket "hooks lost"), MCP `.mcp.json`->`config.toml`, crons (union + path-translate + James-reroute), sqlite integrity re-copy, boot-state continuity, and a `verify.py` outcome-assertion gate. Cardinal rule: never silently drop an artifact.

Ships `detect.py` / `convert.py` / `verify.py`, `references/`, and a test suite.

## Test Plan / does-it-run evidence (honest framing)

What is proven in this PR:
- **Unit suite: 65/0** — `tests/test_migration_bakes.py`, convict-AND-acquit with discriminating cases (dangling-symlink vs islink-only, torn-db repair + unrepairable hard-fail, MCP host-collision no-partial-write, cron segment-boundary, config/registry drift guard) and negative cases.
- **`verify.py` Tier-1 structural: ALL GREEN** on a fresh current-code conversion — runtime flipped to `codex-app-server`, model set, every custom-skill symlink RESOLVES (not merely exists), migrated `*.db` pass `integrity_check`, `.force-fresh` present, no stale `*thread.json`, crons migrated + path-translated + James-rerouted, routing+approval guardrails present, `plugins/docs` compat symlink resolves.
- **Two live production migrations**: `donna-codex` and `data-codex` were produced by this skill and run healthy in the fleet. (These were converted by an earlier revision of the scripts; they establish the end-to-end pattern boots+loops.)

Recommended reviewer verification (not claimed here):
- A **Tier-2 live boot probe of the current-code output** — enable a throwaway converted agent, confirm `[codex-app-server] ready thread=` + one loop/heartbeat in its own scoped log, then disable. Current-code structural output is green; a live boot of the exact current scripts is the recommended final check before merge.

Non-destructive by construction: dry-run is the default, the source is never touched without an explicit opt-in cutover flag, and `verify.py` is a hard outcome-assertion gate (a non-zero exit blocks "done").