### PR TITLE
fix(daemon): don't count a missing agent binary as an agent crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,56 @@
 
 ## [Unreleased]
 
+### Fixed — a missing agent binary was counted as an agent crash, halting agents
+
+Every agent runs under its own `CLAUDE_CONFIG_DIR`, so each Claude Code instance
+believes it is a standalone install and independently schedules its own
+auto-update — but all agents share ONE binary
+(`~/.local/bin/claude -> versions/<version>`). N private updaters, one shared
+file, no lock.
+
+Observed on a 9-agent fleet: two updaters fired 250ms apart, both reported
+`install_failed`, and left the symlink dangling at an already-deleted version
+for ~12 minutes. node-pty hands back a pid for a dangling symlink, and the child
+then exits 1 having written zero bytes — verified directly against one:
+
+```
+pid assigned: 69035
+exitCode: 1  signal: 0
+output bytes: 0 ""
+```
+
+The daemon could not distinguish that from an agent crash, so it charged the
+daily crash budget with exponential backoff. Two agents walked to
+`max_crashes_per_day` and HALTED — for a condition no restart could fix, which
+healed on its own the moment the binary reappeared. Only agents that RESTARTED
+during the window were affected, so the fleet looked half-healthy and the
+failure masqueraded as agent-specific.
+
+- **`src/pty/agent-pty.ts`** — `getBaseEnv()` now sets `DISABLE_AUTOUPDATER=1`
+  for every agent PTY. Updating the runtime is an operator action taken when the
+  fleet is quiet, not something N unsupervised agents each attempt against one
+  shared file. *(Prevention.)*
+- **`src/pty/agent-pty.ts`** — new exported `isBinaryAvailable(binary)`:
+  resolves against `PATH` and checks `X_OK`. `existsSync` follows symlinks, so a
+  dangling symlink and a partially-written binary both report unavailable.
+- **`src/daemon/agent-process.ts`** — `handleExit()` gained a
+  binary-unavailable exemption alongside the existing image-poison block: an
+  exit that is code 1 AND accompanied by a runtime that is not executable on
+  `PATH` right now is retried WITHOUT charging `max_crashes_per_day`, logged as
+  `BINARY_UNAVAILABLE_RECOVERY`. If the binary is not executable, a restart
+  cannot succeed regardless of why the process exited — charging the budget only
+  guarantees a permanent HALT instead of recovery. *(Resilience — also covers
+  any other cause of a vanished runtime: botched upgrade, unmounted volume, bad
+  `PATH`.)*
+- **Retry cadence** is two-tier, keyed on how long the binary has been gone: 30s
+  for the first 15 minutes (a real install window is minutes, and a failed exec
+  costs ~1ms so polling is free), then 5min — an outage that long is a broken
+  runtime needing a human, and the slower tier bounds `restarts.log` growth
+  without ever giving up, since nothing else would bring the agent back. Outage
+  age is derived from timestamps rather than an attempt counter, so no reset has
+  to stay in sync with `start()`.
+
 ### Hook Framework — Loop Detection (B1)
 
 - **`hook-loop-detector`**: new PreToolUse hook that detects and blocks repeated Claude tool-call loops. Two patterns are detected: (a) the same tool invoked with identical arguments 15+ times within the last 30 calls, and (b) two tools ping-ponging (24+ alternations within a 12-call dominant-pair window). Blocked calls are NOT recorded into history, so the wedge cannot self-perpetuate. History is time-windowed (60s) so a stale prior-session tail does not block the first call of a new session. After 30 minutes of continuous block, exactly one tool call is allowed through ("emergency escape") so the agent can issue a Telegram alert before re-entering the blocked window.

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -2,7 +2,7 @@ import { appendFileSync, existsSync, readFileSync, statSync, unlinkSync, writeFi
 import { join, sep } from 'path';
 import { homedir } from 'os';
 import type { AgentConfig, AgentStatus, CtxEnv } from '../types/index.js';
-import { AgentPTY } from '../pty/agent-pty.js';
+import { AgentPTY, isBinaryAvailable } from '../pty/agent-pty.js';
 import { CodexAppServerPTY } from '../pty/codex-app-server-pty.js';
 import { HermesPTY, hermesDbExists } from '../pty/hermes-pty.js';
 import { OpencodePTY, opencodeSessionExists } from '../pty/opencode-pty.js';
@@ -14,6 +14,13 @@ import { getOverdueReminders } from '../bus/reminders.js';
 import { resolvePaths } from '../utils/paths.js';
 
 type LogFn = (msg: string) => void;
+
+// Binary-unavailable retry tiers. See binaryUnavailableRetryDelayMs().
+// The fast tier covers an in-flight install (an observed outage was ~12min);
+// the slow tier is for a runtime that is broken rather than mid-update.
+const BINARY_UNAVAILABLE_FAST_MS = 30_000;
+const BINARY_UNAVAILABLE_FAST_WINDOW_MS = 15 * 60_000;
+const BINARY_UNAVAILABLE_SLOW_MS = 5 * 60_000;
 
 /**
  * Manages a single agent's lifecycle.
@@ -33,6 +40,11 @@ export class AgentProcess {
   private crashTimestamps: number[] = [];
   private crashWindowMs: number = 0;
   private crashWindowMax: number = 0;
+  // Binary-unavailable outage tracking (see binaryUnavailableRetryDelayMs).
+  // Timestamps, not an attempt counter, so no reset has to stay in sync with
+  // start() — a long enough gap is itself the signal that the outage ended.
+  private binaryUnavailableSince: number = 0;
+  private lastBinaryUnavailableAt: number = 0;
   private sessionStart: Date | null = null;
   private status: AgentStatus['status'] = 'stopped';
   private stopping: boolean = false;
@@ -506,6 +518,52 @@ export class AgentProcess {
     }
   }
 
+  /**
+   * The binary this agent's PTY execs, mirroring the runtime switch in start().
+   * Kept in sync with that ternary — the two are the only places a runtime maps
+   * to a concrete executable.
+   */
+  private agentBinaryName(): string {
+    if (this.config.runtime === 'hermes') return 'hermes';
+    if (this.config.runtime === 'opencode') return 'opencode';
+    if (this.config.runtime === 'codex-app-server') return 'codex';
+    return 'claude';
+  }
+
+  /**
+   * How long to wait before re-spawning an agent whose binary is missing.
+   *
+   * This retry does NOT count against max_crashes_per_day, so the loop is the
+   * agent's only route back to life — the delay is an availability trade-off,
+   * not a tuning constant. Too short and the daemon spins against a torn-down
+   * install; too long and the agent stays dark after the installer already
+   * finished, missing cron fires and inbox messages.
+   *
+   * Two tiers, keyed on how long the binary has been gone:
+   *   - First BINARY_UNAVAILABLE_FAST_WINDOW_MS: poll every 30s. A real install
+   *     window is minutes, so this is the case that actually happens, and a
+   *     failed exec costs ~1ms — the polling itself is free.
+   *   - After that: 5min. An outage this long is a broken runtime needing a
+   *     human, not an in-flight install. Slowing down bounds restarts.log
+   *     growth without ever giving up, since nothing else would bring the
+   *     agent back if we did.
+   *
+   * Outage age comes from timestamps rather than an attempt counter so there is
+   * no reset to keep in sync with start(): a gap longer than the slow tier means
+   * the previous outage ended and recovery already happened, so the next failure
+   * starts fresh at the fast tier.
+   */
+  private binaryUnavailableRetryDelayMs(): number {
+    const now = Date.now();
+    if (now - this.lastBinaryUnavailableAt > BINARY_UNAVAILABLE_SLOW_MS * 2) {
+      this.binaryUnavailableSince = now;
+    }
+    this.lastBinaryUnavailableAt = now;
+    return now - this.binaryUnavailableSince < BINARY_UNAVAILABLE_FAST_WINDOW_MS
+      ? BINARY_UNAVAILABLE_FAST_MS
+      : BINARY_UNAVAILABLE_SLOW_MS;
+  }
+
   private handleExit(exitCode: number): void {
     // Capture last 16KB of the agent's stdout BEFORE nulling pty.
     // Used by the image-poison auto-recovery check below — reads the log
@@ -589,6 +647,39 @@ export class AgentProcess {
           this.start().catch(err => this.log(`Image-poison restart failed: ${err}`));
         }
       }, 5000);
+      return;
+    }
+
+    // Binary-unavailable exemption. Companion to the image-poison block above:
+    // both are "upstream condition, not agent malfunction".
+    //
+    // node-pty returns a pid for a binary that cannot actually be exec'd (a
+    // dangling symlink, a half-written install, a bad PATH), and the child then
+    // exits 1 having produced no output. That is indistinguishable from a crash
+    // at this layer, so the daemon charged the daily budget with exponential
+    // backoff and eventually HALTED agents — for a condition no restart could
+    // have fixed and that resolves itself the moment the binary reappears.
+    //
+    // Both conditions are required. exitCode 1 is the exec-failure shape, and
+    // the binary check is decisive: if the runtime is not executable right now,
+    // a restart cannot succeed regardless of why the process exited, so
+    // charging the crash budget only guarantees the agent halts permanently
+    // instead of recovering when the binary returns.
+    if (exitCode === 1 && !isBinaryAvailable(this.agentBinaryName())) {
+      const retryMs = this.binaryUnavailableRetryDelayMs();
+      this.log(
+        `Agent binary "${this.agentBinaryName()}" is not executable on PATH — runtime is missing or ` +
+        `mid-install, not an agent fault. Retrying in ${retryMs / 1000}s without counting against ` +
+        `max_crashes_per_day.`,
+      );
+      this.appendCrashToRestartsLog(exitCode, retryMs, 'BINARY_UNAVAILABLE_RECOVERY');
+      this.status = 'crashed';
+      this.notifyStatusChange();
+      setTimeout(() => {
+        if (this.status === 'crashed') {
+          this.start().catch(err => this.log(`Binary-unavailable restart failed: ${err}`));
+        }
+      }, retryMs);
       return;
     }
 
@@ -976,7 +1067,8 @@ export class AgentProcess {
   private appendCrashToRestartsLog(
     exitCode: number,
     backoffMs: number,
-    kind: 'CRASH' | 'HALTED' | 'CRASH_LOOP' | 'IMAGE_POISON_RECOVERY',
+    kind: 'CRASH' | 'HALTED' | 'CRASH_LOOP' | 'IMAGE_POISON_RECOVERY'
+      | 'BINARY_UNAVAILABLE_RECOVERY',
   ): void {
     try {
       const logDir = join(this.env.ctxRoot, 'logs', this.name);
@@ -985,7 +1077,7 @@ export class AgentProcess {
       const details =
         kind === 'HALTED'
           ? `exit_code=${exitCode} crash_count=${this.crashCount} max_crashes=${this.maxCrashesPerDay}`
-          : kind === 'IMAGE_POISON_RECOVERY'
+          : (kind === 'IMAGE_POISON_RECOVERY' || kind === 'BINARY_UNAVAILABLE_RECOVERY')
             ? `exit_code=${exitCode} backoff_s=${backoffMs / 1000} (not counted toward max_crashes)`
             : `exit_code=${exitCode} crash_count=${this.crashCount} backoff_s=${backoffMs / 1000}`;
       const logLine = `[${timestamp}] ${kind}: ${details}\n`;

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -1,9 +1,40 @@
 import { join } from 'path';
-import { existsSync, readFileSync, readdirSync } from 'fs';
+import { existsSync, readFileSync, readdirSync, accessSync, constants } from 'fs';
 import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
 import { injectMessage as injectMessageIntoPty } from './inject.js';
+
+/**
+ * Is `binary` resolvable on PATH and executable RIGHT NOW?
+ *
+ * Used by AgentProcess.handleExit() to tell "the agent crashed" apart from
+ * "the runtime was yanked out from under it mid-restart". A missing or
+ * half-installed binary is an environmental condition, not an agent fault, and
+ * must not burn the agent's daily crash budget.
+ *
+ * existsSync FOLLOWS symlinks, which is exactly the property this needs: a
+ * dangling `~/.local/bin/claude -> versions/<deleted-version>` reports false.
+ * A present-but-not-yet-chmod'd binary (partially written by an in-flight
+ * installer) fails the X_OK check and is likewise reported missing.
+ */
+export function isBinaryAvailable(binary: string): boolean {
+  const sep = platform() === 'win32' ? ';' : ':';
+  const pathDirs = (process.env.PATH || '').split(sep).filter(Boolean);
+  for (const dir of pathDirs) {
+    const candidate = join(dir, binary);
+    if (!existsSync(candidate)) continue;
+    try {
+      accessSync(candidate, constants.X_OK);
+      return true;
+    } catch {
+      // Present but not executable — an installer may still be writing it.
+      // Keep scanning; a later PATH entry may hold a usable copy.
+    }
+  }
+  return false;
+}
+
 
 // node-pty types
 interface IPty {
@@ -405,6 +436,29 @@ export class AgentPTY {
         env[key] = process.env[key]!;
       }
     }
+
+
+    // Pin the agent runtime's auto-updater OFF.
+    //
+    // Each agent runs under its own CLAUDE_CONFIG_DIR, so each Claude Code
+    // instance believes it is a standalone install and independently schedules
+    // its own update — but every agent shares ONE binary
+    // (~/.local/bin/claude -> versions/<version>). N private updaters, one
+    // shared file, no lock.
+    //
+    // When two race, the loser leaves the install torn down. Observed on a
+    // 9-agent fleet: two updaters fired 250ms apart, both reported
+    // install_failed, and the symlink pointed at an already-deleted version for
+    // ~12 minutes. Any agent that respawned in that window exec'd a dangling
+    // symlink — node-pty hands back a pid, then the child exits 1 having
+    // written zero bytes, which the daemon cannot distinguish from an agent
+    // crash. It charged the daily crash budget and halted agents at the cap.
+    //
+    // Updating the runtime is an operator action taken when the fleet is quiet,
+    // not something N unsupervised agents should each attempt against one
+    // shared file. handleExit()'s binary-unavailable exemption is the
+    // resilience companion to this.
+    env['DISABLE_AUTOUPDATER'] = '1';
 
     // Windows: ensure UTF-8 locale so emoji and Unicode pass through the PTY
     if (platform() === 'win32') {

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -14,9 +14,18 @@ const mockPty = {
   }),
 };
 
+// Getter defers the lookup until call time, so the hoisted vi.mock factory can
+// reference ptyMocks (declared below) — same idiom as the fs mock further down.
 vi.mock('../../../src/pty/agent-pty.js', () => ({
   AgentPTY: function AgentPTY() { return mockPty; },
+  get isBinaryAvailable() { return ptyMocks.isBinaryAvailable; },
 }));
+
+const ptyMocks = {
+  // Default true: the runtime is present, so every pre-existing test keeps
+  // taking the ordinary crash path.
+  isBinaryAvailable: vi.fn().mockReturnValue(true),
+};
 
 const mockInjectMessage = vi.fn();
 vi.mock('../../../src/pty/inject.js', () => ({
@@ -105,6 +114,86 @@ beforeEach(() => {
   fsMocks.writeFileSync.mockReset();
   fsMocks.appendFileSync.mockReset();
   fsMocks.statSync.mockReset();
+  ptyMocks.isBinaryAvailable.mockReset().mockReturnValue(true);
+});
+
+describe('AgentProcess — binary-unavailable exemption', () => {
+  // node-pty returns a pid for a binary that cannot be exec'd (dangling
+  // symlink, half-written install, bad PATH); the child then exits 1 having
+  // written nothing. Verified against a real dangling symlink:
+  //   pid assigned: 69035 / exitCode: 1 signal: 0 / output bytes: 0
+  // The daemon read that as an agent crash and charged the daily budget, so a
+  // ~12min install window walked agents to max_crashes_per_day and HALTED them
+  // — for a condition no restart could fix and that heals on its own.
+
+  it('does NOT count a crash when the binary is missing from PATH', async () => {
+    ptyMocks.isBinaryAvailable.mockReturnValue(false);
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    capturedOnExit!(1, 0);
+
+    const [logPath, logLine] = fsMocks.appendFileSync.mock.calls[0];
+    expect(String(logPath)).toContain('/logs/alice/restarts.log');
+    expect(String(logLine)).toContain('BINARY_UNAVAILABLE_RECOVERY');
+    expect(String(logLine)).toContain('(not counted toward max_crashes)');
+    // The decisive assertion: .crash_count_today must be untouched. Writing it
+    // is what marches an agent toward a HALT it can never recover from.
+    const crashCountWrites = fsMocks.writeFileSync.mock.calls
+      .filter(c => String(c[0]).endsWith('.crash_count_today'));
+    expect(crashCountWrites).toHaveLength(0);
+  });
+
+  it('still counts an ordinary crash when the binary IS present (regression guard)', async () => {
+    ptyMocks.isBinaryAvailable.mockReturnValue(true);
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    capturedOnExit!(1, 0);
+
+    const [, logLine] = fsMocks.appendFileSync.mock.calls[0];
+    expect(String(logLine)).toMatch(/\] CRASH: exit_code=1 crash_count=1/);
+    expect(String(logLine)).not.toContain('BINARY_UNAVAILABLE_RECOVERY');
+  });
+
+  it('does not exempt a clean exit(0) even while the binary is missing', async () => {
+    // A missing binary explains exit 1 (exec failure), not a graceful exit 0.
+    ptyMocks.isBinaryAvailable.mockReturnValue(false);
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    capturedOnExit!(0, 0);
+
+    const [, logLine] = fsMocks.appendFileSync.mock.calls[0];
+    expect(String(logLine)).not.toContain('BINARY_UNAVAILABLE_RECOVERY');
+  });
+
+  it('polls fast during a fresh outage, then backs off once it is not an install', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    const delayFor = () =>
+      (ap as unknown as { binaryUnavailableRetryDelayMs(): number }).binaryUnavailableRetryDelayMs();
+    const nowSpy = vi.spyOn(Date, 'now');
+
+    // t=0 — outage begins. Fast tier keeps downtime within a minute of the
+    // binary reappearing.
+    nowSpy.mockReturnValue(1_000_000);
+    expect(delayFor()).toBe(30_000);
+
+    // t=+10min — still inside the fast window (the observed outage was ~12min).
+    nowSpy.mockReturnValue(1_000_000 + 10 * 60_000);
+    expect(delayFor()).toBe(30_000);
+
+    // t=+20min — no longer an in-flight install; slow down to bound log growth.
+    nowSpy.mockReturnValue(1_000_000 + 20 * 60_000);
+    expect(delayFor()).toBe(5 * 60_000);
+
+    // A gap longer than the slow tier means the previous outage ended and the
+    // agent recovered — a later failure is a NEW outage and starts fast again.
+    nowSpy.mockReturnValue(1_000_000 + 20 * 60_000 + 60 * 60_000);
+    expect(delayFor()).toBe(30_000);
+
+    nowSpy.mockRestore();
+  });
 });
 
 describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {

--- a/tests/unit/pty/agent-pty.test.ts
+++ b/tests/unit/pty/agent-pty.test.ts
@@ -60,3 +60,22 @@ describe('AgentPTY --dangerously-skip-permissions toggle', () => {
     }
   });
 });
+
+describe('AgentPTY auto-updater pinning (shared-binary race)', () => {
+  // Every agent gets its own CLAUDE_CONFIG_DIR, so each Claude Code instance
+  // believes it is a standalone install and independently schedules updates —
+  // but all agents share ONE binary (~/.local/bin/claude -> versions/<v>).
+  // Two updaters firing 250ms apart both reported install_failed and left the
+  // symlink dangling at a deleted version for ~12min; every agent that
+  // respawned in that window exec'd a symlink to nothing (pid assigned, then
+  // exit 1 with zero output) and the daemon read it as an agent crash.
+  function baseEnvFor(config: any): Record<string, string> {
+    const pty = new AgentPTY(mockEnv, config);
+    return (pty as unknown as { getBaseEnv(): Record<string, string> }).getBaseEnv();
+  }
+
+  it('sets DISABLE_AUTOUPDATER=1 so agents never race on the shared binary', () => {
+    expect(baseEnvFor({})['DISABLE_AUTOUPDATER']).toBe('1');
+  });
+});
+


### PR DESCRIPTION
## Summary

An agent binary that can't be exec'd was being counted as an agent crash, which walked agents to `max_crashes_per_day` and HALTED them — for a condition no restart could fix, and which heals by itself.

Every agent runs under its own `CLAUDE_CONFIG_DIR`, so each Claude Code instance believes it's a standalone install and independently schedules its own auto-update. But all agents share **one** binary (`~/.local/bin/claude -> versions/<version>`): N private updaters, one shared file, no lock.

On a 9-agent fleet two updaters fired 250ms apart, both reported `install_failed`, and left the symlink dangling at an already-deleted version for ~12 minutes:

```
ruby:  14:05:30.564Z  2.1.220 → 2.1.221  install_failed
pearl: 14:05:30.812Z  2.1.220 → 2.1.221  install_failed
```

node-pty hands back a pid for a dangling symlink, and the child then exits 1 having written **zero** bytes. Verified directly against a dangling symlink:

```
pid assigned: 69035
exitCode: 1  signal: 0
output bytes: 0 ""
```

That's byte-for-byte what the daemon logs — `Running (pid: N)` → `Exited with code 1 signal 0`, nothing in `stdout.log`. Indistinguishable from a crash at that layer, so the daemon charged the daily budget with exponential backoff. Two agents hit the cap and HALTED. Only agents that *restarted* during the window were affected, so the fleet looked half-healthy and it read as agent-specific. It had also fired silently ~13h earlier and gone unnoticed because the hang-detector happened to rescue it.

**Prevention** — `getBaseEnv()` sets `DISABLE_AUTOUPDATER=1`. Updating the runtime is an operator action taken when the fleet is quiet, not something N unsupervised agents attempt against one shared file.

**Resilience** — `handleExit()` gains a binary-unavailable exemption beside the existing image-poison block. Exit code 1 plus a runtime that isn't executable on `PATH` right now is retried *without* charging `max_crashes_per_day`, logged as `BINARY_UNAVAILABLE_RECOVERY`. The reasoning for those two conditions being sufficient: if the binary can't be exec'd, a restart cannot succeed regardless of why the process exited, so charging the budget only guarantees a permanent HALT instead of recovery when the binary returns. This also covers any other cause of a vanished runtime — botched upgrade, unmounted volume, bad `PATH`.

Retry cadence is two-tier on outage age: 30s for the first 15 minutes (real install windows are minutes, and a failed exec costs ~1ms so polling is free), then 5min — that long an outage is a broken runtime needing a human, and the slower tier bounds `restarts.log` growth without ever giving up, since nothing else would bring the agent back. Age comes from timestamps rather than an attempt counter, so no reset has to stay in sync with `start()`.

`agentBinaryName()` mirrors the runtime switch in `start()` and covers all four runtimes (claude / hermes / opencode / codex).

## Test plan

- `npm run typecheck` — clean
- `npm run build` — clean
- `npx vitest run tests/unit/daemon/ tests/unit/pty/` — **508/508 passing**
- New tests: exemption doesn't touch `.crash_count_today`; an ordinary crash with the binary present still counts (regression guard); a clean `exit(0)` is not exempted even while the binary is missing; retry tiers fast → slow → reset-on-new-outage
- **Mutation-tested**: disabling the exemption (`if (false)`) makes the primary test fail, so it isn't a vacuous assertion
- The `pid/exit-1/zero-bytes` signature above was reproduced against a real dangling symlink via node-pty before writing the fix

## Checklist

- [x] `npm run build` passes
- [x] `npm test` passes (daemon + pty suites; 508/508)
- [x] No new secrets or credentials committed
- [x] **Agent Awareness:** no command/endpoint/hook surface change — daemon-internal crash classification plus one env var on the agent PTY
- [x] **Migration Parity:** no agent-installed files change; existing agents pick both halves up on next daemon restart
