### PR TITLE
chore: gitignore community catalog install targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,16 @@ node_modules/
 dist/
 ecosystem.config.js
 
+# Community catalog installs — local artifacts, not framework source.
+# `cortextos bus install-community-item <name>` copies
+# community/{agents,orgs}/<name> to templates/{personas,orgs}/<name>
+# (src/bus/catalog.ts:266-271). The source already lives under community/ and is
+# tracked, so committing the copy duplicates tracked content and lets the two
+# drift silently. Regenerate at any time with:
+#   cortextos bus install-community-item <name>
+templates/personas/
+templates/orgs/
+
 # User-created org data (not part of the framework)
 orgs/
 # But community subdirectories ARE part of the framework


### PR DESCRIPTION
Closes #850.

## Problem

`cortextos bus install-community-item <name>` copies `community/{agents,orgs}/<name>` into `templates/personas/<name>` or `templates/orgs/<name>` (`src/bus/catalog.ts:266-271`). Neither destination was gitignored, so installing any community agent or org template leaves the copy as untracked content in `git status`.

Since the install is a byte-for-byte copy of already-tracked content, committing it duplicates `community/agents/<name>/` and lets the two copies drift; not committing it leaves permanent untracked noise.

## Change

Ignore both install targets, with a comment pointing at the code that creates them and the command that regenerates them.

## Verification

Installed `agentic-crm-assistant`, then:

```
$ diff -rq community/agents/agentic-crm-assistant templates/personas/agentic-crm-assistant
(no output — identical)

$ git check-ignore -v templates/personas/agentic-crm-assistant/config.json
.gitignore:19:templates/personas/	templates/personas/agentic-crm-assistant/config.json

$ git check-ignore -v templates/personas/agentic-crm-assistant/.claude/settings.json
.gitignore:19:templates/personas/	templates/personas/agentic-crm-assistant/.claude/settings.json

$ git check-ignore -v templates/agent/.claude/settings.json
(no match — still tracked, as intended)

$ git status --short
 M .gitignore
```

The pre-existing `!templates/**/.claude/` negations are unaffected: git cannot re-include a path whose parent directory is excluded, so the install target is ignored in full while the shipped templates keep their `.claude/` contents tracked.

- `npm run build` — clean
- `npm test` — 1952 passed, 1 failed, 3 skipped. The single failure is `tests/unit/hooks/hooks.test.ts:154` (`isClaudeDirOperation`), which fails identically on an unmodified `main` at `a15baad` and is unrelated to this change (`.gitignore` only, no source touched).

🤖 Generated with [Claude Code](https://claude.com/claude-code)