### PR TITLE
docs(worker-agents): tighten worker Done-contract + add reap-on-done guidance

### DIFF
--- a/community/skills/worker-agents/SKILL.md
+++ b/community/skills/worker-agents/SKILL.md
@@ -57,7 +57,7 @@ Before spawning, answer:
 ```bash
 cortextos spawn-worker <worker-name> \
   --dir <absolute-path-to-project-dir> \
-  --prompt "Read AGENTS.md for your task. Deliverables: <list>. When done: cortextos bus send-message $CTX_AGENT_NAME normal 'Done: <summary>'" \
+  --prompt "Read AGENTS.md for your task. Deliverables: <list>. When done, send EXACTLY: cortextos bus send-message $CTX_AGENT_NAME normal 'Done: <summary>' — then STOP (no further output). Do not keep working after the deliverable." \
   --parent $CTX_AGENT_NAME
 ```
 
@@ -106,6 +106,8 @@ Nudge a stuck worker (equivalent of tmux send-keys):
 ```bash
 cortextos inject-worker <worker-name> "Continue with phase 3. What's blocking you?"
 ```
+
+**REAP ON DONE (prevents budget leak):** the moment a worker sends its `Done:` message, terminate it — `cortextos terminate-worker <worker-name>`. Never leave a finished worker running. Periodically run `cortextos list-workers` and terminate any that are done or idle.
 
 ### Step 6: Cleanup
 


### PR DESCRIPTION
Workers that keep running after their deliverable (or that a parent forgets to reap) leak budget — a finished worker session left alive keeps consuming tokens with no one reading its output.

Two doc-only changes to `community/skills/worker-agents/SKILL.md`:

1. **Tighten the spawn prompt** so the worker's completion contract is explicit: send EXACTLY the `Done:` bus message, then STOP — no further output, no continuing to work after the deliverable.
2. **Add a REAP-ON-DONE rule** after the monitoring section: the moment a worker sends `Done:`, the parent terminates it (`cortextos terminate-worker`), and periodically sweeps `cortextos list-workers` for done/idle stragglers.

We adopted this discipline in a downstream deployment after a leaked worker fed a host CPU-saturation event; the doc change is the portable half of that lesson. No code/behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)