### PR TITLE
fix(daemon): stop map-entry races between agent start and teardown

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -23,6 +23,33 @@ import { BuzzRelayClient, BuzzDispatcher, loadBuzzConfig, type NostrEvent } from
 
 type LogFn = (msg: string) => void;
 
+/**
+ * One agent's registry entry. Named (was an inline literal on `agents`) so the
+ * map-entry-race identity guard below can be typed honestly.
+ */
+type AgentEntry = {
+  process: AgentProcess;
+  checker: FastChecker;
+  poller?: TelegramPoller;
+  activityPoller?: TelegramPoller;
+  telegramRejectCount?: number;
+  telegramLastRejectAlertAt?: number;
+  /**
+   * Round 3 (F5/F2): set by stopAgent the moment a teardown of THIS entry begins.
+   *
+   * Distinct from `stillMapped()` on purpose, and the distinction is the whole
+   * point. stillMapped answers "does the name still resolve to me", which is
+   * false in TWO very different situations: I was stopped, or I am still running
+   * and somebody else took my name. Callbacks that arrive from MY OWN poller are
+   * legitimately mine in the second case and must still be handled — that is what
+   * T13/T14 pin. Only the first case means "do not act on the world".
+   *
+   * A per-entry flag rather than a map lookup because teardown is a fact about
+   * this object, and the object is what we still hold across the await.
+   */
+  stopped?: boolean;
+};
+
 // liveness fix: OS-level pid liveness probe using the same signal-0 idiom as
 // src/utils/lock.ts — signal 0 sends nothing, it only tests process existence +
 // our permission to signal it. We DELIBERATELY diverge from lock.ts on EPERM:
@@ -41,7 +68,7 @@ function isPidAlive(pid: number): boolean {
  * Manages all agents in a cortextOS instance.
  */
 export class AgentManager {
-  private agents: Map<string, { process: AgentProcess; checker: FastChecker; poller?: TelegramPoller; activityPoller?: TelegramPoller; telegramRejectCount?: number; telegramLastRejectAlertAt?: number }> = new Map();
+  private agents: Map<string, AgentEntry> = new Map();
   private workers: Map<string, WorkerProcess> = new Map();
   /**
    * Org-level singleton Buzz relay client + dispatcher, keyed by org — one
@@ -286,6 +313,22 @@ export class AgentManager {
     return !!pid && isPidAlive(pid);           // running => must have a live pid
   }
 
+  /**
+   * map-entry-race fix: true iff `name` still resolves to the exact instance
+   * captured before an await. `this.agents.set` is the single call site in this
+   * class and always stores a freshly-constructed object literal, so reference
+   * identity is exact and cannot ABA (a re-registered agent is never the same
+   * object as the one we captured).
+   *
+   * Same question AgentProcess.lifecycleGeneration answers one layer down ("is
+   * this still my lifecycle?"), but compared against the object rather than a
+   * counter: the caller already holds the reference across the await, so no
+   * parallel counter keyed by the re-bindable name is needed.
+   */
+  private stillMapped(name: string, entry: AgentEntry): boolean {
+    return this.agents.get(name) === entry;
+  }
+
   inspectAgentOp(op: 'start' | 'stop' | 'restart', name: string): { ok: true } | { ok: false; code: 'DEDUPED' | 'NOT_FOUND'; message: string } {
     const inRegistry = this.agents.has(name);
     if (op === 'start') {
@@ -342,6 +385,16 @@ export class AgentManager {
       // stopped, or a running entry whose OS pid is gone). Evict the stale entry
       // and fall through to a fresh start rather than stranding the agent.
       if (this.evictingAgents.has(name)) {
+        // DELIBERATE EXCEPTION to the identity rule below: this set is keyed by
+        // NAME on purpose. The thing being deduplicated is "spawn a PTY for this
+        // name", which is a claim about the name, not about an object — so a
+        // membership test is the right question here and an identity guard would
+        // be the wrong one. Residual, judged acceptable: if our eviction later
+        // aborts because it was superseded, a start that arrived during our
+        // await was refused for nothing. The marker is cleared synchronously in
+        // the `finally` on the same tick as that abort, so the stale window is
+        // the eviction's own lifetime and never outlives it.
+        //
         // A concurrent startAgent is already evicting+restarting this dead entry.
         // Return instead of spawning a second PTY — the in-flight eviction will
         // bring the agent up. Mirrors the alive in-flight dedup above.
@@ -356,6 +409,33 @@ export class AgentManager {
       try {
         console.log(`[agent-manager] ${name} in registry but not actually alive — evicting stale entry and starting fresh.`);
         const stale = this.agents.get(name)!;
+        // Round 4 (F-B1): mark the teardown on the entry itself, BEFORE the await
+        // below, exactly as stopAgent does at its own pre-await point. Eviction is
+        // a teardown of `stale` and was the only teardown path that never said so.
+        //
+        // Without this write, a start still parked in agentProcess.start() resumes
+        // after we have stopped its checker and unmapped it, reads
+        // `!ownEntry.stopped` as true at the checker-start guard, and re-arms that
+        // checker. Nothing can ever stop it again: every later stopAgent reaches a
+        // checker only by name, and the name belongs to the newcomer — so it keeps
+        // injecting into a dead PTY for the life of the daemon.
+        //
+        // Set here rather than next to this branch's `agents.delete(name)` because
+        // the hazard is the AWAIT, not the unmapping: the parked start can resume
+        // any time after `stale.process.stop()` yields, which is before the delete
+        // is reached. Deferring the write to the delete leaves that sub-window open.
+        //
+        // Referred to by symbol, not by line number, on purpose: this very comment
+        // shifted every line below it by 15, which silently falsified 41 numeric
+        // references in the round-4 tests. A line number in a comment is a
+        // hand-maintained index with no checker, and it rots on the next edit.
+        stale.stopped = true;
+        // map-entry-race fix: capture the scheduler BEFORE the await below.
+        // `evictingAgents` blocks a concurrent startAgent but NOT a concurrent
+        // stopAgent, so the name can be re-bound while we are parked here.
+        // RULE: act unconditionally on the objects you captured; act by name
+        // only while the name still resolves to you. See stillMapped().
+        const staleScheduler = this.cronSchedulers.get(name);
         try { stale.poller?.stop(); } catch { /* best-effort */ }
         try { stale.activityPoller?.stop(); } catch { /* best-effort */ }
         try { stale.checker.stop(); } catch { /* best-effort */ }
@@ -363,10 +443,50 @@ export class AgentManager {
         // crash-backoff setTimeout on the old AgentProcess (its `if (status ===
         // 'crashed')` guard now fails), so no orphan PTY is spawned after eviction.
         try { await stale.process.stop(); } catch { /* best-effort */ }
+        if (staleScheduler) {
+          staleScheduler.stop();
+          if (this.cronSchedulers.get(name) === staleScheduler) {
+            this.cronSchedulers.delete(name);
+            // Symmetric with stopAgent below: if a new instance took the name
+            // while we were tearing down, its own startAgentCronScheduler() may
+            // have been refused by the "already running" guard because OURS was
+            // still mapped. Re-wire now the slot is free.
+            if (!this.stillMapped(name, stale)) this.startAgentCronScheduler(name);
+          }
+        } else if (this.stillMapped(name, stale)) {
+          // The hoisted capture above has a blind spot the post-await read it
+          // replaced did not: a scheduler wired for the stale entry DURING our
+          // await (startAgent's post-start wiring, or reloadCrons' lazy-create)
+          // was not capturable before it. Nothing else will ever stop it — it
+          // outlives the agent as a live setInterval AND blocks the fresh start
+          // below from getting a scheduler at all. Safe to act by name here
+          // precisely because the name still resolves to the entry we are
+          // evicting, so anything under it is ours.
+          const late = this.cronSchedulers.get(name);
+          if (late) {
+            late.stop();
+            this.cronSchedulers.delete(name);
+          }
+        }
+        // Round 3 (F3): stillMapped() is `agents.get(name) === entry`, which is
+        // false BOTH when a different entry holds the name AND when nothing holds
+        // it at all. Only the first case means "somebody else is starting" — the
+        // second means the slot is empty and we should carry on with the fresh
+        // start. Ask the has() question first so the two stop being the same
+        // answer; without it we abort a start that nothing is replacing and the
+        // warning below asserts a re-registration that provably did not happen.
+        if (this.agents.has(name) && !this.stillMapped(name, stale)) {
+          // A different instance took this name while we tore the stale one
+          // down. The fresh-start path below deletes by name and then ends in an
+          // UNCONDITIONAL agents.set(), either of which would orphan a live
+          // agent — the exact failure this fix exists to prevent. The newcomer
+          // is already starting; our work here is done. The return is inside
+          // the try, so `finally` still clears the evicting marker.
+          console.warn(`[agent-manager] ${name} was re-registered during eviction — aborting this start.`);
+          return;
+        }
         this.agents.delete(name);
         this.pendingRestarts.delete(name);
-        const staleScheduler = this.cronSchedulers.get(name);
-        if (staleScheduler) { staleScheduler.stop(); this.cronSchedulers.delete(name); }
       } finally {
         this.evictingAgents.delete(name);
       }
@@ -502,7 +622,12 @@ export class AgentManager {
       });
     }
 
-    this.agents.set(name, { process: agentProcess, checker });
+    // map-entry-race fix: hold our own entry reference. Everything below runs
+    // after at least one await, so looking the entry back up by name can return
+    // a DIFFERENT instance's entry — attaching our poller to it would break that
+    // entry's teardown and guarantee ours leaks.
+    const ownEntry: AgentEntry = { process: agentProcess, checker };
+    this.agents.set(name, ownEntry);
 
     // Start agent
     await agentProcess.start();
@@ -519,12 +644,43 @@ export class AgentManager {
     // The scheduler reads crons.json, fires crons, and injects prompts into
     // the agent PTY via injectAgent().  This is the Phase 2 daemon-managed
     // external cron system — agents no longer need to call CronCreate on boot.
-    this.startAgentCronScheduler(name);
+    //
+    // map-entry-race fix: everything from here down runs AFTER
+    // `await agentProcess.start()`, so the name may have been re-bound while we
+    // were parked. Two distinct hazards, one guard each:
+    if (this.stillMapped(name, ownEntry)) {
+      const existing = this.cronSchedulers.get(name);
+      if (existing) {
+        // (a) A predecessor's supersede-re-wire installed a scheduler under our
+        // name while we were parked. It read crons.json BEFORE
+        // migrateCronsForAgent above wrote it, so it holds ZERO crons — and
+        // startAgentCronScheduler's "already running — skipped" guard would
+        // leave it that way DURABLY: tick() never reloads, and reload() is
+        // otherwise only reachable over IPC. Refresh it instead of skipping.
+        existing.reload();
+      } else {
+        this.startAgentCronScheduler(name);
+      }
+    }
+    // (b) If we are NOT still mapped we were stopped or superseded mid-start.
+    // Wiring a scheduler here would install OURS under the newcomer's name,
+    // where its "already running" guard then denies the newcomer its own.
 
-    // Start fast checker in background
-    checker.start().catch(err => {
-      console.error(`[${name}] Fast checker error:`, err);
-    });
+    // Start fast checker in background.
+    // Round 3 (F2): same identity question as the scheduler block above, which
+    // this originally did not ask. stopAgent calls entry.checker.stop() BEFORE
+    // its await, so a start parked in agentProcess.start() would resume here and
+    // re-arm a checker that was already torn down. It can never be stopped again:
+    // stopAgent reaches a checker only through a by-name lookup, and by then the
+    // name belongs to somebody else — so it would keep injecting into the PTY the
+    // operator asked to stop for the life of the daemon.
+    // Guarded on OUR teardown rather than on map identity: a start that was merely
+    // superseded still owns a live process that needs its checker.
+    if (!ownEntry.stopped) {
+      checker.start().catch(err => {
+        console.error(`[${name}] Fast checker error:`, err);
+      });
+    }
 
     // Register Telegram slash commands at startup (fix for issue #1)
     if (telegramApi && botToken) {
@@ -565,8 +721,23 @@ export class AgentManager {
             const rejectedFrom = msg.from?.first_name || msg.from?.username || 'unknown';
             log(`Ignoring message from unauthorized user (allowed_user gate): from=${fromId} (${rejectedFrom})`);
             // #459 reject-count watchdog: alert after N consecutive rejects (multi-user gate from #467 preserved).
-            const entry = this.agents.get(name);
-            if (entry) {
+            // map-entry-race fix: count on OUR entry. A by-name lookup here
+            // credits the reject to whichever instance holds the name now, which
+            // both corrupts the successor's counter and loses ours.
+            // Round 3 (F5): guard on IDENTITY, not on truthiness. This block used
+            // to read `const entry = this.agents.get(name); if (entry) {`, and that
+            // `if` was doing real work: it skipped whenever the name was unmapped.
+            // `ownEntry` is an object literal and is NEVER falsy, so replacing the
+            // lookup with it silently made the block unconditional — a stranger
+            // reject arriving in an in-flight getUpdates batch after teardown would
+            // then fire a WATCHDOG Telegram on behalf of a stopped agent.
+            // The predicate is OUR TEARDOWN, not map identity. stillMapped would
+            // ALSO skip when we are still running and merely superseded — but a
+            // reject arriving on our own poller is genuinely ours then, and
+            // dropping it silently disables the ALLOWED_USER watchdog for a live
+            // agent (T13/T14 pin exactly that). `stopped` separates the two.
+            const entry = ownEntry;
+            if (!ownEntry.stopped) {
               entry.telegramRejectCount = (entry.telegramRejectCount ?? 0) + 1;
               if (entry.telegramRejectCount >= REJECT_ALERT_THRESHOLD) {
                 const now = Date.now();
@@ -586,8 +757,8 @@ export class AgentManager {
         }
 
         // Message passed ALLOWED_USER gate — reset rejection counter.
-        const agentEntry = this.agents.get(name);
-        if (agentEntry) agentEntry.telegramRejectCount = 0;
+        // map-entry-race fix: reset OUR counter, not the current name-holder's.
+        ownEntry.telegramRejectCount = 0;
 
         const from = stripControlChars(msg.from?.first_name || msg.from?.username || 'Unknown');
         const msgChatId = msg.chat?.id;
@@ -694,8 +865,21 @@ export class AgentManager {
           if (typeof fromId !== 'number' || !allowedIds.includes(fromId)) {
             log(`Ignoring reaction from unauthorized user (allowed_user gate): from=${fromId}`);
             // #459 reject-count watchdog (multi-user gate from #467 preserved).
-            const entry = this.agents.get(name);
-            if (entry) {
+            // map-entry-race fix: count on OUR entry — see the message handler.
+            // Round 3 (F5): guard on IDENTITY, not on truthiness. This block used
+            // to read `const entry = this.agents.get(name); if (entry) {`, and that
+            // `if` was doing real work: it skipped whenever the name was unmapped.
+            // `ownEntry` is an object literal and is NEVER falsy, so replacing the
+            // lookup with it silently made the block unconditional — a stranger
+            // reject arriving in an in-flight getUpdates batch after teardown would
+            // then fire a WATCHDOG Telegram on behalf of a stopped agent.
+            // The predicate is OUR TEARDOWN, not map identity. stillMapped would
+            // ALSO skip when we are still running and merely superseded — but a
+            // reject arriving on our own poller is genuinely ours then, and
+            // dropping it silently disables the ALLOWED_USER watchdog for a live
+            // agent (T13/T14 pin exactly that). `stopped` separates the two.
+            const entry = ownEntry;
+            if (!ownEntry.stopped) {
               entry.telegramRejectCount = (entry.telegramRejectCount ?? 0) + 1;
               if (entry.telegramRejectCount >= REJECT_ALERT_THRESHOLD) {
                 const now = Date.now();
@@ -714,8 +898,8 @@ export class AgentManager {
           }
         }
 
-        const agentEntry = this.agents.get(name);
-        if (agentEntry) agentEntry.telegramRejectCount = 0;
+        // map-entry-race fix: reset OUR counter, not the current name-holder's.
+        ownEntry.telegramRejectCount = 0;
 
         const from = stripControlChars(reaction.user?.first_name || reaction.user?.username || 'Unknown');
         const reactionChatId = reaction.chat?.id ?? chatId ?? '';
@@ -752,9 +936,25 @@ export class AgentManager {
         const LONG_RUN_RESET_MS = 60_000;
         let consecutiveConflictStart: number | null = null;
         while (true) {
-          // Pre-check: agent may have been deleted from registry during
-          // a previous sleep window. Skip the start() call entirely.
-          if (!this.agents.has(name)) return;
+          // map-entry-race fix: IDENTITY, not presence. `agents.has(name)` asks
+          // "is anyone mapped under this name", and after round 1's guards the
+          // answer is deliberately YES when a NEW instance has superseded us —
+          // so a presence check reads TRUE for an object that is not ours and we
+          // restart a poller that was already torn down. TelegramPoller.start()
+          // has no re-entry guard (`this.running = true` is its first statement,
+          // unconditional), so that restart really does produce a live poll
+          // loop; two loops on one bot token is the 409 Conflict churn this
+          // whole change exists to prevent.
+          //
+          // Pre-fix, stopAgent's UNCONDITIONAL `agents.delete(name)` killed this
+          // wrapper as an accidental side effect. That delete was wrong AND
+          // load-bearing: fixing it removed the protection, turning "both die"
+          // into "the old one comes back".
+          //
+          // lastExitReason cannot cover this: start() blanks it (poller.ts:90),
+          // so a stop() that lands while we are parked in the sleep below leaves
+          // no trace by the time we look.
+          if (!this.stillMapped(name, ownEntry)) return;
           const runStart = Date.now();
           try {
             await poller.start();
@@ -764,7 +964,7 @@ export class AgentManager {
           }
           const runDuration = Date.now() - runStart;
           if (poller.lastExitReason === 'stopped-externally') return;
-          if (!this.agents.has(name)) return;
+          if (!this.stillMapped(name, ownEntry)) return;
           // A poll session that ran for >LONG_RUN_RESET_MS proves the
           // Conflict lock is no longer chronic — reset the retry budget.
           if (runDuration > LONG_RUN_RESET_MS) consecutiveConflictStart = null;
@@ -793,9 +993,9 @@ export class AgentManager {
         }
       });
 
-      // Store poller reference so stopAgent() can clean it up
-      const entry = this.agents.get(name);
-      if (entry) entry.poller = poller;
+      // Store poller reference so stopAgent() can clean it up. Assigned to the
+      // entry we created, never to whatever the name resolves to now.
+      ownEntry.poller = poller;
 
       log('Telegram poller started (with Conflict-restart wrapper)');
 
@@ -807,7 +1007,13 @@ export class AgentManager {
       // — follow-up task_1776054009969_099 tracks migrating to a dedicated
       // singleton or Telegram webhook if the coupling ever causes real
       // operator pain. Non-orchestrator agents skip this entirely.
-      await this.maybeStartActivityChannelPoller(name, org, agentDir, log);
+      // Round 3 (F1): resolvedOrg, NOT the raw `org` parameter. Only
+      // discoverAndStart passes an org; restartAgent, the pendingRestarts honor
+      // path and ipc-server's start-agent handler all pass none, and
+      // maybeStartActivityChannelPoller returns immediately on a falsy org — so
+      // every restart silently dropped the orchestrator's approval-button path,
+      // with stopAgent seeing activityPoller undefined and nothing reporting it.
+      await this.maybeStartActivityChannelPoller(name, resolvedOrg, agentDir, log, ownEntry);
     }
 
     // Buzz (Nostr/NIP-29) registration + org-level relay start. Every agent
@@ -916,8 +1122,20 @@ export class AgentManager {
     org: string | undefined,
     agentDir: string,
     log: LogFn,
+    // map-entry-race fix: the caller's own entry, passed in rather than looked
+    // up by name after the awaits in here. See the ownEntry comment in startAgent().
+    ownEntry: AgentEntry,
   ): Promise<void> {
-    if (!org) return;
+    if (!org) {
+      // Observability, added with the F1 fix: this return used to be silent, and a
+      // silent return is why F1 survived. The poller's SUCCESS path logs, so its
+      // absence in the log was real evidence — but with no line here there was
+      // nothing to distinguish "not the orchestrator" from "org never arrived",
+      // and an approval button that goes nowhere looks exactly like an approval
+      // nobody pressed.
+      log('Activity-channel poller skipped: no org resolved for this agent');
+      return;
+    }
     const orgDir = join(this.frameworkRoot, 'orgs', org);
 
     // Only the org's orchestrator runs the activity-channel poller.
@@ -967,9 +1185,12 @@ export class AgentManager {
     const activityPoller = new TelegramPoller(activityApi, stateDir, 1000, 'activity');
 
     activityPoller.onCallback((query) => {
-      const entry = this.agents.get(name);
-      if (!entry) return;
-      entry.checker.handleActivityCallback(query, activityApi).catch((err) => {
+      // map-entry-race fix: this poller belongs to ownEntry, so its callbacks
+      // serve ownEntry's checker. A by-name lookup would route an approval
+      // button-press into whichever instance holds the name now. The wrapper
+      // above stops this poller as soon as ownEntry is unmapped, so the only
+      // window this closes is an in-flight getUpdates batch.
+      ownEntry.checker.handleActivityCallback(query, activityApi).catch((err) => {
         log(`Activity-channel callback error: ${err}`);
       });
     });
@@ -992,7 +1213,9 @@ export class AgentManager {
       const LONG_RUN_RESET_MS = 60_000;
       let consecutiveConflictStart: number | null = null;
       while (true) {
-        if (!this.agents.has(name)) return;
+        // map-entry-race fix: identity, not presence — see the primary poller's
+        // wrapper for the full reasoning. Same defect, same remedy.
+        if (!this.stillMapped(name, ownEntry)) return;
         const runStart = Date.now();
         try {
           await activityPoller.start();
@@ -1002,7 +1225,7 @@ export class AgentManager {
         }
         const runDuration = Date.now() - runStart;
         if (activityPoller.lastExitReason === 'stopped-externally') return;
-        if (!this.agents.has(name)) return;
+        if (!this.stillMapped(name, ownEntry)) return;
         if (runDuration > LONG_RUN_RESET_MS) consecutiveConflictStart = null;
         if (consecutiveConflictStart === null) consecutiveConflictStart = Date.now();
         if (Date.now() - consecutiveConflictStart > MAX_CONSECUTIVE_CONFLICT_MS) {
@@ -1017,8 +1240,7 @@ export class AgentManager {
       log(`Activity-channel poller wrapper crashed: ${err}`);
     });
 
-    const entry = this.agents.get(name);
-    if (entry) entry.activityPoller = activityPoller;
+    ownEntry.activityPoller = activityPoller;
 
     log(`Activity-channel poller started (chat ${activityChatId}, with Conflict-restart wrapper)`);
   }
@@ -1107,6 +1329,23 @@ export class AgentManager {
       return;
     }
 
+    // map-entry-race fix: capture every name-keyed resource we own BEFORE the
+    // await below. entry.process.stop() yields for up to ~21s (BUG-032's
+    // graceful /exit dance plus BUG-040's 15s exit wait), and a NEW instance can
+    // be registered under this same name inside that window (startAgent's
+    // eviction path, or a fire-and-forget IPC start — ipc-server.ts never awaits
+    // startAgent/stopAgent/restartAgent). After the await, `name` is no longer a
+    // reliable handle to us.
+    // RULE: act unconditionally on the objects you captured; act by name only
+    // while the name still resolves to you. See stillMapped().
+    const scheduler = this.cronSchedulers.get(name);
+
+    // Round 3 (F5/F2): mark the teardown BEFORE it starts, not after it finishes.
+    // A poller's stop() cannot recall a getUpdates batch that is already open, and
+    // process.stop() yields for up to ~21s — so callbacks and a parked startAgent
+    // both land DURING the teardown, which is exactly when they must not act.
+    entry.stopped = true;
+
     if (entry.poller) entry.poller.stop();
     if (entry.activityPoller) entry.activityPoller.stop();
     // Unregister from every org's Buzz dispatcher — harmless no-op for orgs
@@ -1118,14 +1357,58 @@ export class AgentManager {
     }
     entry.checker.stop();
     await entry.process.stop();
-    this.agents.delete(name);
 
-    // Stop and remove the agent's cron scheduler (if one was wired)
-    const scheduler = this.cronSchedulers.get(name);
+    // Our scheduler object: stopping it is always correct (the interval is
+    // ours, and skipping it leaks a setInterval forever). Unmapping it is only
+    // correct while the name still points at it.
+    if (!scheduler && this.stillMapped(name, entry)) {
+      // The capture above has a blind spot the post-await read it replaced did
+      // not: a scheduler wired for US during the await (startAgent's post-start
+      // wiring at the `startAgentCronScheduler` call below, or reloadCrons'
+      // lazy-create) did not exist when we captured. Nothing else ever stops it
+      // — it outlives the agent as a live setInterval whose onFire injects into
+      // a name that is gone, AND it makes the next start's scheduler request hit
+      // the "already running — skipped" guard, so the replacement inherits a
+      // dead scheduler. Acting by name is safe here BECAUSE the name still
+      // resolves to us, so whatever is under it is ours.
+      const late = this.cronSchedulers.get(name);
+      if (late) {
+        late.stop();
+        this.cronSchedulers.delete(name);
+      }
+    }
+
     if (scheduler) {
       scheduler.stop();
-      this.cronSchedulers.delete(name);
+      if (this.cronSchedulers.get(name) === scheduler) {
+        this.cronSchedulers.delete(name);
+        // If a new instance took the name while we were stopping, it may have
+        // been refused a scheduler by startAgentCronScheduler's "already
+        // running" guard because OURS was still mapped. Re-wire now the slot is
+        // free — otherwise the new agent runs with no crons at all. Calling a
+        // start-path helper from the stop path is deliberate: the method is
+        // idempotent and map-driven, and this is the only moment at which the
+        // newcomer's missing scheduler is detectable.
+        if (!this.stillMapped(name, entry)) this.startAgentCronScheduler(name);
+      }
     }
+
+    // Round 3 (F4): same conflation as the eviction path — see the F3 comment in
+    // startAgent(). Reachable here via two concurrent stops for one name (ipc-server
+    // never awaits stopAgent): the first to finish deletes the name, and the second
+    // then took this branch, warned about a re-registration that never happened, and
+    // returned BEFORE the pendingRestarts handling below — stranding a queued restart
+    // that later fires against an unrelated stop.
+    if (this.agents.has(name) && !this.stillMapped(name, entry)) {
+      // Superseded: our instance is fully torn down, but the name belongs to
+      // someone else now. Deleting it here would empty the map slot while the
+      // new agent keeps running — an untracked orphan. pendingRestarts is
+      // deliberately left alone: the queue refers to whoever is mapped.
+      console.warn(`[agent-manager] ${name} was re-registered while stopping — old instance fully torn down, new instance left mapped.`);
+      return;
+    }
+
+    this.agents.delete(name);
 
     // disable-resurrection fix: an explicit user stop/disable must win against a
     // racing queued restart. Drop the pending entry instead of honoring it.
@@ -1169,12 +1452,26 @@ export class AgentManager {
    * Participates in the pendingRestarts race protection used by restart-all.
    */
   async restartAgent(name: string): Promise<void> {
-    if (!this.agents.has(name)) {
+    const entry = this.agents.get(name);
+    if (!entry) {
       console.log(`[agent-manager] Agent ${name} not found — cannot restart`);
       return;
     }
     console.log(`[agent-manager] Restarting ${name}`);
     await this.stopAgent(name);
+    // map-entry-race fix: a normal stop leaves the name UNBOUND, so the test is
+    // "did somebody else bind it", not stillMapped(). If a new instance took the
+    // name while we were stopping, stopAgent correctly left it mapped and
+    // returned early — starting by name here would find that live entry, emit
+    // the "BUG-011 REGRESSION CHECK" warning on a race that is now handled BY
+    // DESIGN (a false alarm on a warning operators are trained to treat as
+    // serious), and leave a pendingRestarts entry that fires a spurious restart
+    // on the newcomer's next stop.
+    const successor = this.agents.get(name);
+    if (successor !== undefined && successor !== entry) {
+      console.log(`[agent-manager] ${name} was re-registered while restarting — a new instance already holds the name, skipping the start.`);
+      return;
+    }
     await this.startAgent(name, '');
     console.log(`[agent-manager] Restart complete for ${name}`);
   }
@@ -1197,6 +1494,25 @@ export class AgentManager {
     this.slackSocketClient?.stop();
     this.slackSocketClient = null;
     this.slackSocketStarted = false;
+    // DELIBERATE EXCEPTION to the identity rule used everywhere else in this
+    // file, and NOT an oversight. Shutdown wants "stop whatever is running under
+    // this name", which is a name question, so acting by name is correct routing
+    // here — an identity guard would make us skip an instance that replaced the
+    // one we snapshotted, i.e. leave MORE running, not less.
+    //
+    // KNOWN RESIDUAL, left unfixed on purpose, and stated at its true scope:
+    // an instance registered under ANY name in this snapshot is never stopped and
+    // survives daemon shutdown as an orphan PTY. That includes the name being
+    // processed RIGHT NOW — the await inside stopAgent is itself a window in which
+    // a newcomer can take the name, and stopAgent then deliberately leaves it
+    // mapped, after which this loop has moved on and never revisits it. It is NOT
+    // limited to names the loop has already passed.
+    // Worse, the .daemon-stop markers are all written in the loop above BEFORE any
+    // stop runs, so the crash-alert hook reports a clean shutdown for an instance
+    // that is still running. Closing this needs a second pass over the map,
+    // not an identity guard — a behaviour change with its own termination
+    // question (a caller that keeps starting agents), so it is deliberately out
+    // of scope for a concurrency-guard change and tracked separately.
     const names = [...this.agents.keys()];
 
     for (const name of names) {
@@ -1314,7 +1630,12 @@ export class AgentManager {
       // Auto-remove finished workers after a short delay so list-workers
       // can still show the final status briefly before cleanup
       setTimeout(() => {
-        if (this.workers.get(workerName)?.isFinished()) {
+        // map-entry-race fix: isFinished() is a liveness question, not an
+        // identity one. Without the reference check this reaps whatever holds
+        // the name 30s later — evicting a DIFFERENT, finished worker and
+        // truncating its status-visibility window.
+        const mapped = this.workers.get(workerName);
+        if (mapped === worker && mapped.isFinished()) {
           this.workers.delete(workerName);
         }
       }, 30_000); // keep for 30s after exit
@@ -1332,7 +1653,13 @@ export class AgentManager {
       throw new Error(`Worker "${name}" not found`);
     }
     await worker.terminate();
-    this.workers.delete(name);
+    // map-entry-race fix: same class as the agents map — terminate() yields, and
+    // unmapping by name after it would evict a REPLACEMENT worker registered
+    // under this name in the meantime. Currently unreachable (spawnWorker's
+    // synchronous `workers.has` guard keeps the name claimed for terminate()'s
+    // whole window) — this makes it robust to that guard or those timings
+    // changing, rather than relying on them.
+    if (this.workers.get(name) === worker) this.workers.delete(name);
   }
 
   /**
@@ -1441,6 +1768,11 @@ export class AgentManager {
     }
 
     const onFire = async (cron: CronDefinition): Promise<void> => {
+      // DELIBERATE EXCEPTION to the identity rule: this fires on a timer long
+      // after any await and injects by NAME, so a cron fires into whichever
+      // instance currently holds the name. That is the intended routing — a cron
+      // belongs to the agent name, not to one PTY lifecycle, and binding it to a
+      // captured entry would silently stop firing across every restart.
       const prompt = cron.prompt ?? `[cron] ${cron.name} fired`;
       // Salt with the fire timestamp so MessageDedup (which hashes the last 100
       // injects) does not reject identical cron prompts on subsequent fires.

--- a/tests/unit/daemon/agent-manager-eviction-race-round4.test.ts
+++ b/tests/unit/daemon/agent-manager-eviction-race-round4.test.ts
@@ -1,0 +1,331 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Round 4 (F-B1). Round 3 added `AgentEntry.stopped` and guarded the fast-checker
+// re-arm on it (agent-manager.ts:637) plus the two Telegram reject watchdogs
+// (:698, :840). `stopped` is written in EXACTLY ONE place — stopAgent, :1141.
+//
+// But the agents map has TWO teardown sites:
+//   stopAgent :1198          — unmaps AND has set stopped = true
+//   startAgent eviction :446 — unmaps and NEVER sets stopped
+//
+// So an entry torn down by EVICTION carries stopped === undefined forever while
+// being unmapped and fully stopped (its checker was stopped at :399, its process
+// at :403). `!ownEntry.stopped` is therefore TRUE on exactly the entries eviction
+// produces, and the round-3 guard falls open on that reachable case.
+//
+// The round-3 test for this class (T27b in agent-manager-map-entry-race.test.ts,
+// :1161) built its scenario by writing the internal map directly
+// (`agentsOf(am).set('alice', E2)`), which constructs a state no code path
+// produces. This file reaches the state ONLY through startAgent(), by letting the
+// real eviction branch run.
+//
+// Route used (reviewer B's route (b), config-independent — no startup_delay
+// needed, and shipped templates all set startup_delay to 0):
+// for runtime 'codex-app-server' the PTY can exit DURING pty.spawn()
+// (agent-process.ts:180-189 — "PTY exited during spawn — handleExit will
+// recover"). handleExit sets status 'crashed' while start() is still parked on
+// the spawn await, so a concurrent start reads status 'crashed', gets
+// isAgentActuallyAlive() === false (:291) and evicts the entry whose start is
+// still in flight.
+//
+// The AgentProcess mock below models exactly that state machine: status
+// 'starting' set synchronously (agent-process.ts:116), then a park that stands in
+// for `await this.pty.spawn(...)`, with a test-driven handleExit that flips the
+// status to 'crashed' mid-park.
+
+type ProcStatus = 'stopped' | 'starting' | 'running' | 'crashed' | 'halted';
+
+const h = vi.hoisted(() => ({
+  /** Every AgentProcess the manager constructed, in construction order. */
+  procs: [] as unknown[],
+  /** Every FastChecker the manager constructed, in construction order. */
+  checkers: [] as unknown[],
+  /** Instance indexes whose start() parks on its spawn gate until released. */
+  parkIndexes: [] as number[],
+}));
+
+vi.mock('../../../src/daemon/agent-process.js', () => ({
+  AgentProcess: class {
+    name: string;
+    index: number;
+    status: ProcStatus = 'stopped';   // constructor default, as in the real class
+    pid: number | undefined;
+    /** Set by simulateExitDuringSpawn — mirrors handleExit() nulling this.pty. */
+    ptyGone = false;
+    private releaseSpawn!: () => void;
+    /** Stands in for `await this.pty.spawn(mode, prompt)`. */
+    spawnGate: Promise<void>;
+
+    constructor(name: string) {
+      this.name = name;
+      this.index = h.procs.length;
+      h.procs.push(this);
+      let release!: () => void;
+      this.spawnGate = new Promise<void>((r) => { release = r; });
+      this.releaseSpawn = release;
+      // Only the instances the test nominates park; everything else spawns
+      // instantly, so the fresh start inside the eviction path completes.
+      if (!h.parkIndexes.includes(this.index)) this.releaseSpawn();
+    }
+
+    async start() {
+      if (this.status === 'running') return;          // agent-process.ts:91-94
+      this.status = 'starting';                       // agent-process.ts:116 — SYNC
+      await this.spawnGate;                           // agent-process.ts:180
+      if (this.ptyGone) return;                       // agent-process.ts:186-189
+      this.status = 'running';
+      this.pid = 4242;
+    }
+
+    async stop() { this.status = 'stopped'; this.pid = undefined; }
+
+    getStatus() { return { name: this.name, status: this.status, pid: this.pid }; }
+
+    onExit() { /* no-op */ }
+    onStatusChanged() { /* no-op */ }
+    setTelegramHandle() { /* no-op */ }
+
+    /**
+     * The PTY exits while start() is still awaiting pty.spawn(). Mirrors
+     * handleExit(): status -> 'crashed' (agent-process.ts:612/667) and this.pty
+     * nulled, which is what the post-spawn `if (!this.pty)` branch reads.
+     */
+    simulateExitDuringSpawn() { this.ptyGone = true; this.status = 'crashed'; }
+
+    /** Test-only: let the parked spawn() resolve. */
+    finishSpawn() { this.releaseSpawn(); }
+  },
+}));
+
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class {
+    /** The AgentProcess this checker was built for — the identity anchor. */
+    process: unknown;
+    startCount = 0;
+    stopCount = 0;
+    constructor(agentProcess: unknown) {
+      this.process = agentProcess;
+      h.checkers.push(this);
+    }
+    // The real FastChecker has `private running = false`, a start() that sets it
+    // true and enters `while (this.running)`, and a stop() that sets it false.
+    // There is no generation counter and no re-entry guard, so a second start()
+    // on a stopped checker genuinely resumes injecting into the PTY.
+    async start() { this.startCount++; }
+    stop() { this.stopCount++; }
+    wake() { /* no-op */ }
+    isDuplicate() { return false; }
+    queueTelegramMessage() { /* no-op */ }
+    async handleActivityCallback() { /* no-op */ }
+  },
+}));
+
+vi.mock('../../../src/telegram/api.js', () => ({
+  TelegramAPI: class { async sendMessage() { /* no-op */ } },
+}));
+vi.mock('../../../src/telegram/poller.js', () => ({
+  TelegramPoller: class {
+    lastExitReason: string | undefined;
+    start() { return new Promise<void>(() => {}); }
+    stop() { this.lastExitReason = 'stopped-externally'; }
+    onMessage() { /* no-op */ }
+    onCallback() { /* no-op */ }
+    onReaction() { /* no-op */ }
+  },
+}));
+vi.mock('../../../src/daemon/cron-scheduler.js', () => ({
+  CronScheduler: class {
+    agentName: string;
+    constructor(opts: { agentName: string }) { this.agentName = opts.agentName; }
+    start() { /* no-op */ }
+    stop() { /* no-op */ }
+    reload() { /* no-op */ }
+    getNextFireTimes() { return []; }
+  },
+}));
+vi.mock('../../../src/daemon/worker-process.js', () => ({
+  WorkerProcess: class {
+    name: string;
+    constructor(name: string) { this.name = name; }
+    async spawn() { /* no-op */ }
+    async terminate() { /* no-op */ }
+    onDone() { /* no-op */ }
+    isFinished() { return true; }
+    getStatus() { return { name: this.name }; }
+  },
+}));
+vi.mock('../../../src/bus/metrics.js', () => ({
+  collectTelegramCommands: () => [],
+  registerTelegramCommands: async () => ({ status: 'empty' as const, count: 0 }),
+}));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+
+type CheckerLike = { process: unknown; startCount: number; stopCount: number };
+type ProcLike = {
+  index: number;
+  status: ProcStatus;
+  simulateExitDuringSpawn(): void;
+  finishSpawn(): void;
+};
+type EntryLike = { checker: CheckerLike; process: unknown; stopped?: boolean };
+
+const agentsOf = (am: unknown) => (am as { agents: Map<string, EntryLike> }).agents;
+const procAt = (i: number) => h.procs[i] as ProcLike;
+const checkerFor = (p: unknown) => h.checkers.find((c) => (c as CheckerLike).process === p) as CheckerLike;
+
+// ⛔ AGENT-MANAGER LINE NUMBERS IN THIS FILE ARE AS-OF 4c30b4d7 (PRE-FIX) AND ARE
+// NOW WRONG. The fix inserted a comment block in startAgent's eviction branch, which
+// shifted every line below it. DO NOT TRUST A NUMBER HERE — grep the symbol instead:
+//   `stale.stopped = true`  ·  `stale.checker.stop`  ·  `if (!ownEntry.stopped)`
+//   `entry.stopped = true`  ·  `this.agents.delete(name)`
+// ⭐ Left as a stated offset rather than renumbered on purpose: renumbering is
+// correct for exactly one commit and then silently wrong again, because a line
+// number in a comment is a hand-maintained index with nothing checking it. This
+// note stays true regardless of where the lines move next.
+describe('AgentManager eviction race (F-B1) — `stopped` is never set on the eviction teardown path', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    h.procs.length = 0;
+    h.checkers.length = 0;
+    h.parkIndexes.length = 0;
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-evict-race-'));
+    agentDir = join(testDir, 'framework', 'orgs', 'acme', 'agents', 'alice');
+    mkdirSync(agentDir, { recursive: true });
+    // No startup_delay key at all: the default is 0, exactly as shipped
+    // templates set it. This scenario does NOT depend on a delayed start.
+    writeFileSync(
+      join(agentDir, 'config.json'),
+      JSON.stringify({ name: 'alice', runtime: 'codex-app-server' }),
+    );
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('R4-CONTROL: two sequential starts of a crashed agent evict cleanly — old checker stopped and not re-armed, new checker live', async () => {
+    // Same public surface, no interleaving: the first start runs to completion,
+    // the process then crashes, and a second start evicts it. This is the
+    // eviction path with nothing parked across it. It passes today; it exists to
+    // prove the harness can DRIVE eviction through startAgent() at all, so a red
+    // in the race test below cannot be blamed on a broken harness or a file that
+    // failed to load.
+    await am.startAgent('alice', agentDir);
+    expect(h.procs.length).toBe(1);
+
+    const first = procAt(0);
+    const firstChecker = checkerFor(first);
+    expect(firstChecker.startCount).toBe(1);   // normal path really armed it
+
+    // The agent crashes after it was up.
+    first.status = 'crashed';
+
+    await am.startAgent('alice', agentDir);
+
+    expect(h.procs.length).toBe(2);            // the eviction really started fresh
+    const second = procAt(1);
+    const secondChecker = checkerFor(second);
+
+    expect(firstChecker.stopCount).toBe(1);    // eviction stopped the old checker
+    expect(firstChecker.startCount).toBe(1);   // and never re-armed it
+    expect(secondChecker.startCount).toBe(1);  // the newcomer is the live one
+    expect(agentsOf(am).get('alice')?.checker).toBe(secondChecker);
+  });
+
+  it('R4-DEFECT: a start evicted mid-spawn must not re-arm the checker the eviction stopped', async () => {
+    h.parkIndexes.push(0);   // instance #0 parks inside its spawn await
+
+    // --- public surface call 1: the start that will be evicted ---------------
+    const firstStart = am.startAgent('alice', agentDir);
+    await Promise.resolve();
+
+    expect(h.procs.length).toBe(1);                        // positive control
+    const evictedProc = procAt(0);
+    const evictedChecker = checkerFor(evictedProc);
+    expect(evictedProc.status).toBe('starting');           // parked in spawn()
+    expect(evictedChecker.startCount).toBe(0);             // not armed yet
+    expect(agentsOf(am).get('alice')?.process).toBe(evictedProc);
+
+    // The codex PTY exits DURING pty.spawn(). handleExit flips the status to
+    // 'crashed' while start() is still parked on the spawn await.
+    evictedProc.simulateExitDuringSpawn();
+    expect(evictedProc.status).toBe('crashed');
+
+    // --- public surface call 2: the concurrent start that evicts -------------
+    // isAgentActuallyAlive() reads 'crashed' -> false -> eviction branch at :388.
+    await am.startAgent('alice', agentDir);
+
+    // The eviction really ran, through the real code path: it stopped our
+    // checker (:399), stopped our process (:403), unmapped us (:446) and started
+    // a fresh instance (:588). Nothing here wrote the agents map by hand.
+    expect(evictedChecker.stopCount).toBe(1);
+    expect(h.procs.length).toBe(2);
+    const newcomerProc = procAt(1);
+    const newcomerChecker = checkerFor(newcomerProc);
+    expect(agentsOf(am).get('alice')?.process).toBe(newcomerProc);
+    expect(newcomerChecker.startCount).toBe(1);            // newcomer is live
+
+    // --- the evicted start now resumes past its spawn await ------------------
+    evictedProc.finishSpawn();
+    await firstStart;
+
+    // The entry the EVICTION tore down. stopAgent would have set stopped = true
+    // before its await (:1141); eviction never sets it, so `!ownEntry.stopped`
+    // at :637 is true and the evicted entry's checker is re-armed — on a checker
+    // that is unmapped and can never be stopped again, because every later
+    // stopAgent reaches a checker only by name and the name now belongs to the
+    // newcomer. It injects into a dead PTY for the life of the daemon.
+    //
+    // IDENTITY, not a count: "checker started once" is also satisfiable by the
+    // WRONG checker surviving, so both halves are asserted separately.
+    expect(newcomerChecker.startCount).toBe(1);
+    expect(evictedChecker.startCount).toBe(0);
+  });
+
+  it('R4-MECHANISM: the identical race stays clean once the evicted entry carries `stopped` — the missing write is the whole defect', async () => {
+    // Attribution control for the red above. Same public-surface race, byte for
+    // byte, with ONE difference: the entry eviction tore down is given the
+    // `stopped` flag stopAgent would have set at :1141. If the checker then stays
+    // disarmed, the guard at :637 is working exactly as designed and the ONLY
+    // thing missing is the write on the eviction teardown path at :446 — which is
+    // what makes the red above a defect in src, not an artefact of this harness.
+    //
+    // Stable across the fix: once eviction sets `stopped` itself, the line below
+    // is a no-op and this test still passes. It is not an anti-regression trap.
+    h.parkIndexes.push(0);
+
+    const firstStart = am.startAgent('alice', agentDir);
+    await Promise.resolve();
+
+    const evictedProc = procAt(0);
+    const evictedChecker = checkerFor(evictedProc);
+    const evictedEntry = agentsOf(am).get('alice') as EntryLike;
+    expect(evictedEntry.process).toBe(evictedProc);     // positive control
+
+    evictedProc.simulateExitDuringSpawn();
+    await am.startAgent('alice', agentDir);
+
+    expect(h.procs.length).toBe(2);                     // eviction really ran
+    expect(evictedChecker.stopCount).toBe(1);
+
+    // The one line src is missing on this path.
+    evictedEntry.stopped = true;
+
+    evictedProc.finishSpawn();
+    await firstStart;
+
+    expect(evictedChecker.startCount).toBe(0);
+    expect(checkerFor(procAt(1)).startCount).toBe(1);
+  });
+});

--- a/tests/unit/daemon/agent-manager-map-entry-race.test.ts
+++ b/tests/unit/daemon/agent-manager-map-entry-race.test.ts
@@ -1,0 +1,1312 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// map-entry-race fix: a NAME is used as a handle to an OBJECT across an await,
+// and the name is re-bindable during that await. These tests force the
+// interleaving DETERMINISTICALLY (deferred stop()/start() promises resolved by
+// hand — the technique already proven at agent-manager-liveness.test.ts:162-187),
+// so there is no timing hope, no fake timers and no retry loop. They are
+// deterministic-unit evidence, NOT a statistical repro rate.
+//
+// Mock harness mirrors agent-manager-liveness.test.ts, plus CronScheduler and
+// bus/metrics: these tests reach further into startAgent() than the liveness
+// tests do, so the real scheduler (setInterval) and the real Telegram
+// command-registration (network) would otherwise run.
+let agentProcessCtorCount = 0;
+vi.mock('../../../src/daemon/agent-process.js', () => ({
+  AgentProcess: class {
+    name: string;
+    dir: unknown;
+    constructor(name: string, dir: unknown) {
+      agentProcessCtorCount++;
+      this.name = name;
+      this.dir = dir;
+    }
+    async start() { /* overridden per-test where a deferred start is needed */ }
+    async stop() { /* no-op */ }
+    getStatus() { return { name: this.name, status: 'stopped' }; }
+    onExit() { /* no-op */ }
+    onStatusChanged() { /* no-op */ }
+    setTelegramHandle() { /* no-op */ }
+  },
+}));
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class {
+    // Round 3 (F2): the real FastChecker has `private running = false`, a
+    // `start()` that unconditionally sets it true and enters `while (this.running)`,
+    // and a `stop()` that sets it false. There is NO generation counter and start
+    // is NOT idempotent-protected, so a second start() on a stopped checker
+    // genuinely resumes injecting into the PTY. Counting calls is therefore the
+    // right probe, exactly as it is for TelegramPoller above.
+    startCount = 0;
+    stopCount = 0;
+    async start() { this.startCount++; }
+    stop() { this.stopCount++; }
+    wake() { /* no-op */ }
+    isDuplicate() { return false; }
+    queueTelegramMessage() { /* no-op */ }
+  },
+}));
+vi.mock('../../../src/telegram/api.js', () => ({
+  TelegramAPI: class { async sendMessage() { /* no-op */ } },
+}));
+// Round 2: the poller mock is no longer a pure no-op. The round-1 harness parked
+// start() in a never-resolving promise, which is exactly what made the
+// poller-RESURRECTION class unobservable — the wrapper could never get back
+// round its loop. `pollerStartMode` lets a single describe opt into a
+// resolving start() without changing the default for every other test.
+const hoisted = vi.hoisted(() => ({ pollerStartMode: 'park' as 'park' | 'conflict-once' }));
+vi.mock('../../../src/telegram/poller.js', () => ({
+  TelegramPoller: class {
+    lastExitReason: string | undefined;
+    /** 4th ctor arg — 'activity' for the activity-channel poller, undefined for the primary. */
+    suffix: string | undefined;
+    startCount = 0;
+    stopCount = 0;
+    messageHandlers: ((m: unknown) => void)[] = [];
+    callbackHandlers: ((q: unknown) => void)[] = [];
+    reactionHandlers: ((r: unknown) => void)[] = [];
+    constructor(_api?: unknown, _stateDir?: string, _interval?: number, suffix?: string) {
+      this.suffix = suffix;
+    }
+    start() {
+      this.startCount++;
+      // Mirrors src/telegram/poller.ts:89-90. start() unconditionally re-arms the
+      // loop and BLANKS lastExitReason, erasing any 'stopped-externally' a
+      // concurrent stop() left behind. The real class has NO re-entry guard —
+      // pinned by 'restarting a stopped poller re-arms it' in
+      // tests/unit/telegram/poller.test.ts — so a second start() on a torn-down
+      // poller genuinely polls again. That is why startCount is the right probe.
+      this.lastExitReason = '';
+      if (hoisted.pollerStartMode === 'conflict-once' && this.startCount === 1) {
+        // poller.ts:104-107 — a 409 Conflict exits the loop asking to be restarted.
+        // Only the FIRST call resolves, so the wrapper gets exactly one trip round
+        // its retry sleep and a resurrection cannot run away with the test.
+        return Promise.resolve().then(() => { this.lastExitReason = 'conflict-self-die'; });
+      }
+      // Never resolves: parks the Conflict-restart wrapper instead of letting it
+      // fall through to its 30s setTimeout and dangle past the test.
+      return new Promise<void>(() => {});
+    }
+    stop() { this.stopCount++; this.lastExitReason = 'stopped-externally'; }
+    onMessage(h: (m: unknown) => void) { this.messageHandlers.push(h); }
+    onCallback(h: (q: unknown) => void) { this.callbackHandlers.push(h); }
+    onReaction(h: (r: unknown) => void) { this.reactionHandlers.push(h); }
+  },
+}));
+vi.mock('../../../src/daemon/cron-scheduler.js', () => ({
+  CronScheduler: class {
+    agentName: string;
+    constructor(opts: { agentName: string }) { this.agentName = opts.agentName; }
+    start() { /* no-op */ }
+    stop() { /* no-op */ }
+    reload() { /* no-op */ }
+    getNextFireTimes() { return []; }
+  },
+}));
+vi.mock('../../../src/daemon/worker-process.js', () => ({
+  WorkerProcess: class {
+    name: string;
+    private doneHandler: ((n: string) => void) | null = null;
+    finished = true;
+    constructor(name: string) { this.name = name; }
+    async spawn() { /* no-op */ }
+    async terminate() { /* no-op */ }
+    onDone(h: (n: string) => void) { this.doneHandler = h; }
+    /** Test-only: fire the onDone callback AgentManager registered in spawnWorker. */
+    fireDone() { this.doneHandler?.(this.name); }
+    isFinished() { return this.finished; }
+    getStatus() { return { name: this.name }; }
+  },
+}));
+vi.mock('../../../src/bus/metrics.js', () => ({
+  collectTelegramCommands: () => [],
+  registerTelegramCommands: async () => ({ status: 'empty' as const, count: 0 }),
+}));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+
+type PollerLike = {
+  startCount: number;
+  stopCount: number;
+  suffix?: string;
+  messageHandlers: ((m: unknown) => void)[];
+  callbackHandlers: ((q: unknown) => void)[];
+  reactionHandlers: ((r: unknown) => void)[];
+};
+type AgentEntryLike = {
+  poller?: unknown;
+  activityPoller?: unknown;
+  telegramRejectCount?: number;
+  checker?: unknown;
+};
+const agentsOf = (am: unknown) => (am as { agents: Map<string, unknown> }).agents;
+const pendingOf = (am: unknown) => (am as { pendingRestarts: Set<string> }).pendingRestarts;
+const cronsOf = (am: unknown) => (am as { cronSchedulers: Map<string, unknown> }).cronSchedulers;
+const workersOf = (am: unknown) => (am as { workers: Map<string, unknown> }).workers;
+const entryOf = (am: unknown, name: string) => agentsOf(am).get(name) as AgentEntryLike;
+
+// Round-1 ids run T1-T7 then T9. THERE IS NO T8, and no record of what it was
+// survives anywhere: searched every commit body on every ref and the whole tree
+// at HEAD for the token, nothing. So this comment cannot say what T8 tested —
+// only that its absence is a gap in the record and NOT a test that was written,
+// run, and deliberately removed, because nothing distinguishes those two from
+// here. Round 2 does not reuse the id; it continues from T10.
+
+const LIVE_PID = 1234;
+
+/** A deferred promise so a test can resolve an await at an exact instant. */
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((r) => { resolve = r; });
+  return { promise, resolve };
+}
+
+/** Minimal stand-in for a mapped agent entry, with a deferred process.stop(). */
+function fakeEntry(stop: () => Promise<void>, status = 'running') {
+  return {
+    process: { getStatus: () => ({ name: 'alice', status, pid: LIVE_PID }), stop },
+    checker: { stop: vi.fn() },
+  };
+}
+
+function fakeScheduler() {
+  return { stop: vi.fn(), start: vi.fn(), reload: vi.fn(), getNextFireTimes: () => [] };
+}
+
+/** Agent dir with a config.json, and optionally the .env the poller branch needs. */
+function makeAgentDir(root: string, org: string, name: string, withTelegram = false): string {
+  const dir = join(root, 'framework', 'orgs', org, 'agents', name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'config.json'), JSON.stringify({ name }));
+  if (withTelegram) {
+    // Format-valid only. TelegramAPI and TelegramPoller are both mocked, so
+    // nothing is contacted and no real token is involved.
+    writeFileSync(
+      join(dir, '.env'),
+      'BOT_TOKEN=123456:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nCHAT_ID=999\nALLOWED_USER=999\n',
+    );
+  }
+  return dir;
+}
+
+/** Make `name` the org's orchestrator and give the org an activity channel. */
+function makeActivityChannel(root: string, org: string, name: string): void {
+  const orgDir = join(root, 'framework', 'orgs', org);
+  mkdirSync(orgDir, { recursive: true });
+  writeFileSync(join(orgDir, 'context.json'), JSON.stringify({ orchestrator: name }));
+  writeFileSync(
+    join(orgDir, 'activity-channel.env'),
+    'ACTIVITY_BOT_TOKEN=654321:BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB\nACTIVITY_CHAT_ID=888\n',
+  );
+}
+
+describe('AgentManager map-entry race — stopAgent must not evict a replacement registered during its await', () => {
+  let testDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-stop-'));
+    mkdirSync(join(testDir, 'framework'), { recursive: true });
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('T1: does not unmap a replacement registered during process.stop()', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const E2 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', E1);
+
+    const p = am.stopAgent('alice', true);   // parks at `await entry.process.stop()`
+    agentsOf(am).set('alice', E2);           // the re-registration, at the exact instant
+    d.resolve();
+    await p;
+
+    // IDENTITY, not presence: a replacement that got deleted and re-added would
+    // pass a `.has()` check while the live newcomer had already been orphaned.
+    expect(agentsOf(am).get('alice')).toBe(E2);
+  });
+
+  it('T2: still unmaps its OWN entry when nobody supersedes it (preservation guard)', async () => {
+    const E1 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', E1);
+
+    await am.stopAgent('alice', true);
+
+    expect(agentsOf(am).has('alice')).toBe(false);
+    expect(E1.checker.stop).toHaveBeenCalled();
+  });
+
+  it('T3: does not stop or unmap a REPLACEMENT\'s scheduler', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const E2 = fakeEntry(async () => {});
+    const S1 = fakeScheduler();
+    const S2 = fakeScheduler();
+    agentsOf(am).set('alice', E1);
+    cronsOf(am).set('alice', S1);
+
+    const p = am.stopAgent('alice', true);
+    agentsOf(am).set('alice', E2);
+    cronsOf(am).set('alice', S2);
+    d.resolve();
+    await p;
+
+    expect(S2.stop).not.toHaveBeenCalled();
+    expect(cronsOf(am).get('alice')).toBe(S2);
+  });
+
+  it('T4: still stops its OWN scheduler when superseded (no leaked interval)', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const E2 = fakeEntry(async () => {});
+    const S1 = fakeScheduler();
+    const S2 = fakeScheduler();
+    agentsOf(am).set('alice', E1);
+    cronsOf(am).set('alice', S1);
+
+    const p = am.stopAgent('alice', true);
+    agentsOf(am).set('alice', E2);
+    cronsOf(am).set('alice', S2);
+    d.resolve();
+    await p;
+
+    // Kills the naive `if (superseded) return;` placed above the scheduler
+    // block: that leaks S1's setInterval forever.
+    expect(S1.stop).toHaveBeenCalled();
+    expect(cronsOf(am).get('alice')).toBe(S2);
+  });
+
+  it('T4b: re-wires a scheduler for the newcomer that our stop left cron-less', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const E2 = fakeEntry(async () => {});
+    const S1 = fakeScheduler();
+    agentsOf(am).set('alice', E1);
+    cronsOf(am).set('alice', S1);
+
+    // No S2: the newcomer's own startAgentCronScheduler() was refused by the
+    // "already running" guard because S1 was still mapped at the time.
+    const p = am.stopAgent('alice', true);
+    agentsOf(am).set('alice', E2);
+    d.resolve();
+    await p;
+
+    expect(S1.stop).toHaveBeenCalled();
+    const rewired = cronsOf(am).get('alice');
+    expect(rewired).toBeDefined();
+    expect(rewired).not.toBe(S1);
+  });
+
+  it('T5: does not consume a replacement\'s queued restart', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const E2 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', E1);
+
+    const p = am.stopAgent('alice', true);   // userInitiated: drops pendingRestarts
+    agentsOf(am).set('alice', E2);
+    pendingOf(am).add('alice');              // queued against the NEWCOMER
+    d.resolve();
+    await p;
+
+    expect(pendingOf(am).has('alice')).toBe(true);
+  });
+
+  it('T6: non-superseded pendingRestarts honor path is unchanged (BUG-011/031 guard)', async () => {
+    const E1 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', E1);
+    pendingOf(am).add('alice');
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue(undefined);
+
+    await am.stopAgent('alice', false);      // internal caller
+
+    expect(startSpy).toHaveBeenCalledWith('alice', '');
+    expect(pendingOf(am).has('alice')).toBe(false);
+    startSpy.mockRestore();
+  });
+});
+
+describe('AgentManager map-entry race — startAgent eviction must abort rather than clobber a replacement', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-evict-'));
+    // A REAL agent dir, unlike agent-manager-liveness.test.ts, so the fresh-start
+    // path runs past `new AgentProcess()` and the unconditional `agents.set()`
+    // instead of bailing early at "Agent directory not found". That is what makes
+    // the clobber (rather than only the delete) observable here.
+    agentDir = join(testDir, 'framework', 'orgs', 'acme', 'agents', 'alice');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'config.json'), JSON.stringify({ name: 'alice' }));
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+    agentProcessCtorCount = 0;
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('T7: aborts the start when a different instance took the name during eviction', async () => {
+    const d = deferred();
+    const stale = fakeEntry(() => d.promise, 'halted');   // dead => eviction path
+    const E2 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', stale);
+
+    const p = am.startAgent('alice', agentDir);   // parks at `await stale.process.stop()`
+    agentsOf(am).set('alice', E2);                // a different instance takes the name
+    d.resolve();
+    await p;
+
+    expect(agentsOf(am).get('alice')).toBe(E2);
+    // Unpatched, the fresh-start path runs and builds a SECOND PTY over E2.
+    expect(agentProcessCtorCount).toBe(0);
+  });
+});
+
+describe('AgentManager map-entry race — a poller must attach to the entry that created it', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-poller-'));
+    agentDir = join(testDir, 'framework', 'orgs', 'acme', 'agents', 'alice');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(join(agentDir, 'config.json'), JSON.stringify({ name: 'alice' }));
+    // Telegram credentials are required for the poller branch to run at all.
+    // The token only has to satisfy the numeric_id:secret format check —
+    // TelegramAPI and TelegramPoller are both mocked, so nothing is contacted.
+    writeFileSync(
+      join(agentDir, '.env'),
+      'BOT_TOKEN=123456:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA\nCHAT_ID=999\nALLOWED_USER=999\n',
+    );
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('T9: attaches its poller to its OWN entry, not to whoever holds the name later', async () => {
+    // Park inside `await agentProcess.start()` — which sits between the
+    // `agents.set()` at the top of the start path and the poller wiring below it.
+    const d = deferred();
+    const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+    const startSpy = vi
+      .spyOn(AgentProcess.prototype as unknown as { start: () => Promise<void> }, 'start')
+      .mockImplementation(() => d.promise);
+
+    const p = am.startAgent('alice', agentDir);
+    await Promise.resolve();                       // let startAgent reach the park
+
+    const ownEntry = agentsOf(am).get('alice') as AgentEntryLike;
+    expect(ownEntry).toBeDefined();                // positive control: we really got the start path
+
+    const E2 = fakeEntry(async () => {}) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', E2);
+    d.resolve();
+    await p;
+
+    // Asserted FIRST so the baseline failure is unambiguous: "expected {...} to
+    // be undefined" can only mean the poller attached itself to the foreign
+    // entry. Asserting ownEntry.poller first would fail identically whether the
+    // defect fired or the poller branch simply never ran.
+    expect(E2.poller).toBeUndefined();
+    // Positive control: without this, `E2.poller === undefined` would also pass
+    // if the poller branch never ran at all (bad .env, changed guard, etc.).
+    expect(ownEntry.poller).toBeDefined();
+
+    startSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ROUND 2 — the same defect at the sites where a name is used to DECIDE WHETHER
+// TO ACT, not only where it is used to DESTROY. A presence check (`agents.has`,
+// `agents.get` truthiness) reads TRUE for a DIFFERENT object that has since
+// taken the name, so the round-1 guards — which correctly leave the name mapped
+// — turned "both die" into "the old one comes back".
+// ---------------------------------------------------------------------------
+
+describe('AgentManager map-entry race — a torn-down poller must not be resurrected by a successor holding the name', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    hoisted.pollerStartMode = 'conflict-once';
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-resurrect-'));
+    agentDir = makeAgentDir(testDir, 'acme', 'alice', true);
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    hoisted.pollerStartMode = 'park';
+    vi.useRealTimers();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // BOTH POLARITIES, DELIBERATELY. A bare "start() was not called twice" is
+  // green on the over-correction — a guard so tight that the NEWCOMER's poller
+  // never starts either. That failure is WORSE than the one this test is named
+  // for: nothing 409s, nothing churns, nothing alarms, the agent just stops
+  // receiving Telegram and every surface looks healthy. And a COUNT ALONE
+  // cannot tell "the right poller is live" from "the stale one is live" —
+  // both are 1 — so the identity assertions below are load-bearing, not colour.
+  it('T10: restarts neither poller by name — the stale one stays dead, the newcomer stays live', async () => {
+    await am.startAgent('alice', agentDir);
+    await vi.advanceTimersByTimeAsync(0);          // let A's wrapper park in its 30s retry sleep
+    const entryA = entryOf(am, 'alice');
+    const pollerA = entryA.poller as PollerLike;
+    expect(pollerA.startCount).toBe(1);            // positive control: the wrapper really ran
+
+    await am.stopAgent('alice', true);             // real teardown: poller.stop() + entry unmapped
+    expect(pollerA.stopCount).toBe(1);             // positive control: A really WAS torn down
+    expect(agentsOf(am).has('alice')).toBe(false);
+
+    // A different instance takes the name. `this.agents.has('alice')` now reads
+    // TRUE for an object that is not A's.
+    await am.startAgent('alice', agentDir);
+    const entryB = entryOf(am, 'alice');
+    const pollerB = entryB.poller as PollerLike;
+    expect(pollerB).not.toBe(pollerA);
+    expect(pollerB.startCount).toBe(1);            // OVER-CORRECTION control: 0 here = silent Telegram
+    expect(pollerB.stopCount).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(30_001);     // A's retry sleep elapses
+
+    // DEFECT control. Unpatched this is 2: the wrapper's `agents.has(name)`
+    // reads TRUE for B, and start() — which has no re-entry guard — re-arms A's
+    // loop, putting a second live poller on the same bot token.
+    expect(pollerA.startCount).toBe(1);
+    expect(pollerA.stopCount).toBe(1);             // still torn down, never revived
+    // IDENTITY: the live poller is the NEWCOMER's, not the superseded one.
+    expect(entryOf(am, 'alice')).toBe(entryB);
+    expect(entryOf(am, 'alice').poller).toBe(pollerB);
+    expect(pollerB.stopCount).toBe(0);             // B was never torn down by A's teardown
+  });
+
+  it('T11: activity-channel wrapper obeys the same rule (orchestrator-only twin of T10)', async () => {
+    makeActivityChannel(testDir, 'acme', 'alice');
+    // The org is passed explicitly here to keep this test aimed at the poller
+    // RESURRECTION defect it exists to pin, and nothing else.
+    // ⛔ It is NOT a fixture requirement. When this was written, :912 passed the
+    // raw `org` rather than the resolvedOrg computed at :434, so an omitted org
+    // meant the activity poller never started at all — and passing it explicitly
+    // WORKED AROUND that production bug (F1) rather than exercising the code the
+    // way every restart path actually calls it. Recording that as a test-setup
+    // requirement is how a defect becomes documented intent: the next reader
+    // inherits "org must be passed" as the design. F1 is fixed and T31 now covers
+    // the no-org path directly; this line stays only to keep T11 single-purpose.
+    await am.startAgent('alice', agentDir, undefined, 'acme');
+    await vi.advanceTimersByTimeAsync(0);
+    const entryA = entryOf(am, 'alice');
+    const actA = entryA.activityPoller as PollerLike;
+    expect(actA).toBeDefined();                    // positive control: the branch really ran
+    expect(actA.suffix).toBe('activity');          // and it is the ACTIVITY poller, not the primary
+    expect(actA.startCount).toBe(1);
+
+    await am.stopAgent('alice', true);
+    expect(actA.stopCount).toBe(1);
+
+    await am.startAgent('alice', agentDir, undefined, 'acme');
+    const actB = entryOf(am, 'alice').activityPoller as PollerLike;
+    expect(actB).not.toBe(actA);
+    expect(actB.startCount).toBe(1);               // over-correction control
+    expect(actB.stopCount).toBe(0);
+
+    await vi.advanceTimersByTimeAsync(30_001);
+
+    expect(actA.startCount).toBe(1);               // defect control: unpatched, 2
+    expect(entryOf(am, 'alice').activityPoller).toBe(actB);
+  });
+});
+
+describe('AgentManager map-entry race — the activity poller attaches to the entry that created it', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-actattach-'));
+    agentDir = makeAgentDir(testDir, 'acme', 'alice', true);
+    makeActivityChannel(testDir, 'acme', 'alice');
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // Closes the coverage gap the review measured as M7: reverting the
+  // activity-poller attach from the captured entry to a by-name lookup left the
+  // ENTIRE suite green.
+  it('T12: attaches its activity poller to its OWN entry, not to whoever holds the name later', async () => {
+    const d = deferred();
+    const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+    const startSpy = vi
+      .spyOn(AgentProcess.prototype as unknown as { start: () => Promise<void> }, 'start')
+      .mockImplementation(() => d.promise);
+
+    const p = am.startAgent('alice', agentDir, undefined, 'acme');
+    await Promise.resolve();
+
+    const ownEntry = entryOf(am, 'alice');
+    expect(ownEntry).toBeDefined();                // positive control: we really got the start path
+
+    const E2 = fakeEntry(async () => {}) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', E2);
+    d.resolve();
+    await p;
+
+    // Asserted FIRST so the baseline failure is unambiguous, same reasoning as T9.
+    expect(E2.activityPoller).toBeUndefined();
+    // Positive control: without this, `E2.activityPoller === undefined` also
+    // passes when the activity branch never ran at all (no context.json, wrong
+    // orchestrator, missing env).
+    expect(ownEntry.activityPoller).toBeDefined();
+
+    startSpy.mockRestore();
+  });
+});
+
+describe('AgentManager map-entry race — poller callbacks act on their own entry', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-cb-'));
+    agentDir = makeAgentDir(testDir, 'acme', 'alice', true);
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // Two-sided in one test BECAUSE the two halves are different objects: the
+  // counter must land on ours AND must not land on the successor's. Asserting
+  // only the second half would be green if the handler counted nothing at all.
+  it('T13: the reject counter increments OUR entry, never the successor holding the name', async () => {
+    await am.startAgent('alice', agentDir);
+    const ownEntry = entryOf(am, 'alice');
+    const poller = ownEntry.poller as PollerLike;
+    expect(poller.messageHandlers).toHaveLength(1);   // positive control: handler really registered
+
+    const E2 = fakeEntry(async () => {}) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', E2);
+
+    // An unauthorized sender: ALLOWED_USER is 999, this is not it.
+    poller.messageHandlers[0]({ from: { id: 111, first_name: 'mallory' }, chat: { id: 999 }, text: 'hi' });
+
+    expect(ownEntry.telegramRejectCount).toBe(1);
+    expect(E2.telegramRejectCount).toBeUndefined();
+  });
+
+  it('T14: the reaction reject counter does the same', async () => {
+    await am.startAgent('alice', agentDir);
+    const ownEntry = entryOf(am, 'alice');
+    const poller = ownEntry.poller as PollerLike;
+    expect(poller.reactionHandlers).toHaveLength(1);
+
+    const E2 = fakeEntry(async () => {}) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', E2);
+
+    poller.reactionHandlers[0]({ user: { id: 111, first_name: 'mallory' }, chat: { id: 999 }, message_id: 1 });
+
+    expect(ownEntry.telegramRejectCount).toBe(1);
+    expect(E2.telegramRejectCount).toBeUndefined();
+  });
+
+  it('T15: an activity-channel callback routes to OUR checker, not the successor\'s', async () => {
+    makeActivityChannel(testDir, 'acme', 'alice');
+    await am.startAgent('alice', agentDir, undefined, 'acme');
+    const ownEntry = entryOf(am, 'alice');
+    const actPoller = ownEntry.activityPoller as PollerLike;
+    expect(actPoller.callbackHandlers).toHaveLength(1);
+
+    const ownHandled = vi.fn().mockResolvedValue(undefined);
+    (ownEntry.checker as { handleActivityCallback: unknown }).handleActivityCallback = ownHandled;
+    const foreignHandled = vi.fn().mockResolvedValue(undefined);
+    const E2 = { process: {}, checker: { handleActivityCallback: foreignHandled } };
+    agentsOf(am).set('alice', E2);
+
+    actPoller.callbackHandlers[0]({ id: '1', data: 'appr_allow_x' });
+
+    expect(ownHandled).toHaveBeenCalled();          // ours ran (over-correction control)
+    expect(foreignHandled).not.toHaveBeenCalled();  // the successor's did not
+  });
+});
+
+describe('AgentManager map-entry race — startAgent eviction, scheduler handling after the await', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-evictsched-'));
+    agentDir = makeAgentDir(testDir, 'acme', 'alice');
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+    agentProcessCtorCount = 0;
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // Closes the coverage gap the review measured as M8: reverting the
+  // staleScheduler hoist AND its identity guard to an unguarded post-await read
+  // left the ENTIRE suite green. This is the eviction-path analogue of T3/T4 —
+  // the stopAgent side had them, this side had nothing.
+  it('T16: does not stop or unmap a REPLACEMENT\'s scheduler while evicting', async () => {
+    const d = deferred();
+    const stale = fakeEntry(() => d.promise, 'halted');   // dead => eviction path
+    const E2 = fakeEntry(async () => {});
+    const S1 = fakeScheduler();
+    const S2 = fakeScheduler();
+    agentsOf(am).set('alice', stale);
+    cronsOf(am).set('alice', S1);
+
+    const p = am.startAgent('alice', agentDir);   // parks at `await stale.process.stop()`
+    agentsOf(am).set('alice', E2);
+    cronsOf(am).set('alice', S2);
+    d.resolve();
+    await p;
+
+    expect(S2.stop).not.toHaveBeenCalled();       // the newcomer's scheduler survives
+    expect(cronsOf(am).get('alice')).toBe(S2);
+    expect(S1.stop).toHaveBeenCalled();           // OPPOSITE POLARITY: ours is still stopped,
+                                                  // otherwise the eviction leaks a setInterval
+  });
+
+  // I-1 in the review: stopAgent got this re-wire and its structural twin here
+  // did not. Reported separately — I could not construct the interleaving the
+  // review describes; see the round-2 report.
+  it('T17: re-wires a scheduler for the newcomer that our eviction left cron-less', async () => {
+    const d = deferred();
+    const stale = fakeEntry(() => d.promise, 'halted');
+    const E2 = fakeEntry(async () => {});
+    const S1 = fakeScheduler();
+    agentsOf(am).set('alice', stale);
+    cronsOf(am).set('alice', S1);
+
+    // No S2: the newcomer's own startAgentCronScheduler() was refused by the
+    // "already running" guard because S1 was still mapped at the time.
+    const p = am.startAgent('alice', agentDir);
+    agentsOf(am).set('alice', E2);
+    d.resolve();
+    await p;
+
+    expect(S1.stop).toHaveBeenCalled();
+    const rewired = cronsOf(am).get('alice');
+    expect(rewired).toBeDefined();
+    expect(rewired).not.toBe(S1);
+    expect(agentProcessCtorCount).toBe(0);        // and we still aborted, not restarted
+  });
+
+  // The hoist's own blind spot, in BOTH paths: a scheduler that did not exist at
+  // capture time but was wired for us DURING the await is invisible to the
+  // captured variable. Pre-hoist the post-await read saw it; post-hoist nothing
+  // does, and it outlives the agent as a live setInterval that also blocks the
+  // next start from getting a scheduler at all.
+  it('T18: eviction stops a scheduler that appeared for the stale entry during the await', async () => {
+    const d = deferred();
+    const stale = fakeEntry(() => d.promise, 'halted');
+    const Slate = fakeScheduler();
+    agentsOf(am).set('alice', stale);             // NO scheduler mapped at capture time
+
+    const p = am.startAgent('alice', agentDir);
+    cronsOf(am).set('alice', Slate);              // wired for the stale entry mid-await
+    d.resolve();
+    await p;
+
+    expect(Slate.stop).toHaveBeenCalled();
+    expect(cronsOf(am).get('alice')).not.toBe(Slate);
+  });
+
+  it('T19: but leaves a late scheduler alone when it belongs to a SUCCESSOR', async () => {
+    const d = deferred();
+    const stale = fakeEntry(() => d.promise, 'halted');
+    const E2 = fakeEntry(async () => {});
+    const Slate = fakeScheduler();
+    agentsOf(am).set('alice', stale);
+
+    const p = am.startAgent('alice', agentDir);
+    agentsOf(am).set('alice', E2);                // superseded FIRST
+    cronsOf(am).set('alice', Slate);              // the scheduler is the newcomer's
+    d.resolve();
+    await p;
+
+    expect(Slate.stop).not.toHaveBeenCalled();
+    expect(cronsOf(am).get('alice')).toBe(Slate);
+  });
+});
+
+describe('AgentManager map-entry race — stopAgent, scheduler that appears during the await', () => {
+  let testDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-latesched-'));
+    mkdirSync(join(testDir, 'framework'), { recursive: true });
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('T20: stops and unmaps a scheduler wired for US during process.stop()', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const Slate = fakeScheduler();
+    agentsOf(am).set('alice', E1);                // NO scheduler at capture time
+
+    const p = am.stopAgent('alice', true);
+    cronsOf(am).set('alice', Slate);              // startAgent:553 wires it mid-await
+    d.resolve();
+    await p;
+
+    expect(Slate.stop).toHaveBeenCalled();
+    expect(cronsOf(am).has('alice')).toBe(false);
+  });
+
+  it('T21: but leaves it alone when a SUCCESSOR took the name (opposite polarity)', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const E2 = fakeEntry(async () => {});
+    const Slate = fakeScheduler();
+    agentsOf(am).set('alice', E1);
+
+    const p = am.stopAgent('alice', true);
+    agentsOf(am).set('alice', E2);
+    cronsOf(am).set('alice', Slate);
+    d.resolve();
+    await p;
+
+    expect(Slate.stop).not.toHaveBeenCalled();
+    expect(cronsOf(am).get('alice')).toBe(Slate);
+  });
+});
+
+describe('AgentManager map-entry race — startAgent must not wire a scheduler it no longer owns', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-startsched-'));
+    agentDir = makeAgentDir(testDir, 'acme', 'alice');
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  async function parkedStart() {
+    const d = deferred();
+    const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+    const startSpy = vi
+      .spyOn(AgentProcess.prototype as unknown as { start: () => Promise<void> }, 'start')
+      .mockImplementation(() => d.promise);
+    const p = am.startAgent('alice', agentDir);
+    await Promise.resolve();
+    return { p, d, startSpy };
+  }
+
+  it('T22: a superseded start does not install a scheduler under the newcomer\'s name', async () => {
+    const { p, d, startSpy } = await parkedStart();
+    const ownEntry = entryOf(am, 'alice');
+    expect(ownEntry).toBeDefined();               // positive control: we reached the park
+
+    const E2 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', E2);
+    d.resolve();
+    await p;
+
+    expect(cronsOf(am).get('alice')).toBeUndefined();
+    startSpy.mockRestore();
+  });
+
+  it('T23: a NORMAL start still wires one (opposite polarity of T22)', async () => {
+    const { p, d, startSpy } = await parkedStart();
+    d.resolve();
+    await p;
+
+    expect(cronsOf(am).get('alice')).toBeDefined();
+    startSpy.mockRestore();
+  });
+
+  // I-2 in the review: a predecessor's supersede-re-wire installs a scheduler
+  // under our name while we are parked in agentProcess.start(). It read
+  // crons.json BEFORE our migrateCronsForAgent wrote it, so it holds zero crons,
+  // and startAgentCronScheduler's "already running — skipped" guard leaves it
+  // that way DURABLY: tick() never reloads and reload() is otherwise IPC-only.
+  it('T24: refreshes a scheduler installed under our name while we were starting', async () => {
+    const { p, d, startSpy } = await parkedStart();
+    const Spre = fakeScheduler();
+    cronsOf(am).set('alice', Spre);               // the predecessor's re-wire, pre-migration
+    d.resolve();
+    await p;
+
+    expect(Spre.reload).toHaveBeenCalled();
+    expect(Spre.stop).not.toHaveBeenCalled();     // refreshed, not replaced
+    expect(cronsOf(am).get('alice')).toBe(Spre);
+    startSpy.mockRestore();
+  });
+});
+
+describe('AgentManager map-entry race — restartAgent must not restart on top of a successor', () => {
+  let testDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-restart-'));
+    mkdirSync(join(testDir, 'framework'), { recursive: true });
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('T25: skips the start half when a different instance took the name during the stop', async () => {
+    const d = deferred();
+    const E1 = fakeEntry(() => d.promise);
+    const E2 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', E1);
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue(undefined);
+
+    const p = am.restartAgent('alice');
+    agentsOf(am).set('alice', E2);
+    d.resolve();
+    await p;
+
+    // Unpatched: startAgent runs, sees a live entry, and emits the
+    // "BUG-011 REGRESSION CHECK" warning on a race that is handled BY DESIGN —
+    // a false alarm on a warning operators are trained to treat as serious —
+    // and leaves a pendingRestarts entry that fires a spurious restart later.
+    expect(startSpy).not.toHaveBeenCalled();
+    expect(pendingOf(am).has('alice')).toBe(false);
+    expect(agentsOf(am).get('alice')).toBe(E2);
+    startSpy.mockRestore();
+  });
+
+  it('T26: still restarts normally when nobody supersedes it (opposite polarity)', async () => {
+    const E1 = fakeEntry(async () => {});
+    agentsOf(am).set('alice', E1);
+    const startSpy = vi.spyOn(am, 'startAgent').mockResolvedValue(undefined);
+
+    await am.restartAgent('alice');
+
+    expect(startSpy).toHaveBeenCalledWith('alice', '');
+    startSpy.mockRestore();
+  });
+});
+
+describe('AgentManager map-entry race — worker registry', () => {
+  let testDir: string;
+  let am: InstanceType<typeof AgentManager>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-worker-'));
+    mkdirSync(join(testDir, 'framework'), { recursive: true });
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('T27: terminateWorker does not unmap a replacement registered during terminate()', async () => {
+    const d = deferred();
+    const W1 = { terminate: () => d.promise };
+    const W2 = { terminate: async () => {} };
+    workersOf(am).set('w1', W1);
+
+    const p = am.terminateWorker('w1');
+    workersOf(am).set('w1', W2);
+    d.resolve();
+    await p;
+
+    expect(workersOf(am).get('w1')).toBe(W2);
+  });
+
+  it('T28: terminateWorker still unmaps its OWN worker (opposite polarity)', async () => {
+    const W1 = { terminate: async () => {} };
+    workersOf(am).set('w1', W1);
+
+    await am.terminateWorker('w1');
+
+    expect(workersOf(am).has('w1')).toBe(false);
+  });
+
+  it('T29: the 30s reaper does not evict a DIFFERENT worker holding the name', async () => {
+    vi.useFakeTimers();
+    try {
+      await am.spawnWorker('w1', join(testDir, 'framework'), 'do a thing');
+      const W1 = workersOf(am).get('w1') as { fireDone: () => void };
+      expect(W1).toBeDefined();                   // positive control: spawn really registered it
+      W1.fireDone();                              // schedules the 30s reaper
+
+      const W2 = { isFinished: () => true };
+      workersOf(am).set('w1', W2);                // a NEW worker takes the name
+
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      expect(workersOf(am).get('w1')).toBe(W2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('T30: the reaper still evicts its OWN finished worker (opposite polarity)', async () => {
+    vi.useFakeTimers();
+    try {
+      await am.spawnWorker('w1', join(testDir, 'framework'), 'do a thing');
+      const W1 = workersOf(am).get('w1') as { fireDone: () => void };
+      W1.fireDone();
+
+      await vi.advanceTimersByTimeAsync(30_001);
+
+      expect(workersOf(am).has('w1')).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe('AgentManager map-entry race — the no-ABA precondition is enforced, not asserted', () => {
+  // stillMapped()'s doc says `this.agents.set` is the single call site in the
+  // class, and the no-ABA argument rests on it: one call site storing a freshly
+  // built literal means a re-registered agent is never reference-equal to a
+  // captured one. NOTHING enforced that claim — a second `agents.set` could be
+  // added tomorrow and every test would stay green while the guard silently
+  // weakened. This is an ENFORCEMENT assertion, not a behavioural regression
+  // control: it was never red, and it fails only when the precondition is
+  // actually broken, which is exactly when someone needs to be told.
+  it('T31: this.agents.set has exactly one call site in agent-manager.ts', () => {
+    const src = readFileSync(
+      new URL('../../../src/daemon/agent-manager.ts', import.meta.url),
+      'utf-8',
+    );
+    const callSites = src
+      .split('\n')
+      .map((l) => l.trim())
+      .filter((l) => !l.startsWith('*') && !l.startsWith('//') && !l.startsWith('/*'))
+      .filter((l) => /this\.agents\.set\(/.test(l));
+    expect(callSites).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ROUND 3 — findings from the two independent reviewers run against round 2.
+//
+// F5 and F2 are the same class round 1 and round 2 each hit once (B1, then N2):
+// REMOVING A BUG REMOVED AN ACCIDENTAL PROTECTION. F5 is the third instance and
+// the first one that arrived INSIDE the fix for the previous two.
+//
+// Every test below is paired. A guard that never lets the block run is exactly
+// as wrong as one that always does, and a single assertion cannot carry both
+// directions — so each defect gets a DEFECT test and an OVER-CORRECTION test
+// rather than one assertion asked to mean two things.
+// ---------------------------------------------------------------------------
+
+describe('AgentManager map-entry race — round 3: an unmapped entry must not act on the world', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-map-race-r3-'));
+    agentDir = makeAgentDir(testDir, 'acme', 'alice', true);
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  // --- F5: the reject-count watchdog ---------------------------------------
+  // Round 2 replaced `const entry = this.agents.get(name); if (entry) {...}`
+  // with `const entry = ownEntry; {...}`. ownEntry is an object literal typed
+  // non-optional and never reassigned, so it is NEVER FALSY and the block became
+  // unconditional. The `if (entry)` it replaced was a real gate that skipped
+  // whenever the name was unmapped.
+
+  it('T23 (F5 DEFECT, message handler): a stranger reject after teardown must not touch a stopped agent', async () => {
+    await am.startAgent('alice', agentDir);
+    const entryA = entryOf(am, 'alice');
+    const pollerA = entryA.poller as PollerLike;
+    expect(pollerA.messageHandlers.length).toBe(1);   // positive control: the handler really was wired
+
+    await am.stopAgent('alice', true);
+    expect(agentsOf(am).has('alice')).toBe(false);    // positive control: really unmapped
+
+    // A message already in flight in the getUpdates batch that was open when
+    // stop() was called. The poller mock does not itself gate delivery, which
+    // mirrors the real class: stop() sets a flag, it cannot recall a batch.
+    pollerA.messageHandlers[0]({ from: { id: 111 } });
+
+    // UNPATCHED this is 1 — and at the threshold it sends a WATCHDOG Telegram on
+    // behalf of an agent the operator has already stopped.
+    expect(entryA.telegramRejectCount ?? 0).toBe(0);
+  });
+
+  it('T24 (F5 OVER-CORRECTION, message handler): while still mapped the watchdog must still count', async () => {
+    await am.startAgent('alice', agentDir);
+    const entryA = entryOf(am, 'alice');
+    const pollerA = entryA.poller as PollerLike;
+
+    pollerA.messageHandlers[0]({ from: { id: 111 } });
+
+    // 0 here means the guard swallowed the live path: the ALLOWED_USER watchdog
+    // silently stops working and unsolicited contact is never surfaced. That is
+    // a worse failure than the one T23 fixes, because nothing looks wrong.
+    expect(entryA.telegramRejectCount).toBe(1);
+  });
+
+  it('T25 (F5 DEFECT, reaction handler): the twin site must be guarded too', async () => {
+    await am.startAgent('alice', agentDir);
+    const entryA = entryOf(am, 'alice');
+    const pollerA = entryA.poller as PollerLike;
+    expect(pollerA.reactionHandlers.length).toBe(1);  // positive control
+
+    await am.stopAgent('alice', true);
+    pollerA.reactionHandlers[0]({ user: { id: 111 } });
+
+    expect(entryA.telegramRejectCount ?? 0).toBe(0);
+  });
+
+  it('T26 (F5 OVER-CORRECTION, reaction handler): while still mapped the reaction gate must still count', async () => {
+    await am.startAgent('alice', agentDir);
+    const entryA = entryOf(am, 'alice');
+    const pollerA = entryA.poller as PollerLike;
+
+    pollerA.reactionHandlers[0]({ user: { id: 111 } });
+
+    expect(entryA.telegramRejectCount).toBe(1);
+  });
+
+  // --- F2: the fast checker ------------------------------------------------
+  // The diff asks the identity question for the cron scheduler at :588 and does
+  // NOT ask it for the checker ten lines later at :607. stopAgent calls
+  // entry.checker.stop() BEFORE its await, so a start parked in
+  // agentProcess.start() resumes and re-arms a checker that was already stopped.
+  // Because our entry is unmapped, stopAgent — which reaches the checker only
+  // via a by-name lookup — can never stop it again.
+
+  it('T27 (F2 DEFECT): a start parked across a teardown must not re-arm the stopped checker', async () => {
+    const d = deferred();
+    const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+    const startSpy = vi
+      .spyOn(AgentProcess.prototype as unknown as { start: () => Promise<void> }, 'start')
+      .mockImplementation(() => d.promise);
+
+    const p = am.startAgent('alice', agentDir);
+    await Promise.resolve();                          // reach the park inside start()
+
+    const ownEntry = agentsOf(am).get('alice') as AgentEntryLike;
+    expect(ownEntry).toBeDefined();                   // positive control: we really got the start path
+    const ownChecker = ownEntry.checker as { startCount: number; stopCount: number };
+    expect(ownChecker.startCount).toBe(0);            // positive control: parked, not started yet
+
+    // The operator stops the agent while our start is still parked. This is the
+    // real ordering: stopAgent stops the checker BEFORE its own await.
+    const stopP = am.stopAgent('alice', true);
+    await Promise.resolve();
+    expect(ownChecker.stopCount).toBe(1);             // positive control: OUR checker really was stopped
+
+    d.resolve();
+    await p;
+    await stopP;
+
+    // UNPATCHED this is 1: a checker re-armed after teardown, and unreachable by
+    // any future stopAgent because the name no longer resolves to this entry.
+    expect(ownChecker.startCount).toBe(0);
+
+    startSpy.mockRestore();
+  });
+
+  it('T27b (F2 DISCRIMINATOR): a merely SUPERSEDED start must STILL arm its checker', async () => {
+    // This is the test that rules out the obvious-looking remedy. Guarding the
+    // checker on stillMapped() would pass T27 and fail here: being superseded is
+    // not being stopped, our process is alive, and an agent whose checker never
+    // starts is completely dead — no Telegram, no hooks, no injection — while
+    // every liveness surface still reports it running.
+    const d = deferred();
+    const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+    const startSpy = vi
+      .spyOn(AgentProcess.prototype as unknown as { start: () => Promise<void> }, 'start')
+      .mockImplementation(() => d.promise);
+
+    const p = am.startAgent('alice', agentDir);
+    await Promise.resolve();
+
+    const ownEntry = agentsOf(am).get('alice') as AgentEntryLike;
+    const ownChecker = ownEntry.checker as { startCount: number };
+
+    // Somebody else takes the name. Nothing stopped US.
+    const E2 = fakeEntry(async () => {}) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', E2);
+
+    d.resolve();
+    await p;
+
+    expect(ownChecker.startCount).toBe(1);
+
+    startSpy.mockRestore();
+  });
+
+  it('T28 (F2 OVER-CORRECTION): the normal path must still start the checker', async () => {
+    await am.startAgent('alice', agentDir);
+    const entryA = entryOf(am, 'alice');
+    const checker = entryA.checker as { startCount: number };
+
+    // 0 here is a completely dead agent: no Telegram, no hooks, no injection,
+    // and every liveness surface still reports it running.
+    expect(checker.startCount).toBe(1);
+  });
+
+  // --- F3/F4: stillMapped conflates REPLACED with REMOVED -------------------
+  // stillMapped() is `this.agents.get(name) === entry`. When NOTHING holds the
+  // name, get() returns undefined and the comparison is false — identical to the
+  // genuinely-re-registered case. The superseded branches then warn about a
+  // re-registration that provably did not happen and return early, skipping the
+  // pendingRestarts handling below them.
+
+  it('T29 (F3/F4 DEFECT): a second stop of an already-removed name must not claim a re-registration', async () => {
+    const d = deferred();
+    const stopped = fakeEntry(() => d.promise) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', stopped);
+    pendingOf(am).add('alice');
+
+    const first = am.stopAgent('alice', true);
+    await Promise.resolve();                          // park inside process.stop()
+
+    // A concurrent stop completes and removes the name. ipc-server never awaits
+    // stopAgent (see the comment at the top of stopAgent), so two stops for the
+    // same name genuinely interleave.
+    agentsOf(am).delete('alice');
+
+    // mockClear immediately: vi.spyOn on an ALREADY-spied console.warn returns
+    // the SAME mock, and a mockRestore() written after an assertion never runs
+    // when that assertion throws. Measured: T29 failing pre-fix left its spy
+    // installed and T30 then read T29's warning as its own, turning a passing
+    // over-correction control into a false red. Cleanup after an assertion is
+    // cleanup that only happens when it is not needed.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warn.mockClear();
+    d.resolve();
+    await first;
+
+    // UNPATCHED: warns "was re-registered while stopping" about a name nothing
+    // holds, and returns before the pendingRestarts handling — stranding a
+    // queued restart that later fires against an unrelated stop.
+    const reRegisteredWarnings = warn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('re-registered'));
+    expect(reRegisteredWarnings).toEqual([]);
+    expect(pendingOf(am).has('alice')).toBe(false);
+
+    warn.mockRestore();
+  });
+
+  it('T30 (F3/F4 OVER-CORRECTION): a genuine re-registration must STILL be detected and left alone', async () => {
+    const d = deferred();
+    const stopped = fakeEntry(() => d.promise) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', stopped);
+
+    const first = am.stopAgent('alice', true);
+    await Promise.resolve();
+
+    // This time a DIFFERENT instance really does take the name.
+    const E2 = fakeEntry(async () => {}) as unknown as AgentEntryLike;
+    agentsOf(am).set('alice', E2);
+
+    // mockClear immediately: vi.spyOn on an ALREADY-spied console.warn returns
+    // the SAME mock, and a mockRestore() written after an assertion never runs
+    // when that assertion throws. Measured: T29 failing pre-fix left its spy
+    // installed and T30 then read T29's warning as its own, turning a passing
+    // over-correction control into a false red. Cleanup after an assertion is
+    // cleanup that only happens when it is not needed.
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    warn.mockClear();
+    d.resolve();
+    await first;
+
+    // The newcomer must survive: deleting here would empty the slot while the
+    // new agent keeps running, which is the orphan this branch exists to stop.
+    expect(agentsOf(am).get('alice')).toBe(E2);
+    const reRegisteredWarnings = warn.mock.calls
+      .map((c) => String(c[0]))
+      .filter((m) => m.includes('re-registered'));
+    expect(reRegisteredWarnings.length).toBe(1);
+
+    warn.mockRestore();
+  });
+
+  // --- F1: the activity-channel poller gets the RAW org ---------------------
+  // :912 passes `org`, the raw parameter, not the `resolvedOrg` computed at :434
+  // for exactly this reason. maybeStartActivityChannelPoller returns immediately
+  // on a falsy org. THREE callers pass no org: restartAgent, the pendingRestarts
+  // honor path, and ipc-server.ts's start-agent handler.
+
+  it('T31 (F1 DEFECT): a start with no explicit org must still wire the activity poller', async () => {
+    makeActivityChannel(testDir, 'acme', 'alice');
+
+    // No 4th argument — exactly what restartAgent, the pendingRestarts honor
+    // path, and the IPC start handler all pass.
+    await am.startAgent('alice', agentDir);
+
+    const entryA = entryOf(am, 'alice');
+    expect(entryA.poller).toBeDefined();              // positive control: the telegram branch ran at all
+    // UNPATCHED this is undefined: every dashboard restart, CLI start-agent and
+    // restartAgent silently drops the orchestrator's approval-button path.
+    expect(entryA.activityPoller).toBeDefined();
+  });
+
+  it('T32 (F1 OVER-CORRECTION): a non-orchestrator must still NOT get an activity poller', async () => {
+    // Activity channel exists, but bob is not the org's orchestrator.
+    makeActivityChannel(testDir, 'acme', 'alice');
+    const bobDir = makeAgentDir(testDir, 'acme', 'bob', true);
+
+    await am.startAgent('bob', bobDir);
+
+    const entryB = entryOf(am, 'bob');
+    expect(entryB.poller).toBeDefined();              // positive control: the telegram branch ran
+    // Resolving the org must not turn the orchestrator-only gate into an
+    // every-agent gate — that would put N pollers on one bot token.
+    expect(entryB.activityPoller).toBeUndefined();
+  });
+});

--- a/tests/unit/daemon/agent-manager-stopagent-window-round4b.test.ts
+++ b/tests/unit/daemon/agent-manager-stopagent-window-round4b.test.ts
@@ -1,0 +1,334 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Round 4b. Companion to agent-manager-eviction-race-round4.test.ts.
+//
+// THE TWO STATES, NAMED BY STATE AND NEVER BY LETTER:
+//
+//   `stopped`-FALSE-and-UNMAPPED   the evicted zombie. MEASURED RED, round-4 file.
+//                                  `!ownEntry.stopped` says ACT — wrongly.
+//                                  `stillMapped` says don't act — correctly.
+//
+//   `stopped`-TRUE-and-STILL-MAPPED   THIS FILE. stopAgent sets `stopped` at :1141
+//                                  and does not unmap until :1198, so for the whole
+//                                  of `await entry.process.stop()` (:1146) the name
+//                                  still resolves to an entry that is being torn down.
+//                                  `stillMapped` says ACT — wrongly.
+//                                  `!ownEntry.stopped` says don't act — correctly.
+//
+// EACH PREDICATE ALONE FAILS OPEN IN ONE OF THESE, AND THEY ARE DIFFERENT ONES.
+//
+// ⛔⛔ SUPERSEDED — READ THIS BEFORE THE PARAGRAPH ABOVE ACTS ON YOU.
+// This header used to conclude "that is why the guard has to be the conjunction",
+// and to call the second conjunct LOAD-BEARING. THE SHIPPED FIX TOOK THE OPPOSITE
+// ROUTE AND THE OPPOSITE ROUTE IS CORRECT. Round 4 (F-B1) found that `stopped` was
+// simply never SET on the eviction teardown path; setting it there makes the SINGLE
+// predicate `!ownEntry.stopped` cover both teardown states, and src still guards on
+// that one predicate alone.
+//
+// ⛔ DO NOT "COMPLETE" THE GUARD INTO A CONJUNCTION ON THE STRENGTH OF THIS FILE.
+// Adding `stillMapped` as a conjunct would BREAK the superseded-but-alive case that
+// T13/T14 exist to pin: an entry that is still running under someone else's name is
+// legitimately entitled to its own checker, and a conjunction would deny it. The
+// distinction is spelled out on the `stopped` field in AgentEntry.
+//
+// ✅ WHAT THIS FILE STILL WITNESSES, AND IT IS WORTH KEEPING: that
+// `stillMapped`-ALONE would ACT in the stopped-and-still-mapped state, i.e. map
+// identity is the wrong question to ask. That remains true and is why the guard asks
+// about TEARDOWN. What does NOT follow from it is that BOTH questions must be asked.
+// ⭐ The two are not the same claim, and this header conflated them for one commit:
+// "map identity alone is insufficient" is not "map identity is necessary".
+//
+// ⛔ WHAT THIS FILE DOES NOT DO, STATED SO NOBODY HAS TO INFER IT:
+// it does NOT go red against current src. Current src guards :637 on
+// `!ownEntry.stopped`, which is CORRECT in this state. This is a REACHABILITY
+// WITNESS for the state, not a defect report. It asserts the STATE the manager is
+// observably in at the moment a parked start resumes — from which it follows that a
+// guard reading map identity alone would act there. It deliberately does NOT
+// evaluate a candidate predicate of its own: a test that scores an expression the
+// test itself wrote is scoring the test, not src.
+//
+// ⛔ AND IT DOES NOT SPEAK TO PRODUCTION WINDOW WIDTH. The harness decides when
+// `process.stop()` resolves, so the window here is as wide as the test wants. Width
+// on the real code is a separate measurement against the real AgentProcess.stop(),
+// where the sleeps are branch-conditional on `config.runtime` (default 6s floor,
+// codex-app-server none). NOTHING HERE MEASURES THAT. See the runtime note below.
+
+type ProcStatus = 'stopped' | 'starting' | 'running' | 'crashed' | 'halted';
+
+const h = vi.hoisted(() => ({
+  procs: [] as unknown[],
+  checkers: [] as unknown[],
+  /** Instance indexes whose start() parks on its spawn gate until released. */
+  parkIndexes: [] as number[],
+  /** Instance indexes whose stop() parks until released. */
+  stopParkIndexes: [] as number[],
+}));
+
+vi.mock('../../../src/daemon/agent-process.js', () => ({
+  AgentProcess: class {
+    name: string;
+    index: number;
+    status: ProcStatus = 'stopped';
+    pid: number | undefined;
+    ptyGone = false;
+    private releaseSpawn!: () => void;
+    private releaseStop!: () => void;
+    spawnGate: Promise<void>;
+    stopGate: Promise<void>;
+    /** Flips true the moment stop() is entered, BEFORE it parks. */
+    stopEntered = false;
+
+    constructor(name: string) {
+      this.name = name;
+      this.index = h.procs.length;
+      h.procs.push(this);
+      let releaseA!: () => void;
+      this.spawnGate = new Promise<void>((r) => { releaseA = r; });
+      this.releaseSpawn = releaseA;
+      if (!h.parkIndexes.includes(this.index)) this.releaseSpawn();
+
+      let releaseB!: () => void;
+      this.stopGate = new Promise<void>((r) => { releaseB = r; });
+      this.releaseStop = releaseB;
+      if (!h.stopParkIndexes.includes(this.index)) this.releaseStop();
+    }
+
+    async start() {
+      if (this.status === 'running') return;
+      this.status = 'starting';
+      await this.spawnGate;
+      if (this.ptyGone) return;
+      this.status = 'running';
+      this.pid = 4242;
+    }
+
+    /**
+     * Stands in for the real AgentProcess.stop(). The real one yields for a
+     * runtime-dependent floor (default branch: sleep(1000) + sleep(5000) inside
+     * `if (pty)`); the gate here stands in for that yield so the test controls the
+     * window rather than waiting on wall-clock.
+     */
+    async stop() {
+      this.stopEntered = true;
+      await this.stopGate;
+      this.status = 'stopped';
+      this.pid = undefined;
+    }
+
+    finishStop() { this.releaseStop(); }
+    finishSpawn() { this.releaseSpawn(); }
+
+    getStatus() { return { name: this.name, status: this.status, pid: this.pid }; }
+    onExit() { /* no-op */ }
+    onStatusChanged() { /* no-op */ }
+    setTelegramHandle() { /* no-op */ }
+    simulateExitDuringSpawn() { this.ptyGone = true; this.status = 'crashed'; }
+  },
+}));
+
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class {
+    process: unknown;
+    startCount = 0;
+    stopCount = 0;
+    constructor(agentProcess: unknown) {
+      this.process = agentProcess;
+      h.checkers.push(this);
+    }
+    async start() { this.startCount++; }
+    stop() { this.stopCount++; }
+    wake() { /* no-op */ }
+    isDuplicate() { return false; }
+    queueTelegramMessage() { /* no-op */ }
+    async handleActivityCallback() { /* no-op */ }
+  },
+}));
+
+vi.mock('../../../src/telegram/api.js', () => ({
+  TelegramAPI: class { async sendMessage() { /* no-op */ } },
+}));
+vi.mock('../../../src/telegram/poller.js', () => ({
+  TelegramPoller: class {
+    lastExitReason: string | undefined;
+    start() { return new Promise<void>(() => {}); }
+    stop() { this.lastExitReason = 'stopped-externally'; }
+    onMessage() { /* no-op */ }
+    onCallback() { /* no-op */ }
+    onReaction() { /* no-op */ }
+  },
+}));
+vi.mock('../../../src/daemon/cron-scheduler.js', () => ({
+  CronScheduler: class {
+    agentName: string;
+    constructor(opts: { agentName: string }) { this.agentName = opts.agentName; }
+    start() { /* no-op */ }
+    stop() { /* no-op */ }
+    reload() { /* no-op */ }
+    getNextFireTimes() { return []; }
+  },
+}));
+vi.mock('../../../src/daemon/worker-process.js', () => ({
+  WorkerProcess: class {
+    name: string;
+    constructor(name: string) { this.name = name; }
+    async spawn() { /* no-op */ }
+    async terminate() { /* no-op */ }
+    onDone() { /* no-op */ }
+    isFinished() { return true; }
+    getStatus() { return { name: this.name }; }
+  },
+}));
+vi.mock('../../../src/bus/metrics.js', () => ({
+  collectTelegramCommands: () => [],
+  registerTelegramCommands: async () => ({ status: 'empty' as const, count: 0 }),
+}));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+
+type CheckerLike = { process: unknown; startCount: number; stopCount: number };
+type ProcLike = {
+  index: number;
+  status: ProcStatus;
+  stopEntered: boolean;
+  finishStop(): void;
+  finishSpawn(): void;
+};
+type EntryLike = { checker: CheckerLike; process: unknown; stopped?: boolean };
+
+const agentsOf = (am: unknown) => (am as { agents: Map<string, EntryLike> }).agents;
+const procAt = (i: number) => h.procs[i] as ProcLike;
+const checkerFor = (p: unknown) => h.checkers.find((c) => (c as CheckerLike).process === p) as CheckerLike;
+
+/** Let every already-queued microtask drain, so a parked await actually resumes. */
+const drain = async () => { for (let i = 0; i < 8; i++) await Promise.resolve(); };
+
+// ⛔ AGENT-MANAGER LINE NUMBERS IN THIS FILE ARE AS-OF 4c30b4d7 (PRE-FIX) AND ARE
+// NOW WRONG — the fix shifted every line below startAgent's eviction branch. Grep
+// the symbol, not the number: `entry.stopped = true`, `if (!ownEntry.stopped)`,
+// `this.agents.delete(name)`, `stillMapped`.
+describe('AgentManager stopAgent window — the `stopped`-TRUE-and-STILL-MAPPED state', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  // ⛔ RUNTIME IS PINNED TO THE DEFAULT (Claude Code) BRANCH ON PURPOSE, AND THE
+  // REASON IS A TRAP THIS SUITE ALREADY WALKED INTO ONCE.
+  // The round-4 red uses `runtime: 'codex-app-server'` because that was the
+  // config-independent route into the evicted-zombie state. codex-app-server is
+  // ALSO the one runtime whose real stop() path skips the whole Ctrl-C//exit
+  // dance, so it has NO stop-path sleep floor at all. Carrying that fixture over
+  // here — same file, same harness, the obvious move — would have measured the
+  // zero-floor branch. The state below is manager-level and does not depend on the
+  // runtime, but the pin is kept so that nothing downstream can read a result from
+  // this file as a statement about the zero-floor branch.
+  const RUNTIME = 'claude-code';
+
+  beforeEach(() => {
+    h.procs.length = 0;
+    h.checkers.length = 0;
+    h.parkIndexes.length = 0;
+    h.stopParkIndexes.length = 0;
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-stopwindow-'));
+    agentDir = join(testDir, 'framework', 'orgs', 'acme', 'agents', 'alice');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, 'config.json'),
+      JSON.stringify({ name: 'alice', runtime: RUNTIME }),
+    );
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('R4B-CONTROL: an ordinary stop with nothing parked across it tears down and unmaps — proves the harness can drive stopAgent at all', async () => {
+    await am.startAgent('alice', agentDir);
+    const proc = procAt(0);
+    const checker = checkerFor(proc);
+    expect(checker.startCount).toBe(1);                 // normal path armed it
+    expect(agentsOf(am).get('alice')?.process).toBe(proc);
+
+    await am.stopAgent('alice', true);
+
+    expect(checker.stopCount).toBe(1);
+    expect(agentsOf(am).has('alice')).toBe(false);      // :1198 really ran
+    expect(checker.startCount).toBe(1);                 // and nothing re-armed it
+  });
+
+  it('R4B-WITNESS: a start parked in spawn() resumes while stopAgent holds the name — `stopped` TRUE and the name STILL RESOLVING to the same entry', async () => {
+    h.parkIndexes.push(0);       // the start parks inside its spawn await (:591)
+    h.stopParkIndexes.push(0);   // and stopAgent will park inside process.stop() (:1146)
+
+    // --- public surface call 1: a start that will still be in flight ----------
+    const parkedStart = am.startAgent('alice', agentDir);
+    await drain();
+
+    const proc = procAt(0);
+    const checker = checkerFor(proc);
+    const entry = agentsOf(am).get('alice') as EntryLike;
+
+    // positive controls: we are where we think we are before anything interesting
+    expect(h.procs.length).toBe(1);
+    expect(entry.process).toBe(proc);
+    expect(proc.status).toBe('starting');
+    expect(checker.startCount).toBe(0);                 // :637 not reached yet
+    expect(entry.stopped).toBeUndefined();              // :1141 not reached yet
+
+    // --- public surface call 2: the stop, left in flight ----------------------
+    // Deliberately NOT awaited: stopAgent parks on `await entry.process.stop()`
+    // at :1146, which is the whole point — :1141 has run, :1198 has not.
+    const parkedStop = am.stopAgent('alice', true);
+    await drain();
+
+    // THE STATE, OBSERVED — nothing here wrote the map or the flag by hand.
+    expect(proc.stopEntered).toBe(true);                // we really are inside :1146
+    expect(entry.stopped).toBe(true);                   // :1141 ran
+    expect(agentsOf(am).get('alice')).toBe(entry);      // :1198 has NOT run — IDENTITY, not has()
+    expect(checker.stopCount).toBe(1);                  // :1145 tore the checker down
+
+    // ⇒ THIS IS THE STATE THE WHOLE FILE EXISTS TO WITNESS. A guard that asks only
+    // "does the name still resolve to me" gets TRUE here, on an entry whose
+    // teardown has already begun and whose checker has already been stopped.
+
+    // --- the parked start now resumes past its spawn await into :637 ----------
+    proc.finishSpawn();
+    await parkedStart;
+
+    // Current src guards on `!ownEntry.stopped`, which is CORRECT in this state,
+    // so the checker stays disarmed. This assertion is the load-bearing one: it is
+    // what a `stillMapped`-only guard would break, and it passes today only because
+    // the `stopped` conjunct exists.
+    expect(checker.startCount).toBe(0);
+
+    // Let the stop finish so the test leaves no parked promise behind.
+    proc.finishStop();
+    await parkedStop;
+    expect(agentsOf(am).has('alice')).toBe(false);
+  });
+
+  it('R4B-NEGATIVE-CONTROL: with the stop NOT in flight, the same parked start DOES re-arm — so the assertion above can fail, and is not passing for want of a code path', async () => {
+    // Same fixture, same parked start, one difference: nobody stops the agent. If
+    // the re-arm assertion above passed merely because this harness never reaches
+    // :637 at all, this test would show a startCount of 0 too. It must show 1.
+    h.parkIndexes.push(0);
+
+    const parkedStart = am.startAgent('alice', agentDir);
+    await drain();
+
+    const proc = procAt(0);
+    const checker = checkerFor(proc);
+    expect(checker.startCount).toBe(0);
+
+    proc.finishSpawn();
+    await parkedStart;
+
+    expect(checker.startCount).toBe(1);   // :637 IS reachable in this harness
+  });
+});

--- a/tests/unit/daemon/agent-process-stop-width-round4c.test.ts
+++ b/tests/unit/daemon/agent-process-stop-width-round4c.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi } from 'vitest';
+
+// ⚠ RUN THIS FILE WITH `--reporter=verbose`.
+// THE DEFAULT REPORTER SWALLOWS THE MEASURED TABLE ENTIRELY: the run prints
+// "2 passed" and NONE of the evidence, with nothing to indicate a measurement was
+// supposed to exist. That green is indistinguishable from a green that measured
+// something. The table is the human-readable artefact; it is NOT what makes this
+// file safe — see the next paragraph.
+//
+// THE NUMBERS ARE LOAD-BEARING, NOT DECORATIVE. Each case asserts the measured
+// elapsed time against its documented floor (>= floor, < floor + 4s) AND asserts
+// the exact bytes the branch wrote to the PTY. So a regression fails under ANY
+// reporter; only the printed summary is reporter-dependent. A printed number
+// nobody reads is decoration — an asserted one fails.
+//
+// Round 4c — WIDTH OF THE stopAgent TEARDOWN WINDOW, MEASURED PER RUNTIME.
+//
+// WHY THIS FILE EXISTS. The window between `entry.stopped = true`
+// (agent-manager.ts:1141) and `this.agents.delete(name)` (:1198) is dominated by
+// the single `await entry.process.stop()` at :1146. Its width was previously
+// argued from CONSTANTS READ OUT OF agent-process.ts — and that argument was
+// wrong twice in one hour:
+//
+//   1. Five sleep constants were quoted as if they summed. FOUR OF THEM SIT ON
+//      MUTUALLY EXCLUSIVE `if (this.config.runtime === …)` BRANCHES. The numbers
+//      were all real; the addition was fiction.
+//   2. `Promise.race([exitPromise, sleep(15000)])` was spent as a FLOOR. It is a
+//      CEILING — it resolves early on exit. An upper bound of 21s is perfectly
+//      consistent with a real window of zero.
+//
+// A MEASUREMENT KILLS BOTH FAILURE MODES AT ONCE, because elapsed wall-clock on
+// one branch cannot accidentally include another branch's constants.
+//
+// ⛔ WHAT THIS FILE DOES **NOT** ESTABLISH — READ BEFORE CITING IT.
+// (a) IT DOES NOT SPAWN AN OS PROCESS. `this.pty` is set to a stub whose only
+//     job is to be non-null and to answer isAlive(). That is enough for the real
+//     branch to execute, because THE FLOOR IS PRODUCED BY `await sleep(...)`
+//     CALLS INSIDE agent-process.ts THAT READ NOTHING FROM THE CHILD — they are
+//     gated only on `config.runtime` and on `if (pty)` at :228. So the width
+//     figures below are figures about THE REAL CODE. They are NOT evidence that
+//     a real Claude Code PTY reaches this path in production.
+// (b) IT SAYS NOTHING ABOUT FREQUENCY. A 6s floor means the window is REAL on one
+//     runtime. It does not say how often anything lands inside it. DO NOT LET 6s
+//     MIGRATE FROM REACHABILITY TO FREQUENCY, OR ACROSS RUNTIMES.
+// (c) A ZERO FLOOR IS NOT A ZERO WIDTH. codex-app-server has no GUARANTEED
+//     minimum; there is still real work between :1141 and :1198. Write
+//     "UNPROVEN on codex-app-server", NEVER "unreachable".
+
+vi.mock('../../../src/pty/agent-pty.js', () => ({ AgentPTY: class {} }));
+vi.mock('../../../src/pty/codex-app-server-pty.js', () => ({ CodexAppServerPTY: class {} }));
+vi.mock('../../../src/pty/hermes-pty.js', () => ({ HermesPTY: class {}, hermesDbExists: () => false }));
+vi.mock('../../../src/pty/opencode-pty.js', () => ({ OpencodePTY: class {}, opencodeSessionExists: () => false }));
+
+const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+
+/**
+ * The narrowest stand-in that lets the real stop() run its real branch:
+ * non-null (so `if (pty)` at :228 passes) and answering isAlive() (:272).
+ * Records what the branch actually wrote, so the runtime branch taken is
+ * OBSERVED rather than assumed from the config we passed in.
+ */
+function makeStubPty() {
+  const writes: string[] = [];
+  return {
+    writes,
+    write(s: string) { writes.push(s); },
+    isAlive() { return false; },   // false ⇒ kill() is skipped, per :272
+    kill() { /* unreachable while isAlive() is false */ },
+  };
+}
+
+type RuntimeCase = {
+  runtime: string;
+  /** Documented floor from the branch bodies, for comparison against measurement. */
+  expectedFloorMs: number;
+  /** What the branch is expected to have written to the PTY. */
+  expectedWrites: string[];
+  /**
+   * Explicit upper bound. Needed because a floor of 0 makes
+   * `toBeGreaterThanOrEqual(floor)` an assertion that CANNOT FAIL, so the
+   * zero-floor row would otherwise carry no timing evidence at all while still
+   * appearing in a table of measurements.
+   */
+  expectedCeilingMs: number;
+  /**
+   * ⛔ Set where the row cannot be told apart from this file's own no-pty negative
+   * control. Recorded on the row rather than in prose so it travels with the data.
+   */
+  notDiscriminable?: string;
+};
+
+const CASES: RuntimeCase[] = [
+  { runtime: 'claude-code',      expectedFloorMs: 6000, expectedCeilingMs: 10000, expectedWrites: ['\x03', '/exit\r\n'] },
+  { runtime: 'hermes',           expectedFloorMs: 3000, expectedCeilingMs: 7000,  expectedWrites: ['\x04'] },
+  { runtime: 'opencode',         expectedFloorMs: 1000, expectedCeilingMs: 5000,  expectedWrites: ['\x03'] },
+  {
+    runtime: 'codex-app-server', expectedFloorMs: 0,    expectedCeilingMs: 250,   expectedWrites: [],
+    // ⛔ THIS ROW PROVES NOTHING ON ITS OWN AND MUST NOT BE COUNTED AS EVIDENCE.
+    // Its floor is 0, so the floor assertion cannot fail; and BOTH of its
+    // observable signatures — ~0ms elapsed and zero PTY writes — are exactly what
+    // the no-pty negative control below produces. So a run where `pty` was never
+    // attached, or where dispatch silently skipped this branch, is INDISTINGUISHABLE
+    // from a correct run of it.
+    // ⭐ Kept because documenting "this runtime has no stop sleeps" is still useful,
+    // and the 250ms ceiling still catches a runaway. But it is a DOCUMENTED SHAPE,
+    // not a measurement, and the label says so where a reader of the table will see it.
+    notDiscriminable:
+      'zero-floor + zero-writes is identical to the no-pty negative control; ' +
+      'this row documents an expected shape and carries no independent evidence',
+  },
+];
+
+function buildProcess(runtime: string) {
+  const env = { agentName: 'alice', org: 'acme' } as never;
+  const config = { name: 'alice', runtime } as never;
+  const proc = new AgentProcess('alice', env, config, () => { /* silence */ });
+  const pty = makeStubPty();
+  // Private by design; this is the whole seam. Setting it is the ONLY thing this
+  // test does that a caller could not do — everything after is the real stop().
+  (proc as unknown as { pty: unknown }).pty = pty;
+  return { proc, pty };
+}
+
+// NOTE: this file's line references point at agent-process.ts, NOT agent-manager.ts,
+// and were re-verified as still accurate after the round-4 fix (which touched only
+// agent-manager.ts). Kept as numbers for that reason.
+describe('AgentProcess.stop() — teardown width is a property of config.runtime', () => {
+  // 6s + 3s + 1s of real sleeping, plus overhead.
+  const TIMEOUT = 30_000;
+
+  it(
+    'measures the stop-path floor on every runtime branch, and prints what it measured',
+    async () => {
+      const rows: string[] = [];
+
+      for (const c of CASES) {
+        const { proc, pty } = buildProcess(c.runtime);
+
+        // Condition: a PTY is present, so `if (pty)` at :228 passes. Asserted
+        // rather than assumed — without it every branch would measure ~0 and the
+        // whole table would agree for the wrong reason.
+        expect((proc as unknown as { pty: unknown }).pty).not.toBeNull();
+
+        const t0 = Date.now();
+        await proc.stop();
+        const elapsed = Date.now() - t0;
+
+        // The branch taken is OBSERVED from what it wrote, not inferred from the
+        // config we handed in. If a future refactor changes the dispatch, this
+        // fails instead of silently measuring a different branch.
+        expect(pty.writes).toEqual(c.expectedWrites);
+
+        rows.push(
+          `runtime=${c.runtime.padEnd(17)} pty=PRESENT(stub) ` +
+          `writes=[${pty.writes.map((w) => JSON.stringify(w)).join(', ')}] ` +
+          `documented_floor=${c.expectedFloorMs}ms measured=${elapsed}ms` +
+          // Printed next to the number it qualifies, so the caveat cannot be
+          // separated from the row by anyone reading only the output.
+          (c.notDiscriminable ? `  ⛔ NOT-DISCRIMINABLE: ${c.notDiscriminable}` : ''),
+        );
+
+        // Floor, not equality: the branch must take AT LEAST its sleeps.
+        // ⚠ For a row whose floor is 0 this assertion CANNOT FAIL — that row's only
+        // real bound is the explicit ceiling below, and its `notDiscriminable` label.
+        expect(elapsed).toBeGreaterThanOrEqual(c.expectedFloorMs);
+        // Explicit per-case ceiling rather than floor+4000, so the zero-floor row
+        // gets a bound that actually separates it from the multi-second branches
+        // instead of inheriting a 4s allowance that overlaps three of them.
+        expect(elapsed).toBeLessThan(c.expectedCeilingMs);
+      }
+
+      // Printed on purpose: a width claim that cannot show which branch it took,
+      // that a PTY was present, and what it actually measured is not a
+      // measurement anyone else can check.
+      console.log('\n[round4c] STOP-PATH WIDTH, MEASURED ON THE REAL AgentProcess.stop():');
+      for (const r of rows) console.log('  ' + r);
+      console.log(
+        '  NOTE: stub PTY, no OS process. Floors come from `await sleep()` inside\n' +
+        '  agent-process.ts gated on config.runtime and `if (pty)`; they read nothing\n' +
+        '  from the child. Width only — NOT frequency, and a zero FLOOR is not a zero WIDTH.\n',
+      );
+    },
+    TIMEOUT,
+  );
+
+  it('NEGATIVE CONTROL: with NO pty the whole branch is skipped and every runtime collapses to ~0 — so the numbers above are the `if (pty)` guard doing real work', async () => {
+    for (const c of CASES) {
+      const env = { agentName: 'alice', org: 'acme' } as never;
+      const config = { name: 'alice', runtime: c.runtime } as never;
+      const proc = new AgentProcess('alice', env, config, () => { /* silence */ });
+      // pty left null — the `if (pty)` guard at :228 is false.
+      const t0 = Date.now();
+      await proc.stop();
+      const elapsed = Date.now() - t0;
+      expect(elapsed).toBeLessThan(250);
+    }
+  }, 15_000);
+});

--- a/tests/unit/telegram/poller.test.ts
+++ b/tests/unit/telegram/poller.test.ts
@@ -242,3 +242,78 @@ describe('TelegramPoller — offset-after-handler', () => {
     expect(poller.lastExitReason).toBe('stopped-externally');
   });
 });
+
+describe('TelegramPoller — start() re-entry (LINK A for the map-entry-race poller resurrection)', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'cortextos-poller-reentry-'));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  // WHY THIS EXISTS. The agent-manager poller-supervisor fix rests on a two-step
+  // claim, and only the second step is about Telegram:
+  //   LINK A  start() called again on a torn-down poller -> a live poll loop again
+  //   LINK B  two live loops on one bot token            -> 409 Conflict churn
+  // Link B is Telegram's semantics and stays INFERRED. Link A is OUR code and is
+  // therefore checkable, so it is checked here rather than asserted in prose —
+  // otherwise a two-step chain reads as a one-step one and the severity of the
+  // whole finding rests on a step nobody measured.
+  //
+  // This is a CHARACTERISATION assertion, not a regression control for that fix:
+  // it pins current behaviour of a file the fix does not touch, so it was never
+  // red and cannot be. It fails if someone later adds a re-entry guard here —
+  // at which point the severity rating of the resurrection class must be
+  // revisited, which is exactly the moment someone needs to be told.
+  it('restarting a stopped poller re-arms it: start() has NO re-entry guard', async () => {
+    const { api } = makeStubApi([]);
+    const poller = new TelegramPoller(api, stateDir, 1);
+    const calls = () => (api.getUpdates as unknown as { mock: { calls: unknown[] } }).mock.calls.length;
+
+    const first = poller.start();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls()).toBeGreaterThan(0);            // it really polled
+
+    poller.stop();
+    await first;                                   // the loop has exited, not merely been asked to
+    const afterStop = calls();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls()).toBe(afterStop);               // positive control: stop() really stops it
+
+    // The resurrection. No guard rejects this, no in-flight flag absorbs it:
+    // poller.ts:89 sets `this.running = true` unconditionally as its FIRST
+    // statement. Contrast AgentProcess.start(), which opens with
+    // `if (this.status === 'running') return;` — the absence here is specific to
+    // this class, not a codebase-wide convention.
+    const second = poller.start();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(calls()).toBeGreaterThan(afterStop);    // LINK A: it is polling again
+
+    poller.stop();
+    await second;
+  });
+
+  it('start() also erases the stopped-externally signal its supervisor reads', async () => {
+    const { api } = makeStubApi([]);
+    const poller = new TelegramPoller(api, stateDir, 1);
+
+    const first = poller.start();
+    await new Promise((r) => setTimeout(r, 20));
+    poller.stop();
+    await first;
+    expect(poller.lastExitReason).toBe('stopped-externally');
+
+    // poller.ts:90 blanks it. This is why the supervisor's `lastExitReason`
+    // check cannot defend the case where the stop lands while the supervisor is
+    // parked in its 30s retry sleep: by the time it looks, the evidence is gone.
+    const second = poller.start();
+    await new Promise((r) => setTimeout(r, 5));
+    expect(poller.lastExitReason).toBe('');
+
+    poller.stop();
+    await second;
+  });
+});


### PR DESCRIPTION
## Summary

`AgentManager` keeps agents in a `Map` keyed by name, and both `startAgent` and
`stopAgent` yield partway through. Across those awaits the name can be re-bound, so
code that looked the entry back up **by name** could act on a different instance than
the one it was serving. This series makes each path act on the object it captured and
ask an identity question before acting by name.

Four rounds, each cut as a red test followed by the fix, driven by two independent
reviews plus an adversarial review of round 4.

- **Rounds 1-3** — the DECIDE-to-act sites: a teardown evicting its own replacement, a
  name restarting an object it no longer owns, and a torn-down entry still acting on
  the world (reject-count watchdog firing for a stopped agent, a checker being re-armed
  after teardown, `stillMapped` conflating *removed* with *replaced*, a restart silently
  dropping the activity poller).
- **Round 4 (F-B1)** — the one line this PR turns on: round 3 introduced a per-entry
  `stopped` flag set at the top of `stopAgent`, but **taught only one of the two teardown
  paths to set it.** The eviction branch in `startAgent` also tears an entry down and
  never said so. A start parked in `agentProcess.start()` that gets evicted mid-spawn
  resumed, read `!ownEntry.stopped` as true, and re-armed a checker the eviction had
  already stopped — **unstoppable thereafter**, because every later `stopAgent` reaches a
  checker only by name and the name now belongs to the newcomer. It injects into a dead
  PTY for the life of the daemon.

The fix is `stale.stopped = true` before the branch's only await. Placement is
load-bearing, not stylistic: the hazard is the await, not the unmapping, so deferring
the write to the `agents.delete` would leave a sub-window open.

## Test Plan

- `tsc --noEmit` — clean.
- **`R4-DEFECT` was seen RED on this exact source before the fix** (`AssertionError:
  expected 1 to be +0`, evicted checker `startCount` 1), then green after.
- Round-4 files + the existing map-entry-race suite: **50/50 green** across 4 files.
- `tests/unit/daemon`: **437/441**. The 4 failures are in `cron-scheduler.test.ts` and are
  **pre-existing** — proven by stashing this change and reproducing them without it, and
  confirmed independently by the reviewer against `main` at `72708bdd`, where the same 4
  fail. `cron-scheduler.ts` does not import `agent-manager`.
- Each round ships an **attribution control**: `R4-CONTROL` proves the harness can drive
  eviction through the real public surface, and `R4-MECHANISM` runs the identical race
  with only the missing write applied, so the red is attributable to src and not to the
  harness. Assertions are on **identity, not counts** — "the checker started once" is also
  satisfied by the wrong checker surviving.

## Scope and limits, stated so review does not have to infer them

- **No guard predicate changes.** `!ownEntry.stopped` is untouched at all three read
  sites. Whether any of them should *also* ask `stillMapped()` is a separate question
  with no test behind it either way and is deliberately not decided here.
- Standing form from the round-4b work: a guard that **drops** `stopped` is *refuted by
  test*; one that **adds** `stillMapped` is *preferred by argument only*. Do not read the
  refutation of one candidate as evidence for another.
- **Single-authored, one machine, one tree.** Reviewed by an independent adversarial pass
  (verdict: ship-with-notes) but **not independently reproduced.**

## Carried forward, NOT fixed here

The adversarial review's strongest finding, which this series does not introduce and does
not claim to fix: the two Telegram **poller** wrappers guard on `stillMapped`, which is
**true** throughout the `stopped`-but-still-mapped window this fix marks. A start resuming
inside that window could still arm a poller for an entry being evicted — after the
eviction's `poller?.stop()` has run and before it unmaps — giving a dual-`getUpdates`/409
window against the newcomer. **Suspected, not confirmed:** reachability is a conjunction of
runtime properties that were not executed, and the runtime which produces a parked start is
also the one with a ~0ms stop floor, which argues the resume lands after the unmap.
Deliberately not widened into this diff. Notably it is the first *concrete* hazard attached
to the otherwise argument-only `stillMapped` question, and it points at the **poller** sites
rather than the checker site.

## ⛔ Do not merge yet

Opened under an active **merge freeze**. Not merged, and no daemon bounce — nothing in here
takes effect until the daemon restarts, which is a separate coordinated decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)