### PR TITLE
fix(hooks): pre-push must run in a clean env, and gate the refs actually being pushed

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -13,8 +13,37 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# Run build and tests in CI's environment, not the caller's.
+#
+# Two families of ambient env vars leak into vitest subprocesses and cause
+# failures CI never reproduces, aborting pushes over green code:
+#
+#   CTX_*  A live cortextOS agent session exports CTX_AGENT_DIR,
+#          CTX_PROJECT_ROOT and CTX_FRAMEWORK_ROOT. The sandbox/live isolation
+#          guard in src/utils/env.ts (issue #313) then sees a CTX_FRAMEWORK_ROOT
+#          the test overrode alongside a CTX_AGENT_DIR it did not, and throws.
+#
+#   GIT_*  git itself exports GIT_DIR, GIT_INDEX_FILE and friends when it
+#          invokes a hook. Tests that shell out to git in a temp repo inherit
+#          them and operate on THIS repo's gitdir and index instead of their own
+#          fixture. This one only reproduces under `git push` — running the hook
+#          by hand leaves GIT_* unset and looks green.
+#
+# Both are the same defect class: ambient env inherited by a subprocess that
+# assumed a clean one. CI has neither, so strip both and match it. Enumerated by
+# prefix rather than by name so a var added later is covered without editing
+# this file. The scrub applies only to build/test — the `git rev-parse` above
+# deliberately still sees GIT_DIR so it resolves the right worktree.
+env_scrub=()
+for _v in ${!CTX_@} ${!GIT_@}; do env_scrub+=(-u "$_v"); done
+run_clean() { env ${env_scrub[@]+"${env_scrub[@]}"} "$@"; }
+
+if [[ ${#env_scrub[@]} -gt 0 ]]; then
+  echo "[pre-push] Scrubbing ${#env_scrub[@]} ambient CTX_*/GIT_* var(s) from the build/test environment."
+fi
+
 echo "[pre-push] Running build..."
-if ! npm run build --silent; then
+if ! run_clean npm run build --silent; then
   echo ""
   echo "[pre-push] Build failed. Fix the error before pushing." >&2
   echo "[pre-push] Push aborted." >&2
@@ -22,7 +51,7 @@ if ! npm run build --silent; then
 fi
 
 echo "[pre-push] Running tests..."
-if ! npm test --silent; then
+if ! run_clean npm test --silent; then
   echo ""
   echo "[pre-push] Tests failed. Fix the failing tests before pushing." >&2
   echo "[pre-push] Push aborted." >&2

--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -13,6 +13,52 @@ set -euo pipefail
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 
+# Refuse to gate code we are not actually testing.
+#
+# This hook tests the WORKING TREE: it runs `npm test` on whatever is checked
+# out. Git supplies the refs actually being pushed on stdin, which this hook
+# previously never read. The two are only the same thing when the branch being
+# pushed is HEAD. Push some other branch — e.g. `git push fork other-branch`
+# from a worktree sitting on your own branch — and the suite happily tests your
+# branch, reports green, and pushes code it never looked at. Two different
+# branches pushed from one worktree produce byte-identical results.
+#
+# A gate that passes on code it never ran is worse than no gate, because the
+# green check stops anyone from looking twice. So: read the refs, and require
+# every pushed commit to be the one we are about to test. Testing each pushed
+# ref properly would mean a detached worktree per ref; refusing is the cheap
+# honest alternative — it makes the guarantee true rather than broad.
+#
+# Deletions are exempt: there is no code to test.
+# Stdin is consumed here rather than left for npm/vitest to inherit.
+#
+# The `-t 0` guard: git always pipes this hook's stdin, never a terminal. A
+# terminal on stdin therefore means someone is hand-running the hook, where a
+# bare `read` would block on the keyboard and look like a hang. Skip the check
+# there — and note that a hand-run consequently proves nothing about ref
+# gating, which is the general reason not to verify a hook by hand-running it.
+HEAD_SHA="$(git rev-parse HEAD)"
+mismatched=()
+while [[ ! -t 0 ]] && read -r local_ref local_sha remote_ref remote_sha; do
+  [[ -z "${local_ref:-}" ]] && continue           # deletion: no local ref
+  [[ "$local_sha" =~ ^0+$ ]] && continue          # deletion: all-zero sha
+  [[ "$local_sha" == "$HEAD_SHA" ]] && continue   # this is what we test
+  mismatched+=("$local_ref @ ${local_sha:0:12}")
+done
+
+if [[ ${#mismatched[@]} -gt 0 ]]; then
+  echo "" >&2
+  echo "[pre-push] Refusing: you are pushing refs that are not your checked-out HEAD." >&2
+  echo "[pre-push] This hook tests the working tree, so it would test HEAD and tell you" >&2
+  echo "[pre-push] nothing about:" >&2
+  for _m in "${mismatched[@]}"; do echo "[pre-push]     $_m" >&2; done
+  echo "[pre-push]" >&2
+  echo "[pre-push] HEAD is ${HEAD_SHA:0:12}. Check the branch out and push from there:" >&2
+  echo "[pre-push]     git worktree add ../wt-<name> <branch> && cd ../wt-<name> && git push" >&2
+  echo "[pre-push] Push aborted." >&2
+  exit 1
+fi
+
 # Run build and tests in CI's environment, not the caller's.
 #
 # Two families of ambient env vars leak into vitest subprocesses and cause


### PR DESCRIPTION
## Problem

The pre-push hook runs bare `npm run build && npm test`, inheriting whatever environment the caller has. Two families of ambient vars leak into vitest subprocesses and produce failures **CI never reproduces** — so the hook aborts pushes over green code.

**`CTX_*`** — a live cortextOS agent session exports `CTX_AGENT_DIR`, `CTX_PROJECT_ROOT`, `CTX_FRAMEWORK_ROOT`. The sandbox/live isolation guard in `src/utils/env.ts` (issue #313) then sees a `CTX_FRAMEWORK_ROOT` the test overrode alongside a `CTX_AGENT_DIR` it did not, and throws.

**`GIT_*`** — git exports `GIT_DIR`, `GIT_INDEX_FILE` and friends when invoking a hook. Tests that shell out to git in a temp fixture repo inherit them and operate on *this* repo's gitdir and index instead of their own. **This one only reproduces under an actual `git push`** — running the hook by hand leaves `GIT_*` unset and looks green, which is why it hid behind the `CTX_*` failures.

Both are the same defect class: ambient env inherited by a subprocess that assumed a clean one.

## Fix

Run build and tests with both prefixes stripped, so the hook predicts CI instead of the caller. Vars are enumerated by prefix (`${!CTX_@}`, `${!GIT_@}`) rather than by name, so one added later is covered without editing the file again. The scrub applies only to build/test — the `git rev-parse --show-toplevel` above it deliberately still sees `GIT_DIR` so it resolves the right worktree.

## Verification

Measured in a live agent session with 10 `CTX_*` exported, via real `git push` (not a hand-run of the hook):

| Arm | Result |
|---|---|
| Before, unscrubbed | 41 failed / 1911 passed, 5 files — push aborted |
| `CTX_*` scrubbed only | 8 failed / 1944 passed, 1 file — push still aborted (the `GIT_*` leak) |
| `CTX_*` + `GIT_*` scrubbed | **115 files passed, 1952 passed / 4 skipped — push succeeded** |

Isolating the `GIT_*` mechanism on `tests/unit/bus/system.test.ts`: with `GIT_DIR`/`GIT_INDEX_FILE` set → 8 failed / 14 passed; without → 22/22 passed. Same 8 as the real push.

Controls:
- **Not toothless.** With the final hook installed, a deliberately failing test committed and pushed for real → tests fail, push aborted, exit 1.
- **Skips nothing.** Identical test population in both arms (1956), so the scrub is not silencing tests by omitting them.
- **Empty-array safe.** With zero `CTX_`/`GIT_` vars present, the prefix expansion under `set -euo pipefail` does not error.

## Known gap (not addressed here)

`scripts/setup-hooks.sh` is deliberately non-clobbering: it skips when an existing hook differs. **Anyone who already installed the old hook will not pick this up by re-running it** — they must copy `scripts/hooks/pre-push` into `.git/hooks/` manually. Left alone rather than weakening the non-clobber guard; worth a follow-up that detects a known-old version and says so.

---

# Second commit: the hook was gating the working tree, not the refs being pushed

Found while preparing to use this hook to gate a backlog of unpushed branches.

## Problem

The hook tests **whatever is checked out**. Git supplies the refs **actually being pushed** on stdin — which the hook never read. Those two coincide only when the pushed ref is `HEAD`.

Push any other branch from a checkout sitting on your own — `git push fork other-branch` — and the suite tests *your* branch, reports green, and pushes code it never looked at.

Proven before writing the fix: pushing `docs/kb-collection-correction` from a worktree parked on a different branch produced **byte-identical** suite output (115 passed / 2 skipped / 1952 passed / 4 skipped) to pushing that worktree's own branch. A planned 32-branch campaign would have been one suite run 32 times, all green, certifying nothing.

A gate that passes on code it never ran is worse than no gate, because the green check stops anyone from looking twice.

## Fix

Read the refs from stdin and refuse if any pushed commit is not `HEAD`. Testing each pushed ref properly would need a detached worktree per ref; refusing is the cheap honest alternative — it makes the guarantee **true** rather than broad. Deletions are exempt (no code to test). Stdin is consumed here rather than inherited by vitest.

A `[[ ! -t 0 ]]` guard skips the loop when stdin is a terminal: git always pipes it, so a terminal means someone is hand-running the hook, where a bare `read` would block on the keyboard and look like a hang.

## Verification

Real `git push`, not a hand-run:

| Arm | Result |
|---|---|
| Push a branch that is not HEAD | **Refused in 1s, exit 1, suite never ran, nothing pushed** |
| Push HEAD's own branch | Suite ran (29.8s), 1952 passed / 4 skipped, **push succeeded** |

Plus six arms against the real hook file with a stubbed npm — HEAD's ref, a different sha, a deletion, a mixed push, empty stdin, and a terminal on stdin.

Controls:
- **Opposite-mutation control.** The same six arms run against the *previous* commit's hook: exactly the two ref-mismatch arms flip to green-and-pushing, every other arm identical. The arms detect ref gating specifically, not something incidental.
- **Not toothless.** With a matching ref but a failing test, the hook still aborts, exit 1.
- **Empty-array safe** under `set -euo pipefail`, same control as the env fix.

## Note on the `set -e` risk

The loop body uses `[[ ... ]] && continue`. Bash exempts a failing command in a `&&` list when it is not the final command, so a non-matching test does not abort the hook — but this was **verified by running it** (arm: push HEAD's own ref proceeds to build/test), not by reasoning alone. Had it been wrong, the hook would have exited 1 silently and blocked every push.
