### PR TITLE
fix(daemon): restart a dead-but-mapped agent instead of stranding it

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -19,6 +19,20 @@ import { stripBom } from '../utils/strip-bom.js';
 
 type LogFn = (msg: string) => void;
 
+// liveness fix: OS-level pid liveness probe using the same signal-0 idiom as
+// src/utils/lock.ts — signal 0 sends nothing, it only tests process existence +
+// our permission to signal it. We DELIBERATELY diverge from lock.ts on EPERM:
+// lock.ts treats every error as dead, but here a process owned by another user
+// (EPERM) is alive and must NOT be evicted — only ESRCH (process gone) is dead.
+function isPidAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
 /**
  * Manages all agents in a cortextOS instance.
  */
@@ -30,6 +44,11 @@ export class AgentManager {
   // Tracks agents that received a start request while still stopping.
   // stopAgent() honors these after cleanup completes so restart-all is race-free.
   private pendingRestarts: Set<string> = new Set();
+  // liveness fix: names currently being evicted+restarted. Claimed synchronously
+  // BEFORE the eviction's `await`, so a concurrent startAgent() for the same dead
+  // entry returns instead of double-spawning a PTY (same hazard class BUG-011's
+  // pendingRestarts guards for alive entries).
+  private evictingAgents: Set<string> = new Set();
   private instanceId: string;
   private ctxRoot: string;
   private frameworkRoot: string;
@@ -228,10 +247,32 @@ export class AgentManager {
    * restartAgent is unchanged — this read-only check exists purely to give
    * the IPC layer enough info to set IPCResponse.code. See issue #346.
    */
+  /**
+   * liveness fix: true liveness for a mapped agent — presence in this.agents is
+   * NOT proof of life. An entry is actually alive only if its AgentProcess
+   * reports a live status AND (for a running entry) its OS pid is actually alive.
+   * 'starting' is treated as alive with NO pid check: an in-flight start has not
+   * spawned a pid yet, and preempting it would break the BUG-011 in-flight-restart
+   * dedup. All other statuses (stopped/crashed/halted) — and 'running' with a
+   * dead/absent pid — are dead and eligible for eviction.
+   */
+  private isAgentActuallyAlive(name: string): boolean {
+    const entry = this.agents.get(name);
+    if (!entry) return false;
+    const { status, pid } = entry.process.getStatus();
+    if (status === 'starting') return true;   // in-flight start — never evict
+    if (status !== 'running') return false;   // stopped / crashed / halted => dead
+    return !!pid && isPidAlive(pid);           // running => must have a live pid
+  }
+
   inspectAgentOp(op: 'start' | 'stop' | 'restart', name: string): { ok: true } | { ok: false; code: 'DEDUPED' | 'NOT_FOUND'; message: string } {
     const inRegistry = this.agents.has(name);
     if (op === 'start') {
-      if (inRegistry) {
+      // liveness fix: only DEDUP a start against a genuinely-alive entry. A
+      // mapped-but-dead entry (halted/crashed/stopped, or a running entry whose
+      // pid is gone) must NOT report "already running" — startAgent will evict it
+      // and start fresh, so tell the caller the start is proceeding.
+      if (inRegistry && this.isAgentActuallyAlive(name)) {
         return { ok: false, code: 'DEDUPED', message: `start request for "${name}" deduped — agent already in registry (in-flight start or already running)` };
       }
       return { ok: true };
@@ -258,20 +299,57 @@ export class AgentManager {
       // the core stability test plan + cycle 2 of PR #13 both confirmed
       // this branch is dormant. Once we have weeks of zero-warning
       // production data, we can delete the queue mechanism entirely.
-      if (this.daemonJustCrashed) {
-        // Post-crash startup. The previous daemon exited via
-        // uncaughtException without running stopAll(), so the in-memory
-        // registry from the prior process is gone — but the post-crash
-        // discoverAndStart pass can briefly re-enter startAgent for an
-        // agent whose pendingRestarts entry survived. This is benign and
-        // distinct from the BUG-011 in-flight race PR #11 closed. Log at
-        // info level so operators don't think PR #11 has regressed.
-        console.log(`[agent-manager] ${name} already in registry (post-crash discovery overlap, expected). Queueing restart.`);
-      } else {
-        console.warn(`[agent-manager] BUG-011 REGRESSION CHECK: ${name} still in registry during startAgent — pendingRestarts queueing engaged. This should not happen with PR #11 in place.`);
+      if (this.isAgentActuallyAlive(name)) {
+        // ALIVE entry: preserve the existing BUG-011/031/040 dedup/queue behavior
+        // EXACTLY — this is the legitimate in-flight-restart race path.
+        if (this.daemonJustCrashed) {
+          // Post-crash startup. The previous daemon exited via
+          // uncaughtException without running stopAll(), so the in-memory
+          // registry from the prior process is gone — but the post-crash
+          // discoverAndStart pass can briefly re-enter startAgent for an
+          // agent whose pendingRestarts entry survived. This is benign and
+          // distinct from the BUG-011 in-flight race PR #11 closed. Log at
+          // info level so operators don't think PR #11 has regressed.
+          console.log(`[agent-manager] ${name} already in registry (post-crash discovery overlap, expected). Queueing restart.`);
+        } else {
+          console.warn(`[agent-manager] BUG-011 REGRESSION CHECK: ${name} still in registry during startAgent — pendingRestarts queueing engaged. This should not happen with PR #11 in place.`);
+        }
+        this.pendingRestarts.add(name);
+        return;
       }
-      this.pendingRestarts.add(name);
-      return;
+      // liveness fix: entry exists but is NOT actually alive (halted/crashed/
+      // stopped, or a running entry whose OS pid is gone). Evict the stale entry
+      // and fall through to a fresh start rather than stranding the agent.
+      if (this.evictingAgents.has(name)) {
+        // A concurrent startAgent is already evicting+restarting this dead entry.
+        // Return instead of spawning a second PTY — the in-flight eviction will
+        // bring the agent up. Mirrors the alive in-flight dedup above.
+        console.log(`[agent-manager] ${name} eviction already in flight — skipping duplicate start.`);
+        return;
+      }
+      // Claimed synchronously BEFORE the eviction's `await` so a second caller
+      // hits the guard above. The fresh-start path below has NO await before
+      // `this.agents.set(name, ...)`, so once we release the marker and fall
+      // through, the new entry is mapped before any caller can interleave.
+      this.evictingAgents.add(name);
+      try {
+        console.log(`[agent-manager] ${name} in registry but not actually alive — evicting stale entry and starting fresh.`);
+        const stale = this.agents.get(name)!;
+        try { stale.poller?.stop(); } catch { /* best-effort */ }
+        try { stale.activityPoller?.stop(); } catch { /* best-effort */ }
+        try { stale.checker.stop(); } catch { /* best-effort */ }
+        // process.stop() sets status='stopped', which neutralizes any pending
+        // crash-backoff setTimeout on the old AgentProcess (its `if (status ===
+        // 'crashed')` guard now fails), so no orphan PTY is spawned after eviction.
+        try { await stale.process.stop(); } catch { /* best-effort */ }
+        this.agents.delete(name);
+        this.pendingRestarts.delete(name);
+        const staleScheduler = this.cronSchedulers.get(name);
+        if (staleScheduler) { staleScheduler.stop(); this.cronSchedulers.delete(name); }
+      } finally {
+        this.evictingAgents.delete(name);
+      }
+      // fall through synchronously to the fresh-start path below
     }
 
     // BUG-043 fix: resolve the agent's true org instead of using `this.org`.
@@ -943,7 +1021,14 @@ export class AgentManager {
   getAllStatuses(): AgentStatus[] {
     const statuses: AgentStatus[] = [];
     for (const [, entry] of this.agents) {
-      statuses.push(entry.process.getStatus());
+      const status = entry.process.getStatus();
+      // liveness fix: a mapped entry still reporting 'running' whose OS pid is
+      // gone is dead, not running. getStatus() returns a fresh object, so
+      // correcting .status here does not mutate AgentProcess internal state.
+      if (status.status === 'running' && (!status.pid || !isPidAlive(status.pid))) {
+        status.status = 'stopped';
+      }
+      statuses.push(status);
     }
     return statuses;
   }

--- a/tests/unit/daemon/agent-manager-inspect-op.test.ts
+++ b/tests/unit/daemon/agent-manager-inspect-op.test.ts
@@ -49,7 +49,12 @@ describe('AgentManager.inspectAgentOp — issue #346 (DEDUPED vs NOT_FOUND)', ()
     // Simulate an in-flight start by injecting an entry into the private map.
     // This is the exact precondition that triggers the BUG-011 dedup branch
     // in startAgent — we need to confirm it surfaces as DEDUPED, not NOT_FOUND.
-    (am as unknown as { agents: Map<string, unknown> }).agents.set('alice', { /* sentinel */ } as unknown);
+    // liveness fix: DEDUP now requires a genuinely-alive entry, so the fixture
+    // reports a running status with a live pid (the test process's own pid,
+    // which process.kill(pid, 0) can always signal — no spy needed).
+    (am as unknown as { agents: Map<string, unknown> }).agents.set('alice', {
+      process: { getStatus: () => ({ name: 'alice', status: 'running', pid: process.pid }) },
+    } as unknown);
 
     const r = am.inspectAgentOp('start', 'alice');
     expect(r.ok).toBe(false);

--- a/tests/unit/daemon/agent-manager-liveness.test.ts
+++ b/tests/unit/daemon/agent-manager-liveness.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// liveness fix: mirror the mock harness of agent-manager-inspect-op.test.ts so
+// AgentManager can be constructed without spawning anything real. These tests
+// exercise the true-liveness distinction: presence in the agents Map is NOT
+// proof of life. We control what getStatus() reports for injected fakes and
+// spy on process.kill to simulate OS-level pid liveness (NEVER a real pid).
+vi.mock('../../../src/daemon/agent-process.js', () => ({
+  AgentProcess: class {
+    name: string;
+    dir: string;
+    constructor(name: string, dir: string) { this.name = name; this.dir = dir; }
+    async start() { /* no-op */ }
+    async stop() { /* no-op */ }
+    getStatus() { return { name: this.name, status: 'stopped' }; }
+    onExit() { /* no-op */ }
+  },
+}));
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class { start() {} stop() {} wake() {} },
+}));
+vi.mock('../../../src/telegram/api.js', () => ({ TelegramAPI: class { constructor() {} } }));
+vi.mock('../../../src/telegram/poller.js', () => ({ TelegramPoller: class { start() {} stop() {} } }));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+
+type AgentsMap = Map<string, unknown>;
+const agentsOf = (am: unknown) => (am as { agents: AgentsMap }).agents;
+const pendingOf = (am: unknown) => (am as { pendingRestarts: Set<string> }).pendingRestarts;
+
+// pids used only inside the process.kill spy — never signalled for real.
+const LIVE_PID = 1234;
+const DEAD_PID = 4321;
+
+function spyKill() {
+  return vi.spyOn(process, 'kill').mockImplementation(((pid: number) => {
+    if (pid === DEAD_PID) {
+      const err = new Error('kill ESRCH') as NodeJS.ErrnoException;
+      err.code = 'ESRCH';
+      throw err;
+    }
+    return true;
+  }) as typeof process.kill);
+}
+
+describe('AgentManager liveness — inspectAgentOp(start) distinguishes map-membership from real liveness', () => {
+  let testDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof spyKill>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-liveness-test-'));
+    mkdirSync(join(testDir, 'framework'), { recursive: true });
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = spyKill();
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('mapped-but-halted entry: start proceeds (ok true, NOT DEDUPED)', () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'halted' }) } });
+    const r = am.inspectAgentOp('start', 'alice');
+    expect(r.ok).toBe(true);
+  });
+
+  it('mapped-but-stopped entry: start proceeds (ok true)', () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'stopped' }) } });
+    const r = am.inspectAgentOp('start', 'alice');
+    expect(r.ok).toBe(true);
+  });
+
+  it('running entry with a DEAD pid: start proceeds (ok true)', () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'running', pid: DEAD_PID }) } });
+    const r = am.inspectAgentOp('start', 'alice');
+    expect(r.ok).toBe(true);
+  });
+
+  it('genuinely-running entry with a LIVE pid: DEDUPED (preservation guard)', () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'running', pid: LIVE_PID }) } });
+    const r = am.inspectAgentOp('start', 'alice');
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.code).toBe('DEDUPED');
+      expect(r.message).toContain('alice');
+    }
+  });
+
+  it("'starting' in-flight entry with no pid: DEDUPED (guards BUG-011 special-case)", () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'starting' }) } });
+    const r = am.inspectAgentOp('start', 'alice');
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.code).toBe('DEDUPED');
+  });
+
+  it('inspectAgentOp(start) does not mutate the agents map', () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'halted' }) } });
+    const before = agentsOf(am).size;
+    am.inspectAgentOp('start', 'alice');
+    expect(agentsOf(am).size).toBe(before);
+  });
+});
+
+describe('AgentManager liveness — startAgent evicts a dead entry but preserves a live one', () => {
+  let testDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof spyKill>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-liveness-start-test-'));
+    // Deliberately do NOT create orgs/acme/agents/alice — startAgent will evict
+    // the stale entry, then bail at the "Agent directory not found" early return
+    // (agentDir passed empty). This exercises eviction without the spawn tail.
+    mkdirSync(join(testDir, 'framework'), { recursive: true });
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = spyKill();
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('dead entry (halted): evicts — stop called, unmapped, not queued', async () => {
+    const processStop = vi.fn(async () => {});
+    const checkerStop = vi.fn();
+    const stale = {
+      process: { getStatus: () => ({ name: 'alice', status: 'halted' }), stop: processStop },
+      checker: { stop: checkerStop },
+    };
+    agentsOf(am).set('alice', stale);
+
+    await am.startAgent('alice', '');
+
+    expect(processStop).toHaveBeenCalled();
+    expect(checkerStop).toHaveBeenCalled();
+    expect(pendingOf(am).has('alice')).toBe(false);
+    expect(agentsOf(am).has('alice')).toBe(false);
+  });
+
+  it('genuinely-alive entry (running, live pid): preserved — queued, not stopped', async () => {
+    const processStop = vi.fn(async () => {});
+    const checkerStop = vi.fn();
+    const alive = {
+      process: { getStatus: () => ({ name: 'alice', status: 'running', pid: LIVE_PID }), stop: processStop },
+      checker: { stop: checkerStop },
+    };
+    agentsOf(am).set('alice', alive);
+
+    await am.startAgent('alice', '');
+
+    expect(pendingOf(am).has('alice')).toBe(true);
+    expect(processStop).not.toHaveBeenCalled();
+    expect(agentsOf(am).has('alice')).toBe(true);
+  });
+
+  it('concurrent starts on a dead entry evict once (evictingAgents guard, no double-spawn)', async () => {
+    // Deterministic race: stop() is deferred so the first startAgent parks
+    // mid-eviction (marker held) while the second must hit the guard and return.
+    // Without the guard both callers fall through and stop() is called twice.
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((r) => { resolveStop = r; });
+    const stopSpy = vi.fn(() => stopPromise);
+    const dead = {
+      process: { getStatus: () => ({ name: 'alice', status: 'halted' }), stop: stopSpy },
+      checker: { stop: vi.fn() },
+    };
+    agentsOf(am).set('alice', dead);
+
+    const p1 = am.startAgent('alice', '');   // enters eviction, parks on stopSpy
+    const p2 = am.startAgent('alice', '');    // must hit the guard and return
+    await p2;
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);            // discriminates: 2 without guard
+    expect((am as unknown as { evictingAgents: Set<string> }).evictingAgents.has('alice')).toBe(true);
+
+    resolveStop();
+    await p1;
+
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+    expect((am as unknown as { evictingAgents: Set<string> }).evictingAgents.has('alice')).toBe(false);
+  });
+});
+
+describe('AgentManager liveness — getAllStatuses corrects a running-but-dead entry', () => {
+  let testDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof spyKill>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-liveness-status-test-'));
+    mkdirSync(join(testDir, 'framework'), { recursive: true });
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = spyKill();
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('running entry with a dead pid is reported as stopped', () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'running', pid: DEAD_PID }) } });
+    const statuses = am.getAllStatuses();
+    expect(statuses[0].status).toBe('stopped');
+  });
+
+  it('running entry with a live pid stays running', () => {
+    agentsOf(am).set('alice', { process: { getStatus: () => ({ name: 'alice', status: 'running', pid: LIVE_PID }) } });
+    const statuses = am.getAllStatuses();
+    expect(statuses[0].status).toBe('running');
+  });
+});


### PR DESCRIPTION
## Summary

The daemon's `AgentManager` treated presence in its in-memory `this.agents` Map as proof that an agent is alive. When an agent's PTY dies out-of-band — crash-halted after exceeding the crash limit, or a PTY that exited without the map entry being cleared — the stale entry persists and:

- `inspectAgentOp('start', name)` returns `DEDUPED` (the map has it), so the user is told the agent is "already running" when it is actually dead.
- `startAgent(name, …)` sees `this.agents.has(name)`, queues a `pendingRestart`, and returns **without starting** — the dead agent is stranded stopped and `start`/`restart` silently no-op.
- `status` misreports the dead-but-mapped agent as running.

This fix distinguishes map membership from **real liveness** — the `AgentProcess` status plus an OS-level pid probe (`process.kill(pid, 0)`) — and acts on it:

- **`inspectAgentOp`** only `DEDUP`s a start against a genuinely-alive entry.
- **`startAgent`** evicts a dead entry and starts fresh instead of queueing a `pendingRestart`. A synchronous `evictingAgents` guard — claimed before the eviction `await` and released in `finally` — prevents concurrent same-name starts from double-spawning a PTY during the await window.
- **`getAllStatuses`** reports a `running` entry whose pid is gone as `stopped`.

The `starting` state is treated as alive with **no** pid check, so the existing BUG-011 in-flight-restart dedup is preserved; the alive path (including the `daemonJustCrashed` branch) is byte-for-byte unchanged. Only the dead-entry case is new.

Inspired by community reports #757 (staleness detector) and #620 (pid-alive spawn verification); this PR implements the focused liveness fix rather than merging their broader changes.

## Test Plan

New `tests/unit/daemon/agent-manager-liveness.test.ts` (11 tests) — each discriminating test fails against the pre-fix code:

- `inspectAgentOp('start')`: mapped-but-halted / -stopped / running-with-dead-pid → returns `ok` (not `DEDUPED`); genuinely-running (live pid) and `starting` (in-flight) → still `DEDUPED`; does not mutate the agents map.
- `startAgent`: a dead entry is evicted (`process.stop`/`checker.stop` called, entry unmapped, no `pendingRestart` queued) and a fresh start proceeds; a genuinely-alive entry still queues a `pendingRestart` and is not evicted.
- Concurrent same-name starts on a dead entry evict exactly once (the `evictingAgents` guard) — verified to fail (deadlock) when the guard is neutralized.
- `getAllStatuses`: a `running` entry with a dead pid is reported `stopped`; with a live pid stays `running`.

Verification:

- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/daemon/agent-manager-liveness.test.ts tests/unit/daemon/agent-manager-inspect-op.test.ts` — 25 passed.

(The one change to `agent-manager-inspect-op.test.ts` updates a fixture whose bare sentinel encoded the old map-membership-only contract; it now provides a live-pid process so the original `DEDUPED` intent holds under the new liveness semantics.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
