### PR TITLE
fix(daemon): stop migrate-crons --force wiping a live crons.json [HELD - DO NOT MERGE]

### DIFF
--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -2277,6 +2277,19 @@ busCommand
         case 'no-crons':
           console.log(`Skipped ${agentArg}: config.json has no crons — empty crons.json written`);
           break;
+        case 'preserved-existing-crons':
+          console.log(
+            `Preserved ${agentArg}: config.json has no crons to migrate, but crons.json is non-empty — ` +
+            `live crons left untouched`
+          );
+          break;
+        case 'aborted-unparseable-config':
+          console.error(
+            `ABORTED ${agentArg}: config.json could not be parsed. Nothing was written — ` +
+            `crons.json and the migration marker are both untouched. Repair config.json and re-run.`
+          );
+          process.exit(1);
+          break;
         case 'migrated':
           console.log(
             `Migrated ${agentArg}: ${result.cronsMigrated} cron(s) migrated` +
@@ -2292,6 +2305,8 @@ busCommand
       const skippedAlready = summary.results.filter(r => r.status === 'skipped-already-migrated').length;
       const noConfig = summary.results.filter(r => r.status === 'no-config').length;
       const noCrons = summary.results.filter(r => r.status === 'no-crons').length;
+      const preserved = summary.results.filter(r => r.status === 'preserved-existing-crons');
+      const aborted = summary.results.filter(r => r.status === 'aborted-unparseable-config');
 
       console.log(`\nMigration summary:`);
       console.log(`  Agents processed    : ${summary.processed}`);
@@ -2299,6 +2314,17 @@ busCommand
       console.log(`  Already migrated    : ${skippedAlready}`);
       console.log(`  No config.json      : ${noConfig}`);
       console.log(`  No crons in config  : ${noCrons}`);
+      console.log(`  Live crons preserved: ${preserved.length}`);
+      console.log(`  Aborted (bad config): ${aborted.length}`);
+
+      if (aborted.length > 0) {
+        // Name them: a count cannot tell an operator which config.json to repair.
+        console.error(
+          `\nABORTED for ${aborted.length} agent(s) — config.json could not be parsed and nothing ` +
+          `was written for them: ${aborted.map(r => r.agentName).join(', ')}`
+        );
+        process.exit(1);
+      }
     }
   });
 

--- a/src/daemon/cron-migration.ts
+++ b/src/daemon/cron-migration.ts
@@ -22,6 +22,24 @@
  *
  * ## Non-destructive
  * The original `crons` array in config.json is never modified.
+ *
+ * ## --force is a re-migration against a LIVE store, not a bootstrap
+ * `force: true` deletes the marker BEFORE the idempotency gate, so the whole body
+ * re-runs against a crons.json that is by then the authoritative daemon-managed
+ * store — one that has drifted from config.json on purpose (crons added, renamed,
+ * re-scheduled and paused through `update-cron` and the dashboard, none of which
+ * write back to config.json). Three guards exist for that case, and all three are
+ * load-bearing only on the `--force` path:
+ *
+ *   1. A source with nothing to migrate (config.json missing, or no crons array)
+ *      never overwrites a NON-EMPTY crons.json. Note that "no crons array" is the
+ *      normal steady state for every already-migrated agent, which makes the most
+ *      innocuous-looking config the most destructive input.
+ *   2. An UNPARSEABLE config.json aborts outright — no crons write, no marker.
+ *   3. A cron paused in the live store is not re-enabled by re-migrating it.
+ *
+ * `readCrons` is called for (1) and (3); before it was called nowhere here, which
+ * is what made a merge impossible by construction.
  */
 
 import { existsSync, readFileSync, writeFileSync, unlinkSync, mkdirSync } from 'fs';
@@ -166,8 +184,15 @@ function convertEntry(
   // Treat absent `type` as "recurring" (spec requirement)
   const effectiveType = type ?? 'recurring';
 
+  // Resolve pause intent AT THE READER, from every spelling an operator can write,
+  // rather than from one field we happen to model. `type: "disabled"` and
+  // `enabled: false` are two spellings of one instruction; honouring only the first
+  // meant the second was silently inert while looking authoritative on disk.
+  const disabledByType = effectiveType === 'disabled';
+  const disabledByFlag = entry.enabled === false;
+
   // Disabled crons: migrate as disabled (preserve operator intent)
-  if (effectiveType === 'disabled') {
+  if (disabledByType || disabledByFlag) {
     // Disabled entries still need a schedule — use interval or cron expression if present
     const schedule = cronExpr ?? interval;
     if (!schedule) {
@@ -252,8 +277,24 @@ export interface MigrationOptions {
 export interface MigrationResult {
   /** Agent name processed. */
   agentName: string;
-  /** Disposition: skipped-already-migrated | no-config | no-crons | migrated */
-  status: 'skipped-already-migrated' | 'no-config' | 'no-crons' | 'migrated';
+  /**
+   * Disposition.
+   *
+   * `preserved-existing-crons` — the source had nothing to migrate (config.json
+   * missing, or carrying no crons array) but the destination crons.json was
+   * NON-EMPTY. The live store is left untouched and the marker is (re)written.
+   *
+   * `aborted-unparseable-config` — config.json could not be parsed. Nothing is
+   * written: not crons.json, not the marker. See `runMigrationCore` for why this
+   * aborts rather than degrading to an empty write.
+   */
+  status:
+    | 'skipped-already-migrated'
+    | 'no-config'
+    | 'no-crons'
+    | 'migrated'
+    | 'preserved-existing-crons'
+    | 'aborted-unparseable-config';
   /** Number of crons written to crons.json (only set when status === "migrated"). */
   cronsMigrated?: number;
   /** Names of crons that were skipped (one-shots, missing fields, etc.). */
@@ -298,6 +339,47 @@ export function migrateCronsForAgent(
   return result;
 }
 
+/**
+ * True when this agent's crons.json already holds at least one cron.
+ *
+ * FAILS TOWARD PRESERVATION. If the store cannot be read at all we return true,
+ * because "I could not establish that the destination is empty" and "the
+ * destination is empty" are different states and only one of them makes an
+ * overwrite safe. The whole class of bug this guards against comes from treating
+ * an unread value as a known-empty one.
+ */
+function hasLiveCrons(agentName: string, log: (msg: string) => void): boolean {
+  try {
+    return readCrons(agentName).length > 0;
+  } catch (err) {
+    log(
+      `WARNING: could not read existing crons.json for "${agentName}" — assuming NON-EMPTY and ` +
+        `preserving it. Error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return true;
+  }
+}
+
+/**
+ * Names of crons the operator has currently paused in the LIVE store.
+ *
+ * Read at migration time rather than inferred from config.json, because the pause
+ * is applied to crons.json (via `update-cron` / the dashboard) and config.json has
+ * no way to learn about it. Without this, a --force re-migration silently flips a
+ * deliberately-paused cron back on and it starts firing again.
+ */
+function liveDisabledNames(agentName: string, log: (msg: string) => void): Set<string> {
+  try {
+    return new Set(readCrons(agentName).filter((c) => c.enabled === false).map((c) => c.name));
+  } catch (err) {
+    log(
+      `WARNING: could not read existing crons.json for "${agentName}" while resolving paused crons — ` +
+        `no re-enable fence applied. Error: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return new Set();
+  }
+}
+
 /** Core migration logic. Public callers go through `migrateCronsForAgent`. */
 function runMigrationCore(
   agentName: string,
@@ -320,6 +402,14 @@ function runMigrationCore(
 
   // Read config.json — no-op on missing file
   if (!existsSync(configJsonPath)) {
+    if (hasLiveCrons(agentName, log)) {
+      log(
+        `No config.json found for "${agentName}" at ${configJsonPath}, but crons.json is NON-EMPTY — ` +
+          `preserving the live store (nothing to migrate is not the same as migrate nothing)`,
+      );
+      writeMarker(ctxRoot, agentName);
+      return { agentName, status: 'preserved-existing-crons' };
+    }
     log(`No config.json found for "${agentName}" at ${configJsonPath} — writing empty crons.json + marker`);
     writeCrons(agentName, []);
     writeMarker(ctxRoot, agentName);
@@ -330,15 +420,24 @@ function runMigrationCore(
   try {
     rawConfig = JSON.parse(readFileSync(configJsonPath, 'utf-8'));
   } catch (err) {
-    // Unreadable / corrupt config.json: write empty crons.json + marker so we
-    // don't retry on every boot with the same broken file
+    // ABORT — write nothing at all, and do NOT drop the marker.
+    //
+    // This path used to write an empty crons.json plus the marker so the daemon
+    // would not retry a broken file every boot. Both halves of that were wrong on
+    // a --force re-run against a live agent:
+    //   - The empty write destroys the authoritative store on the strength of a
+    //     value we never established. We did not read "no crons"; we failed to read.
+    //   - The marker then makes the loss permanent: once config.json is repaired,
+    //     the idempotency gate skips it forever, so the real content never migrates.
+    // Aborting leaves both artifacts untouched and the failure loud and recoverable.
+    // The cost is a repeated log line per boot while the file stays broken, which is
+    // the intended pressure.
     log(
-      `WARNING: failed to parse config.json for "${agentName}" — writing empty crons.json + marker. ` +
+      `ABORT: failed to parse config.json for "${agentName}" — wrote nothing (crons.json and ` +
+        `migration marker both left untouched). Repair the file and re-run. ` +
         `Error: ${err instanceof Error ? err.message : String(err)}`,
     );
-    writeCrons(agentName, []);
-    writeMarker(ctxRoot, agentName);
-    return { agentName, status: 'no-crons' };
+    return { agentName, status: 'aborted-unparseable-config' };
   }
 
   // Extract crons array — treat missing / empty as "no crons"
@@ -353,6 +452,15 @@ function runMigrationCore(
   }
 
   if (configCrons.length === 0) {
+    if (hasLiveCrons(agentName, log)) {
+      log(
+        `No crons array in config.json for "${agentName}", but crons.json is NON-EMPTY — ` +
+          `preserving the live store. This is the STEADY STATE for an already-migrated agent: ` +
+          `the config.json array is a spent one-time seed and is routinely absent.`,
+      );
+      writeMarker(ctxRoot, agentName);
+      return { agentName, status: 'preserved-existing-crons' };
+    }
     log(`No crons array in config.json for "${agentName}" — writing empty crons.json + marker`);
     writeCrons(agentName, []);
     writeMarker(ctxRoot, agentName);
@@ -363,9 +471,22 @@ function runMigrationCore(
   const converted: CronDefinition[] = [];
   const skipped: string[] = [];
 
+  // RE-ENABLE FENCE. A cron paused in the live store stays paused across a
+  // re-migration. config.json cannot express "I paused this yesterday" — the pause
+  // lives in crons.json — so a straight re-convert stamps `enabled: true` over it
+  // and the cron silently resumes firing. Observed twice in production on one cron.
+  const pausedInLiveStore = liveDisabledNames(agentName, log);
+
   for (const entry of configCrons) {
     const result = convertEntry(entry, agentName);
     if ('cron' in result) {
+      if (result.cron.enabled && pausedInLiveStore.has(result.cron.name)) {
+        result.cron.enabled = false;
+        log(
+          `  Re-enable fence: cron "${entry.name}" is paused in the live crons.json — ` +
+            `migrating it as DISABLED rather than re-enabling it from config.json`,
+        );
+      }
       converted.push(result.cron);
       log(`  Migrated cron "${entry.name}" for "${agentName}" (schedule: ${result.cron.schedule})`);
     } else {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -236,6 +236,19 @@ export interface CronEntry {
   /** "recurring" (default) restores on every session start.
    *  "once" restores only if fire_at is still in the future; deleted after firing. */
   type?: 'recurring' | 'once' | 'disabled';
+  /**
+   * Operator pause switch, mirroring `CronDefinition.enabled`.
+   *
+   * Added because it was already being WRITTEN in real config.json files while
+   * being absent from this interface — so the migration reader, which resolved
+   * enabled-ness from `type` alone, silently discarded it. A key that an operator
+   * can write and the reader cannot see is not a no-op: it reads as "this cron is
+   * paused" and behaves as "this cron is live". `enabled: false` here is now
+   * honoured exactly like `type: "disabled"`.
+   *
+   * @default true
+   */
+  enabled?: boolean;
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration/cron-migration-banner.test.ts
+++ b/tests/integration/cron-migration-banner.test.ts
@@ -248,7 +248,11 @@ describe('migrateCronsForAgent — cron-teaching upgrade banner', () => {
       { log: cap.log },
     );
 
-    expect(result.status).toBe('no-crons');
+    // A corrupt config.json now ABORTS the data migration (it used to degrade to an
+    // empty write plus the marker, which destroyed a live crons.json on --force).
+    // The point of THIS test is unchanged: the advisory is independent of the data
+    // migration, so it still runs and still does not throw when migration fails.
+    expect(result.status).toBe('aborted-unparseable-config');
     const banner = cap.lines.find((l) =>
       l.includes('cron-teaching upgrade recommended'),
     );

--- a/tests/integration/cron-migration-force-guard.test.ts
+++ b/tests/integration/cron-migration-force-guard.test.ts
@@ -1,0 +1,408 @@
+/**
+ * cron-migration-force-guard.test.ts
+ *
+ * REGRESSION GUARD for the `migrate-crons --force` wipe-to-empty class.
+ *
+ * ## The defect
+ *
+ * `runMigrationCore` deletes the idempotency marker BEFORE the `isMigrated` gate,
+ * so `--force` re-runs the whole migration body against a crons.json that is, by
+ * now, the AUTHORITATIVE daemon-managed store — not an empty bootstrap target.
+ * `readCrons` is never called on that path, so a merge is impossible by construction.
+ *
+ * THREE DIFFERENT CAUSES CONVERGE ON ONE DESTRUCTIVE EFFECT — `writeCrons(agent, [])`:
+ *
+ *   1. config.json MISSING      -> writeCrons([]) + marker
+ *   2. config.json UNPARSEABLE  -> writeCrons([]) + marker
+ *   3. config.json has NO crons -> writeCrons([]) + marker
+ *
+ * Cause (3) is the steady state for every already-migrated agent in the fleet: the
+ * `crons` array in config.json is a spent one-time seed and is routinely absent.
+ * THE SAFEST-LOOKING CONFIG IS THE MOST DESTRUCTIVE INPUT.
+ *
+ * ## The contract this file pins
+ *
+ * - MISSING / NO-CRONS: never clobber a NON-EMPTY crons.json. Preserve it, drop the
+ *   marker so we do not loop, and report `preserved-existing-crons`.
+ * - UNPARSEABLE: ABORT, not merely gate. Write NOTHING — not the crons, not the
+ *   marker. Writing an empty store on an input we failed to read destroys data on
+ *   the strength of a value we never established; writing the marker as well would
+ *   permanently foreclose migrating the real content once the file is repaired.
+ * - The legitimate bootstrap path (empty/absent destination) MUST still write the
+ *   empty store and the marker. A guard that breaks first-run migration is not a fix.
+ *
+ * Each arm carries a NEGATIVE CONTROL: the same call against an EMPTY destination,
+ * which must still take the original path. A guard that preserves unconditionally
+ * would pass the positive arms alone, so the positive arms are not controls.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const CRONS_DIR = '.cortextOS/state/agents';
+const CRONS_FILE = 'crons.json';
+const MARKER_FILE = '.crons-migrated';
+
+const AGENT = 'guarded';
+
+let tmpCtxRoot: string;
+let tmpAgentDir: string;
+const originalCtxRoot = process.env.CTX_ROOT;
+
+let migrateCronsForAgent: typeof import('../../src/daemon/cron-migration.js').migrateCronsForAgent;
+let isMigrated: typeof import('../../src/daemon/cron-migration.js').isMigrated;
+let readCrons: typeof import('../../src/bus/crons.js').readCrons;
+let writeCrons: typeof import('../../src/bus/crons.js').writeCrons;
+
+async function reloadModules(): Promise<void> {
+  vi.resetModules();
+  const migMod = await import('../../src/daemon/cron-migration.js');
+  migrateCronsForAgent = migMod.migrateCronsForAgent;
+  isMigrated = migMod.isMigrated;
+  const cronsMod = await import('../../src/bus/crons.js');
+  readCrons = cronsMod.readCrons;
+  writeCrons = cronsMod.writeCrons;
+}
+
+function markerPath(): string {
+  return join(tmpCtxRoot, CRONS_DIR, AGENT, MARKER_FILE);
+}
+
+function cronsPath(): string {
+  return join(tmpCtxRoot, CRONS_DIR, AGENT, CRONS_FILE);
+}
+
+/**
+ * Seed a LIVE, daemon-managed crons.json — i.e. the state every already-migrated
+ * agent is in. Deliberately holds a cron that exists in NO config.json, which is
+ * exactly the content a re-migration cannot reconstruct.
+ */
+function seedLiveCrons(): void {
+  writeCrons(AGENT, [
+    {
+      name: 'daemon-created-watch',
+      prompt: 'Created by the daemon after migration. Exists in no config.json.',
+      schedule: '12,42 * * * *',
+      enabled: true,
+      created_at: '2026-08-01T00:00:00.000Z',
+    },
+    {
+      name: 'heartbeat',
+      prompt: 'Run the heartbeat workflow.',
+      schedule: '8h',
+      enabled: true,
+      created_at: '2026-08-01T00:00:00.000Z',
+    },
+  ]);
+  // Migration has already happened for this agent — that is the whole premise.
+  mkdirSync(join(tmpCtxRoot, CRONS_DIR, AGENT), { recursive: true });
+  writeFileSync(markerPath(), '', 'utf-8');
+}
+
+function writeConfig(contents: string): string {
+  const p = join(tmpAgentDir, 'config.json');
+  writeFileSync(p, contents, 'utf-8');
+  return p;
+}
+
+beforeEach(async () => {
+  tmpCtxRoot = mkdtempSync(join(tmpdir(), 'force-guard-ctx-'));
+  tmpAgentDir = mkdtempSync(join(tmpdir(), 'force-guard-agent-'));
+  process.env.CTX_ROOT = tmpCtxRoot;
+  await reloadModules();
+});
+
+afterEach(() => {
+  if (originalCtxRoot === undefined) delete process.env.CTX_ROOT;
+  else process.env.CTX_ROOT = originalCtxRoot;
+  rmSync(tmpCtxRoot, { recursive: true, force: true });
+  rmSync(tmpAgentDir, { recursive: true, force: true });
+});
+
+describe('migrate-crons --force must not wipe a live crons.json', () => {
+  // -------------------------------------------------------------------------
+  // Cause 1 — config.json MISSING
+  // -------------------------------------------------------------------------
+  it('CAUSE 1 (missing config.json): preserves a populated crons.json', () => {
+    seedLiveCrons();
+    expect(readCrons(AGENT)).toHaveLength(2);
+
+    const missingConfig = join(tmpAgentDir, 'config.json'); // never created
+    expect(existsSync(missingConfig)).toBe(false);
+
+    const result = migrateCronsForAgent(AGENT, missingConfig, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    const after = readCrons(AGENT);
+    expect(after).toHaveLength(2);
+    expect(after.map((c) => c.name).sort()).toEqual(['daemon-created-watch', 'heartbeat']);
+    expect(result.status).toBe('preserved-existing-crons');
+    // Marker restored so the daemon does not loop on every boot.
+    expect(isMigrated(tmpCtxRoot, AGENT)).toBe(true);
+  });
+
+  it('CAUSE 1 NEGATIVE CONTROL (missing config.json, EMPTY destination): still bootstraps', () => {
+    const missingConfig = join(tmpAgentDir, 'config.json');
+    const result = migrateCronsForAgent(AGENT, missingConfig, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    expect(result.status).toBe('no-config');
+    expect(readCrons(AGENT)).toHaveLength(0);
+    expect(existsSync(cronsPath())).toBe(true);
+    expect(isMigrated(tmpCtxRoot, AGENT)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cause 2 — config.json UNPARSEABLE. ABORT, not gate.
+  // -------------------------------------------------------------------------
+  it('CAUSE 2 (unparseable config.json): ABORTS — writes neither crons nor marker', () => {
+    seedLiveCrons();
+    const configPath = writeConfig('{ "crons": [ this is not json');
+
+    const logs: string[] = [];
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, {
+      force: true,
+      log: (m) => logs.push(m),
+    });
+
+    expect(result.status).toBe('aborted-unparseable-config');
+    const after = readCrons(AGENT);
+    expect(after).toHaveLength(2);
+    expect(after.map((c) => c.name).sort()).toEqual(['daemon-created-watch', 'heartbeat']);
+    // The marker must NOT be re-written: a repaired config.json has to be able to
+    // migrate later. Writing it here would foreclose that permanently.
+    expect(isMigrated(tmpCtxRoot, AGENT)).toBe(false);
+    expect(logs.join('\n')).toMatch(/ABORT/i);
+  });
+
+  it('CAUSE 2 (unparseable config.json, EMPTY destination): STILL aborts — never writes on unread input', () => {
+    // Abort is unconditional. It is not a function of what the destination holds:
+    // we failed to read the source, so we have established nothing to act on.
+    const configPath = writeConfig('}{ broken');
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    expect(result.status).toBe('aborted-unparseable-config');
+    expect(existsSync(cronsPath())).toBe(false);
+    expect(isMigrated(tmpCtxRoot, AGENT)).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Cause 3 — config.json present, NO crons array. The fleet steady state.
+  // -------------------------------------------------------------------------
+  it('CAUSE 3 (config.json with no crons array): preserves a populated crons.json', () => {
+    seedLiveCrons();
+    const configPath = writeConfig(JSON.stringify({ name: AGENT, enabled: true }));
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    const after = readCrons(AGENT);
+    expect(after).toHaveLength(2);
+    expect(after.map((c) => c.name).sort()).toEqual(['daemon-created-watch', 'heartbeat']);
+    expect(result.status).toBe('preserved-existing-crons');
+    expect(isMigrated(tmpCtxRoot, AGENT)).toBe(true);
+  });
+
+  it('CAUSE 3 variant (crons present but EMPTY array): preserves a populated crons.json', () => {
+    seedLiveCrons();
+    const configPath = writeConfig(JSON.stringify({ name: AGENT, crons: [] }));
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    expect(readCrons(AGENT)).toHaveLength(2);
+    expect(result.status).toBe('preserved-existing-crons');
+  });
+
+  it('CAUSE 3 NEGATIVE CONTROL (no crons array, EMPTY destination): still bootstraps', () => {
+    const configPath = writeConfig(JSON.stringify({ name: AGENT, enabled: true }));
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    expect(result.status).toBe('no-crons');
+    expect(readCrons(AGENT)).toHaveLength(0);
+    expect(existsSync(cronsPath())).toBe(true);
+    expect(isMigrated(tmpCtxRoot, AGENT)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Unchanged behaviour: a POPULATED config.json still migrates on --force.
+  // This arm exists so the guard cannot be widened into a no-op by accident.
+  // -------------------------------------------------------------------------
+  it('UNCHANGED: --force with a populated config.json still migrates (documented full replace)', () => {
+    seedLiveCrons();
+    const configPath = writeConfig(
+      JSON.stringify({
+        name: AGENT,
+        crons: [
+          { name: 'from-config', type: 'recurring', interval: '6h', prompt: 'seeded by config' },
+        ],
+      }),
+    );
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    expect(result.status).toBe('migrated');
+    expect(result.cronsMigrated).toBe(1);
+    const after = readCrons(AGENT);
+    expect(after.map((c) => c.name)).toEqual(['from-config']);
+    expect(isMigrated(tmpCtxRoot, AGENT)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // F38 — --force must not silently RE-ENABLE a cron paused in the live store.
+  //
+  // The pause is applied to crons.json (update-cron / dashboard). config.json has
+  // no channel to learn about it, so a straight re-convert stamps enabled:true over
+  // the operator's intent and the cron resumes firing. Observed twice in production
+  // on one cron. Documentation was tried as the remedy and did not hold, so this is
+  // pinned in code.
+  // -------------------------------------------------------------------------
+  it('F38: a cron paused in crons.json is NOT re-enabled by --force', () => {
+    writeCrons(AGENT, [
+      {
+        name: 'subtitle-backfill',
+        prompt: 'paused by the operator',
+        schedule: '6h',
+        enabled: false,
+        created_at: '2026-08-01T00:00:00.000Z',
+      },
+    ]);
+    mkdirSync(join(tmpCtxRoot, CRONS_DIR, AGENT), { recursive: true });
+    writeFileSync(markerPath(), '', 'utf-8');
+
+    // config.json says nothing about enablement — the historical "unconditional" case.
+    const configPath = writeConfig(
+      JSON.stringify({
+        name: AGENT,
+        crons: [
+          { name: 'subtitle-backfill', type: 'recurring', interval: '6h', prompt: 'seeded' },
+        ],
+      }),
+    );
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, {
+      force: true,
+      log: () => {},
+    });
+
+    expect(result.status).toBe('migrated');
+    const after = readCrons(AGENT);
+    expect(after).toHaveLength(1);
+    expect(after[0].name).toBe('subtitle-backfill');
+    expect(after[0].enabled).toBe(false);
+  });
+
+  it('F38 NEGATIVE CONTROL: a cron ENABLED in the live store is not forced off', () => {
+    // The fence must be one-directional. If it disabled everything it would pass the
+    // arm above while destroying the feature, so this arm is what makes that one mean
+    // something.
+    writeCrons(AGENT, [
+      {
+        name: 'live-and-enabled',
+        prompt: 'running',
+        schedule: '6h',
+        enabled: true,
+        created_at: '2026-08-01T00:00:00.000Z',
+      },
+    ]);
+    mkdirSync(join(tmpCtxRoot, CRONS_DIR, AGENT), { recursive: true });
+    writeFileSync(markerPath(), '', 'utf-8');
+
+    const configPath = writeConfig(
+      JSON.stringify({
+        name: AGENT,
+        crons: [
+          { name: 'live-and-enabled', type: 'recurring', interval: '6h', prompt: 'seeded' },
+        ],
+      }),
+    );
+
+    migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, { force: true, log: () => {} });
+
+    const after = readCrons(AGENT);
+    expect(after).toHaveLength(1);
+    expect(after[0].enabled).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // F39 — resolve the leg at the READER, never at the field.
+  //
+  // `enabled` was writable in config.json and absent from the CronEntry interface,
+  // so the reader resolved pause intent from `type` alone and discarded it. On disk
+  // the key looked authoritative; in behaviour it was inert.
+  // -------------------------------------------------------------------------
+  it('F39: config.json "enabled": false is honoured, not silently discarded', () => {
+    const configPath = writeConfig(
+      JSON.stringify({
+        name: AGENT,
+        crons: [
+          {
+            name: 'paused-in-config',
+            type: 'recurring',
+            interval: '6h',
+            prompt: 'operator wrote enabled:false here',
+            enabled: false,
+          },
+        ],
+      }),
+    );
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, { log: () => {} });
+
+    expect(result.status).toBe('migrated');
+    const after = readCrons(AGENT);
+    expect(after).toHaveLength(1);
+    expect(after[0].enabled).toBe(false);
+  });
+
+  it('F39 NEGATIVE CONTROL: "enabled": true and an absent key both migrate as enabled', () => {
+    const configPath = writeConfig(
+      JSON.stringify({
+        name: AGENT,
+        crons: [
+          { name: 'explicit-true', type: 'recurring', interval: '6h', prompt: 'p', enabled: true },
+          { name: 'key-absent', type: 'recurring', interval: '6h', prompt: 'p' },
+        ],
+      }),
+    );
+
+    migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, { log: () => {} });
+
+    const after = readCrons(AGENT);
+    expect(after).toHaveLength(2);
+    expect(after.every((c) => c.enabled === true)).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // The non-force daemon path is gated by the marker and must be untouched.
+  // -------------------------------------------------------------------------
+  it('UNCHANGED: without --force the marker still short-circuits everything', () => {
+    seedLiveCrons();
+    const configPath = writeConfig(JSON.stringify({ name: AGENT }));
+
+    const result = migrateCronsForAgent(AGENT, configPath, tmpCtxRoot, { log: () => {} });
+
+    expect(result.status).toBe('skipped-already-migrated');
+    expect(readCrons(AGENT)).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
## ⛔ HELD — DO NOT MERGE

Opened for review only, at the request of the coordinating orchestrator. Do not merge until that
hold is lifted explicitly.

---

## What breaks today

`migrate-crons --force` deletes the idempotency marker **before** the `isMigrated` gate, so the
whole migration body re-runs against a `crons.json` that is by then the authoritative,
daemon-managed store. `readCrons` is imported but called **nowhere** in that module, so the
migration never looks at the file it is about to replace — a merge is impossible by construction.

Three distinct causes funnel into one destructive effect, `writeCrons(agent, [])`:

| Cause | Today | Why it matters |
|---|---|---|
| `config.json` missing | wipe to empty + write marker | one-shot, unrecoverable by retry |
| `config.json` unparseable | wipe to empty + write marker | we did not read "no crons" — we *failed to read* |
| `config.json` has no `crons` array | wipe to empty + write marker | **this is the fleet steady state** |

The third case is the dangerous one. The `crons` array in `config.json` is a spent one-time
migration seed, so on a healthy, fully-migrated agent it is routinely absent — meaning **the
safest-looking config is the most destructive input.** The marker is written *after* the empty
write, so re-running never heals it.

## What this changes

- **MISSING / NO-CRONS array** — never overwrite a **non-empty** `crons.json`. Preserve it, and
  still write the marker so the daemon does not loop. New status: `preserved-existing-crons`.
  The empty-destination bootstrap path is unchanged.
- **UNPARSEABLE** — **abort.** No crons write, and deliberately **no marker**: writing the marker
  made the loss permanent the moment the file was repaired.
- `hasLiveCrons` **fails toward preservation** — an unreadable store counts as non-empty.
- **Re-enable fence** — a cron paused in the live store is not silently flipped back on by
  re-migration. (Historical casualty: `subtitle-backfill`, re-enabled twice on 07-05.)
- **`CronEntry.enabled` added to the interface.** The key was already being written into real
  `config.json` files but was **absent from the type**, so the reader resolved enablement from
  `type` alone and silently discarded it. It is now honoured exactly like `type: "disabled"`.
- **CLI** — reports both new statuses, **names** the aborted agents (a bare count cannot tell an
  operator which file to repair), and exits non-zero on abort.

## Deliberately out of scope

With a **populated** `config.json`, `--force` still full-replaces `crons.json`, which drops
daemon-created crons. That is a different effect from the wipe-to-empty class fixed here, so it is
flagged as follow-up rather than silently widened into this change.

## Verification

Base for all numbers below: `72708bd`.

- **New tests:** `tests/integration/cron-migration-force-guard.test.ts`, 13 tests, all passing.
- **Fail-first proof:** against the unfixed code the new file was **5 failed / 4 passed** — the 5
  being exactly the three causes' positive arms; the 4 that passed were the negative controls and
  the unchanged-behaviour arms. After the fix: **13/13**.
- **`npx tsc --noEmit`:** clean.
- **Full root suite on this branch:** `1 failed | 1990 passed | 10 skipped (2001)`.

### About that 1 failure — it is pre-existing and unrelated

`tests/unit/hooks/hooks.test.ts > isClaudeDirOperation (permission-gate hardening) > refuses a
write that escapes via a symlink inside .claude (#18, codex)`.

It reproduces **identically at base `72708bd` without this change** (measured, same clean
environment). It is in the hooks permission gate and touches none of the five files here.

### Why an earlier draft of this description would have said "29 failed"

Running the suite from a worktree inside an agent session produced **29 failures**. Those are
environmental, and both causes were measured rather than assumed:

1. **Ambient `CTX_*` leak.** `resolveEnv` correctly refuses when `CTX_AGENT_DIR` is inherited from
   the parent shell while `CTX_FRAMEWORK_ROOT` is overridden by the test. Two-directional control
   on `tests/unit/cli/bus-crons.test.ts`: ambient → **16 failed / 12 passed**; `CTX_*` cleared →
   **28 passed / 0 failed**.
2. **Missing `dashboard/node_modules`** in the worktree (`Cannot find package 'next/server'`,
   `better-sqlite3`), which the root vitest config needs because it resolves
   `dashboard/src/**/__tests__`.

With both corrected, 29 → 1.

**The claim that actually matters:** the same suite run at base `72708bd` in the *same* environment
fails **29 tests across 15 files**, and the sorted failing-test set is **byte-identical** to this
branch's. Passing count goes **1782 → 1795** — exactly the 13 tests this PR adds, with no other
movement. This change introduces no failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
