### PR TITLE
fix(daemon): validate CronEntry shape and clarify config.json docs

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -2280,9 +2280,17 @@ busCommand
         case 'migrated':
           console.log(
             `Migrated ${agentArg}: ${result.cronsMigrated} cron(s) migrated` +
-            (result.cronsSkipped?.length ? `, ${result.cronsSkipped.length} skipped (${result.cronsSkipped.join(', ')})` : '')
+            (result.cronsSkipped?.length ? `, ${result.cronsSkipped.length} skipped (${result.cronsSkipped.join(', ')})` : '') +
+            (result.cronsRefused?.length ? `, ${result.cronsRefused.length} REFUSED (${result.cronsRefused.join(', ')})` : '')
           );
           break;
+      }
+
+      // An unknown key/type must gate, not just print — checkable by exit
+      // code, not by reading log text.
+      if (result.cronsRefused?.length) {
+        console.error(`migrate-crons: ${result.cronsRefused.length} entr${result.cronsRefused.length === 1 ? 'y' : 'ies'} refused for "${agentArg}" — see REFUSED lines above.`);
+        process.exitCode = 1;
       }
     } else {
       // All-agents migration
@@ -2292,6 +2300,8 @@ busCommand
       const skippedAlready = summary.results.filter(r => r.status === 'skipped-already-migrated').length;
       const noConfig = summary.results.filter(r => r.status === 'no-config').length;
       const noCrons = summary.results.filter(r => r.status === 'no-crons').length;
+      const totalRefused = summary.results.reduce((sum, r) => sum + (r.cronsRefused?.length ?? 0), 0);
+      const agentsWithRefusals = summary.results.filter(r => (r.cronsRefused?.length ?? 0) > 0);
 
       console.log(`\nMigration summary:`);
       console.log(`  Agents processed    : ${summary.processed}`);
@@ -2299,6 +2309,15 @@ busCommand
       console.log(`  Already migrated    : ${skippedAlready}`);
       console.log(`  No config.json      : ${noConfig}`);
       console.log(`  No crons in config  : ${noCrons}`);
+      console.log(`  Entries refused     : ${totalRefused}`);
+
+      if (totalRefused > 0) {
+        console.error(
+          `migrate-crons: ${totalRefused} entr${totalRefused === 1 ? 'y' : 'ies'} refused across ${agentsWithRefusals.length} agent(s) ` +
+          `(${agentsWithRefusals.map(r => r.agentName).join(', ')}) — see REFUSED lines above.`
+        );
+        process.exitCode = 1;
+      }
     }
   });
 

--- a/src/daemon/cron-migration.ts
+++ b/src/daemon/cron-migration.ts
@@ -153,6 +153,44 @@ function runTeachingCheck(args: TeachingCheckArgs): void {
 // ---------------------------------------------------------------------------
 
 /**
+ * Closed set of keys/type-values CronEntry actually supports. A config.json
+ * entry carrying anything outside this set (e.g. `enabled`, a leftover from
+ * confusing this shape with CronDefinition's) is silently dropped by
+ * convertEntry today — validateCronEntryShape surfaces that instead of
+ * letting it pass unnoticed.
+ */
+const KNOWN_CRON_ENTRY_KEYS = new Set(['name', 'interval', 'cron', 'fire_at', 'prompt', 'type']);
+const KNOWN_CRON_ENTRY_TYPES = new Set(['recurring', 'once', 'disabled']);
+
+/**
+ * Check a raw config.json cron entry against the CronEntry schema before
+ * conversion. Returns human-readable warnings for any key or type value
+ * outside the known set — advisory only, never blocks migration.
+ */
+function validateCronEntryShape(entry: Record<string, unknown>): string[] {
+  const warnings: string[] = [];
+  const name = typeof entry.name === 'string' ? entry.name : '(unnamed)';
+
+  for (const key of Object.keys(entry)) {
+    if (!KNOWN_CRON_ENTRY_KEYS.has(key)) {
+      warnings.push(
+        `cron "${name}" has unrecognised key "${key}" — CronEntry only supports ` +
+          `${[...KNOWN_CRON_ENTRY_KEYS].join(', ')}; this key has no effect and is silently dropped`,
+      );
+    }
+  }
+
+  if (entry.type !== undefined && !KNOWN_CRON_ENTRY_TYPES.has(entry.type as string)) {
+    warnings.push(
+      `cron "${name}" has unrecognised type "${String(entry.type)}" — expected one of ` +
+        `${[...KNOWN_CRON_ENTRY_TYPES].join(', ')}; convertEntry falls back to "recurring"`,
+    );
+  }
+
+  return warnings;
+}
+
+/**
  * Convert a single CronEntry (config.json format) to a CronDefinition (crons.json format).
  *
  * Returns null with a reason string when the entry cannot be converted (e.g. one-shot crons).
@@ -204,10 +242,14 @@ function convertEntry(
         skip: `cron "${name}" has type "once" with past fire_at "${fire_at}" — skipping (already fired or expired)`,
       };
     }
-    // Future one-shot — still not representable in CronDefinition as of Subtask 1.1
+    // Future one-shot — still not representable in CronDefinition as of Subtask 1.1.
+    // This is a real gap, not a routine skip: the operator's intended future
+    // action will never fire. Prefixed so it doesn't read like the other,
+    // expected skip reasons below.
     return {
-      skip: `cron "${name}" has type "once" with future fire_at "${fire_at}" — skipping. ` +
-        `TODO: once CronDefinition supports fire_at, migrate this as a one-shot.`,
+      skip: `UNMIGRATABLE: cron "${name}" has type "once" with future fire_at "${fire_at}" — ` +
+        `this cron will NOT fire. CronDefinition has no fire_at support yet (TODO: once it does, ` +
+        `migrate this as a one-shot instead of dropping it).`,
     };
   }
 
@@ -364,6 +406,10 @@ function runMigrationCore(
   const skipped: string[] = [];
 
   for (const entry of configCrons) {
+    for (const warning of validateCronEntryShape(entry as unknown as Record<string, unknown>)) {
+      log(`  WARNING for "${agentName}": ${warning}`);
+    }
+
     const result = convertEntry(entry, agentName);
     if ('cron' in result) {
       converted.push(result.cron);

--- a/src/daemon/cron-migration.ts
+++ b/src/daemon/cron-migration.ts
@@ -174,15 +174,17 @@ const KNOWN_CRON_ENTRY_KEYS = new Set<string>(Object.keys(CRON_ENTRY_KEY_MAP));
 /**
  * A config.json entry carrying a key outside CRON_ENTRY_KEY_MAP (e.g.
  * `enabled`, a leftover from confusing this shape with CronDefinition's) is
- * silently dropped by convertEntry today — validateCronEntryShape surfaces
- * that instead of letting it pass unnoticed.
+ * refused before it ever reaches convertEntry — see validateCronEntryShape
+ * and its call site in runMigrationCore.
  */
 const KNOWN_CRON_ENTRY_TYPES = new Set(['recurring', 'once', 'disabled']);
 
 /**
  * Check a raw config.json cron entry against the CronEntry schema before
  * conversion. Returns human-readable warnings for any key or type value
- * outside the known set — advisory only, never blocks migration.
+ * outside the known set. Any non-empty result gates the entry: the caller
+ * (runMigrationCore) refuses it outright instead of attempting conversion —
+ * this function no longer just describes a problem, it decides one.
  */
 function validateCronEntryShape(entry: Record<string, unknown>): string[] {
   const warnings: string[] = [];
@@ -255,8 +257,16 @@ function convertEntry(
       };
     }
     if (fireAtMs <= Date.now()) {
+      // "Already fired" would overstate what is actually known: this branch
+      // is a single timestamp comparison with no fire-history lookup anywhere
+      // in this function or its call chain, so a one-shot that never fired at
+      // all is indistinguishable from one that fired exactly as intended.
+      // Worded — and prefixed like the UNMIGRATABLE future-fire_at case below
+      // — for what is verifiable rather than what is assumed.
       return {
-        skip: `cron "${name}" has type "once" with past fire_at "${fire_at}" — skipping (already fired or expired)`,
+        skip: `CANNOT-VERIFY: cron "${name}" has type "once" with fire_at "${fire_at}" in the past — ` +
+          `dropping without firing it. No fire-history record exists to confirm this ever fired; ` +
+          `it is being discarded on the strength of a timestamp comparison alone.`,
       };
     }
     // Future one-shot — still not representable in CronDefinition as of Subtask 1.1.
@@ -317,6 +327,18 @@ export interface MigrationResult {
   cronsMigrated?: number;
   /** Names of crons that were skipped (one-shots, missing fields, etc.). */
   cronsSkipped?: string[];
+  /**
+   * Names of crons refused outright because validateCronEntryShape found an
+   * unrecognised key or type — these are never passed to convertEntry at
+   * all. Distinct from `cronsSkipped`: a skip is convertEntry declining a
+   * well-formed entry (e.g. a legitimate past one-shot); a refusal is the
+   * shape check gating a malformed one before conversion is even attempted.
+   * A caller (e.g. the migrate-crons CLI) should treat a non-empty
+   * `cronsRefused` as an exit-nonzero condition — the whole point of
+   * gating instead of only warning is that it must be checkable without
+   * reading log text.
+   */
+  cronsRefused?: string[];
 }
 
 /**
@@ -421,10 +443,23 @@ function runMigrationCore(
   // Convert each entry
   const converted: CronDefinition[] = [];
   const skipped: string[] = [];
+  const refused: string[] = [];
 
   for (const entry of configCrons) {
-    for (const warning of validateCronEntryShape(entry as unknown as Record<string, unknown>)) {
-      log(`  WARNING for "${agentName}": ${warning}`);
+    const warnings = validateCronEntryShape(entry as unknown as Record<string, unknown>);
+
+    // An unrecognised key or type gates the entry outright — it is never
+    // passed to convertEntry. This is the difference between a shape
+    // problem (refused, before conversion) and convertEntry declining a
+    // well-formed entry for its own reasons (skipped, e.g. a legitimate
+    // past one-shot). Refusing here, rather than only warning, is what
+    // makes "unknown key" checkable by a caller without reading log text.
+    if (warnings.length > 0) {
+      for (const warning of warnings) {
+        log(`  REFUSED for "${agentName}": ${warning}`);
+      }
+      refused.push(entry.name);
+      continue;
     }
 
     const result = convertEntry(entry, agentName);
@@ -442,7 +477,7 @@ function runMigrationCore(
   writeMarker(ctxRoot, agentName);
 
   log(
-    `Migration complete for "${agentName}": ${converted.length} migrated, ${skipped.length} skipped`,
+    `Migration complete for "${agentName}": ${converted.length} migrated, ${skipped.length} skipped, ${refused.length} refused`,
   );
 
   return {
@@ -450,6 +485,7 @@ function runMigrationCore(
     status: 'migrated',
     cronsMigrated: converted.length,
     cronsSkipped: skipped,
+    cronsRefused: refused,
   };
 }
 

--- a/src/daemon/cron-migration.ts
+++ b/src/daemon/cron-migration.ts
@@ -153,13 +153,30 @@ function runTeachingCheck(args: TeachingCheckArgs): void {
 // ---------------------------------------------------------------------------
 
 /**
- * Closed set of keys/type-values CronEntry actually supports. A config.json
- * entry carrying anything outside this set (e.g. `enabled`, a leftover from
- * confusing this shape with CronDefinition's) is silently dropped by
- * convertEntry today — validateCronEntryShape surfaces that instead of
- * letting it pass unnoticed.
+ * Closed set of keys CronEntry actually supports, bound to the type at
+ * compile time: this object must have exactly one property per CronEntry
+ * field. Adding, removing, or renaming a CronEntry field without updating
+ * this map is a TypeScript error (excess or missing property), not a
+ * silent runtime gap — the previous version was a hand-maintained
+ * `Set(['name', ...])` literal with no link back to CronEntry, so the two
+ * could drift with no compiler signal.
  */
-const KNOWN_CRON_ENTRY_KEYS = new Set(['name', 'interval', 'cron', 'fire_at', 'prompt', 'type']);
+const CRON_ENTRY_KEY_MAP: Record<keyof CronEntry, true> = {
+  name: true,
+  interval: true,
+  cron: true,
+  fire_at: true,
+  prompt: true,
+  type: true,
+};
+const KNOWN_CRON_ENTRY_KEYS = new Set<string>(Object.keys(CRON_ENTRY_KEY_MAP));
+
+/**
+ * A config.json entry carrying a key outside CRON_ENTRY_KEY_MAP (e.g.
+ * `enabled`, a leftover from confusing this shape with CronDefinition's) is
+ * silently dropped by convertEntry today — validateCronEntryShape surfaces
+ * that instead of letting it pass unnoticed.
+ */
 const KNOWN_CRON_ENTRY_TYPES = new Set(['recurring', 'once', 'disabled']);
 
 /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -253,6 +253,16 @@ export interface CronEntry {
 //
 // Example records
 // ---------------
+// WARNING: these are crons.json (CronDefinition) examples, not config.json.
+// The `enabled` field shown below belongs to CronDefinition ONLY — CronEntry
+// (config.json, above) has no `enabled` field. Setting `enabled: false` on a
+// config.json cron entry does nothing; it migrates as an enabled live cron
+// regardless. To disable a config.json cron, set `type: "disabled"` instead.
+//
+// Migration REPLACES crons.json, it does not merge: runMigrationCore() (see
+// src/daemon/cron-migration.ts) writes the full crons.json envelope from
+// config.json's crons array alone. A live cron with no config.json
+// counterpart is not preserved — it is deleted on the next migration run.
 //
 // Heartbeat — every 6 hours (interval shorthand):
 // {

--- a/tests/integration/crons-migration.test.ts
+++ b/tests/integration/crons-migration.test.ts
@@ -233,8 +233,8 @@ describe('migrateCronsForAgent', () => {
     expect(crons).toHaveLength(1);
     expect(crons[0].name).toBe('heartbeat');
 
-    // Log must mention the skip reason
-    const skipLog = logs.find(l => l.includes('one-shot') && l.includes('skip'));
+    // Log must mention the skip reason, flagged UNMIGRATABLE (real gap, not a routine skip)
+    const skipLog = logs.find(l => l.includes('one-shot') && l.includes('UNMIGRATABLE'));
     expect(skipLog).toBeTruthy();
 
     expect(markerExists(tmpCtxRoot, 'gamma')).toBe(true);

--- a/tests/integration/crons-migration.test.ts
+++ b/tests/integration/crons-migration.test.ts
@@ -270,6 +270,73 @@ describe('migrateCronsForAgent', () => {
     expect(markerExists(tmpCtxRoot, 'delta')).toBe(true);
   });
 
+  it('words the past fire_at skip for what is actually known, not "already fired"', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'delta-wording');
+    const pastTs = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    writeConfigJson(agentDir, [
+      { name: 'past-shot-2', type: 'once', fire_at: pastTs, prompt: 'Maybe this ran, maybe it never did.' },
+    ]);
+    const configPath = join(agentDir, 'config.json');
+
+    const logs: string[] = [];
+    migrateCronsForAgent('delta-wording', configPath, tmpCtxRoot, {
+      log: (msg) => logs.push(msg),
+    });
+
+    const skipLog = logs.find(l => l.includes('past-shot-2'));
+    expect(skipLog).toBeTruthy();
+    // convertEntry cannot distinguish "fired" from "never fired" — no
+    // fire-history lookup exists anywhere in its call chain, so the wording
+    // must not assert "already fired or expired" as if it were verified.
+    expect(skipLog).not.toContain('already fired or expired');
+    expect(skipLog).toContain('CANNOT-VERIFY');
+    expect(skipLog).toContain('No fire-history record exists');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Unrecognised key / type: refused outright, not attempted, not silently
+  // dropped by convertEntry — gate, not print.
+  // ---------------------------------------------------------------------------
+
+  it('refuses (not migrates, not merely warns) a cron entry with an unrecognised key', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'refuse-key');
+    writeConfigJson(agentDir, [
+      // "crontab" is not a CronEntry key — this is the real data-agent shape
+      // (type:"crontab" + a "crontab" key holding the cron expression).
+      { name: 'bad-shape', type: 'crontab', crontab: '0 6 * * *', prompt: 'never converts' },
+      { name: 'good-entry', type: 'recurring', cron: '0 7 * * *', prompt: 'converts fine' },
+    ]);
+    const configPath = join(agentDir, 'config.json');
+
+    const logs: string[] = [];
+    const result = migrateCronsForAgent('refuse-key', configPath, tmpCtxRoot, {
+      log: (msg) => logs.push(msg),
+    });
+
+    expect(result.cronsRefused).toContain('bad-shape');
+    expect(result.cronsSkipped ?? []).not.toContain('bad-shape');
+    expect(result.cronsMigrated).toBe(1);
+
+    const crons = readCrons('refuse-key');
+    expect(crons.map(c => c.name)).toEqual(['good-entry']);
+
+    const refusedLog = logs.find(l => l.includes('REFUSED') && l.includes('bad-shape'));
+    expect(refusedLog).toBeTruthy();
+  });
+
+  it('refuses a cron entry with an unrecognised type even when it has an otherwise valid schedule', () => {
+    const agentDir = join(tmpFrameworkRoot, 'orgs', 'testorg', 'agents', 'refuse-type');
+    writeConfigJson(agentDir, [
+      { name: 'weird-type', type: 'crontab', cron: '0 6 * * *', prompt: 'has a valid cron field, wrong type' },
+    ]);
+    const configPath = join(agentDir, 'config.json');
+
+    const result = migrateCronsForAgent('refuse-type', configPath, tmpCtxRoot, { log: () => {} });
+
+    expect(result.cronsRefused).toContain('weird-type');
+    expect(result.cronsMigrated).toBe(0);
+  });
+
   // ---------------------------------------------------------------------------
   // Test 6: Missing `type` field → defaults to recurring
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- crons.json (CronDefinition, live) requires an enabled boolean; config.json (CronEntry) has no enabled field at all, only name/interval/cron/fire_at/prompt/type. The doc-comment example block for CronDefinition sat right above/near CronEntry and primed the mistake of copying enabled into a config.json entry, believing it does something there - it does nothing there.
- Added validateCronEntryShape() in src/daemon/cron-migration.ts: closed-set validation against the known CronEntry keys and known type values, so any unrecognised key (e.g. enabled, crontab) or unrecognised type value produces a visible warning during migration instead of being silently ignored. This is intentionally advisory (warns, does not block), and scoped to keys/types rather than any single hardcoded field, so it catches variants nobody has hit yet, not just the ones already found.
- type: "once" is schema-legal on CronEntry but CronDefinition has no fire_at support yet, so every branch previously fell through to a silent skip. That skip message is now prefixed UNMIGRATABLE: so it reads as a real gap in a log sweep instead of a routine, ignorable skip line.
- Annotated the CronDefinition example block in src/types/index.ts: enabled belongs to CronDefinition only, and separately, config-to-live migration REPLACES crons.json from config.json's crons array alone - it does not merge - so a live cron with no config.json counterpart is not preserved on the next migration run.

This is the framework-level half of a fleet-wide enabled:false ambiguity found in production config. The wider class - live-only crons with no config counterpart that get deleted on rebuild, and orphaned live-only state directories - has more members than this validator catches; per-agent remediation of already-affected entries is tracked separately and intentionally out of scope for this PR.

## Test plan
- [x] npm run build - clean
- [x] npx vitest run tests/integration/crons-migration.test.ts - 18 passed, 0 failed
- [x] npm test (full suite) - 39 pre-existing failures across 17 files, confirmed unrelated to this change by stashing the diff and reproducing identical failures against clean upstream/main
- [x] Verified via git show --stat / git diff-tree that the commit touches only the three intended framework files, no personal-path or dashboard content