### PR TITLE
feat(autoresearch): G3 baseline-drift detection + baseline suggestion

### DIFF
--- a/src/bus/experiment.ts
+++ b/src/bus/experiment.ts
@@ -25,6 +25,12 @@ export interface Experiment {
   started_at: string | null;
   completed_at: string | null;
   changes_description: string | null;
+  /**
+   * Set by the G1 zero-delta gate when an evaluation is the Nth consecutive
+   * flat (non-improving) window on the same surface. Optional/back-compat:
+   * absent on experiments created before the gate and on non-triggering ones.
+   */
+  guardrail_note?: string | null;
 }
 
 export interface ExperimentCreateOptions {
@@ -115,6 +121,43 @@ function saveExperiment(agentDir: string, experiment: Experiment): void {
   const dir = historyDir(agentDir);
   ensureDir(dir);
   atomicWriteSync(join(dir, `${experiment.id}.json`), JSON.stringify(experiment, null, 2));
+}
+
+/**
+ * G1 zero-delta gate limit: number of consecutive flat (non-improving) windows
+ * on the same surface that forces the surface to be abandoned. Per the
+ * autoresearch skill's zero-delta rule ("result <= baseline for the SAME
+ * surface change 3 windows in a row — discard and re-hypothesize").
+ */
+export const ZERO_DELTA_GATE_LIMIT = 3;
+
+/**
+ * Count how many of the most-recent CONSECUTIVE completed experiments on the
+ * given surface ended in 'discard' (a flat / non-improving window). A 'keep'
+ * breaks the streak — the skill's rule is explicitly about not chaining keeps
+ * on flat results, so any real improvement resets the counter. Ordered by
+ * completion time (newest first) so the streak reflects recent history, not
+ * creation order. Returns 0 for an empty surface (cannot group).
+ */
+function countConsecutiveFlatOnSurface(
+  agentDir: string,
+  surface: string,
+  excludeId: string,
+): number {
+  if (!surface) return 0;
+  const completed = listExperiments(agentDir, { status: 'completed' })
+    .filter((e) => e.surface === surface && e.id !== excludeId)
+    .sort(
+      (a, b) =>
+        new Date(b.completed_at ?? b.created_at).getTime() -
+        new Date(a.completed_at ?? a.created_at).getTime(),
+    );
+  let streak = 0;
+  for (const e of completed) {
+    if (e.decision === 'discard') streak++;
+    else break;
+  }
+  return streak;
 }
 
 export function loadExperimentConfig(agentDir: string): ExperimentConfig {
@@ -289,10 +332,34 @@ export function evaluateExperiment(
     experiment.decision = decision;
   }
 
+  // G1 zero-delta gate: if this is a flat (non-improving) window and the same
+  // surface already produced ZERO_DELTA_GATE_LIMIT-1 consecutive flat windows,
+  // the surface is exhausted. Force discard (belt-and-suspenders: a flat result
+  // already discards) and record a tamper-proof re-hypothesize note in the
+  // learning so the agent cannot keep chaining experiments on a dead surface.
+  let guardrailNote: string | null = null;
+  if (decision === 'discard' && experiment.surface) {
+    const priorFlat = countConsecutiveFlatOnSurface(
+      agentDir,
+      experiment.surface,
+      experiment.id,
+    );
+    if (priorFlat + 1 >= ZERO_DELTA_GATE_LIMIT) {
+      decision = 'discard';
+      experiment.decision = 'discard';
+      guardrailNote =
+        `G1 zero-delta gate: ${priorFlat + 1} consecutive flat windows on surface ` +
+        `'${experiment.surface}' — metric not moving. Abandon this surface and ` +
+        `re-hypothesize with a materially different change; do not keep chaining.`;
+      experiment.guardrail_note = guardrailNote;
+    }
+  }
+
   // Build learning from options
   const learningParts: string[] = [];
   if (options?.learning) learningParts.push(options.learning);
   if (options?.justification) learningParts.push(options.justification);
+  if (guardrailNote) learningParts.push(`⚠ ${guardrailNote}`);
   if (learningParts.length > 0) {
     experiment.learning = learningParts.join(' — ');
   }

--- a/src/bus/experiment.ts
+++ b/src/bus/experiment.ts
@@ -31,6 +31,13 @@ export interface Experiment {
    * absent on experiments created before the gate and on non-triggering ones.
    */
   guardrail_note?: string | null;
+  /**
+   * Set by the G3 baseline-drift detector when recent results on the surface
+   * cluster within DRIFT_DELTA of the baseline for DRIFT_WINDOW+ windows.
+   * Advisory only — never changes the decision or the baseline. Optional/
+   * back-compat: absent on non-triggering evaluations.
+   */
+  drift_note?: string | null;
 }
 
 export interface ExperimentCreateOptions {
@@ -39,6 +46,8 @@ export interface ExperimentCreateOptions {
   window?: string;
   measurement?: string;
   approval_required?: boolean;
+  /** Explicit starting baseline. Defaults to 0. See suggestBaselineFromSurface. */
+  baseline?: number;
 }
 
 export interface ExperimentEvaluateOptions {
@@ -160,6 +169,83 @@ function countConsecutiveFlatOnSurface(
   return streak;
 }
 
+/**
+ * G3 baseline-drift parameters. A run of DRIFT_WINDOW+ recent windows whose
+ * results all sit within DRIFT_DELTA of the current baseline means the metric
+ * is stuck — the baseline is pegged and no longer discriminating. Calibrated
+ * for 1-10 qualitative scores (±1). Detection is advisory only.
+ */
+export const DRIFT_DELTA = 1;
+export const DRIFT_WINDOW = 5;
+
+/** Median of a numeric list (average of the two middle values for even n). */
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+/**
+ * G3 create-time helper: suggest a starting baseline for a new experiment on
+ * a surface as the median of the last 5 completed results on that surface (or
+ * all of them if fewer than 5). Median — not min — so a single outlier window
+ * does not drag the floor. Returns null when the surface has no prior results,
+ * so the caller can fall back to the default baseline of 0.
+ */
+export function suggestBaselineFromSurface(
+  agentDir: string,
+  surface: string,
+): number | null {
+  if (!surface) return null;
+  const results = listExperiments(agentDir, { status: 'completed' })
+    .filter((e) => e.surface === surface && typeof e.result_value === 'number')
+    .sort(
+      (a, b) =>
+        new Date(b.completed_at ?? b.created_at).getTime() -
+        new Date(a.completed_at ?? a.created_at).getTime(),
+    )
+    .slice(0, 5)
+    .map((e) => e.result_value as number);
+  if (results.length === 0) return null;
+  return median(results);
+}
+
+/**
+ * G3 evaluate-time helper: detect baseline drift. Counts, newest-first, how
+ * many recent windows on the surface (the current result plus prior completed
+ * results) sit within DRIFT_DELTA of the reference baseline in an unbroken run.
+ * Returns the run length; the caller warns when it reaches DRIFT_WINDOW.
+ */
+function driftRunLength(
+  agentDir: string,
+  surface: string,
+  excludeId: string,
+  currentResult: number,
+  baselineRef: number,
+): number {
+  if (!surface) return 0;
+  const priorResults = listExperiments(agentDir, { status: 'completed' })
+    .filter(
+      (e) =>
+        e.surface === surface &&
+        e.id !== excludeId &&
+        typeof e.result_value === 'number',
+    )
+    .sort(
+      (a, b) =>
+        new Date(b.completed_at ?? b.created_at).getTime() -
+        new Date(a.completed_at ?? a.created_at).getTime(),
+    )
+    .map((e) => e.result_value as number);
+  const sequence = [currentResult, ...priorResults];
+  let run = 0;
+  for (const v of sequence) {
+    if (Math.abs(v - baselineRef) <= DRIFT_DELTA) run++;
+    else break;
+  }
+  return run;
+}
+
 export function loadExperimentConfig(agentDir: string): ExperimentConfig {
   return loadConfig(agentDir);
 }
@@ -214,7 +300,7 @@ export function createExperiment(
     window: options?.window ?? cycleDefaults.window ?? '24h',
     measurement: options?.measurement ?? cycleDefaults.measurement ?? '',
     status: 'proposed',
-    baseline_value: 0,
+    baseline_value: options?.baseline ?? 0,
     result_value: null,
     decision: null,
     learning: '',
@@ -355,11 +441,36 @@ export function evaluateExperiment(
     }
   }
 
+  // G3 baseline-drift detector (advisory only — never changes the decision or
+  // the baseline; baseline stays ground truth). If recent windows on the
+  // surface cluster within DRIFT_DELTA of the baseline for DRIFT_WINDOW+ in a
+  // row, the baseline is pegged and no longer discriminating — warn so the
+  // agent closes the cycle and re-creates with a fresh baseline.
+  let driftNote: string | null = null;
+  if (experiment.surface) {
+    const baselineRef = experiment.baseline_value;
+    const run = driftRunLength(
+      agentDir,
+      experiment.surface,
+      experiment.id,
+      measuredValue,
+      baselineRef,
+    );
+    if (run >= DRIFT_WINDOW) {
+      driftNote =
+        `baseline drift suspected: results stuck at ${baselineRef} ± ${DRIFT_DELTA} for ` +
+        `${run} windows on surface '${experiment.surface}'; consider closing this cycle ` +
+        `and re-creating with baseline=${baselineRef}.`;
+      experiment.drift_note = driftNote;
+    }
+  }
+
   // Build learning from options
   const learningParts: string[] = [];
   if (options?.learning) learningParts.push(options.learning);
   if (options?.justification) learningParts.push(options.justification);
   if (guardrailNote) learningParts.push(`⚠ ${guardrailNote}`);
+  if (driftNote) learningParts.push(`⚠ ${driftNote}`);
   if (learningParts.length > 0) {
     experiment.learning = learningParts.join(' — ');
   }

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -9,7 +9,7 @@ import { saveOutput } from '../bus/save-output.js';
 import { logEvent } from '../bus/event.js';
 import { updateHeartbeat, readAllHeartbeats } from '../bus/heartbeat.js';
 import { selfRestart, hardRestart, autoCommit, checkGoalStaleness, postActivity } from '../bus/system.js';
-import { createExperiment, runExperiment, evaluateExperiment, listExperiments, gatherContext, manageCycle, loadExperimentConfig } from '../bus/experiment.js';
+import { createExperiment, runExperiment, evaluateExperiment, listExperiments, gatherContext, manageCycle, loadExperimentConfig, suggestBaselineFromSurface } from '../bus/experiment.js';
 import { browseCatalog, installCommunityItem, prepareSubmission, submitCommunityItem } from '../bus/catalog.js';
 import { collectMetrics, parseUsageOutput, storeUsageData, checkUpstream, collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
 import { createApproval, updateApproval } from '../bus/approval.js';
@@ -705,13 +705,30 @@ busCommand
   .option('--surface <path>', 'Surface file path')
   .option('--direction <dir>', 'Direction: higher or lower', 'higher')
   .option('--window <dur>', 'Measurement window', '24h')
-  .action(async (metric: string, hypothesis: string, opts: { surface?: string; direction?: string; window?: string }) => {
+  .option('--baseline <n>', 'Explicit starting baseline (default 0)')
+  .action(async (metric: string, hypothesis: string, opts: { surface?: string; direction?: string; window?: string; baseline?: string }) => {
     const env = resolveEnv();
     const agentDir = env.agentDir || process.cwd();
+
+    // G3: if the surface has prior results and no baseline was given, suggest
+    // the median of the last 5 as an informational starting point (stderr, so
+    // stdout stays the bare experiment id for capture). The agent may override
+    // with --baseline; the baseline itself is never auto-applied.
+    if (opts.baseline === undefined && opts.surface) {
+      const suggested = suggestBaselineFromSurface(agentDir, opts.surface);
+      if (suggested !== null) {
+        console.error(
+          `ℹ baseline suggestion for surface '${opts.surface}': ${suggested} ` +
+          `(median of recent results). Pass --baseline to set it; default is 0.`,
+        );
+      }
+    }
+
     const id = createExperiment(agentDir, env.agentName, metric, hypothesis, {
       surface: opts.surface,
       direction: opts.direction as 'higher' | 'lower',
       window: opts.window,
+      baseline: opts.baseline !== undefined ? parseFloat(opts.baseline) : undefined,
     });
     console.log(id);
 
@@ -761,6 +778,9 @@ busCommand
     });
     if (experiment.guardrail_note) {
       console.error(`⚠ ${experiment.guardrail_note}`);
+    }
+    if (experiment.drift_note) {
+      console.error(`⚠ ${experiment.drift_note}`);
     }
     console.log(JSON.stringify(experiment, null, 2));
   });

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -759,6 +759,9 @@ busCommand
       score: opts.score ? parseInt(opts.score, 10) : undefined,
       justification: opts.justification,
     });
+    if (experiment.guardrail_note) {
+      console.error(`⚠ ${experiment.guardrail_note}`);
+    }
     console.log(JSON.stringify(experiment, null, 2));
   });
 

--- a/tests/sprint3-experiments.test.ts
+++ b/tests/sprint3-experiments.test.ts
@@ -257,6 +257,72 @@ describe('Sprint 3: Experiment Framework', () => {
     });
   });
 
+  describe('G1 zero-delta gate', () => {
+    const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+    // Create + run + evaluate a flat (non-improving) window on a surface.
+    // direction=higher, baseline starts at 0, so value<=0 → discard.
+    function flat(surface: string, value = 0): ReturnType<typeof evaluateExperiment> {
+      const id = createExperiment(testDir, 'testbot', 'engagement', 'flat hypothesis', {
+        surface,
+        direction: 'higher',
+      });
+      runExperiment(testDir, id);
+      return evaluateExperiment(testDir, id, value);
+    }
+
+    it('flags the 3rd consecutive flat window on the same surface', () => {
+      const s = 'surfaces/g1.md';
+
+      const r1 = flat(s);
+      expect(r1.decision).toBe('discard');
+      expect(r1.guardrail_note ?? null).toBeNull();
+
+      const r2 = flat(s);
+      expect(r2.guardrail_note ?? null).toBeNull();
+
+      const r3 = flat(s);
+      expect(r3.decision).toBe('discard');
+      expect(r3.guardrail_note).toBeTruthy();
+      expect(r3.guardrail_note).toContain(s);
+
+      // Note is persisted to learnings.md (tamper-proof record)
+      const learnings = readFileSync(join(testDir, 'experiments', 'learnings.md'), 'utf-8');
+      expect(learnings).toContain('zero-delta gate');
+    });
+
+    it('does not accumulate flats spread across different surfaces', () => {
+      flat('surfaces/a.md');
+      flat('surfaces/b.md');
+      const r3 = flat('surfaces/c.md');
+      expect(r3.guardrail_note ?? null).toBeNull();
+    });
+
+    it('a keep resets the flat streak (does not chain)', async () => {
+      const s = 'surfaces/reset.md';
+      flat(s); // discard 1
+      flat(s); // discard 2
+
+      // A genuine improvement (keep) must break the streak. Space completions
+      // apart by >1s so the truncated-to-seconds completed_at ordering is
+      // unambiguous (the keep sorts newest before the following flat).
+      await sleep(1100);
+      const k = createExperiment(testDir, 'testbot', 'engagement', 'real improvement', {
+        surface: s,
+        direction: 'higher',
+      });
+      runExperiment(testDir, k);
+      const rk = evaluateExperiment(testDir, k, 5); // 5 > baseline 0 → keep
+      expect(rk.decision).toBe('keep');
+      expect(rk.guardrail_note ?? null).toBeNull();
+
+      await sleep(1100);
+      const r = flat(s, 0); // baseline now 5, value 0 → discard, but streak reset
+      expect(r.decision).toBe('discard');
+      expect(r.guardrail_note ?? null).toBeNull();
+    });
+  });
+
   describe('listExperiments', () => {
     it('returns all experiments sorted by created_at desc', () => {
       createExperiment(testDir, 'bot1', 'metric_a', 'hyp1');

--- a/tests/sprint3-experiments.test.ts
+++ b/tests/sprint3-experiments.test.ts
@@ -9,6 +9,7 @@ import {
   listExperiments,
   gatherContext,
   manageCycle,
+  suggestBaselineFromSurface,
 } from '../src/bus/experiment.js';
 
 describe('Sprint 3: Experiment Framework', () => {
@@ -320,6 +321,88 @@ describe('Sprint 3: Experiment Framework', () => {
       const r = flat(s, 0); // baseline now 5, value 0 → discard, but streak reset
       expect(r.decision).toBe('discard');
       expect(r.guardrail_note ?? null).toBeNull();
+    });
+  });
+
+  describe('G3 baseline drift', () => {
+    it('createExperiment honours an explicit baseline', () => {
+      const id = createExperiment(testDir, 'testbot', 'quality', 'h', {
+        surface: 'surfaces/g3.md',
+        baseline: 7,
+      });
+      const exp = JSON.parse(
+        readFileSync(join(testDir, 'experiments', 'history', `${id}.json`), 'utf-8').trim(),
+      );
+      expect(exp.baseline_value).toBe(7);
+    });
+
+    it('suggestBaselineFromSurface returns median of recent results (null when none)', () => {
+      const s = 'surfaces/g3-suggest.md';
+      expect(suggestBaselineFromSurface(testDir, s)).toBeNull();
+
+      // Produce completed results 4, 6, 8 on the surface (baseline 0, higher).
+      for (const v of [4, 6, 8]) {
+        const id = createExperiment(testDir, 'testbot', 'quality', 'h', {
+          surface: s,
+          direction: 'higher',
+        });
+        runExperiment(testDir, id);
+        evaluateExperiment(testDir, id, v);
+      }
+      // Median of [4,6,8] = 6.
+      expect(suggestBaselineFromSurface(testDir, s)).toBe(6);
+    });
+
+    it('warns when results cluster within ±1 of baseline for 5+ windows', () => {
+      const s = 'surfaces/g3-drift.md';
+      // Fixed baseline 7 via explicit baseline; direction lower so results at
+      // 7 (== baseline) discard without moving the baseline, keeping it pegged.
+      let last: ReturnType<typeof evaluateExperiment> | null = null;
+      for (let i = 0; i < 5; i++) {
+        const id = createExperiment(testDir, 'testbot', 'quality', 'h', {
+          surface: s,
+          direction: 'lower',
+          baseline: 7,
+        });
+        runExperiment(testDir, id);
+        last = evaluateExperiment(testDir, id, 7); // |7-7|=0 ≤ 1, discard, baseline stays 7
+      }
+      expect(last!.drift_note).toBeTruthy();
+      expect(last!.drift_note).toContain('drift');
+    });
+
+    it('does not warn before 5 clustered windows', () => {
+      const s = 'surfaces/g3-nodrift.md';
+      let last: ReturnType<typeof evaluateExperiment> | null = null;
+      for (let i = 0; i < 4; i++) {
+        const id = createExperiment(testDir, 'testbot', 'quality', 'h', {
+          surface: s,
+          direction: 'lower',
+          baseline: 7,
+        });
+        runExperiment(testDir, id);
+        last = evaluateExperiment(testDir, id, 7);
+      }
+      expect(last!.drift_note ?? null).toBeNull();
+    });
+
+    it('a result outside ±1 breaks the drift run', () => {
+      const s = 'surfaces/g3-break.md';
+      const mk = (v: number) => {
+        const id = createExperiment(testDir, 'testbot', 'quality', 'h', {
+          surface: s,
+          direction: 'lower',
+          baseline: 7,
+        });
+        runExperiment(testDir, id);
+        return evaluateExperiment(testDir, id, v);
+      };
+      mk(7);
+      mk(7);
+      mk(20); // far from baseline → breaks the run
+      mk(7);
+      const last = mk(7); // only 2 clustered since the break → no warn
+      expect(last.drift_note ?? null).toBeNull();
     });
   });
 


### PR DESCRIPTION
Clean recreation of #890 — branched off `upstream/main` so the diff is only the 3 real files, not the ~485-file fleet-branch divergence that made the original CONFLICTING.

## What
G3 guardrail (DETECT + WARN, never auto-adjust):
- `create-experiment` **suggests** a baseline = median of the last 5 results on the surface.
- `evaluate-experiment` **warns** via `drift_note` when `|result − baseline| ≤ 1` for 5+ consecutive windows (the metric has drifted flat around baseline).

Adds `median()`, `suggestBaselineFromSurface()`, `driftRunLength()`, `DRIFT_DELTA`/`DRIFT_WINDOW`, and `baseline` on `ExperimentCreateOptions`.

## Stacking
Contains the G1 commit (#902) plus G3 on top, matching the original pair — G3 modifies G1's evaluate path, so they ship together. Once #902 merges, this reduces to the G3 delta.

## Files
- `src/bus/experiment.ts` — G3 drift detection + baseline suggestion (on top of G1)
- `src/cli/bus.ts` — CLI wiring
- `tests/sprint3-experiments.test.ts` — coverage (35/35 pass)

Supersedes #890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)