### PR TITLE
fix(templates): quote date -u format so agent records get stamped

### DIFF
--- a/community/agents/agent/AGENTS.md
+++ b/community/agents/agent/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/agent/HEARTBEAT.md
+++ b/community/agents/agent/HEARTBEAT.md
@@ -63,7 +63,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/agentic-crm-assistant/HEARTBEAT.md
+++ b/community/agents/agentic-crm-assistant/HEARTBEAT.md
@@ -42,7 +42,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC)
+## Heartbeat Update - $(date -u +'%H:%M UTC')
 - WORKING ON: <task_id or none>
 - CRM status: <contacts/followups/drafts/meetings>
 - Inbox: <clear / pending / blocked>

--- a/community/agents/analyst/AGENTS.md
+++ b/community/agents/analyst/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/analyst/HEARTBEAT.md
+++ b/community/agents/analyst/HEARTBEAT.md
@@ -54,7 +54,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/orchestrator/AGENTS.md
+++ b/community/agents/orchestrator/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/orchestrator/HEARTBEAT.md
+++ b/community/agents/orchestrator/HEARTBEAT.md
@@ -91,7 +91,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/research-agent/.claude/skills/memory/SKILL.md
+++ b/community/agents/research-agent/.claude/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/community/agents/research-agent/AGENTS.md
+++ b/community/agents/research-agent/AGENTS.md
@@ -72,7 +72,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -254,7 +254,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -263,7 +263,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/community/agents/research-agent/HEARTBEAT.md
+++ b/community/agents/research-agent/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/agents/security/HEARTBEAT.md
+++ b/community/agents/security/HEARTBEAT.md
@@ -63,7 +63,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/community/skills/memory/SKILL.md
+++ b/community/skills/memory/SKILL.md
@@ -27,7 +27,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -38,7 +38,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -47,7 +47,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -61,7 +61,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent-codex/AGENTS.md
+++ b/templates/agent-codex/AGENTS.md
@@ -71,7 +71,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-   ## Session End - $(date -u +%H:%M:%S UTC)
+   ## Session End - $(date -u +'%H:%M:%S UTC')
    - Status: [done/interrupted/context-full]
    - Current state: [where things stand — specific enough that the next session can resume cold]
    - Active threads: [anything in progress or mid-task with current state]
@@ -260,7 +260,7 @@ This is your session journal. It survives crashes and context compactions. The g
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 
 ```bash
@@ -268,7 +268,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/agent-codex/HEARTBEAT.md
+++ b/templates/agent-codex/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
+++ b/templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent-opencode/AGENTS.md
+++ b/templates/agent-opencode/AGENTS.md
@@ -71,7 +71,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-   ## Session End - $(date -u +%H:%M:%S UTC)
+   ## Session End - $(date -u +'%H:%M:%S UTC')
    - Status: [done/interrupted/context-full]
    - Current state: [where things stand — specific enough that the next session can resume cold]
    - Active threads: [anything in progress or mid-task with current state]
@@ -266,7 +266,7 @@ This is your session journal. It survives crashes and context compactions. The g
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 
 ```bash
@@ -274,7 +274,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/agent-opencode/HEARTBEAT.md
+++ b/templates/agent-opencode/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/agent-opencode/plugins/cortextos-agent-skills/skills/memory/SKILL.md
+++ b/templates/agent-opencode/plugins/cortextos-agent-skills/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent/.claude/skills/memory/SKILL.md
+++ b/templates/agent/.claude/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/agent/AGENTS.md
+++ b/templates/agent/AGENTS.md
@@ -55,7 +55,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -266,7 +266,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -275,7 +275,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/agent/HEARTBEAT.md
+++ b/templates/agent/HEARTBEAT.md
@@ -69,7 +69,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/analyst/.claude/skills/memory/SKILL.md
+++ b/templates/analyst/.claude/skills/memory/SKILL.md
@@ -26,7 +26,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <output of `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">
@@ -37,7 +37,7 @@ MEMEOF
 
 ### Mid-work inline note (write immediately when something important happens)
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Don't wait for the heartbeat. Use for: significant decisions, user preferences learned, non-obvious situations, anything you would want the next session to know. One line.
 
@@ -46,7 +46,7 @@ Don't wait for the heartbeat. Use for: significant decisions, user preferences l
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Heartbeat - $(date -u +%H:%M:%S UTC)
+## Heartbeat - $(date -u +'%H:%M:%S UTC')
 - Current focus: <what I am working on and why>
 - Active threads: <anything in progress or being monitored — state of each>
 - Key decisions: <decisions made since last entry with brief rationale>
@@ -60,7 +60,7 @@ MEMEOF
 TODAY=$(date -u +%Y-%m-%d)
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]

--- a/templates/analyst/AGENTS.md
+++ b/templates/analyst/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/analyst/HEARTBEAT.md
+++ b/templates/analyst/HEARTBEAT.md
@@ -83,7 +83,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>

--- a/templates/orchestrator/AGENTS.md
+++ b/templates/orchestrator/AGENTS.md
@@ -50,7 +50,7 @@ Run these steps before any restart (hard or soft) and on context exhaustion.
    TODAY=$(date -u +%Y-%m-%d)
    cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session End - $(date -u +%H:%M:%S UTC)
+## Session End - $(date -u +'%H:%M:%S UTC')
 - Status: [done/interrupted/context-full]
 - Current state: [where things stand — specific enough that the next session can resume cold]
 - Active threads: [anything in progress or mid-task with current state]
@@ -232,7 +232,7 @@ Each entry should answer: **"if my context was wiped right now, what would I nee
 
 **Mid-work inline notes — write immediately, don't wait for heartbeat:**
 ```bash
-echo "NOTE $(date -u +%H:%M UTC): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
+echo "NOTE $(date -u +'%H:%M UTC'): <key decision / discovery / user preference / non-obvious thing>" >> "memory/$TODAY.md"
 ```
 Use this when: you make a significant decision, learn something about the user, hit a non-obvious situation, or encounter anything you would want the next session to know. One line is enough. The heartbeat is for structured summaries — inline notes capture the moment.
 
@@ -241,7 +241,7 @@ TODAY=$(date -u +%Y-%m-%d)
 mkdir -p memory
 cat >> "memory/$TODAY.md" << MEMEOF
 
-## Session Start - $(date -u +%H:%M:%S UTC)
+## Session Start - $(date -u +'%H:%M:%S UTC')
 - Status: online
 - Crons active: <list from `cortextos bus list-crons $CTX_AGENT_NAME`>
 - Inbox: <N messages or "empty">

--- a/templates/orchestrator/HEARTBEAT.md
+++ b/templates/orchestrator/HEARTBEAT.md
@@ -97,7 +97,7 @@ MEMORY_DIR="$(pwd)/memory"
 mkdir -p "$MEMORY_DIR"
 cat >> "$MEMORY_DIR/$TODAY.md" << MEMORY
 
-## Heartbeat Update - $(date -u +%H:%M UTC) / $LOCAL_TIME
+## Heartbeat Update - $(date -u +'%H:%M UTC') / $LOCAL_TIME
 - WORKING ON: <task_id or "none">
 - Status: <healthy/working/blocked>
 - Inbox: <N messages processed>


### PR DESCRIPTION
## Summary

Agent templates tell agents to stamp memory and heartbeat records with
`date -u +%H:%M UTC` and `date -u +%H:%M:%S UTC`. The bare `UTC` token after the
format string is parsed as a positional operand, so `date` rejects it:

```
$ date -u +%H:%M:%S UTC
date: illegal time format
usage: date [-jnRu] ...
$ echo $?
1
```

`date` exits 1 and prints nothing, but the wrapping `echo`/heredoc still exits 0.
The result is a well-formed record with an empty timestamp, written successfully,
with no error surfaced anywhere:

```
$ echo "NOTE $(date -u +%H:%M UTC): decision"
NOTE : decision                     <-- echo exit 0

$ cat << MEMEOF
## Session Start - $(date -u +%H:%M:%S UTC)
MEMEOF
## Session Start -                  <-- cat exit 0
```

The `date` call fails on every invocation for every agent scaffolded from these
templates. The failure is silent by construction: the only signal is a missing
timestamp inside an otherwise correct-looking record. Whether the blank stamp
survives into the final file varies — an agent that notices the empty output may
work around it, at the cost of extra turns and degraded output (see the sandbox
results below).

This quotes the format string so it is a single operand:

```
$ date -u +'%H:%M UTC'
21:50 UTC                           (exit 0)
```

## Scope

62 occurrences across 26 tracked files, split across the two directories that
ship agent scaffolding:

| directory | variant A `+%H:%M UTC` | variant B `+%H:%M:%S UTC` | total | files |
|---|---|---|---|---|
| `templates/` | 14 | 22 | 36 | 14 |
| `community/` | 12 | 14 | 26 | 12 |
| **total** | **26** | **36** | **62** | **26** |

`community/` is included deliberately rather than deferred to a follow-up: it is
the same defect, and those are the agents a catalog install actually creates, so
a `templates/`-only fix would not reach the surface where it matters most.

### Per-file counts (post-fix, quoted form)

| file | `+'%H:%M UTC'` | `+'%H:%M:%S UTC'` |
|---|---|---|
| `community/agents/agent/AGENTS.md` | 1 | 2 |
| `community/agents/agent/HEARTBEAT.md` | 1 | 0 |
| `community/agents/agentic-crm-assistant/HEARTBEAT.md` | 1 | 0 |
| `community/agents/analyst/AGENTS.md` | 1 | 2 |
| `community/agents/analyst/HEARTBEAT.md` | 1 | 0 |
| `community/agents/orchestrator/AGENTS.md` | 1 | 2 |
| `community/agents/orchestrator/HEARTBEAT.md` | 1 | 0 |
| `community/agents/research-agent/.claude/skills/memory/SKILL.md` | 1 | 3 |
| `community/agents/research-agent/AGENTS.md` | 1 | 2 |
| `community/agents/research-agent/HEARTBEAT.md` | 1 | 0 |
| `community/agents/security/HEARTBEAT.md` | 1 | 0 |
| `community/skills/memory/SKILL.md` | 1 | 3 |
| `templates/agent/AGENTS.md` | 1 | 2 |
| `templates/agent/HEARTBEAT.md` | 1 | 0 |
| `templates/agent/.claude/skills/memory/SKILL.md` | 1 | 3 |
| `templates/agent-codex/AGENTS.md` | 1 | 2 |
| `templates/agent-codex/HEARTBEAT.md` | 1 | 0 |
| `templates/agent-codex/plugins/cortextos-agent-skills/skills/memory/SKILL.md` | 1 | 3 |
| `templates/agent-opencode/AGENTS.md` | 1 | 2 |
| `templates/agent-opencode/HEARTBEAT.md` | 1 | 0 |
| `templates/agent-opencode/plugins/cortextos-agent-skills/skills/memory/SKILL.md` | 1 | 3 |
| `templates/analyst/AGENTS.md` | 1 | 2 |
| `templates/analyst/HEARTBEAT.md` | 1 | 0 |
| `templates/analyst/.claude/skills/memory/SKILL.md` | 1 | 3 |
| `templates/orchestrator/AGENTS.md` | 1 | 2 |
| `templates/orchestrator/HEARTBEAT.md` | 1 | 0 |
| **26 files** | **26** | **36** |

## What is deliberately NOT changed

- **`templates/hermes/HEARTBEAT.md`** uses `date -u +%H:%M` with no trailing `UTC`
  token. That is a correct, working call. Quoting it would be churn and breaking
  it would be a regression. Untouched, and it does not appear in `git status`.
- **`date -u +%H:%M:%S)`** — 8 occurrences, 4 in `templates/orchestrator/.claude/skills/`
  and a separate 4 in `community/skills/`, across the morning-review, weekly-review,
  evening-review and nighttime-mode skills. The format is terminated by `)`, so these
  are correct calls. All 8 verified unchanged.
- Every `date -u +%Y-%m-%d...` and `date -u +%Y-%m-%dT%H:%M:%SZ...` shape.
- **`templates/hermes/AGENTS.md`** carries 3 more occurrences but is untracked and
  gitignored (root `.gitignore` ignores bare `AGENTS.md` at any depth), so it is
  not in this repo's tree and no install receives it. Anyone auditing a working
  tree that happens to contain that file will still find 3 occurrences after this
  merges — **that is not an incomplete fix.**

## Style

Quotes are placed after the `+` (`date -u +'%H:%M UTC'`) to match existing repo
convention: `date +'...'` appears 26 times in `templates/`, several of them on the
line directly above a fixed occurrence. The `"+..."` form appears 0 times
repo-wide.

## Test plan

Every occurrence is a literal two-character quote insertion; no line is otherwise
modified, which is asserted programmatically rather than reviewed by eye.

**Audit command — do not use a bare recursive `grep` for this.** In some shells
`grep` is shadowed by a function that execs `ugrep --ignore-files`, which silently
skips gitignore-matched paths *including tracked ones* and will report a false
zero on several of the files below. Use `command grep`, `/usr/bin/grep`, or python:

```bash
# must both return 0
command grep -rF -o "date -u +%H:%M UTC"    templates/ community/ | wc -l
command grep -rF -o "date -u +%H:%M:%S UTC" templates/ community/ | wc -l

# must return 26 and 36
command grep -rF -o "date -u +'%H:%M UTC'"    templates/ community/ | wc -l
command grep -rF -o "date -u +'%H:%M:%S UTC'" templates/ community/ | wc -l
```

Verified before merge:

1. **Residual audit** — both unquoted variants at 0; quoted variants at 26 and 36.
2. **Collateral-damage control** — the count of the literal substring `date -u` is
   unchanged in each directory independently (`templates/` 125 before and after,
   `community/` 93 before and after), and the full histogram of `date -u +<shape>`
   is byte-identical except the two rows that were fixed. This is the check that
   catches an accidental edit to a different format string.
3. **Diff shape** — every `-`/`+` pair satisfies `minus.replace(bug, fixed) == plus`
   exactly, proving pure quote insertion with no other edit; no line-ending or
   trailing-newline changes.
4. **Executable smoke check** — the fixed idiom was run in all three contexts it
   appears in (nested `$()` inside a double-quoted `echo`, and two unquoted
   heredocs), asserting exit 0 and a non-empty stamp. The **broken** form was run
   in the same three contexts and shown producing an empty stamp while still
   exiting 0, so the check discriminates rather than merely passing.
5. `npx tsc --noEmit` passes, and is explicitly **not** evidence here — these are
   markdown files and it passes regardless.

## Platform coverage — all platforms, not just BSD/macOS

**The defect is argv-level, not implementation-level.** An unquoted format string followed by a bare `UTC`
is *two words* at shell parse time in every shell, so `date` always receives `UTC` as a trailing operand
regardless of which `date` is on PATH. BSD reports `illegal time format`, GNU reports `extra operand 'UTC'`
— same argv defect, different wording. On that mechanism the bug affects **all platforms, including Linux**,
and the quoted form is a single well-formed `+FORMAT` operand everywhere.

Measurement, stated with its bound: what actually executed was **GNU coreutils `date` 9.11 via a PATH shim
on macOS** — base **62 of 153** broken, head **0 of 153**, full sweep rather than spot checks.
**No Linux run happened.** The mechanism carries Linux; the measurement does not.

```
base:  $(date -u +%H:%M:%S UTC)     rc=1   date: extra operand 'UTC'
head:  $(date -u +'%H:%M:%S UTC')   rc=0   22:32:27 UTC
```

## Live sandbox validation

Validated on a full sandbox instance (live daemon, real scaffolded agents), with an **unpatched-base control
so the check could actually fail — and it did**:

| surface | base (72708bdd) | head |
|---|---|---|
| mechanism sweep, 26 changed files | 62 blank of 153 | **0 of 153** |
| copied workspace, agent template | 8 of 8 blank | **0 of 8** |
| per-template scaffold, all 5 templates | 36 of 36 blank | **0 of 36** |
| community sources, all 7 paths | 26 of 26 blank | **0 of 26** |

The 62 failures map 1:1 onto this PR's 62 changed lines. Same instruction, same minute, both agents running
the documented `HEARTBEAT.md` block verbatim:

```
control (unpatched):  ## Heartbeat Update -  / 10:28 PM UTC        <- blank
patched  (this PR):   ## Heartbeat Update - 22:28 UTC / 10:28 PM UTC
```

The local-time half populates on both sides, so the record looks structurally healthy and only the UTC stamp
is missing. That is the silent-corruption signature.

**Nuance worth stating:** at the live-agent surface the damage is non-deterministic. In the control run the
agent *noticed* the empty output and papered over it — 3 failed bash calls, then a workaround, then a full
rewrite of the file — so its final memory file looked fine. The true on-disk state was recovered from the
session transcript and did carry blank stamps. **The bug fires every time; whether it survives into the
artifact depends on whether the agent notices**, and the repair costs extra turns and degrades output
(lost `%S` precision, one heartbeat lost its local-time half). Anything non-LLM reading those stamps gets a
blank. Control needed 16 bash calls and hit 3 `date` failures; patched needed 7 and hit 0.

Repo-wide at head: 1071 tracked files, 236 `date` occurrences executed, **zero remaining of this class**.
Sandbox daemon logs: 0 errors, no crashes, no restarts. Typecheck, CLI build and dashboard build all pass.

### Known limitation

This corrects newly scaffolded agents. Already-deployed agents read from their own
copied workspace, not from `templates/`, so their existing copies are unaffected by
this change.
