### PR TITLE
fix(cron-state): cronExpressionMinIntervalMs honors day-of-month/day-of-week (monthly=28d, weekly=7d)

### DIFF
--- a/src/bus/cron-state.ts
+++ b/src/bus/cron-state.ts
@@ -103,7 +103,7 @@ export function cronExpressionMinIntervalMs(expr: string): number {
   const FALLBACK_MS = 48 * 3_600_000;
   const parts = expr.trim().split(/\s+/);
   if (parts.length !== 5) return FALLBACK_MS;
-  const [minute, hour] = parts;
+  const [minute, hour, dom, , dow] = parts;
 
   // Every N minutes: */N * * * *
   const everyMin = /^\*\/(\d+)$/.exec(minute);
@@ -113,7 +113,15 @@ export function cronExpressionMinIntervalMs(expr: string): number {
   const everyHour = /^\*\/(\d+)$/.exec(hour);
   if (everyHour) return parseInt(everyHour[1], 10) * 3_600_000;
 
-  // Fixed hour — fires daily (or on restricted days; 24h is the minimum gap)
+  // Fixed hour restricted to a specific day-of-month (e.g. "0 7 1 * *"):
+  // fires at most once a month — 28 days is the minimum gap, not daily.
+  if (/^\d+$/.test(hour) && dom !== '*') return 28 * 24 * 3_600_000;
+
+  // Fixed hour restricted to a specific day-of-week (e.g. "0 9 * * 0"):
+  // fires at most once a week — 7 days is the minimum gap, not daily.
+  if (/^\d+$/.test(hour) && dow !== '*') return 7 * 24 * 3_600_000;
+
+  // Fixed hour, every day — fires daily (24h is the minimum gap)
   if (/^\d+$/.test(hour)) return 24 * 3_600_000;
 
   return FALLBACK_MS;

--- a/tests/unit/bus/cron-state.test.ts
+++ b/tests/unit/bus/cron-state.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { updateCronFire, readCronState, parseDurationMs } from '../../../src/bus/cron-state';
+import { updateCronFire, readCronState, parseDurationMs, cronExpressionMinIntervalMs } from '../../../src/bus/cron-state';
 
 let tmpDir: string;
 
@@ -44,6 +44,36 @@ describe('parseDurationMs', () => {
   it('returns NaN for unknown unit', () => {
     expect(parseDurationMs('5y')).toBeNaN();
     expect(parseDurationMs('10s')).toBeNaN();
+  });
+});
+
+describe('cronExpressionMinIntervalMs', () => {
+  it('handles every-N-minutes expressions', () => {
+    expect(cronExpressionMinIntervalMs('*/5 * * * *')).toBe(5 * 60_000);
+  });
+
+  it('handles every-N-hours expressions', () => {
+    expect(cronExpressionMinIntervalMs('0 */6 * * *')).toBe(6 * 3_600_000);
+  });
+
+  it('treats a fixed hour with day-of-month restricted as monthly (28d minimum)', () => {
+    // A monthly cron like "0 7 1 * *" fires once a month, not daily.
+    expect(cronExpressionMinIntervalMs('0 7 1 * *')).toBe(28 * 24 * 3_600_000);
+  });
+
+  it('treats a fixed hour with day-of-week restricted as weekly (7d minimum)', () => {
+    // A weekly cron like "0 9 * * 0" fires once a week, not daily.
+    expect(cronExpressionMinIntervalMs('0 9 * * 0')).toBe(7 * 24 * 3_600_000);
+    expect(cronExpressionMinIntervalMs('0 9 * * 3')).toBe(7 * 24 * 3_600_000);
+  });
+
+  it('treats a fixed hour with no day restriction as daily', () => {
+    expect(cronExpressionMinIntervalMs('0 8 * * *')).toBe(24 * 3_600_000);
+  });
+
+  it('falls back to the conservative 48h default for unrecognized patterns', () => {
+    expect(cronExpressionMinIntervalMs('not-a-cron')).toBe(48 * 3_600_000);
+    expect(cronExpressionMinIntervalMs('* * * * *')).toBe(48 * 3_600_000);
   });
 });
 


### PR DESCRIPTION
## The bug

`cronExpressionMinIntervalMs(expr)` treats any fixed-hour cron expression as firing daily — it destructures only `[minute, hour]` and ignores day-of-month/day-of-week restrictions (its own comment says *"or on restricted days; 24h is the minimum gap"*). Any consumer using it to judge whether a cron has had time to fire (never-fired / overdue sweeps) will escalate:

- monthly crons (`0 7 1 * *`) judged against **24h** instead of ~28d
- weekly crons (`0 9 * * 0`) judged against **24h** instead of 7d

→ false-positive "overdue" escalations days before the cron is ever due. We hit this in production in a downstream deployment's cron-overdue sweep.

## The fix

Destructure `dom`/`dow` and return the correct minimum gap before the daily fallback: day-of-month restricted → 28d, day-of-week restricted → 7d, unrestricted fixed hour → 24h (unchanged). 28d (not 31) and 7d are the conservative **minimum** gaps, matching the function's "minimum interval" contract. The 48h fallback for unrecognized patterns is unchanged.

## Tests

Adds a `cronExpressionMinIntervalMs` describe block to `tests/unit/bus/cron-state.test.ts` (6 cases): every-N-minutes · every-N-hours · dom-restricted → 28d · dow-restricted → 7d · fixed-hour → daily · unrecognized → 48h fallback. `npx vitest run tests/unit/bus/cron-state.test.ts` 19/19 green on this branch; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)