### PR TITLE
fix(cron): persist next_fire_at to stop restart drift (theta 61)

### DIFF
--- a/docs/architecture/cron-persistent-next-fire.md
+++ b/docs/architecture/cron-persistent-next-fire.md
@@ -1,0 +1,201 @@
+# Cron Scheduler — Persistent `next_fire_at`
+
+**Status:** Design — not yet implemented
+**Priority:** Medium (silent bug affects weekly/daily crons; short crons unharmed)
+**Owner:** develop (implementation), analyst (design)
+**Last updated:** 2026-08-11
+**Related:** theta 61, `project_cron_reanchor_drift`
+
+---
+
+## Problem
+
+Daemon-managed crons drift on restart when they have never fired successfully, or when they were crashed mid-fire. The drift equals up to one full interval.
+
+Observed 2026-08-11 (designer, theta 60 aftermath):
+- Cron `experiment-user-acceptance`, schedule `168h`, last_fired_at = `-` (never fired)
+- Pre-restart next fire: `2026-08-17 06:09 UTC`
+- After config-reload cascade at 11:59:14Z + daemon reload: next fire slipped to `2026-08-18 12:02 UTC` (+30h)
+- After another restart at ~12:02Z: next fire slipped to `2026-08-18 18:02 UTC` (+36h from original)
+
+Each restart re-anchors next fire to `restart_time + interval`.
+
+## Root cause
+
+`src/daemon/cron-scheduler.ts:392–397`:
+
+```typescript
+const stateFire = stateLastFireByName.get(def.name);
+const candidates: number[] = [];
+if (def.last_fired_at) candidates.push(new Date(def.last_fired_at).getTime());
+if (def.last_fire_attempted_at) candidates.push(new Date(def.last_fire_attempted_at).getTime());
+if (stateFire) candidates.push(new Date(stateFire).getTime());
+const referenceMs = candidates.length > 0 ? Math.max(...candidates) : now;
+
+let nextFireAt = computeNextFireAt(def, referenceMs);
+```
+
+For a cron with **no** `last_fired_at`, no `last_fire_attempted_at`, and no cron-state entry, the `candidates` array is empty and `referenceMs` falls back to `now` (i.e. daemon-restart time). Result: `next_fire_at = restart_time + interval`, sliding forward on every restart.
+
+The `last_fire_attempted_at` field mitigates crash-mid-fire (avoids double-firing the same slot), but when the daemon crashes before ANY successful fire, `attempted_at` becomes an anchor for the same drift.
+
+## Blast radius (by cron interval)
+
+| Interval    | Drift per restart | Practical impact                                   |
+|-------------|-------------------|----------------------------------------------------|
+| 10m         | ≤ 10 min          | Invisible — restarts settle within one tick        |
+| 4h          | ≤ 4 h             | Barely noticeable; heartbeats catch up             |
+| 12h         | ≤ 12 h            | Autoresearch windows slip by half a day            |
+| 24h         | ≤ 24 h            | Nightly reports miss a day                         |
+| **168h**    | **≤ 7 days**      | **Weekly cycles can skip a whole cadence**         |
+
+## Proposed fix
+
+Persist `next_fire_at` in crons.json whenever it is computed, and treat it as the authoritative future anchor on load.
+
+### Data model change
+
+Add optional `next_fire_at: string | null` (ISO-8601) to `CronDefinition` in `src/types/index.ts`. Backwards-compatible: absent field means "compute from scratch" (current behavior).
+
+### Load path change (`loadCrons()`)
+
+Insert a branch before the current referenceMs computation at cron-scheduler.ts:392:
+
+```typescript
+// PERSISTED next_fire_at — authoritative when present and future.
+// Bypasses referenceMs recomputation so never-fired crons don't drift
+// on daemon restart.
+if (def.next_fire_at) {
+  const persisted = new Date(def.next_fire_at).getTime();
+  if (!isNaN(persisted) && persisted > now) {
+    nextScheduled.set(def.name, {
+      definition: def,
+      nextFireAt: persisted,
+      changeKey: key,
+    });
+    continue;
+  }
+  // persisted is in the past → fall through to catch-up policy below.
+}
+```
+
+If `next_fire_at` is stale (past), the existing catch-up logic (lines 411–416) handles it correctly by scheduling immediate fire.
+
+### Write path change (2 sites)
+
+**Site 1 — after successful fire, `cron-scheduler.ts:499`** (existing code):
+
+```typescript
+const nextFireAt = computeNextFireAt(cron, now);
+updateCron(this.agentName, name, {
+  last_fired_at: nowIso,
+  next_fire_at: new Date(nextFireAt).toISOString(),  // NEW
+  fire_count: newFireCount,
+});
+```
+
+**Site 2 — when a cron is loaded fresh (new/modified, or persistence-migration), cron-scheduler.ts:418**:
+
+```typescript
+nextScheduled.set(def.name, { definition: def, nextFireAt, changeKey: key });
+
+// Persist next_fire_at so subsequent restarts don't drift.
+if (!def.next_fire_at || new Date(def.next_fire_at).getTime() !== nextFireAt) {
+  try {
+    updateCron(this.agentName, def.name, {
+      next_fire_at: new Date(nextFireAt).toISOString(),
+    });
+  } catch (err) {
+    // Non-fatal — log and continue with in-memory schedule.
+    this.logger(
+      `[cron-scheduler] failed to persist next_fire_at for "${def.name}": ` +
+      `${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+}
+```
+
+### Migration
+
+None required — new field is optional and null on existing crons.json files. First fire (or first load after this ships) populates it. Zero-downtime rollout.
+
+### Interaction with `reload()` semantics
+
+Unchanged. `reload()` still preserves `nextFireAt` for crons whose `changeKey` is unchanged (line 365–368). The persisted `next_fire_at` only comes into play on cold start (fresh daemon process). This is correct because `reload()` runs in the same process where the in-memory `scheduled` map already holds the truth.
+
+### Interaction with `last_fire_attempted_at` guard
+
+Unchanged. The attempted_at field still prevents double-fire on crash-mid-fire. When `next_fire_at` is persisted at post-success (Site 1), the write happens AFTER `last_fired_at` is written, so a crash between them leaves the schedule slightly ahead but never behind → catch-up still handles it.
+
+---
+
+## Test spec (for develop)
+
+New tests in `tests/daemon/cron-scheduler.test.ts` (or matching test file):
+
+### Test 1: never-fired cron survives restart without drift
+
+```
+given: cron "weekly-test" schedule=168h, added at T0, never fired
+when:  daemon starts at T0, computes next_fire_at = T0+168h, persists it
+       daemon stops at T0+1h
+       daemon restarts at T0+1h
+then:  cron's in-memory nextFireAt === T0+168h (NOT T0+1h+168h)
+```
+
+### Test 2: successfully-fired cron unchanged behavior
+
+```
+given: cron with last_fired_at=T1, next_fire_at=T1+interval
+when:  daemon restarts at T1+interval-30s (still in future)
+then:  nextFireAt === T1+interval (preserved)
+```
+
+### Test 3: stale persisted next_fire_at triggers catch-up
+
+```
+given: cron with next_fire_at=T-past
+when:  daemon starts at now > T-past
+then:  scheduler fires once immediately (catch-up policy still applies)
+```
+
+### Test 4: persisted next_fire_at written on every fire
+
+```
+given: cron fires successfully at T
+when:  post-fire updateCron() is called
+then:  crons.json contains next_fire_at = T + interval (ISO string)
+```
+
+### Test 5: persistence write failure does not crash the tick
+
+```
+given: crons.json is write-locked or ENOSPC
+when:  scheduler tries to persist next_fire_at after successful fire
+then:  logger records warning, in-memory schedule unchanged, tick loop continues
+```
+
+### Test 6: manage-cycle modify triggers fresh next_fire_at
+
+```
+given: cron with next_fire_at persisted
+when:  schedule changes 12h → 168h, changeKey differs, reload() runs
+then:  next_fire_at is recomputed from now (not preserved), fresh value written
+```
+
+---
+
+## Rollout
+
+1. develop implements design + tests, forks + PR
+2. capitan reviews (analyst can verify test scenarios match the report)
+3. Merge to main
+4. No agent-side changes needed. Next daemon restart begins populating `next_fire_at` across the fleet
+5. Retro after 2 weeks: designer's weekly cron next_fire should stay stable across all daemon restarts in the window
+
+## Out of scope
+
+- Migrating existing crons.json files eagerly (unnecessary — lazy population is safe)
+- Adding a `first_scheduled_at` field for audit (nice-to-have; not blocking)
+- Rewriting the `last_fire_attempted_at` anti-double-fire mechanism (orthogonal, works correctly)
+- Fixing designer's cron in-place (will self-correct on next successful fire or after this ships)

--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -409,6 +409,32 @@ export class CronScheduler {
         continue;
       }
 
+      // PERSISTED next_fire_at (theta 61) — authoritative when present and in
+      // the future, but ONLY on cold start (a fresh daemon process). Bypasses
+      // the referenceMs recomputation below so that a never-fired (or
+      // crashed-before-first-fire) cron does not slide forward by one interval
+      // on every daemon restart. A stale (past) persisted value falls through
+      // to the normal path, where the catch-up policy + last_fire_attempted_at
+      // guard apply. Skipped on reload: reload preserves unchanged crons via
+      // the changeKey guard above, and any cron reaching here on reload was
+      // modified — its schedule may differ from the one that produced the
+      // stored next_fire_at, so it must recompute.
+      // See docs/architecture/cron-persistent-next-fire.md.
+      if (!isReload && def.next_fire_at) {
+        const persisted = new Date(def.next_fire_at).getTime();
+        if (!isNaN(persisted) && persisted > now) {
+          nextScheduled.set(def.name, {
+            definition: def,
+            nextFireAt: persisted,
+            changeKey: key,
+          });
+          // Skips the fresh-schedule persist below when the future value is
+          // valid — no double-write, keeps the load idempotent across restarts.
+          continue;
+        }
+        // persisted is unparseable or in the past → fall through to catch-up.
+      }
+
       // New or modified cron — compute fresh nextFireAt.
       // Base: take the most recent of crons.json.last_fired_at,
       // crons.json.last_fire_attempted_at (set pre-onFire to detect crash
@@ -442,6 +468,29 @@ export class CronScheduler {
       }
 
       nextScheduled.set(def.name, { definition: def, nextFireAt, changeKey: key });
+
+      // Persist next_fire_at (theta 61) so subsequent restarts anchor to this
+      // computed future value instead of re-deriving from `now`. Only persist
+      // genuine FUTURE anchors: a catch-up fire (nextFireAt clamped to now) is
+      // about to run and its post-fire Site-1 write will persist the real next
+      // value, so writing `now` here would be redundant. Idempotent: skip when
+      // the stored value already matches. Non-fatal: a persist failure leaves
+      // the in-memory schedule authoritative.
+      if (
+        nextFireAt > now &&
+        (!def.next_fire_at || new Date(def.next_fire_at).getTime() !== nextFireAt)
+      ) {
+        try {
+          updateCron(this.agentName, def.name, {
+            next_fire_at: new Date(nextFireAt).toISOString(),
+          });
+        } catch (err) {
+          this.logger(
+            `[cron-scheduler] failed to persist next_fire_at for "${def.name}": ` +
+            `${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
     }
 
     // LAST-GOOD-SCHEDULE FALLBACK (corruption-only)
@@ -546,10 +595,15 @@ export class CronScheduler {
         // crash the tick loop — we log and keep the in-memory schedule intact.
         const nowIso = new Date(now).toISOString();
         const newFireCount = (cron.fire_count ?? 0) + 1;
+        // Compute the next fire once and persist it (theta 61) so a restart
+        // before the next tick re-anchors from this value instead of `now`.
+        const next = computeNextFireAt(cron, now);
+        const nextFireIso = isNaN(next) ? null : new Date(next).toISOString();
         try {
           updateCron(this.agentName, name, {
             last_fired_at: nowIso,
             fire_count: newFireCount,
+            ...(nextFireIso ? { next_fire_at: nextFireIso } : {}),
           });
         } catch (err) {
           this.logger(
@@ -559,11 +613,10 @@ export class CronScheduler {
           );
         }
 
-        // Advance in-memory nextFireAt
-        const next = computeNextFireAt(cron, now);
+        // Advance in-memory nextFireAt (reuse the value computed above)
         if (!isNaN(next)) {
           sc.nextFireAt = next;
-          sc.definition = { ...cron, last_fired_at: nowIso, fire_count: newFireCount };
+          sc.definition = { ...cron, last_fired_at: nowIso, fire_count: newFireCount, next_fire_at: nextFireIso };
         } else {
           // Unrecognised schedule after fire — remove from schedule to avoid infinite loops
           this.scheduled.delete(name);

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -397,6 +397,18 @@ export interface CronDefinition {
   fire_count?: number;
 
   /**
+   * ISO 8601 UTC timestamp of the next scheduled fire, persisted so the
+   * daemon does not re-anchor never-fired (or crashed-before-first-fire)
+   * crons to `restart_time + interval` on every restart. Treated as the
+   * authoritative future anchor by `loadCrons()` when present and still in
+   * the future; a past value falls through to the catch-up policy. Written
+   * by the scheduler after each fire and when a cron is scheduled fresh.
+   * Backwards-compatible: absent means "compute from scratch" (legacy
+   * behavior). See docs/architecture/cron-persistent-next-fire.md (theta 61).
+   */
+  next_fire_at?: string | null;
+
+  /**
    * ISO 8601 UTC timestamp for one-shot crons — when the cron should fire once
    * and then be deleted. Mutually exclusive with recurring `schedule` semantics:
    * if `fire_at` is set, the daemon treats this as a one-shot regardless of

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -352,9 +352,10 @@ describe('CronScheduler', () => {
     await vi.advanceTimersByTimeAsync(60_000 + TICK + 1_000 + 500);
 
     expect(flakyFire).toHaveBeenCalledTimes(2);
-    // 2 updateCron calls: 1 pre-fire attempted_at (iter 11) + 1 post-success
-    // last_fired_at/fire_count.
-    expect(mockUpdateCron).toHaveBeenCalledTimes(2);
+    // 3 updateCron calls: 1 fresh-schedule next_fire_at persist during load
+    // (theta 61, future anchor for this '1m' cron) + 1 pre-fire attempted_at
+    // (iter 11) + 1 post-success last_fired_at/fire_count.
+    expect(mockUpdateCron).toHaveBeenCalledTimes(3);
     expect(mockUpdateCron).toHaveBeenCalledWith(
       'test-agent',
       'test-cron',
@@ -981,5 +982,125 @@ describe('CronScheduler', () => {
     // ...and the reload IS announced because the schedule changed.
     const newLogs = logs.slice(logsBefore);
     expect(newLogs.some(l => l.includes('reloaded') && l.includes('cron(s) active'))).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // theta 61 — persisted next_fire_at (anti-drift on daemon restart)
+  // Each "restart" is modelled as a fresh CronScheduler instance whose
+  // mocked crons.json carries the previously-persisted next_fire_at.
+  // -------------------------------------------------------------------------
+  describe('persisted next_fire_at (theta 61)', () => {
+    const WEEK = 168 * 60 * 60 * 1000;
+    const SIXH = 6 * 60 * 60 * 1000;
+    const T0 = new Date('2026-08-11T06:00:00.000Z').getTime();
+
+    function freshScheduler(localLogs: string[], localFired?: CronDefinition[]): CronScheduler {
+      return new CronScheduler({
+        agentName: 'test-agent',
+        onFire: (cron) => { localFired?.push(cron); return true; },
+        logger: (m) => { localLogs.push(m); },
+      });
+    }
+
+    it('Test 1: never-fired cron survives restart without drift', () => {
+      vi.setSystemTime(T0);
+      mockReadCrons.mockReturnValue([makeCron({ name: 'weekly', schedule: '168h' })]);
+      const a = freshScheduler([]);
+      a.start();
+      const first = a.getNextFireTimes().find(e => e.name === 'weekly')!.nextFireAt;
+      expect(first).toBe(T0 + WEEK);
+      // fresh-schedule persist wrote the future anchor
+      expect(mockUpdateCron).toHaveBeenCalledWith(
+        'test-agent', 'weekly',
+        expect.objectContaining({ next_fire_at: new Date(T0 + WEEK).toISOString() }),
+      );
+      a.stop();
+
+      // Restart 1h later; crons.json now carries the persisted next_fire_at.
+      vi.setSystemTime(T0 + 60 * 60 * 1000);
+      mockReadCrons.mockReturnValue([makeCron({
+        name: 'weekly', schedule: '168h',
+        next_fire_at: new Date(T0 + WEEK).toISOString(),
+      })]);
+      const b = freshScheduler([]);
+      b.start();
+      const after = b.getNextFireTimes().find(e => e.name === 'weekly')!.nextFireAt;
+      expect(after).toBe(T0 + WEEK); // NOT (T0 + 1h) + WEEK
+      b.stop();
+    });
+
+    it('Test 2: successfully-fired cron preserves future next_fire_at across restart', () => {
+      vi.setSystemTime(T0 + SIXH - 30_000);
+      mockReadCrons.mockReturnValue([makeCron({
+        name: 'sixh', schedule: '6h',
+        last_fired_at: new Date(T0).toISOString(),
+        next_fire_at: new Date(T0 + SIXH).toISOString(),
+      })]);
+      const s = freshScheduler([]);
+      s.start();
+      expect(s.getNextFireTimes().find(e => e.name === 'sixh')!.nextFireAt).toBe(T0 + SIXH);
+      s.stop();
+    });
+
+    it('Test 3: stale persisted next_fire_at falls through to catch-up', async () => {
+      vi.setSystemTime(T0);
+      const fired: CronDefinition[] = [];
+      const s = freshScheduler([], fired);
+      mockReadCrons.mockReturnValue([makeCron({
+        name: 'stale', schedule: '1m',
+        last_fired_at: new Date(T0 - 5 * 60_000).toISOString(),
+        next_fire_at: new Date(T0 - 4 * 60_000).toISOString(), // past → not authoritative
+      })]);
+      s.start();
+      await vi.advanceTimersByTimeAsync(TICK);
+      expect(fired.length).toBeGreaterThanOrEqual(1); // catch-up fired once immediately
+      s.stop();
+    });
+
+    it('Test 4: next_fire_at persisted on every successful fire', async () => {
+      vi.setSystemTime(T0);
+      const s = freshScheduler([], []);
+      mockReadCrons.mockReturnValue([makeCron({ name: 'oneMin', schedule: '1m' })]);
+      s.start();
+      mockUpdateCron.mockClear(); // ignore the fresh-schedule persist during start()
+      await vi.advanceTimersByTimeAsync(60_000 + TICK);
+      const postFire = mockUpdateCron.mock.calls.find(
+        c => c[1] === 'oneMin' && c[2] && 'last_fired_at' in c[2] && 'next_fire_at' in c[2],
+      );
+      expect(postFire).toBeDefined();
+      s.stop();
+    });
+
+    it('Test 5: persist-write failure does not crash the load', () => {
+      vi.setSystemTime(T0);
+      const localLogs: string[] = [];
+      mockUpdateCron.mockImplementation(() => { throw new Error('ENOSPC'); });
+      mockReadCrons.mockReturnValue([makeCron({ name: 'w', schedule: '6h' })]);
+      const s = freshScheduler(localLogs);
+      expect(() => s.start()).not.toThrow();
+      expect(s.getNextFireTimes().find(e => e.name === 'w')).toBeDefined(); // schedule intact
+      expect(localLogs.some(l => l.includes('failed to persist next_fire_at'))).toBe(true);
+      s.stop();
+    });
+
+    it('Test 6: schedule change on reload recomputes next_fire_at (ignores stale persisted)', () => {
+      vi.setSystemTime(T0);
+      mockReadCrons.mockReturnValue([makeCron({ name: 'chg', schedule: '12h' })]);
+      const s = freshScheduler([]);
+      s.start();
+      const before = s.getNextFireTimes().find(e => e.name === 'chg')!.nextFireAt;
+      expect(before).toBe(T0 + 12 * 60 * 60 * 1000);
+
+      // Modify the schedule; crons.json still holds the OLD (future) next_fire_at.
+      mockReadCrons.mockReturnValue([makeCron({
+        name: 'chg', schedule: '168h',
+        next_fire_at: new Date(T0 + 12 * 60 * 60 * 1000).toISOString(),
+      })]);
+      s.reload();
+      const after = s.getNextFireTimes().find(e => e.name === 'chg')!.nextFireAt;
+      expect(after).toBe(T0 + WEEK); // recomputed from now for the new schedule
+      expect(after).not.toBe(before);
+      s.stop();
+    });
   });
 });


### PR DESCRIPTION
Clean recreation of #896 — branched off `upstream/main` so the diff is only the 4 real files, not the ~485-file fleet-branch divergence that made the original CONFLICTING.

## Problem
On daemon restart, never-fired (or crashed-before-first-fire) crons re-anchor to `restart_time + interval` every time, so a 12h cron can drift up to +12h per restart.

## Fix
Persist `next_fire_at` (ISO-8601 UTC) in `crons.json`. `loadCrons()` treats a present, still-future value as the authoritative anchor; a past value falls through to the existing catch-up policy. Written after each fire and on fresh schedule. Backwards-compatible: absent = compute-from-scratch (legacy).

Cold-start-only (`!isReload`) guard so a config reload that changes a schedule doesn't honor a stale-but-future persisted anchor.

## Files
- `src/daemon/cron-scheduler.ts` — persist + honor `next_fire_at`
- `src/types/index.ts` — `next_fire_at?: string | null` on `CronDefinition`
- `tests/unit/daemon/cron-scheduler.test.ts` — coverage (34/34 pass)
- `docs/architecture/cron-persistent-next-fire.md` — design (force-added past `docs/.gitignore`)

Supersedes #896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)