### PR TITLE
perf(dashboard): read each agent's execution log once in GET /crons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 ## [Unreleased]
 
+### Fixed — `GET /api/workflows/crons` re-read each agent's execution log once per cron
+
+`readLastExecution(agent, cronName)` re-read and re-parsed the agent's entire
+`cron-execution.log` once **per cron**. At 10 crons per agent that is ten full
+reads of the same file per request. `/health` already read each agent's log
+exactly once, which is why it benchmarked several times faster than `/crons`
+over the same dataset.
+
+Replaced with a single backward pass per agent building a
+`Map<cronName, lastEntry>`; keeping the first hit per name preserves "last entry
+in file order wins" exactly. Cost is now O(agents) reads instead of O(crons).
+
+Measured on `tests/integration/phase4-performance.test.ts`:
+
+| dataset | p50 before | p50 after | p95 before | p95 after |
+|---|---|---|---|---|
+| 50 crons  | 79.0ms | **19.4ms** | 88.7ms | **21.5ms** |
+| 100 crons | 76.3ms | **18.0ms** | 77.3ms | **18.8ms** |
+
 ### Hook Framework — Loop Detection (B1)
 
 - **`hook-loop-detector`**: new PreToolUse hook that detects and blocks repeated Claude tool-call loops. Two patterns are detected: (a) the same tool invoked with identical arguments 15+ times within the last 30 calls, and (b) two tools ping-ponging (24+ alternations within a 12-call dominant-pair window). Blocked calls are NOT recorded into history, so the wedge cannot self-perpetuate. History is time-windowed (60s) so a stale prior-session tail does not block the first call of a new session. After 30 minutes of continuous block, exactly one tool call is allowed through ("emergency escape") so the agent can issue a Telegram alert before re-entering the blocked window.

--- a/dashboard/src/app/api/workflows/crons/route.ts
+++ b/dashboard/src/app/api/workflows/crons/route.ts
@@ -75,28 +75,40 @@ function readAgentCrons(agentName: string): CronDefinition[] {
   }
 }
 
-function readLastExecution(
-  agentName: string,
-  cronName: string,
-): CronExecutionLogEntry | null {
+/**
+ * Last execution entry for EVERY cron of an agent, from ONE pass over the log.
+ *
+ * This replaced a per-cron `readLastExecution(agent, cronName)`, which re-read
+ * and re-parsed the agent's entire cron-execution.log on every call — with 10
+ * crons per agent, ten full reads of the same file per request. /health already
+ * read each agent's log exactly once, which is why it benchmarked several times
+ * faster than /crons over the same dataset. Cost is now O(agents) reads instead
+ * of O(crons).
+ *
+ * Walking backwards and keeping the FIRST hit per cron name preserves the old
+ * "last entry in file order wins" semantics exactly.
+ */
+function readLastExecutions(agentName: string): Map<string, CronExecutionLogEntry> {
+  const byCron = new Map<string, CronExecutionLogEntry>();
   const logPath = path.join(CTX_ROOT, CRONS_DIR, agentName, 'cron-execution.log');
-  if (!fs.existsSync(logPath)) return null;
+  if (!fs.existsSync(logPath)) return byCron;
   try {
     const raw = fs.readFileSync(logPath, 'utf-8');
-    const lines = raw.split('\n').filter(l => l.trim());
-    // Walk backwards to find last entry for this cron
+    const lines = raw.split('\n');
     for (let i = lines.length - 1; i >= 0; i--) {
+      const line = lines[i].trim();
+      if (!line) continue;
       try {
-        const entry = JSON.parse(lines[i]) as CronExecutionLogEntry;
-        if (entry.cron === cronName) return entry;
+        const entry = JSON.parse(line) as CronExecutionLogEntry;
+        if (!byCron.has(entry.cron)) byCron.set(entry.cron, entry);
       } catch {
         // skip malformed line
       }
     }
-    return null;
   } catch {
-    return null;
+    // unreadable log -> no history
   }
+  return byCron;
 }
 
 // ---------------------------------------------------------------------------
@@ -119,10 +131,12 @@ export async function GET(request: NextRequest) {
 
     for (const agent of agents) {
       const crons = readAgentCrons(agent.name);
+      // One log read per AGENT, reused across that agent's crons.
+      const lastExecutions = readLastExecutions(agent.name);
       for (const cron of crons) {
         if (searchFilter && !cron.name.toLowerCase().includes(searchFilter)) continue;
 
-        const lastEntry = readLastExecution(agent.name, cron.name);
+        const lastEntry = lastExecutions.get(cron.name) ?? null;
 
         rows.push({
           agent: agent.name,


### PR DESCRIPTION
## Summary

`GET /api/workflows/crons` re-read and re-parsed each agent's entire `cron-execution.log` **once per cron**. With 10 crons per agent that's ten full reads of the same file per request.

The tell was already in the benchmark: `/health` consistently measured several times faster than `/crons` over the same dataset, despite doing strictly more work — because `/health` already reads each agent's log exactly once (`readExecutionLog(agentName)`) while `/crons` called `readLastExecution(agent, cronName)` inside the per-cron loop.

One backward pass per agent now builds a `Map<cronName, lastEntry>`. Keeping the **first** hit per cron name preserves the previous "last entry in file order wins" semantics exactly — the old code walked backwards and returned its first match for that cron, which is the same entry. Cost is O(agents) reads instead of O(crons).

Measured with `tests/integration/phase4-performance.test.ts` on this branch vs `main`, alternating runs on the same machine:

| dataset | p50 before | p50 after | p95 before | p95 after |
|---|---|---|---|---|
| 50 crons  | 79.0ms | **19.4ms** | 88.7ms | **21.5ms** |
| 100 crons | 76.3ms | **18.0ms** | 77.3ms | **18.8ms** |

~4.2x, and stable across repeated A/B runs (baseline 78.9/81.9ms, patched 19.4/18.2ms). Note the benchmark writes only 5 execution entries per cron, so this is close to the floor of the win — the gap widens with real logs, where agents accumulate thousands of entries.

## Test plan

- `npm run typecheck` — clean
- `npm run build` — clean
- `npx tsc --noEmit` in `dashboard/` — clean
- Regression: the four existing integration suites that exercise this route's `lastFire` / `lastStatus` output — `phase5-user-journeys`, `phase4-dashboard-backtest`, `phase5-e2e-simulation`, `phase4-performance` — **87/87 passing**. Those cover the semantics this change touches, so a behavior change would surface there.
- Perf numbers above reproduced by stashing/unstashing the patch and re-running on the same machine.

## Checklist

- [x] `npm run build` passes
- [x] `npm test` passes (87/87 across the four suites covering this route)
- [x] No new secrets or credentials committed
- [x] **Agent Awareness:** no command/endpoint/hook surface change — response shape is byte-identical, this is purely how the data is gathered
- [x] **Migration Parity:** no agent-installed files change
