### PR TITLE
feat(autoresearch): G1 zero-delta gate in evaluate-experiment

### DIFF
--- a/src/bus/experiment.ts
+++ b/src/bus/experiment.ts
@@ -25,6 +25,12 @@ export interface Experiment {
   started_at: string | null;
   completed_at: string | null;
   changes_description: string | null;
+  /**
+   * Set by the G1 zero-delta gate when an evaluation is the Nth consecutive
+   * flat (non-improving) window on the same surface. Optional/back-compat:
+   * absent on experiments created before the gate and on non-triggering ones.
+   */
+  guardrail_note?: string | null;
 }
 
 export interface ExperimentCreateOptions {
@@ -115,6 +121,43 @@ function saveExperiment(agentDir: string, experiment: Experiment): void {
   const dir = historyDir(agentDir);
   ensureDir(dir);
   atomicWriteSync(join(dir, `${experiment.id}.json`), JSON.stringify(experiment, null, 2));
+}
+
+/**
+ * G1 zero-delta gate limit: number of consecutive flat (non-improving) windows
+ * on the same surface that forces the surface to be abandoned. Per the
+ * autoresearch skill's zero-delta rule ("result <= baseline for the SAME
+ * surface change 3 windows in a row — discard and re-hypothesize").
+ */
+export const ZERO_DELTA_GATE_LIMIT = 3;
+
+/**
+ * Count how many of the most-recent CONSECUTIVE completed experiments on the
+ * given surface ended in 'discard' (a flat / non-improving window). A 'keep'
+ * breaks the streak — the skill's rule is explicitly about not chaining keeps
+ * on flat results, so any real improvement resets the counter. Ordered by
+ * completion time (newest first) so the streak reflects recent history, not
+ * creation order. Returns 0 for an empty surface (cannot group).
+ */
+function countConsecutiveFlatOnSurface(
+  agentDir: string,
+  surface: string,
+  excludeId: string,
+): number {
+  if (!surface) return 0;
+  const completed = listExperiments(agentDir, { status: 'completed' })
+    .filter((e) => e.surface === surface && e.id !== excludeId)
+    .sort(
+      (a, b) =>
+        new Date(b.completed_at ?? b.created_at).getTime() -
+        new Date(a.completed_at ?? a.created_at).getTime(),
+    );
+  let streak = 0;
+  for (const e of completed) {
+    if (e.decision === 'discard') streak++;
+    else break;
+  }
+  return streak;
 }
 
 export function loadExperimentConfig(agentDir: string): ExperimentConfig {
@@ -289,10 +332,34 @@ export function evaluateExperiment(
     experiment.decision = decision;
   }
 
+  // G1 zero-delta gate: if this is a flat (non-improving) window and the same
+  // surface already produced ZERO_DELTA_GATE_LIMIT-1 consecutive flat windows,
+  // the surface is exhausted. Force discard (belt-and-suspenders: a flat result
+  // already discards) and record a tamper-proof re-hypothesize note in the
+  // learning so the agent cannot keep chaining experiments on a dead surface.
+  let guardrailNote: string | null = null;
+  if (decision === 'discard' && experiment.surface) {
+    const priorFlat = countConsecutiveFlatOnSurface(
+      agentDir,
+      experiment.surface,
+      experiment.id,
+    );
+    if (priorFlat + 1 >= ZERO_DELTA_GATE_LIMIT) {
+      decision = 'discard';
+      experiment.decision = 'discard';
+      guardrailNote =
+        `G1 zero-delta gate: ${priorFlat + 1} consecutive flat windows on surface ` +
+        `'${experiment.surface}' — metric not moving. Abandon this surface and ` +
+        `re-hypothesize with a materially different change; do not keep chaining.`;
+      experiment.guardrail_note = guardrailNote;
+    }
+  }
+
   // Build learning from options
   const learningParts: string[] = [];
   if (options?.learning) learningParts.push(options.learning);
   if (options?.justification) learningParts.push(options.justification);
+  if (guardrailNote) learningParts.push(`⚠ ${guardrailNote}`);
   if (learningParts.length > 0) {
     experiment.learning = learningParts.join(' — ');
   }

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -759,6 +759,9 @@ busCommand
       score: opts.score ? parseInt(opts.score, 10) : undefined,
       justification: opts.justification,
     });
+    if (experiment.guardrail_note) {
+      console.error(`⚠ ${experiment.guardrail_note}`);
+    }
     console.log(JSON.stringify(experiment, null, 2));
   });
 

--- a/tests/sprint3-experiments.test.ts
+++ b/tests/sprint3-experiments.test.ts
@@ -257,6 +257,72 @@ describe('Sprint 3: Experiment Framework', () => {
     });
   });
 
+  describe('G1 zero-delta gate', () => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    // Create + run + evaluate a flat (non-improving) window on a surface.
+    // direction=higher, baseline starts at 0, so value<=0 → discard.
+    function flat(surface: string, value = 0): ReturnType<typeof evaluateExperiment> {
+      const id = createExperiment(testDir, 'testbot', 'engagement', 'flat hypothesis', {
+        surface,
+        direction: 'higher',
+      });
+      runExperiment(testDir, id);
+      return evaluateExperiment(testDir, id, value);
+    }
+
+    it('flags the 3rd consecutive flat window on the same surface', () => {
+      const s = 'surfaces/g1.md';
+
+      const r1 = flat(s);
+      expect(r1.decision).toBe('discard');
+      expect(r1.guardrail_note ?? null).toBeNull();
+
+      const r2 = flat(s);
+      expect(r2.guardrail_note ?? null).toBeNull();
+
+      const r3 = flat(s);
+      expect(r3.decision).toBe('discard');
+      expect(r3.guardrail_note).toBeTruthy();
+      expect(r3.guardrail_note).toContain(s);
+
+      // Note is persisted to learnings.md (tamper-proof record)
+      const learnings = readFileSync(join(testDir, 'experiments', 'learnings.md'), 'utf-8');
+      expect(learnings).toContain('zero-delta gate');
+    });
+
+    it('does not accumulate flats spread across different surfaces', () => {
+      flat('surfaces/a.md');
+      flat('surfaces/b.md');
+      const r3 = flat('surfaces/c.md');
+      expect(r3.guardrail_note ?? null).toBeNull();
+    });
+
+    it('a keep resets the flat streak (does not chain)', async () => {
+      const s = 'surfaces/reset.md';
+      flat(s); // discard 1
+      flat(s); // discard 2
+
+      // A genuine improvement (keep) must break the streak. Space completions
+      // apart by >1s so the truncated-to-seconds completed_at ordering is
+      // unambiguous (the keep sorts newest before the following flat).
+      await sleep(1100);
+      const k = createExperiment(testDir, 'testbot', 'engagement', 'real improvement', {
+        surface: s,
+        direction: 'higher',
+      });
+      runExperiment(testDir, k);
+      const rk = evaluateExperiment(testDir, k, 5); // 5 > baseline 0 → keep
+      expect(rk.decision).toBe('keep');
+      expect(rk.guardrail_note ?? null).toBeNull();
+
+      await sleep(1100);
+      const r = flat(s, 0); // baseline now 5, value 0 → discard, but streak reset
+      expect(r.decision).toBe('discard');
+      expect(r.guardrail_note ?? null).toBeNull();
+    });
+  });
+
   describe('listExperiments', () => {
     it('returns all experiments sorted by created_at desc', () => {
       createExperiment(testDir, 'bot1', 'metric_a', 'hyp1');


### PR DESCRIPTION
Clean recreation of #889 — branched off `upstream/main` so the diff is only the 3 real files, not the ~485-file fleet-branch divergence that made the original CONFLICTING.

## What
G1 guardrail: `evaluate-experiment` auto-discards an experiment after 3 consecutive zero-delta results on the target surface (a variant that never moves the metric is noise). Adds `countConsecutiveFlatOnSurface()` and a `guardrail_note` on the result.

## Files
- `src/bus/experiment.ts` — G1 gate in `evaluateExperiment` + helper
- `src/cli/bus.ts` — CLI wiring for the note
- `tests/sprint3-experiments.test.ts` — coverage (30/30 pass)

Supersedes #889. (Pairs with the G3 baseline-drift PR, which stacks G3 on top of this.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)