### PR TITLE
fix(telegram): remove pasted ulimit output corrupting buildRecentHistory JSDoc

### DIFF
--- a/src/telegram/logging.ts
+++ b/src/telegram/logging.ts
@@ -188,14 +188,6 @@ export function readLastSent(
 
 /**
  * Build a short recent conversation snippet for context injection.
- * Reads the last cputime         unlimited
-filesize        unlimited
-datasize        unlimited
-stacksize       7MB
-
-
-/**
- * Build a short recent conversation snippet for context injection.
  * Reads the last `limit` messages (combined inbound + outbound) for the
  * given agent/chatId, sorts by timestamp, and returns a formatted string.
  * Returns null if no history is available.


### PR DESCRIPTION
An unterminated `/**` block above `buildRecentHistory` in `src/telegram/logging.ts` contains pasted `ulimit -a` output. Block comments do not nest, so the real JSDoc that followed was swallowed into the same span, and the IDE hover for a public exported function shows shell garbage.

**Comment-only, zero runtime risk.** No executable code was inside the span — `export function buildRecentHistory` was never part of the comment, which is why this compiled fine and went unnoticed.

Pre-existing on `main` (`72708bd`); not introduced by any open PR, and deliberately excluded from PR #31 to keep that diff focused.

## Verification
- `npx tsc --noEmit` — clean (exit 0). Note `npm run build` is tsup/esbuild and does **not** typecheck, so this is the real gate.
- `npm run build` — success
- `npm test` — 1984 passed, 4 skipped, 117 files passed / 2 skipped
- Diff is 8 deletions, all inside the corrupted comment span; no code lines touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)