### PR TITLE
fix: two fresh-clone correctness bugs (macOS .claude guard, pre-push gate report)

### DIFF
--- a/src/cli/init.ts
+++ b/src/cli/init.ts
@@ -222,8 +222,29 @@ export const initCommand = new Command('init')
         existsSync(join(projectRoot, '.git')) &&
         existsSync(join(projectRoot, 'scripts', 'setup-hooks.sh'))) {
       try {
-        execSync('bash scripts/setup-hooks.sh', { cwd: projectRoot, stdio: 'ignore' });
-        console.log('  Installed git pre-push hook (build + test gate)');
+        // Capture stdout rather than discarding it: setup-hooks.sh is
+        // non-clobbering and exits 0 whether it installed the hook, found it
+        // already installed, or LEFT AN EXISTING HOOK IN PLACE. Reporting
+        // "Installed" on exit code alone claimed a build+test gate was active
+        // when a pre-existing hook (e.g. a dotfiles pre-push) meant it was not
+        // — a false assurance about a security control, which is worse than
+        // saying nothing because it stops the operator from looking.
+        const out = execSync('bash scripts/setup-hooks.sh', {
+          cwd: projectRoot,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).toString();
+
+        if (/^\s*Skipped:/m.test(out)) {
+          const line = out.split('\n').find(l => /^\s*Skipped:/.test(l))?.trim();
+          console.log(`  ${line}`);
+          console.log('  WARNING: the build + test pre-push gate is NOT active in this clone.');
+          console.log('           Chain it from your own hook, or install it with:');
+          console.log('             bash scripts/setup-hooks.sh   (after moving your hook aside)');
+        } else if (/^\s*Already installed:/m.test(out)) {
+          console.log('  Git pre-push hook already installed (build + test gate)');
+        } else {
+          console.log('  Installed git pre-push hook (build + test gate)');
+        }
       } catch {
         console.log('  Skipped git pre-push hook install (run: bash scripts/setup-hooks.sh)');
       }

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -252,18 +252,35 @@ export function isClaudeDirOperation(
   // Canonicalize the agent dir first (resolves legitimate symlinks on the install
   // path, e.g. /tmp -> /private/tmp), so the .claude subtree below it is the only
   // thing left to vet.
-  const canonAgentDir = canonicalizePath(resolve(base));
+  const origBase = resolve(base);
+  const canonAgentDir = canonicalizePath(origBase);
   const claudeRoot = join(canonAgentDir, '.claude');
-  const target = resolve(canonAgentDir, filePath);
 
-  // Lexical containment within the agent's own .claude/.
+  // Canonicalize the TARGET the same way as the base before comparing. Without
+  // this, a symlink anywhere on the install path defeats the check: on macOS
+  // the agent dir canonicalizes to /private/var/... while an absolute
+  // file_path keeps its /var/... prefix, so containment failed for legitimate
+  // writes and every .claude operation fell through to the human gate.
+  const lexicalTarget = resolve(origBase, filePath);
+  const target = canonicalizePath(lexicalTarget);
+
+  // Containment within the agent's own .claude/.
   if (target !== claudeRoot && !target.startsWith(claudeRoot + sep)) return false;
 
   // Reject if any component at or below .claude is a symlink — live OR dangling.
   // A planted symlink could otherwise redirect an "inside .claude" write out of
   // the tree. We lstat each component because realpathSync can't observe a
-  // *dangling* symlink (it throws, and canonicalize would fall back to lexical).
-  return !hasSymlinkComponent(canonAgentDir, target);
+  // *dangling* symlink (it throws, and canonicalize would fall back to lexical),
+  // so the containment check above cannot catch that case on its own.
+  //
+  // Both arguments must come from the same (unresolved) namespace. The previous
+  // code mixed them — canonical root, lexical target — and hasSymlinkComponent
+  // bails out immediately when the target does not sit under the root. On any
+  // host where the install path contains a symlink (macOS: /var -> /private/var)
+  // that mismatch made this check unreachable. It was not exploitable, because
+  // the same mismatch also made the containment check above reject everything,
+  // but the guard was dead code rather than defense in depth.
+  return !hasSymlinkComponent(origBase, lexicalTarget);
 }
 
 /**


### PR DESCRIPTION
Closes #852 (items 1 and 2 — see the note on item 3 below).

Two independent fixes, one commit each. Rebased onto current `main`.

### 1. `fix(hooks)` — canonicalize the target before the `.claude` containment check

`isClaudeDirOperation()` canonicalized the agent dir but compared it against a lexically-resolved target. When the install path contains a symlink the two live in different namespaces and every comparison fails:

```
base            /var/folders/xy/T/hookperm-abc/agent
canonAgentDir   /private/var/folders/xy/T/hookperm-abc/agent   (realpath)
claudeRoot      /private/var/.../agent/.claude
file_path       /var/folders/.../agent/.claude/settings.json   (absolute)
target          /var/folders/.../agent/.claude/settings.json   (resolve() ignores
                                                                the base for an
                                                                absolute arg)
target.startsWith(claudeRoot + sep)  ->  false
```

That is every macOS host, where `/var` is a symlink to `/private/var`. Fail-closed, so not exploitable — legitimate `.claude` writes simply stopped being auto-approved and fell through to the human gate. The same mismatch also made the symlink-component walk unreachable (`hasSymlinkComponent()` returns early when the target is not under the root), so the dangling-symlink guard was dead code on macOS rather than defense in depth.

**This fixes an existing in-tree failure.** `tests/unit/hooks/hooks.test.ts:154` fails on macOS at `a15baad`; CI stays green because `/tmp` on Linux is a real directory, so base and target already agree.

No test changes were needed — the dangling-symlink and symlinked-ancestor cases are already pinned at `:196` and `:211`. Worth noting for reviewers that those two pass *both before and after*: with the bug, containment rejected everything, so a `false` expectation was satisfied for the wrong reason. The `:154` sanity assertion is the only one that distinguishes the states.

### 2. `fix(init)` — do not report a pre-push gate that was not installed

`init` ran `setup-hooks.sh` with `stdio: 'ignore'` and printed "Installed git pre-push hook" on exit code alone. The script is non-clobbering (#704) and exits 0 in all three outcomes — installed, already installed, and skipped-because-a-different-hook-exists — printing an accurate line for each, which `init` discarded. On any machine with a pre-existing hook it therefore claimed a build+test gate was active when it was not. Now it surfaces the script's own outcome and warns explicitly when the gate is absent.

### Note on the orchestrator `Stop` hook (item 3 of #852)

Dropped from this PR. #725 already adds the byte-identical `Stop` block to `templates/orchestrator/.claude/settings.json`, and it is the older PR with green CI — merging both would conflict. Item 3 of #852 is resolved by #725; no action needed here.

## Verification

```
$ npm run build
Build success

$ npm test
Test Files  116 passed | 1 skipped (117)
     Tests  1953 passed | 3 skipped (1956)
```

Green with no bypass. Before this branch the same command reported `1 failed | 1952 passed` — the macOS failure in (1).

Also confirmed against a live install: `cortextos init` now prints `Skipped: .git/hooks/pre-push already exists (leaving your hook in place)` plus a "gate is NOT active" warning on a machine with a pre-existing hook, where it previously claimed success.

🤖 Generated with [Claude Code](https://claude.com/claude-code)