### PR TITLE
fix(pty): surface a wedged first-run prompt and validate working_directory

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -94,14 +94,19 @@ function displayStatuses(statuses: AgentStatus[]): void {
   console.log(header);
   console.log(separator);
 
+  let anyAwaiting = false;
   for (const s of statuses) {
     const name = s.name.padEnd(18);
-    const status = s.status.padEnd(12);
+    let label: string = s.status;
+    if (s.awaitingConfirmation) { label = 'unhealthy*'; anyAwaiting = true; }
+    const status = label.padEnd(12);
     const pid = (s.pid?.toString() || '-').padEnd(10);
     const uptime = s.uptime ? formatUptime(s.uptime).padEnd(12) : '-'.padEnd(12);
     const model = s.model || '-';
     console.log(`  ${name}${status}${pid}${uptime}${model}`);
   }
+
+  if (anyAwaiting) console.log('  * awaiting interactive confirmation (first-run prompt not accepted)\n');
 
   console.log('');
 }

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -382,6 +382,10 @@ export class AgentProcess {
       sessionStart: this.sessionStart?.toISOString(),
       crashCount: this.crashCount,
       model: this.config.model,
+      awaitingConfirmation:
+        this.pty && 'isAwaitingInteractiveConfirmation' in this.pty
+          ? this.pty.isAwaitingInteractiveConfirmation()
+          : false,
     };
   }
 

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -32,6 +32,9 @@ type SpawnFn = (file: string, args: string[], options: IPtySpawnOptions) => IPty
 export class AgentPTY {
   private pty: IPty | null = null;
   private _alive = false;
+  // first-run observability fix: set at the auto-accept backstop when the PTY is
+  // still parked on a first-run prompt and never bootstrapped (a wedge).
+  private _awaitingInteractiveConfirmation = false;
   private outputBuffer: OutputBuffer;
   protected env: CtxEnv;
   protected config: AgentConfig;
@@ -61,7 +64,22 @@ export class AgentPTY {
       this.spawnFn = nodePty.spawn;
     }
 
-    const cwd = this.config.working_directory || this.env.agentDir || process.cwd();
+    const configuredCwd = this.config.working_directory;
+    // first-run observability fix: validate an explicitly-set working_directory so a
+    // typo'd/nonexistent/whitespace path fails loudly HERE instead of making node-pty
+    // error cryptically (or silently running in the wrong dir). The empty string is the
+    // framework's "unset" sentinel (import-agent.ts writes working_directory: '') so it
+    // still falls through to agentDir — only a non-empty value is validated.
+    if (configuredCwd !== undefined && configuredCwd !== '') {
+      const trimmed = configuredCwd.trim();
+      if (trimmed === '') {
+        throw new Error(`[agent-pty] ${this.env.agentName}: working_directory is whitespace-only; set a valid path or remove it`);
+      }
+      if (!existsSync(trimmed)) {
+        throw new Error(`[agent-pty] ${this.env.agentName}: working_directory does not exist: ${trimmed}`);
+      }
+    }
+    const cwd = (configuredCwd && configuredCwd.trim()) || this.env.agentDir || process.cwd();
 
     // Build environment variables for the PTY process
     const ptyEnv: Record<string, string> = {
@@ -186,9 +204,13 @@ export class AgentPTY {
     let bypassHandled = false;
     const promptPoll = setInterval(() => {
       if (!this.pty) { clearInterval(promptPoll); return; }
+      // first-run observability fix: stop BEFORE evaluating any prompt branch — once the
+      // real session is up, never write a stray keystroke (Down/CR/Enter) into it.
+      if (this.outputBuffer.isBootstrapped()) { clearInterval(promptPoll); return; }
       const recent = this.outputBuffer.getRecent().replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
-      const showingBypass = recent.includes('Bypass') && recent.includes('accept');
-      const showingTrust = recent.includes('trust') && recent.includes('folder');
+      const kind = this.detectFirstRunPrompt(recent);
+      const showingBypass = kind === 'bypass';
+      const showingTrust = kind === 'trust';
       if (showingBypass && !bypassHandled) {
         // Bypass screen: default selection is "1. No, exit". Move DOWN to
         // "2. Yes, I accept", then confirm. Bare Enter here would quit the agent.
@@ -211,12 +233,28 @@ export class AgentPTY {
         this.pty.write('\r');     // trust screen default is "Yes, I trust"
         return;
       }
-      // No first-run prompt pending and the real session is up -> stop polling so we
-      // never write a stray keystroke into the live agent session.
-      if (this.outputBuffer.isBootstrapped()) { clearInterval(promptPoll); return; }
     }, 1200);
-    // Unconditional backstop: never let the poll outlive first-run.
-    setTimeout(() => clearInterval(promptPoll), 20000);
+    // first-run observability fix: broaden window (20s -> 45s) so a late second screen
+    // still auto-accepts, and at the backstop surface a wedge instead of a false 'running'.
+    setTimeout(() => {
+      clearInterval(promptPoll);
+      if (this.pty && !this.outputBuffer.isBootstrapped()) {
+        const recent = this.outputBuffer.getRecent().replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '');
+        if (this.detectFirstRunPrompt(recent) !== null) {
+          this._awaitingInteractiveConfirmation = true;
+          console.warn(`[agent-pty] ${this.env.agentName}: awaiting interactive confirmation — first-run prompt still showing at backstop, not bootstrapped`);
+        }
+      }
+    }, 45000);
+  }
+
+  // first-run observability fix: co-occurring, prompt-specific tokens only — never a
+  // single word — so live agent output can't trigger a keystroke. Broadened (B) to
+  // catch case + folder/directory variants of the same two first-run screens.
+  private detectFirstRunPrompt(recent: string): 'bypass' | 'trust' | null {
+    if ((recent.includes('Bypass') || recent.includes('bypass')) && recent.includes('accept')) return 'bypass';
+    if (recent.includes('trust') && (recent.includes('folder') || recent.includes('directory'))) return 'trust';
+    return null;
   }
 
   /**
@@ -380,6 +418,12 @@ export class AgentPTY {
    */
   getOutputBuffer(): OutputBuffer {
     return this.outputBuffer;
+  }
+
+  // first-run observability fix: true only while genuinely wedged — AND-gated with
+  // !isBootstrapped so a late recovery auto-reports healthy without extra clearing.
+  isAwaitingInteractiveConfirmation(): boolean {
+    return this._awaitingInteractiveConfirmation && !this.outputBuffer.isBootstrapped();
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -808,4 +808,6 @@ export interface AgentStatus {
   sessionStart?: string;
   crashCount?: number;
   model?: string;
+  awaitingConfirmation?: boolean; // first-run observability fix: PTY parked on an
+  // interactive first-run prompt past the auto-accept backstop (wedged, not bootstrapped)
 }

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -9,6 +9,7 @@ const mockPty = {
   write: vi.fn(),
   getPid: vi.fn().mockReturnValue(12345),
   isAlive: vi.fn().mockReturnValue(true),
+  isAwaitingInteractiveConfirmation: vi.fn().mockReturnValue(false),
   onExit: vi.fn().mockImplementation((cb: (exitCode: number, signal?: number) => void) => {
     capturedOnExit = cb;
   }),
@@ -98,6 +99,8 @@ beforeEach(() => {
   mockPty.write.mockClear();
   mockPty.isAlive.mockClear();
   mockPty.isAlive.mockReturnValue(true);
+  mockPty.isAwaitingInteractiveConfirmation.mockClear();
+  mockPty.isAwaitingInteractiveConfirmation.mockReturnValue(false);
   mockPty.onExit.mockClear();
   mockInjectMessage.mockClear();
   fsMocks.existsSync.mockReset().mockReturnValue(false);
@@ -464,5 +467,22 @@ describe('AgentProcess - onboarding marker (do not auto-write .onboarded on hear
     const prompt = mockPty.spawn.mock.calls[0]?.[1] ?? '';
     expect(prompt).not.toContain('FIRST BOOT');
     expect(prompt).not.toContain('complete the onboarding protocol');
+  });
+});
+
+describe('AgentProcess - first-run observability (awaitingConfirmation)', () => {
+  it('surfaces awaitingConfirmation when the PTY reports a first-run wedge', async () => {
+    mockPty.isAwaitingInteractiveConfirmation.mockReturnValue(true);
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    expect(ap.getStatus().awaitingConfirmation).toBe(true);
+  });
+
+  it('reports awaitingConfirmation falsy for a normal running agent', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    expect(ap.getStatus().awaitingConfirmation).toBeFalsy();
   });
 });

--- a/tests/unit/pty/agent-pty.test.ts
+++ b/tests/unit/pty/agent-pty.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 // node-pty is native; stub it so constructing AgentPTY never touches it.
 vi.mock('node-pty', () => ({ spawn: vi.fn() }));
@@ -58,5 +58,121 @@ describe('AgentPTY --dangerously-skip-permissions toggle', () => {
     } finally {
       warn.mockRestore();
     }
+  });
+});
+
+// A stub node-pty handle injected via spawnFn so spawn() never touches the native addon.
+const mockPty = { pid: 7, write: vi.fn(), onData: vi.fn(), onExit: vi.fn(), kill: vi.fn(), resize: vi.fn() };
+
+function newPty(config: any) {
+  const pty = new AgentPTY(mockEnv, config);
+  (pty as any).spawnFn = () => mockPty;
+  return pty;
+}
+
+describe('AgentPTY working_directory validation', () => {
+  beforeEach(() => { vi.useFakeTimers(); mockPty.write.mockClear(); });
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  it('rejects a whitespace-only working_directory', async () => {
+    await expect(newPty({ working_directory: '   ' }).spawn('fresh', 'P'))
+      .rejects.toThrow(/whitespace-only/);
+  });
+
+  it('rejects a nonexistent working_directory (existsSync=false)', async () => {
+    await expect(newPty({ working_directory: '/no/such/dir' }).spawn('fresh', 'P'))
+      .rejects.toThrow(/does not exist/);
+  });
+
+  it('does NOT validate an unset working_directory (falls through to agentDir)', async () => {
+    const pty = newPty({});
+    await expect(pty.spawn('fresh', 'P')).resolves.toBeUndefined();
+    pty.kill();
+  });
+
+  it('does NOT reject the empty-string "unset" sentinel', async () => {
+    const pty = newPty({ working_directory: '' });
+    await expect(pty.spawn('fresh', 'P')).resolves.toBeUndefined();
+    pty.kill();
+  });
+});
+
+describe('AgentPTY first-run wedge detection (awaiting interactive confirmation)', () => {
+  beforeEach(() => { vi.useFakeTimers(); mockPty.write.mockClear(); });
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  it('flags awaiting when a bypass prompt is still showing at the backstop and not bootstrapped', async () => {
+    const pty = newPty({});
+    await pty.spawn('fresh', 'P');
+    // Capital-P "Permissions" is NOT the lowercase "permissions" bootstrap token.
+    pty.getOutputBuffer().push('2. Yes, I accept - Bypass Permissions mode');
+    await vi.advanceTimersByTimeAsync(46000);
+    expect(pty.isAwaitingInteractiveConfirmation()).toBe(true);
+  });
+
+  it('never flags once the session has bootstrapped', async () => {
+    const pty = newPty({});
+    await pty.spawn('fresh', 'P');
+    pty.getOutputBuffer().push('accept edits · permissions');
+    await vi.advanceTimersByTimeAsync(46000);
+    expect(pty.isAwaitingInteractiveConfirmation()).toBe(false);
+  });
+
+  it('clears the wedge flag on late recovery (bootstrap after the backstop)', async () => {
+    const pty = newPty({});
+    await pty.spawn('fresh', 'P');
+    pty.getOutputBuffer().push('2. Yes, I accept - Bypass Permissions mode');
+    await vi.advanceTimersByTimeAsync(46000);
+    expect(pty.isAwaitingInteractiveConfirmation()).toBe(true);
+    pty.getOutputBuffer().push('permissions');
+    expect(pty.isAwaitingInteractiveConfirmation()).toBe(false);
+  });
+});
+
+describe('AgentPTY broadened auto-accept token match (rec B)', () => {
+  beforeEach(() => { vi.useFakeTimers(); mockPty.write.mockClear(); });
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  it('injects Enter for a "directory" trust-prompt variant', async () => {
+    const pty = newPty({});
+    await pty.spawn('fresh', 'P');
+    pty.getOutputBuffer().push('Do you trust the files in this directory?');
+    await vi.advanceTimersByTimeAsync(1300);
+    expect(mockPty.write).toHaveBeenCalledWith('\r');
+  });
+
+  it('injects Down+Enter for a lowercase "bypass" prompt variant', async () => {
+    // Fixture avoids the lowercase "permissions" bootstrap token so the poll's
+    // top-of-tick bootstrap self-stop does not fire before the bypass branch.
+    const pty = newPty({});
+    await pty.spawn('fresh', 'P');
+    pty.getOutputBuffer().push('bypass mode ... 2. Yes, I accept');
+    await vi.advanceTimersByTimeAsync(1700);
+    expect(mockPty.write).toHaveBeenCalledWith('\x1b[B');
+  });
+
+  it('does NOT inject on benign single-token output', async () => {
+    const pty = newPty({});
+    await pty.spawn('fresh', 'P');
+    pty.getOutputBuffer().push('please accept the changes and open the directory');
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockPty.write).not.toHaveBeenCalled();
+  });
+});
+
+describe('AgentPTY structural no-keystroke-into-live-session invariant', () => {
+  beforeEach(() => { vi.useFakeTimers(); mockPty.write.mockClear(); });
+  afterEach(() => { vi.clearAllTimers(); vi.useRealTimers(); });
+
+  it('writes NO keystroke once bootstrapped even if prompt tokens linger in the buffer', async () => {
+    // The real session is up ("permissions" status bar) but the recent buffer
+    // still carries first-run prompt tokens. The poll must self-stop at the top
+    // of the tick BEFORE any bypass/trust branch, so no stray Down/Enter leaks
+    // into the live session. Fails against the old ordering (branches first).
+    const pty = newPty({});
+    await pty.spawn('fresh', 'P');
+    pty.getOutputBuffer().push('Bypass Permissions ... 2. Yes, I accept · permissions');
+    await vi.advanceTimersByTimeAsync(2000);
+    expect(mockPty.write).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/pty/opencode-pty.test.ts
+++ b/tests/unit/pty/opencode-pty.test.ts
@@ -191,6 +191,9 @@ describe('OpencodePTY', () => {
   });
 
   it('keeps OPENCODE_CONFIG_DIR under the agent directory even when working_directory differs', async () => {
+    // AgentPTY now validates a non-empty working_directory via super.spawn's
+    // existsSync check, so the configured path must resolve as present.
+    fsMocks.existsSync.mockImplementation((p: string) => p === '/tmp/project-checkout');
     const pty = new OpencodePTY(mockEnv, { working_directory: '/tmp/project-checkout' });
     installSpawnMock(pty);
     await pty.spawn('fresh', 'boot');


### PR DESCRIPTION
## Summary

The daemon auto-accepts Claude Code's first-run trust/bypass screens (merged in a15baad4). But if the PTY parks on a prompt the matcher misses — or one rendering after the backstop — the agent sits wedged while `status` still reports it `running`. The wedge is invisible. An invalid `working_directory` also spawned silently or failed cryptically. This PR is the observability + robustness half (the auto-accept keystroke logic is unchanged).

- **Wedge observability**: at the auto-accept backstop, if the PTY is still parked on a first-run prompt and never bootstrapped, set an "awaiting interactive confirmation" flag and log a warning. `AgentProcess.getStatus()` surfaces it as a new optional `AgentStatus.awaitingConfirmation`, and `cortextos status` renders it as `unhealthy*` with a footnote. The getter is AND-gated with `!isBootstrapped()`, so a late recovery auto-reports healthy.
- **working_directory validation**: validate at spawn — throw a clear error on a whitespace-only or nonexistent path. The empty string is the framework's "unset" sentinel (`import-agent` writes `working_directory: ''`) and still falls through to `agentDir`, so imported agents are unaffected. Covers `AgentPTY`-derived runtimes (claude/hermes/opencode); codex-app-server has no first-run TUI and is out of scope.
- **Broadened auto-accept (B)**: match `Bypass`/`bypass` + `accept` and `trust` + `folder`/`directory` via a shared detector — still co-occurring tokens only, so live output can never trigger a stray keystroke — and extend the backstop 20s → 45s for slow first-runs.
- **Structural safety invariant**: the poll now stops the instant the session bootstraps, before evaluating any prompt branch, so no keystroke of any kind can ever reach a live session (converted from an ordering-dependent property into a structural guarantee).

Inspired by community report #623 (restart-into-wedge detection).

## Test Plan

New/extended unit tests (each behavioral claim discriminates against the pre-fix code):

- `working_directory`: rejects whitespace-only and nonexistent; does not validate the unset case; does not reject the `''` sentinel (protects imported agents).
- Wedge detection: a first-run prompt still showing at the backstop with no bootstrap sets the flag and surfaces via `getStatus`; never flags a bootstrapped agent; clears on late recovery.
- Broadened tokens: injects for `directory`/lowercase-`bypass` variants; does not inject on benign single-token output.
- Structural invariant: a bootstrapped buffer with lingering prompt tokens produces NO keystroke (proven to fail on the old ordering).

Verification:

- `npx tsc --noEmit` — clean.
- `npx vitest run tests/unit/pty tests/unit/daemon/agent-process.test.ts` — 158 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
