### PR TITLE
fix(cli): label unset agent model as "default" in status output

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -79,7 +79,7 @@ export const statusCommand = new Command('status')
     }
   });
 
-function displayStatuses(statuses: AgentStatus[]): void {
+export function displayStatuses(statuses: AgentStatus[]): void {
   if (statuses.length === 0) {
     console.log('No agents running.');
     console.log('Add one with: cortextos add-agent <name>');
@@ -99,7 +99,7 @@ function displayStatuses(statuses: AgentStatus[]): void {
     const status = s.status.padEnd(12);
     const pid = (s.pid?.toString() || '-').padEnd(10);
     const uptime = s.uptime ? formatUptime(s.uptime).padEnd(12) : '-'.padEnd(12);
-    const model = s.model || '-';
+    const model = s.model || 'default';
     console.log(`  ${name}${status}${pid}${uptime}${model}`);
   }
 

--- a/tests/unit/cli/status-model-default.test.ts
+++ b/tests/unit/cli/status-model-default.test.ts
@@ -1,0 +1,42 @@
+/**
+ * Unit coverage for the Model column in `cortextos status` output.
+ *
+ * When an agent has no explicit model override (AgentStatus.model unset),
+ * the table must render a clear "default" label rather than a bare "-",
+ * which is ambiguous with the pid/uptime "absent" fallbacks. An agent WITH
+ * an explicit model must still render that model string verbatim.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { displayStatuses } from '../../../src/cli/status';
+import type { AgentStatus } from '../../../src/types/index';
+
+function captureOutput(statuses: AgentStatus[]): string {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  displayStatuses(statuses);
+  const output = spy.mock.calls.map(c => c.join(' ')).join('\n');
+  spy.mockRestore();
+  return output;
+}
+
+describe('cortextos status: Model column', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders "default" when an agent has no explicit model', () => {
+    const output = captureOutput([
+      { name: 'alice', status: 'running', pid: 123, uptime: 42 },
+    ]);
+    // The row must render "default", not fall back to the ambiguous bare "-".
+    expect(output).toContain('default');
+    expect(output).not.toMatch(/running\s+123\s+42s\s+-\s*$/m);
+  });
+
+  it('renders an explicit model verbatim', () => {
+    const output = captureOutput([
+      { name: 'alice', status: 'running', pid: 123, uptime: 42, model: 'claude-opus-4-8' },
+    ]);
+    expect(output).toContain('claude-opus-4-8');
+    expect(output).not.toContain('default');
+  });
+});


### PR DESCRIPTION
## Summary

In `cortextos status`, the "Model" column rendered a bare `-` for any agent with no explicit model override. That marker is identical to the pid/uptime absent-markers, so it reads as "missing/unknown" when the real meaning is "this agent runs the inherited system default model." This relabels that case to `default`.

- `src/cli/status.ts` — the model fallback is now `default` instead of `-`. The `-` markers for pid and uptime (which genuinely mean "absent") are untouched, as is the "Model" header.
- The label matches the terminology already used for the `--model` option ("defaults to org default"), rather than inventing a new term.
- `displayStatuses` is exported so the render logic is unit-testable (its only prior entry point was the IPC-gated command action).

## Test Plan

- New `tests/unit/cli/status-model-default.test.ts` (vitest, `console.log` spy):
  1. an agent with no `model` renders `default`;
  2. an agent with an explicit model renders it verbatim and does not leak `default`.
- `npx tsc --noEmit` clean.
- `npx vitest run tests/unit/cli/status-model-default.test.ts` → 2/2 pass.
- The test is a genuine discriminator: reverting the fallback to `-` makes it fail.
