### PR TITLE
feat(kb): retry-telemetry base + fail-fast on daily-quota exhaustion (theta 48 + 62)

### DIFF
--- a/docs/architecture/kb-retry-fail-fast-on-quota.md
+++ b/docs/architecture/kb-retry-fail-fast-on-quota.md
@@ -1,0 +1,225 @@
+# KB Retry — Fail-Fast on Daily-Quota Exhaustion
+
+**Status:** Design — not yet implemented
+**Priority:** Medium (silent waste; ~6.5min/day per today's telemetry)
+**Owner:** develop (implementation), analyst (design)
+**Last updated:** 2026-08-12
+**Related:** theta 48 (retry wrapper ship), theta 62, `reference_kb_embed_retry`
+
+---
+
+## Problem
+
+`_retry_embed_content` and `_retry_generate_content` in `knowledge-base/scripts/mmrag.py` treat every 429 / `RESOURCE_EXHAUSTED` as transient and burn the full backoff sequence (5s + 15s + 45s ≈ 65s per call) before giving up. This is the correct policy for **per-minute rate limits** — those clear in seconds and the wait helps.
+
+For **daily quota exhaustion**, the wait is dead time. Gemini free-tier caps at ~1000 `embed_content` calls/day; once drained, no amount of backoff within the same UTC day recovers. Every subsequent call still runs the full 65-second retry sequence before failing.
+
+Today's telemetry (2026-08-12 06:36–06:40Z, kb-retry-telemetry.jsonl):
+- 6 exhausted outcomes, all `RESOURCE_EXHAUSTED` from Gemini `embed_content`
+- All within 4 minutes
+- ~6.5 min wall-clock burned on futile backoff waits
+- Retry ratio dropped from stable 1.0 to 0.33 on the day
+
+## Root cause
+
+`mmrag.py:365-393` `_retry_embed_content`:
+
+```python
+for attempt, backoff in enumerate(backoffs, start=1):
+    try:
+        result = client.models.embed_content(...)
+        return result
+    except _genai_errors.APIError as e:
+        is_transient = (e.code in TRANSIENT_HTTP_CODES) or (e.status in TRANSIENT_STATUS_NAMES)
+        if not is_transient:
+            raise
+        if attempt < total:
+            time.sleep(backoff)  # <-- always waits, even if quota is daily
+        else:
+            # exhausted
+```
+
+`TRANSIENT_STATUS_NAMES = {"UNAVAILABLE", "RESOURCE_EXHAUSTED"}` conflates two failure modes that need different responses:
+- **`UNAVAILABLE`** → transient, retry works
+- **`RESOURCE_EXHAUSTED` (per-minute rate limit)** → transient, backoff helps
+- **`RESOURCE_EXHAUSTED` (daily quota)** → structural, backoff is dead time
+
+The wrapper can't tell (2) from (3) at a single call site — the API response body varies but not consistently.
+
+## Proposed fix
+
+Introduce a **sliding-window quota-drained detector** at module level. When we see enough recent exhausted outcomes to conclude the daily quota (not per-minute burst) is drained, gate subsequent calls to fail-fast until UTC midnight or a probe succeeds.
+
+### State (module-level)
+
+```python
+# Sliding window of exhausted timestamps (ISO strings) — most recent K entries.
+_RECENT_EXHAUSTED_MAX = 5  # keep last 5
+_recent_exhausted: list[float] = []       # epoch seconds
+
+# When set (epoch s), reject embed/generate calls with fail-fast until this time.
+_quota_drained_until: float | None = None
+```
+
+### Detection (called after each exhausted outcome)
+
+```python
+def _record_exhausted(status: str, code: int, now: float) -> None:
+    global _quota_drained_until, _recent_exhausted
+    if status != "RESOURCE_EXHAUSTED":
+        return
+    _recent_exhausted.append(now)
+    # Keep only entries within last 5 minutes
+    cutoff = now - 300
+    _recent_exhausted = [t for t in _recent_exhausted if t >= cutoff][-_RECENT_EXHAUSTED_MAX:]
+    # If 2+ exhausted within 5 minutes, treat as daily-quota drained
+    if len(_recent_exhausted) >= 2:
+        _quota_drained_until = _next_utc_midnight(now)
+        print(f"    [kb-retry] daily quota detected drained — fail-fast until {time.strftime('%H:%MZ', time.gmtime(_quota_drained_until))}")
+```
+
+### Gate (called at start of each retry function)
+
+```python
+def _quota_gate_check(func: str, model: str) -> None:
+    """Raise a synthetic exhausted APIError if daily quota is known drained."""
+    global _quota_drained_until
+    if _quota_drained_until is None:
+        return
+    now = time.time()
+    if now >= _quota_drained_until:
+        # Reset — new day (UTC), quota may refill. Clear state and probe normally.
+        _quota_drained_until = None
+        _recent_exhausted.clear()
+        return
+    _log_retry_event(func, model, attempt=0, total_attempts=0, backoff_s=0, outcome="fail_fast_quota", http_code=429, status="RESOURCE_EXHAUSTED")
+    raise _genai_errors.APIError(429, "daily quota drained (fail-fast; retry after UTC midnight)")
+```
+
+### Reset (on any successful embed/generate)
+
+```python
+# In the success branch of _retry_embed_content / _retry_generate_content:
+_log_retry_event(func, model, attempt, total, backoff, "success")
+if _quota_drained_until is not None:
+    _quota_drained_until = None
+    _recent_exhausted.clear()
+return result
+```
+
+### Wire into both retry wrappers
+
+At the top of `_retry_embed_content` and `_retry_generate_content`, before the loop:
+```python
+_quota_gate_check("embed_content" or "generate_content", model)
+```
+
+Inside the exhausted branch, add:
+```python
+_record_exhausted(e.status, e.code, time.time())
+```
+
+### New telemetry outcome
+
+Add a new outcome value `"fail_fast_quota"` alongside `success | transient | exhausted | non_transient`. Makes the fail-fast rate observable in `analytics/kb-retry-telemetry.jsonl` and downstream `KBRetryMetrics.ratio` computation stays unchanged (fail_fast_quota is neither retry-that-saved nor exhausted-that-wasted-backoff — it's the fix's own telemetry).
+
+## Blast radius
+
+- **Saves:** ~65s per call once the gate trips. Today's incident: 6 exhausted × 65s = ~6.5 min. Over a month with same pattern: ~3 hours cumulative.
+- **False-positive risk:** a per-minute burst produces >=2 exhausted within 5min. This would gate the rest of the day incorrectly.
+  - Mitigation: threshold "2 within 5min" is conservative — per-minute limits typically clear within one or two backoff waits. Two consecutive full 3-attempt exhaustions within a 5-minute window is strong evidence of daily-quota exhaustion, not per-minute burst. If false-positives observed, tighten to "3 exhausted within 10min".
+  - Mitigation 2: the gate auto-releases at UTC midnight; a false-positive costs at most the rest of one day, and any successful call in the interim also clears state.
+- **Cost:** ~30 lines of Python, no external deps, no change to public API.
+- **Backwards compat:** telemetry consumers see a new `outcome` value; downstream `KBRetryMetrics` in `src/bus/metrics.ts` needs to know about it (add to switch or default-ignore).
+
+---
+
+## Test spec (for develop)
+
+New tests in `tests/kb/mmrag-retry.test.py` (or matching test file). Use a fake `APIError` client that lets each test control the sequence.
+
+### Test 1: single exhausted does NOT trigger gate
+
+```
+given: fake client returns 3 RESOURCE_EXHAUSTED then normal success on next call
+when:  _retry_embed_content is called once (exhausts), then called again
+then:  second call proceeds normally (no gate) — attempt 1 succeeds
+       telemetry: exhausted → success (no fail_fast_quota event)
+```
+
+### Test 2: two exhausted within 5min triggers gate
+
+```
+given: fake client returns 3 RESOURCE_EXHAUSTED consecutively
+when:  _retry_embed_content called twice within 5 min, both exhaust
+       _retry_embed_content called a third time
+then:  third call raises immediately (fail-fast), NO backoff sleeps
+       telemetry: fail_fast_quota event emitted
+       gate persists until UTC midnight
+```
+
+### Test 3: successful call clears gate
+
+```
+given: gate is set (drained_until = future)
+when:  fake client succeeds on next _retry_embed_content call
+       (simulate by mocking _quota_gate_check to bypass once, or advance time past midnight)
+then:  _quota_drained_until is None after success
+       _recent_exhausted is cleared
+```
+
+### Test 4: gate auto-releases at UTC midnight
+
+```
+given: _quota_drained_until = fixed epoch (e.g. midnight yesterday)
+when:  _retry_embed_content called with now > that time
+then:  gate is cleared, call proceeds normally
+       new exhausted events start a fresh sliding window
+```
+
+### Test 5: gate persists across BOTH retry functions
+
+```
+given: exhausted trips in _retry_embed_content
+when:  _retry_generate_content called next
+then:  fail-fast immediately (shared module state)
+```
+
+### Test 6: false-positive edge — 2 exhausted separated by 10min
+
+```
+given: 2 exhausted events, 10 minutes apart
+when:  _retry_embed_content called a third time within 5min of the 2nd
+then:  gate NOT triggered (sliding window drops the first entry)
+       call proceeds normally
+```
+
+### Test 7: telemetry payload for fail_fast_quota
+
+```
+given: gate active
+when:  _retry_embed_content is called and fails fast
+then:  kb-retry-telemetry.jsonl contains one entry with outcome="fail_fast_quota",
+       http_code=429, status="RESOURCE_EXHAUSTED", attempt=0, backoff_s=0
+```
+
+---
+
+## Rollout
+
+1. develop implements + tests, fork+PR (like #889/#890/#896 pattern)
+2. capitan reviews, merges
+3. No config changes; deployment is a `git pull` on fleet
+4. Also update `src/bus/metrics.ts` `KBRetryMetrics` if it enumerates outcomes explicitly (verify + append `fail_fast_quota` to whitelist, or ensure default handles unknown outcomes gracefully)
+5. Retro after next quota exhaustion cycle: check telemetry for `fail_fast_quota` events; expect wall-clock savings vs pre-fix baseline (roughly N × 65s where N = post-gate calls). Compare against today's 6 × 65s = 390s baseline.
+
+## Out of scope
+
+- Distinguishing daily vs per-minute quota from API response body (unreliable, undocumented)
+- Adding an explicit "quota status" endpoint check (Gemini doesn't expose one, would require probing)
+- Auto-failover to OpenAI (theta 53 track — still blocked on Ilya billing)
+- Retrospective telemetry backfill
+
+## Non-goals
+
+- Perfect quota tracking. This is a heuristic — 2-strikes rule optimizes for cheap detection over precision. False positives are self-healing (release at midnight or on first success).

--- a/knowledge-base/scripts/_test_clients/fault_injection.py
+++ b/knowledge-base/scripts/_test_clients/fault_injection.py
@@ -56,6 +56,13 @@ class _StubResponse:
         self.usage_metadata = None
 
 
+class _StubEmbedResponse:
+    """Minimal stand-in for an embed_content result. The retry wrapper only
+    checks that a non-None result came back, so a single dummy vector suffices."""
+    def __init__(self):
+        self.embeddings = [type("_Emb", (), {"values": [0.0]})()]
+
+
 class _StubModels:
     def __init__(self, script):
         self._script = list(script)
@@ -74,11 +81,22 @@ class _StubModels:
         status = _STATUS_FOR_CODE.get(code, "UNKNOWN")
         raise _InjectedAPIError(code, status, message or f"injected {code} {status}")
 
-    def embed_content(self, *a, **kw):
-        raise RuntimeError(
-            "fault_injection: embed_content is not scripted. Tests should target "
-            "_retry_generate_content directly, not the full ingest_pdf pipeline."
-        )
+    def embed_content(self, model=None, contents=None, config=None, **kwargs):
+        # Scriptable mirror of generate_content (theta 62 quota-gate tests).
+        # Shares the same script/index so a single client can drive mixed
+        # embed/generate sequences. Code 200 returns a stub with an .embeddings
+        # attribute; any other code raises the mapped _InjectedAPIError.
+        if self._index >= len(self._script):
+            raise RuntimeError(
+                f"fault_injection: script exhausted at attempt {self._index + 1} "
+                f"(scripted {len(self._script)} responses)"
+            )
+        code, message = self._script[self._index]
+        self._index += 1
+        if code == 200:
+            return _StubEmbedResponse()
+        status = _STATUS_FOR_CODE.get(code, "UNKNOWN")
+        raise _InjectedAPIError(code, status, message or f"injected {code} {status}")
 
 
 class FaultInjectionClient:

--- a/knowledge-base/scripts/_test_clients/test_retry_quota.py
+++ b/knowledge-base/scripts/_test_clients/test_retry_quota.py
@@ -1,0 +1,226 @@
+"""Behavioral tests for mmrag's theta-62 daily-quota fail-fast gate.
+
+Run from knowledge-base/scripts:
+
+    python -m _test_clients.test_retry_quota
+
+Exits 0 on all-pass, 1 on any failure. Seven scenarios from
+docs/architecture/kb-retry-fail-fast-on-quota.md:
+
+  1. single exhausted does NOT trip the gate
+  2. two exhausted within 5min trips the gate; next call fails fast
+  3. a successful call clears the gate
+  4. gate auto-releases at UTC midnight
+  5. gate persists across BOTH retry functions (shared module state)
+  6. false-positive edge: 2 exhausted 10min apart do NOT trip
+  7. telemetry payload for a fail_fast_quota event
+
+backoffs is passed as (0, 0, 0) so tests run in milliseconds.
+"""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+PARENT = os.path.dirname(HERE)
+if PARENT not in sys.path:
+    sys.path.insert(0, PARENT)
+
+import mmrag
+from _test_clients import fault_injection
+
+
+FAILURES = []
+
+
+def _check(label, cond, detail=""):
+    if cond:
+        print(f"  PASS  {label}")
+    else:
+        print(f"  FAIL  {label}: {detail}")
+        FAILURES.append(label)
+
+
+def _reset_gate():
+    """Clear all module-level quota-gate state between tests."""
+    mmrag._recent_exhausted = []
+    mmrag._quota_drained_until = None
+
+
+def _client(spec):
+    return fault_injection.FaultInjectionClient(fault_injection._parse_script(spec))
+
+
+def _embed(client):
+    return mmrag._retry_embed_content(
+        client, model="x", contents=["x"], embed_config=None, backoffs=(0, 0, 0)
+    )
+
+
+def _generate(client):
+    return mmrag._retry_generate_content(
+        client, model="x", contents=["x"], backoffs=(0, 0, 0)
+    )
+
+
+def test_1_single_exhausted_no_gate():
+    print("\n[test 1/7] single exhausted does NOT trip gate")
+    _reset_gate()
+    client = _client("429,429,429,200")  # first call exhausts (3), second succeeds
+    raised = None
+    try:
+        _embed(client)
+    except Exception as e:
+        raised = e
+    _check("first call exhausted (raised)", raised is not None)
+    _check("gate NOT set after single exhaustion", mmrag._quota_drained_until is None)
+    result = _embed(client)  # should proceed normally, consume the 200
+    _check("second call proceeds and succeeds", result is not None)
+
+
+def test_2_two_exhausted_trips_gate():
+    print("\n[test 2/7] two exhausted within 5min trips gate; 3rd fails fast")
+    _reset_gate()
+    client = _client("429,429,429,429,429,429")  # two full exhaustions
+    for _ in range(2):
+        try:
+            _embed(client)
+        except Exception:
+            pass
+    _check("gate set after 2 exhaustions", mmrag._quota_drained_until is not None)
+    idx_before = client.models._index
+    raised = None
+    try:
+        _embed(client)  # third call — must fail fast, NOT touch the client
+    except Exception as e:
+        raised = e
+    _check("third call raised (fail-fast)", raised is not None)
+    _check("fail-fast error code is 429", getattr(raised, "code", None) == 429)
+    _check("fail-fast status RESOURCE_EXHAUSTED",
+           getattr(raised, "status", None) == "RESOURCE_EXHAUSTED")
+    _check("client NOT called on fail-fast (no backoff, no request)",
+           client.models._index == idx_before, detail=f"index moved to {client.models._index}")
+
+
+def test_3_success_clears_gate():
+    print("\n[test 3/7] successful call clears the gate")
+    _reset_gate()
+    # Simulate an active gate, then bypass the gate check once so a probe runs.
+    mmrag._quota_drained_until = mmrag.time.time() + 3600
+    mmrag._recent_exhausted = [mmrag.time.time()]
+    orig_gate = mmrag._quota_gate_check
+    mmrag._quota_gate_check = lambda func, model: None  # bypass for the probe
+    try:
+        result = _embed(_client("200"))
+    finally:
+        mmrag._quota_gate_check = orig_gate
+    _check("probe succeeded", result is not None)
+    _check("gate cleared after success", mmrag._quota_drained_until is None)
+    _check("sliding window cleared after success", mmrag._recent_exhausted == [])
+
+
+def test_4_midnight_auto_release():
+    print("\n[test 4/7] gate auto-releases at UTC midnight")
+    _reset_gate()
+    mmrag._quota_drained_until = mmrag.time.time() - 10  # already in the past
+    mmrag._recent_exhausted = [mmrag.time.time() - 20]
+    result = _embed(_client("200"))  # gate check sees now >= drained_until → release
+    _check("call proceeded after auto-release", result is not None)
+    _check("gate cleared on auto-release", mmrag._quota_drained_until is None)
+
+
+def test_5_gate_shared_across_functions():
+    print("\n[test 5/7] gate persists across embed + generate (shared state)")
+    _reset_gate()
+    trip = _client("429,429,429,429,429,429")
+    for _ in range(2):
+        try:
+            _embed(trip)
+        except Exception:
+            pass
+    _check("gate set via embed", mmrag._quota_drained_until is not None)
+    gen_client = _client("200")  # would succeed IF called
+    raised = None
+    try:
+        _generate(gen_client)  # must fail fast via shared gate
+    except Exception as e:
+        raised = e
+    _check("generate failed fast via shared gate", raised is not None)
+    _check("generate_content NOT called", gen_client.models._index == 0,
+           detail=f"index={gen_client.models._index}")
+
+
+def test_6_false_positive_10min_apart():
+    print("\n[test 6/7] two exhausted 10min apart do NOT trip (window drops first)")
+    _reset_gate()
+    real_time = mmrag.time.time
+    base = real_time()
+    fake = {"now": base}
+    mmrag.time.time = lambda: fake["now"]
+    try:
+        try:
+            _embed(_client("429,429,429"))
+        except Exception:
+            pass
+        fake["now"] = base + 600  # +10 min
+        try:
+            _embed(_client("429,429,429"))
+        except Exception:
+            pass
+        _check("gate NOT set (exhausted events 10min apart)",
+               mmrag._quota_drained_until is None,
+               detail=f"window={mmrag._recent_exhausted}")
+    finally:
+        mmrag.time.time = real_time
+
+
+def test_7_telemetry_payload():
+    print("\n[test 7/7] telemetry payload for fail_fast_quota")
+    _reset_gate()
+    with tempfile.TemporaryDirectory() as td:
+        tel = Path(td) / "kb-retry-telemetry.jsonl"
+        orig_path = mmrag._RETRY_TELEMETRY_PATH
+        mmrag._RETRY_TELEMETRY_PATH = tel
+        try:
+            trip = _client("429,429,429,429,429,429")
+            for _ in range(2):
+                try:
+                    _embed(trip)
+                except Exception:
+                    pass
+            try:
+                _embed(_client("200"))  # fail-fast → emits fail_fast_quota
+            except Exception:
+                pass
+            lines = [json.loads(l) for l in tel.read_text().splitlines() if l.strip()]
+        finally:
+            mmrag._RETRY_TELEMETRY_PATH = orig_path
+    ff = [r for r in lines if r.get("outcome") == "fail_fast_quota"]
+    _check("exactly one fail_fast_quota event", len(ff) == 1, detail=f"got {len(ff)}")
+    if ff:
+        r = ff[0]
+        _check("http_code 429", r.get("http_code") == 429)
+        _check("status RESOURCE_EXHAUSTED", r.get("status") == "RESOURCE_EXHAUSTED")
+        _check("attempt 0", r.get("attempt") == 0)
+        _check("backoff_s 0", r.get("backoff_s") == 0)
+
+
+if __name__ == "__main__":
+    test_1_single_exhausted_no_gate()
+    test_2_two_exhausted_trips_gate()
+    test_3_success_clears_gate()
+    test_4_midnight_auto_release()
+    test_5_gate_shared_across_functions()
+    test_6_false_positive_10min_apart()
+    test_7_telemetry_payload()
+    print()
+    if FAILURES:
+        print(f"FAILED: {len(FAILURES)} assertion(s)")
+        for f in FAILURES:
+            print(f"  - {f}")
+        sys.exit(1)
+    print("ALL PASS (7 scenarios)")
+    sys.exit(0)

--- a/knowledge-base/scripts/mmrag.py
+++ b/knowledge-base/scripts/mmrag.py
@@ -68,6 +68,115 @@ TRANSIENT_STATUS_NAMES = {"UNAVAILABLE", "RESOURCE_EXHAUSTED"}
 
 USAGE_FILE = MMRAG_DIR / "usage.json"
 
+# Retry telemetry — one JSONL line per attempt (success | transient | exhausted |
+# non_transient). Enables ground-truth analysis of retry:success ratio vs true
+# quota-hard failures. Directory auto-created lazily; write errors are swallowed
+# so telemetry never breaks the retry path itself.
+_RETRY_TELEMETRY_PATH = Path(
+    os.environ.get(
+        "KB_RETRY_TELEMETRY_PATH",
+        str(Path.home() / ".cortextos" / os.environ.get("CTX_INSTANCE_ID", "default") / "analytics" / "kb-retry-telemetry.jsonl"),
+    )
+)
+
+
+def _log_retry_event(func, model, attempt, total_attempts, backoff_s, outcome, http_code=None, status=None):
+    try:
+        _RETRY_TELEMETRY_PATH.parent.mkdir(parents=True, exist_ok=True)
+        rec = {
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime()) + "Z",
+            "func": func,
+            "model": model,
+            "attempt": attempt,
+            "total_attempts": total_attempts,
+            "backoff_s": backoff_s,
+            "outcome": outcome,
+            "http_code": http_code,
+            "status": status,
+        }
+        with open(_RETRY_TELEMETRY_PATH, "a") as f:
+            f.write(json.dumps(rec) + "\n")
+    except Exception:
+        pass  # telemetry must never break the retry path
+
+
+# ---------------------------------------------------------------------------
+# Daily-quota fail-fast gate (theta 62)
+# ---------------------------------------------------------------------------
+# Per-minute rate limits clear within a backoff or two, so retrying is correct.
+# Daily-quota exhaustion (Gemini free tier ~1000 embed calls/day) does NOT
+# recover within the same UTC day, so the 5s+15s+45s backoff is pure dead time.
+# A single response can't distinguish the two, so we detect the daily case by
+# pattern: >=_QUOTA_STRIKES RESOURCE_EXHAUSTED outcomes inside a sliding
+# _QUOTA_WINDOW_SECONDS window. Once tripped, embed/generate calls fail fast
+# (raise immediately, no sleep) until UTC midnight or the next successful call.
+_RECENT_EXHAUSTED_MAX = 5        # cap on retained window entries
+_QUOTA_WINDOW_SECONDS = 300      # 5-minute sliding window
+_QUOTA_STRIKES = 2               # exhausted outcomes in-window that trip the gate
+_recent_exhausted = []           # epoch seconds of recent RESOURCE_EXHAUSTED outcomes
+_quota_drained_until = None      # epoch seconds; when set, fail-fast until this time
+
+
+def _next_utc_midnight(now):
+    """Epoch seconds of the next 00:00:00 UTC strictly after `now`."""
+    t = time.gmtime(now)
+    secs_into_day = t.tm_hour * 3600 + t.tm_min * 60 + t.tm_sec
+    return now - secs_into_day + 86400
+
+
+def _quota_reset(reason=None):
+    """Clear the fail-fast gate and the sliding window (on success or midnight
+    auto-release). Prints only when an active gate is actually being cleared."""
+    global _quota_drained_until, _recent_exhausted
+    if _quota_drained_until is not None and reason:
+        print(f"    [kb-retry] quota gate cleared — {reason}")
+    _quota_drained_until = None
+    _recent_exhausted = []
+
+
+def _record_exhausted(status, now):
+    """Record a RESOURCE_EXHAUSTED outcome; trip the daily-quota gate when the
+    sliding window shows >=_QUOTA_STRIKES within _QUOTA_WINDOW_SECONDS."""
+    global _quota_drained_until, _recent_exhausted
+    if status != "RESOURCE_EXHAUSTED":
+        return
+    cutoff = now - _QUOTA_WINDOW_SECONDS
+    _recent_exhausted = [t for t in _recent_exhausted if t >= cutoff]
+    _recent_exhausted.append(now)
+    _recent_exhausted = _recent_exhausted[-_RECENT_EXHAUSTED_MAX:]
+    if _quota_drained_until is None and len(_recent_exhausted) >= _QUOTA_STRIKES:
+        _quota_drained_until = _next_utc_midnight(now)
+        print(f"    [kb-retry] daily quota detected drained — fail-fast until "
+              f"{time.strftime('%H:%MZ', time.gmtime(_quota_drained_until))}")
+
+
+def _quota_gate_check(func, model):
+    """If the daily-quota gate is active, fail fast (no backoff). Auto-releases
+    once `now` passes UTC midnight. Emits a fail_fast_quota telemetry event and
+    raises an APIError subclass so existing `except APIError` callers still catch
+    it (mirrors the fault-injection error trick: bypass the SDK constructor,
+    which expects a real HTTP response object)."""
+    global _quota_drained_until
+    if _quota_drained_until is None:
+        return
+    now = time.time()
+    if now >= _quota_drained_until:
+        _quota_reset("UTC-midnight auto-release")
+        return
+    _log_retry_event(func, model, 0, 0, 0, "fail_fast_quota", 429, "RESOURCE_EXHAUSTED")
+    from google.genai import errors as _genai_errors
+
+    class _DailyQuotaDrainedError(_genai_errors.APIError):
+        def __init__(self):
+            msg = "daily quota drained (fail-fast; retry after UTC midnight)"
+            Exception.__init__(self, msg)
+            self.code = 429
+            self.status = "RESOURCE_EXHAUSTED"
+            self.message = msg
+
+    raise _DailyQuotaDrainedError()
+
+
 # ---------------------------------------------------------------------------
 # Usage Tracker
 # ---------------------------------------------------------------------------
@@ -174,6 +283,7 @@ def get_api_key(config):
         sys.exit(1)
     return key
 
+
 # ---------------------------------------------------------------------------
 # Gemini clients
 # ---------------------------------------------------------------------------
@@ -230,30 +340,76 @@ def _retry_generate_content(client, *, model, contents, backoffs=(5, 15, 45)):
     attempt count. Tests pass (0, 0, 0) to skip sleeps.
     """
     from google.genai import errors as _genai_errors
+    # theta 62: if the daily-quota gate is tripped, fail fast (no backoff waits).
+    _quota_gate_check("generate_content", model)
     last_err = None
+    total = len(backoffs)
     for attempt, backoff in enumerate(backoffs, start=1):
         try:
-            return client.models.generate_content(model=model, contents=contents)
+            result = client.models.generate_content(model=model, contents=contents)
+            _log_retry_event("generate_content", model, attempt, total, backoff, "success")
+            _quota_reset("probe succeeded")  # theta 62: a success means quota is back
+            return result
         except _genai_errors.APIError as e:
             last_err = e
             is_transient = (e.code in TRANSIENT_HTTP_CODES) or (e.status in TRANSIENT_STATUS_NAMES)
             if not is_transient:
+                _log_retry_event("generate_content", model, attempt, total, backoff, "non_transient", e.code, e.status)
                 raise
-            if attempt < len(backoffs):
-                print(f"    Transient error (HTTP {e.code} {e.status or ''}); retrying in {backoff}s (attempt {attempt}/{len(backoffs)})")
+            if attempt < total:
+                _log_retry_event("generate_content", model, attempt, total, backoff, "transient", e.code, e.status)
+                print(f"    Transient error (HTTP {e.code} {e.status or ''}); retrying in {backoff}s (attempt {attempt}/{total})")
                 time.sleep(backoff)
             else:
+                _log_retry_event("generate_content", model, attempt, total, backoff, "exhausted", e.code, e.status)
+                _record_exhausted(e.status, time.time())  # theta 62: feed the daily-quota detector
                 print(f"    Exhausted retries on transient error: HTTP {e.code} {e.status or ''}")
     raise last_err if last_err else RuntimeError("retry loop completed without response or error")
+
+
+def _retry_embed_content(client, *, model, contents, embed_config, backoffs=(5, 15, 45)):
+    """Call client.models.embed_content with bounded retries on transient APIErrors.
+
+    Mirrors _retry_generate_content — retries on TRANSIENT_HTTP_CODES / TRANSIENT_STATUS_NAMES
+    (429 / RESOURCE_EXHAUSTED are the common ones during ingest bursts against the
+    gemini-embedding-2-preview per-minute rate limit), re-raises other errors immediately.
+    """
+    from google.genai import errors as _genai_errors
+    # theta 62: if the daily-quota gate is tripped, fail fast (no backoff waits).
+    _quota_gate_check("embed_content", model)
+    last_err = None
+    total = len(backoffs)
+    for attempt, backoff in enumerate(backoffs, start=1):
+        try:
+            result = client.models.embed_content(model=model, contents=contents, config=embed_config)
+            _log_retry_event("embed_content", model, attempt, total, backoff, "success")
+            _quota_reset("probe succeeded")  # theta 62: a success means quota is back
+            return result
+        except _genai_errors.APIError as e:
+            last_err = e
+            is_transient = (e.code in TRANSIENT_HTTP_CODES) or (e.status in TRANSIENT_STATUS_NAMES)
+            if not is_transient:
+                _log_retry_event("embed_content", model, attempt, total, backoff, "non_transient", e.code, e.status)
+                raise
+            if attempt < total:
+                _log_retry_event("embed_content", model, attempt, total, backoff, "transient", e.code, e.status)
+                print(f"    Transient embed error (HTTP {e.code} {e.status or ''}); retrying in {backoff}s (attempt {attempt}/{total})")
+                time.sleep(backoff)
+            else:
+                _log_retry_event("embed_content", model, attempt, total, backoff, "exhausted", e.code, e.status)
+                _record_exhausted(e.status, time.time())  # theta 62: feed the daily-quota detector
+                print(f"    Exhausted retries on transient embed error: HTTP {e.code} {e.status or ''}")
+    raise last_err if last_err else RuntimeError("embed retry loop completed without response or error")
 
 
 def embed_content(client, config, content, task_type="RETRIEVAL_DOCUMENT"):
     """Embed content using Gemini Embedding 2. Content can be text string or list of Parts."""
     from google.genai import types
-    result = client.models.embed_content(
+    result = _retry_embed_content(
+        client,
         model=config.get("embedding_model", "gemini-embedding-2-preview"),
         contents=content,
-        config=types.EmbedContentConfig(
+        embed_config=types.EmbedContentConfig(
             output_dimensionality=config.get("embedding_dimensions", DEFAULT_EMBEDDING_DIMENSIONS),
             task_type=task_type,
         ),
@@ -317,7 +473,8 @@ def describe_media(client, config, file_path, media_type="video"):
         ),
     }
 
-    response = client.models.generate_content(
+    response = _retry_generate_content(
+        client,
         model=config.get("gemini_model", "gemini-2.5-flash"),
         contents=[
             types.Part.from_bytes(data=data, mime_type=mime),

--- a/src/bus/metrics.ts
+++ b/src/bus/metrics.ts
@@ -25,10 +25,30 @@ export interface SystemMetrics {
   approvals_pending: number;
 }
 
+export interface KBRetryMetrics {
+  total: number;
+  success: number;
+  transient: number;
+  exhausted: number;
+  non_transient: number;
+  /**
+   * Count of calls short-circuited by the daily-quota fail-fast gate (theta 62,
+   * mmrag.py). Distinct from `exhausted` (backoff burned) — these avoided the
+   * ~65s backoff entirely, so they measure "wasted-attempts avoided" and are
+   * deliberately excluded from the retry `ratio` denominator.
+   */
+  fail_fast_quota: number;
+  retries_that_saved: number;
+  ratio: number | null;
+  window_h: number;
+  last_ts: string | null;
+}
+
 export interface MetricsReport {
   timestamp: string;
   agents: Record<string, AgentMetrics>;
   system: SystemMetrics;
+  kb_retry?: KBRetryMetrics;
 }
 
 export interface UsageData {
@@ -95,6 +115,58 @@ function isErrorEvent(line: string): boolean {
   }
   if (evt.category !== 'error') return false;
   return evt.severity === 'error' || evt.severity === 'critical';
+}
+
+/**
+ * Read the KB retry telemetry JSONL and return an aggregated summary for the
+ * last `windowH` hours. Returns null if the file does not exist (feature not
+ * yet instrumented). Malformed lines are skipped.
+ *
+ * ratio = retries_that_saved / (retries_that_saved + exhausted).
+ * A ratio of 1.0 = every burst caught; 0.0 = every burst exhausted.
+ * null when there is no denominator yet (no retries + no exhaustion).
+ */
+function readKBRetryMetrics(ctxRoot: string, windowH: number): KBRetryMetrics | null {
+  const path = join(ctxRoot, 'analytics', 'kb-retry-telemetry.jsonl');
+  if (!existsSync(path)) return null;
+  const cutoff = Date.now() - windowH * 3600 * 1000;
+  let total = 0, success = 0, transient = 0, exhausted = 0, nonTransient = 0, retriesSaved = 0, failFastQuota = 0;
+  let lastTs: string | null = null;
+  try {
+    const lines = readFileSync(path, 'utf-8').split('\n').filter(Boolean);
+    for (const line of lines) {
+      let evt: { ts?: string; outcome?: string; attempt?: number };
+      try { evt = JSON.parse(line); } catch { continue; }
+      if (!evt.ts || !evt.outcome) continue;
+      const t = new Date(evt.ts).getTime();
+      if (isNaN(t) || t < cutoff) continue;
+      total++;
+      if (!lastTs || evt.ts > lastTs) lastTs = evt.ts;
+      switch (evt.outcome) {
+        case 'success':
+          success++;
+          if ((evt.attempt ?? 1) > 1) retriesSaved++;
+          break;
+        case 'transient': transient++; break;
+        case 'exhausted': exhausted++; break;
+        case 'non_transient': nonTransient++; break;
+        case 'fail_fast_quota': failFastQuota++; break;
+      }
+    }
+  } catch { return null; }
+  const denom = retriesSaved + exhausted;
+  return {
+    total,
+    success,
+    transient,
+    exhausted,
+    non_transient: nonTransient,
+    fail_fast_quota: failFastQuota,
+    retries_that_saved: retriesSaved,
+    ratio: denom > 0 ? retriesSaved / denom : null,
+    window_h: windowH,
+    last_ts: lastTs,
+  };
 }
 
 export function collectMetrics(ctxRoot: string, org?: string): MetricsReport {
@@ -224,6 +296,10 @@ export function collectMetrics(ctxRoot: string, org?: string): MetricsReport {
     }
   }
 
+  // KB retry telemetry — read last 24h from analytics/kb-retry-telemetry.jsonl.
+  // Absent file = feature not instrumented yet; omit section entirely.
+  const kbRetry = readKBRetryMetrics(ctxRoot, 24);
+
   const report: MetricsReport = {
     timestamp,
     agents,
@@ -233,6 +309,7 @@ export function collectMetrics(ctxRoot: string, org?: string): MetricsReport {
       agents_total: agentsTotal,
       approvals_pending: approvalsPending,
     },
+    ...(kbRetry ? { kb_retry: kbRetry } : {}),
   };
 
   // Write to analytics reports


### PR DESCRIPTION
## Scope (read first)

This PR **includes the theta-48 retry-telemetry base**, which was previously uncommitted in a fleet branch and **never landed to main**:
- `_log_retry_event`, `_RETRY_TELEMETRY_PATH`
- `_retry_embed_content` (mirror of the existing `_retry_generate_content`)
- `embed_content` / `describe_media` routed through the retry wrappers
- `src/bus/metrics.ts` → `KBRetryMetrics` + `readKBRetryMetrics`

The **theta-62 fail-fast-on-quota** gate builds directly on that base, so the two ship together as one buildable unit rather than as two stacked PRs waiting on separate reviews.

> Note: this branch is intentionally **independent of** the in-flight theta-53 OpenAI-provider work (which rewrites the same `embed_content` region). Those hunks are deliberately excluded here; theta-53 will rebase onto this base once it lands.

Design doc (lives under gitignored `docs/`, not in the diff): `docs/architecture/kb-retry-fail-fast-on-quota.md`.

## theta-48 — retry telemetry base
- Bounded retry on transient `429 / RESOURCE_EXHAUSTED / 503 / 500`; non-transient errors re-raise immediately.
- Every attempt logs a JSONL event (`success` / `transient` / `exhausted` / `non_transient`) to `analytics/kb-retry-telemetry.jsonl`.
- `KBRetryMetrics` aggregates a 24h window: `ratio = retries_that_saved / (retries_that_saved + exhausted)`.

## theta-62 — fail-fast on daily-quota exhaustion
Problem: once the Gemini **daily** embed quota is drained, every subsequent call burns the full ~65s backoff ladder only to fail — hours of wasted retry loops during a bulk ingest.

Fix: a module-level sliding-window detector.
- **2** `RESOURCE_EXHAUSTED` outcomes within **5 min** → trip a gate that **fails fast (no backoff)** until the next **UTC midnight** (quota reset boundary).
- Any **successful** call clears the gate (quota is back).
- Gate state is **shared** across the embed and generate retry paths.
- New telemetry outcome `fail_fast_quota`, deliberately **excluded** from the retry-ratio denominator (it measures wasted-attempts *avoided*, not retries that failed).
- Per-minute rate-limit bursts (transient, spaced apart) do **not** trip it — see the 10-min false-positive test.

## Tests
- `knowledge-base/scripts/_test_clients/test_retry_quota.py` — 7 scenarios, all pass: single-no-trip · 2-strike-trip+fail-fast · success-clears · UTC-midnight-release · cross-function shared state · false-positive (10 min apart) · telemetry payload.
- `fault_injection.py` — scriptable `embed_content` + `_StubEmbedResponse` (mirrors the existing `generate_content` fault injector).
- `test_retry` regression: 3/3 pass. `npm run build` clean. `sprint5-metrics` 32/32 pass.
- Full `vitest` on this base shows pre-existing failures in unrelated cron/hooks/lifecycle suites (features from other unmerged fleet PRs); identical counts with and without this change → **zero regressions from this PR**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)