### PR TITLE
feat(slack): add Socket Mode adapter for per-agent messaging

### DIFF
--- a/bus/_slack-curl.sh
+++ b/bus/_slack-curl.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# _slack-curl.sh - Shared helper for Slack Web API calls
+# Keeps SLACK_BOT_TOKEN out of shell traces (set +x) while preserving stderr.
+# Source this file, then call the functions. Requires SLACK_BOT_TOKEN in env.
+
+slack_api_post() {
+    local method="$1"; shift
+    (
+        set +x
+        curl -s -X POST "https://slack.com/api/${method}" \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H "Content-Type: application/json; charset=utf-8" \
+            "$@"
+    )
+}

--- a/bus/send-slack.sh
+++ b/bus/send-slack.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# send-slack.sh — post to a Slack channel under an agent's identity.
+# Usage:
+#   bus/send-slack.sh <agent> <channel> "<text>"
+# Reads slack.json from orgs/<org>/agents/<agent>/slack.json (or namespaced).
+# Requires SLACK_BOT_TOKEN in env.
+
+set -euo pipefail
+
+AGENT="${1:?usage: send-slack.sh <agent> <channel> <text>}"
+CHANNEL="${2:?usage: send-slack.sh <agent> <channel> <text>}"
+TEXT="${3:?usage: send-slack.sh <agent> <channel> <text>}"
+
+# Delegate to the CLI for identity resolution + posting — keeps the JSON
+# lookup in one place (TypeScript) instead of duplicating in bash.
+exec node "${CTX_FRAMEWORK_ROOT:-/opt/cortextos}/dist/cli.js" slack test-send \
+    "$CHANNEL" "$TEXT" --as "$AGENT"

--- a/docs/runbook/slack-adapter-setup.md
+++ b/docs/runbook/slack-adapter-setup.md
@@ -1,0 +1,125 @@
+# Slack Adapter Setup
+
+cortextOS agents can send and receive messages over Slack, in addition to
+Telegram. Outbound (`chat.postMessage`) and inbound (Socket Mode) are both
+supported. This guide covers creating the Slack app, configuring an agent,
+and verifying the setup.
+
+## 1. Create a Slack app
+
+1. Go to <https://api.slack.com/apps> and click **Create New App** → **From
+   scratch**.
+2. Name the app and pick the workspace it should install to.
+3. Under **Socket Mode**, enable Socket Mode. This generates an app-level
+   token (`xapp-...`) — save it, you'll need it as `SLACK_APP_TOKEN`.
+4. Under **OAuth & Permissions** → **Scopes** → **Bot Token Scopes**, add:
+   - `chat:write` — post messages (`chat.postMessage`, used by `slack send`
+     / `slack test-send`)
+   - `chat:write.customize` — post under a per-agent display name/icon
+     (`username`/`icon_emoji`/`icon_url` overrides in `slack.json`)
+   - `channels:history` — receive `message`/`app_mention` events from
+     public channels the bot is in (Socket Mode inbound)
+   - `channels:read` — list channels (`conversations.list`, used by
+     `slack discover-channels`)
+   - `users:read` — resolve a Slack user id to a display name for the
+     injected message header (`users.info`)
+   - If the agent needs to read/post in private channels, also add
+     `groups:history` and `groups:read`.
+5. Under **Event Subscriptions**, enable events and subscribe to bot events:
+   `message.channels` (and `message.groups` if using private channels),
+   `app_mention`.
+6. Install the app to the workspace. This generates a bot token
+   (`xoxb-...`) — save it as `SLACK_BOT_TOKEN`.
+7. Invite the bot to each channel it needs to read from or post to
+   (`/invite @your-bot-name` in Slack).
+
+## 2. Configure environment variables
+
+The daemon process needs both tokens in its environment:
+
+```bash
+SLACK_BOT_TOKEN=xoxb-...
+SLACK_APP_TOKEN=xapp-...
+```
+
+`SLACK_BOT_TOKEN` is required for any outbound send (`slack send`,
+`slack test-send`, `slack discover-channels`). Both `SLACK_BOT_TOKEN` and
+`SLACK_APP_TOKEN` are required for inbound Socket Mode — the daemon's
+orchestrator agent starts one shared Socket Mode connection per org at
+startup only when both are present; if either is missing, Slack inbound is
+simply inactive and nothing else is affected (agent startup, Telegram, etc.
+all continue normally).
+
+Socket Mode requires Node's native `WebSocket` global, which is stable
+starting in Node 22 — make sure the daemon runs on Node >=22.
+
+## 3. Configure an agent for Slack (`slack.json`)
+
+Per-agent Slack config lives at `agents/<name>/slack.json` (or the
+namespaced equivalent for `<org>/<agent>` layouts). Schema
+(`SlackConfig`, see `src/slack/identity.ts`):
+
+```json
+{
+  "display_name": "My Agent",
+  "icon_emoji": ":robot_face:",
+  "channels": {
+    "recap": "C0123456789",
+    "ops": "C0987654321"
+  },
+  "allowed_channels": ["C0123456789", "C0987654321"],
+  "allowed_users": ["T01234567:U01234567"]
+}
+```
+
+- `display_name` — the `username` used when posting (requires
+  `chat:write.customize`).
+- `icon_emoji` **or** `icon_url` — optional visual identity override; if
+  both are set, `icon_emoji` wins.
+- `channels` — a purpose → channel-id map for the agent's own reference
+  (e.g. which channel to post recaps to). Not enforced by the adapter
+  itself.
+- `allowed_channels` — channel ids (`Cxxx`) this agent will accept inbound
+  messages from. Required for inbound delivery — a channel not in this
+  list is never routed to the agent.
+- `allowed_users` — **required, fail-closed** allowlist of Slack identities
+  permitted to message this agent, as `"<team_id>:<user_id>"` composite
+  keys (not just `user_id` — Slack user ids are workspace-scoped, not
+  globally unique). An empty or missing list means the agent accepts
+  messages from **no one**, mirroring Telegram's `ALLOWED_USER` behavior
+  when unset. Find `team_id` and `user_id` from a message inspected via the
+  Slack API, or from `discover-channels` output plus Slack's own admin UI.
+
+A missing `slack.json` means the agent is Slack-disabled — this is a
+normal, supported state, not an error.
+
+## 4. Verify
+
+With `SLACK_BOT_TOKEN` set in your shell:
+
+```bash
+# List channels the bot is a member of, with ids
+cortextos slack discover-channels
+
+# Post a test message
+cortextos slack test-send C0123456789 "hello from cortextos" --org myorg
+
+# Post under a specific agent's identity (reads that agent's slack.json)
+cortextos slack test-send C0123456789 "hello" --as my-agent --org myorg
+```
+
+`cortextos slack send` is the same command shape as `test-send` — it's the
+stable command name used internally for replies (the "Reply using: ..."
+line injected into an agent's session when a Slack message arrives).
+
+To verify inbound delivery end-to-end: start the daemon with
+`SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` set, confirm the orchestrator log
+shows `Slack Socket Mode connected`, then post a message in a channel
+listed in an agent's `allowed_channels` from a user listed in that agent's
+`allowed_users`. The message should appear in the agent's session as:
+
+```
+=== SLACK from [USER: <name>] (channel:<id>) ===
+<text>
+Reply using: cortextos slack send <channel> '<your reply>' --as <agent>
+```

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "type": "commonjs",
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "files": [
     "dist/",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "type": "commonjs",
   "engines": {
-    "node": ">=22.0.0"
+    "node": ">=20.0.0"
   },
   "files": [
     "dist/",

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,7 @@ import { spawnWorkerCommand, terminateWorkerCommand, listWorkersCommand, injectW
 import { importAgentCommand } from './import-agent.js';
 import { updateCommand } from './update.js';
 import { lifecycleCommand } from './lifecycle.js';
+import { slackCommand } from './slack.js';
 import { CORTEXTOS_VERSION } from '../version.js';
 
 const program = new Command();
@@ -63,6 +64,7 @@ program.addCommand(injectWorkerCommand);
 program.addCommand(importAgentCommand);
 program.addCommand(updateCommand);
 program.addCommand(lifecycleCommand);
+program.addCommand(slackCommand);
 
 // crash-alert: SessionEnd hook — cross-platform replacement for crash-alert.sh
 const crashAlertCommand = new Command('crash-alert')

--- a/src/cli/slack.ts
+++ b/src/cli/slack.ts
@@ -1,0 +1,104 @@
+import { Command } from 'commander';
+import { SlackAPI, loadSlackIdentity, type PostMessageRequest } from '../slack/index.js';
+import { resolveEnv } from '../utils/env.js';
+
+export interface TestSendOptions {
+  frameworkRoot: string;
+  org: string;
+  agent?: string;
+  channel: string;
+  text: string;
+}
+
+/** Pure function — testable without process exit. */
+export async function runTestSend(opts: TestSendOptions, api: SlackAPI): Promise<void> {
+  const req: PostMessageRequest = { channel: opts.channel, text: opts.text };
+  if (opts.agent) {
+    const id = loadSlackIdentity(opts.frameworkRoot, opts.org, opts.agent);
+    if (!id) throw new Error(`agent "${opts.agent}" has no slack.json (not Slack-enabled)`);
+    req.username = id.username;
+    if (id.icon_emoji) req.icon_emoji = id.icon_emoji;
+    if (id.icon_url) req.icon_url = id.icon_url;
+  }
+  await api.postMessage(req);
+}
+
+function requireToken(): string {
+  const token = process.env.SLACK_BOT_TOKEN;
+  if (!token) {
+    console.error('SLACK_BOT_TOKEN not set. See docs/runbook/slack-adapter-setup.md.');
+    process.exit(1);
+  }
+  return token;
+}
+
+function requireOrg(opt?: string): string {
+  const org = opt || resolveEnv().org;
+  if (!org) {
+    console.error('ERROR: --org or CTX_ORG required');
+    process.exit(1);
+  }
+  return org;
+}
+
+const testSendCommand = new Command('test-send')
+  .argument('<channel>', 'Slack channel id (Cxxx) or name (#general)')
+  .argument('<text>', 'Message text')
+  .option('--as <agent>', 'Post under this agent\'s identity (loads slack.json)')
+  .option('--org <org>', 'Organization name')
+  .description('Post a test message to a Slack channel')
+  .action(async (channel: string, text: string, options: { as?: string; org?: string }) => {
+    const api = new SlackAPI(requireToken());
+    const frameworkRoot =
+      process.env.CTX_FRAMEWORK_ROOT || process.env.CTX_PROJECT_ROOT || process.cwd();
+    const org = requireOrg(options.org);
+    try {
+      await runTestSend({ frameworkRoot, org, agent: options.as, channel, text }, api);
+      console.log('sent');
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+// Stable command name the injected "Reply using:" line invokes. Shares
+// runTestSend's implementation with test-send (same shape, same identity
+// threading via --as) — this is the one operators/agents should treat as
+// the standing reply path; test-send remains for ad-hoc manual testing.
+const sendCommand = new Command('send')
+  .argument('<channel>', 'Slack channel id (Cxxx) or name (#general)')
+  .argument('<text>', 'Message text')
+  .option('--as <agent>', 'Post under this agent\'s identity (loads slack.json)')
+  .option('--org <org>', 'Organization name')
+  .description('Send a Slack message (used by the inbound reply path)')
+  .action(async (channel: string, text: string, options: { as?: string; org?: string }) => {
+    const api = new SlackAPI(requireToken());
+    const frameworkRoot =
+      process.env.CTX_FRAMEWORK_ROOT || process.env.CTX_PROJECT_ROOT || process.cwd();
+    const org = requireOrg(options.org);
+    try {
+      await runTestSend({ frameworkRoot, org, agent: options.as, channel, text }, api);
+      console.log('sent');
+    } catch (err) {
+      console.error(`Error: ${(err as Error).message}`);
+      process.exit(1);
+    }
+  });
+
+const discoverChannelsCommand = new Command('discover-channels')
+  .description('List Slack channels the bot is a member of (with ids)')
+  .action(async () => {
+    const api = new SlackAPI(requireToken());
+    const channels = await api.listChannels();
+    const visible = channels.filter((c) => c.is_member !== false);
+    for (const c of visible) {
+      const prefix = c.is_private ? '🔒' : '#';
+      console.log(`${c.id}\t${prefix}${c.name}`);
+    }
+  });
+
+export const slackCommand = new Command('slack')
+  .description('Slack adapter ops')
+  .addCommand(testSendCommand)
+  .addCommand(sendCommand)
+  .addCommand(discoverChannelsCommand);

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -9,6 +9,9 @@ import { migrateCronsForAgent } from './cron-migration.js';
 import type { CronDefinition } from '../types/index.js';
 import { TelegramAPI } from '../telegram/api.js';
 import { TelegramPoller } from '../telegram/poller.js';
+import { SlackAPI } from '../slack/api.js';
+import { SlackSocketModeClient } from '../slack/socket-mode.js';
+import { dispatchSlackMessage, makeUserNameResolver, type DispatchTarget } from '../slack/dispatcher.js';
 import { resolvePaths } from '../utils/paths.js';
 import { resolveEnv } from '../utils/env.js';
 import { recordInboundTelegram, cacheLastSent, logOutboundMessage, buildRecentHistory } from '../telegram/logging.js';
@@ -62,6 +65,14 @@ export class AgentManager {
   // see overlapping registry state). Cleared after discoverAndStart()
   // finishes so the next clean restart starts from a known-good baseline.
   private daemonJustCrashed: boolean = false;
+
+  // Slack Socket Mode: one shared connection for the whole daemon process
+  // (Slack is one app per workspace, not one bot per agent — see
+  // maybeStartSlackSocketMode's docblock). slackSocketStarted guards
+  // against starting a second connection if startAgent() runs again for
+  // the orchestrator (e.g. a restart) while this daemon process is alive.
+  private slackSocketStarted = false;
+  private slackSocketClient: SlackSocketModeClient | null = null;
 
   constructor(instanceId: string, ctxRoot: string, frameworkRoot: string, org: string) {
     this.instanceId = instanceId;
@@ -788,6 +799,83 @@ export class AgentManager {
       // operator pain. Non-orchestrator agents skip this entirely.
       await this.maybeStartActivityChannelPoller(name, org, agentDir, log);
     }
+
+    // Slack Socket Mode. Deliberately OUTSIDE the Telegram gate above —
+    // Slack must work for an agent that has no Telegram config at all
+    // (a Slack-only agent). Same "only the orchestrator starts the shared
+    // connection" shape as maybeStartActivityChannelPoller, for the same
+    // reason: Slack is one app per workspace (a shared SLACK_BOT_TOKEN /
+    // SLACK_APP_TOKEN), not one bot per agent like Telegram, so there must
+    // be exactly one Socket Mode connection for the whole org, not one per
+    // agent.
+    await this.maybeStartSlackSocketMode(name, org, log);
+  }
+
+  /**
+   * If this agent is the org's orchestrator AND the org has SLACK_APP_TOKEN
+   * (and SLACK_BOT_TOKEN) configured, start the one shared
+   * SlackSocketModeClient for the whole daemon and wire its inbound events
+   * through dispatchSlackMessage() to every agent whose slack.json allows
+   * the channel+user. Safe no-op otherwise (non-orchestrator agent, or the
+   * tokens absent — Slack inbound is simply not configured yet).
+   *
+   * Failure isolation is deliberate and load-bearing: a Slack Socket Mode
+   * failure (a runtime that predates the Node 22 WebSocket global, an
+   * unreachable Slack API, anything unexpected) must degrade to "Slack
+   * inactive," never take down orchestrator startup — startAgent() awaits
+   * this method for every agent, so an uncaught throw here would block the
+   * orchestrator itself from starting. Mirrors
+   * maybeStartActivityChannelPoller's failure-isolation contract exactly.
+   */
+  private async maybeStartSlackSocketMode(
+    name: string,
+    org: string | undefined,
+    log: LogFn,
+  ): Promise<void> {
+    if (!org) return;
+    if (this.slackSocketStarted) return; // already running for this daemon process
+
+    const orgDir = join(this.frameworkRoot, 'orgs', org);
+    let orchestratorName: string | undefined;
+    try {
+      const contextJson = stripBom(readFileSync(join(orgDir, 'context.json'), 'utf-8'));
+      orchestratorName = JSON.parse(contextJson).orchestrator;
+    } catch {
+      return; // No context.json or unreadable — skip
+    }
+    if (!orchestratorName || orchestratorName !== name) return;
+
+    const appToken = process.env.SLACK_APP_TOKEN;
+    const botToken = process.env.SLACK_BOT_TOKEN;
+    if (!appToken || !botToken) return; // Slack inbound not configured — normal state
+
+    this.slackSocketStarted = true;
+    const slackApi = new SlackAPI(botToken);
+    const resolveUserName = makeUserNameResolver((userId) => slackApi.getUserInfo(userId));
+    const client = new SlackSocketModeClient(appToken, { log: (msg) => log(`[slack-socket-mode] ${msg}`) });
+
+    client.onMessage((event) => {
+      const targets: DispatchTarget[] = Array.from(this.agents.entries()).map(([n, entry]) => ({
+        name: n,
+        checker: entry.checker,
+      }));
+      dispatchSlackMessage(event, targets, this.frameworkRoot, org, resolveUserName)
+        .then((result) => {
+          if (result.delivered.length > 0) {
+            log(`[slack-socket-mode] delivered to: ${result.delivered.join(', ')}`);
+          }
+        })
+        .catch((err) => log(`[slack-socket-mode] dispatch error: ${err}`));
+    });
+
+    try {
+      await client.start();
+      this.slackSocketClient = client;
+      log('Slack Socket Mode connected (org-level, orchestrator-owned)');
+    } catch (err) {
+      this.slackSocketStarted = false; // allow a future startAgent() call (e.g. a restart) to retry
+      log(`Slack Socket Mode failed to start (Slack inactive, agent startup unaffected): ${err}`);
+    }
   }
 
   /**
@@ -1002,6 +1090,9 @@ export class AgentManager {
    * time `pty.kill()` runs, every agent already has its marker on disk.
    */
   async stopAll(): Promise<void> {
+    this.slackSocketClient?.stop();
+    this.slackSocketClient = null;
+    this.slackSocketStarted = false;
     const names = [...this.agents.keys()];
 
     for (const name of names) {

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -52,6 +52,14 @@ export class FastChecker {
   // External Telegram handler (set by daemon)
   private telegramMessages: Array<{ formatted: string; ackIds: string[] }> = [];
 
+  // External Slack handler (set by daemon's Slack dispatcher). Deliberately
+  // a separate queue from telegramMessages, not a shared one: draining it
+  // must NOT touch lastMessageInjectedAt, which drives the Telegram typing
+  // indicator — Slack traffic has no equivalent indicator and mixing the
+  // two would restart/extend a Telegram typing indicator for Slack-only
+  // activity.
+  private slackMessages: string[] = [];
+
   // Persistent dedup: message hashes to prevent duplicate delivery
   private seenHashes: Set<string> = new Set();
   private dedupFilePath: string = '';
@@ -181,6 +189,14 @@ export class FastChecker {
   }
 
   /**
+   * Queue a formatted Slack message for injection.
+   * Called by the daemon's Slack Socket Mode dispatcher.
+   */
+  queueSlackMessage(formatted: string): void {
+    this.slackMessages.push(formatted);
+  }
+
+  /**
    * Single poll cycle: check inbox + queued Telegram messages.
    */
   private async pollCycle(): Promise<void> {
@@ -193,6 +209,14 @@ export class FastChecker {
       const msg = this.telegramMessages.shift()!;
       messageBlock += msg.formatted;
       hasTelegramMessage = true;
+    }
+
+    // Process queued Slack messages. Deliberately does NOT set
+    // hasTelegramMessage / lastMessageInjectedAt — see slackMessages'
+    // declaration for why the typing-indicator timer must stay
+    // Telegram-only.
+    while (this.slackMessages.length > 0) {
+      messageBlock += this.slackMessages.shift()!;
     }
 
     // Check agent inbox
@@ -294,6 +318,31 @@ Reply using: cortextos bus send-message ${safeFrom} normal '<your reply>' ${msg.
     return `=== TELEGRAM from [USER: ${sanitizeForPtyInjection(from)}] (chat_id:${chatId}) ===
 ${replyCx}${historyCx}${body}
 ${lastSentCtx}Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
+
+`;
+  }
+
+  /**
+   * Format a Slack text message for injection. Same sanitization posture as
+   * formatTelegramTextMessage (the sender/display-name is untrusted, the
+   * body is untrusted) — see that method's docblock for the reasoning,
+   * unchanged here. `agentName` threads the `--as` flag so the reply
+   * command posts under the correct per-agent Slack identity
+   * (loadSlackIdentity).
+   */
+  static formatSlackTextMessage(
+    from: string,
+    channel: string,
+    text: string,
+    agentName: string,
+  ): string {
+    const isSlashCommand = /^\/[a-zA-Z]/.test(stripControlChars(text).trim());
+    const body = isSlashCommand
+      ? sanitizeForPtyInjection(text).trim()
+      : wrapFenceSafe(text);
+    return `=== SLACK from [USER: ${sanitizeForPtyInjection(from)}] (channel:${sanitizeForPtyInjection(channel)}) ===
+${body}
+Reply using: cortextos slack send ${channel} '<your reply>' --as ${agentName}
 
 `;
   }

--- a/src/slack/api.ts
+++ b/src/slack/api.ts
@@ -1,0 +1,89 @@
+/**
+ * Slack Web API client using built-in fetch (Node.js 20+).
+ * No external dependencies.
+ *
+ * Only the subset we need for SP3a: postMessage, update, files.upload,
+ * conversations.list. SP3b adds Socket Mode; SP3c adds Block Kit + interactive
+ * acks via this same client.
+ */
+
+export interface PostMessageRequest {
+  channel: string;
+  text: string;
+  /** Per-agent visual identity override; requires chat:write.customize scope. */
+  username?: string;
+  icon_emoji?: string;
+  icon_url?: string;
+  thread_ts?: string;
+  /** Block Kit blocks; SP3c uses these for interactive approvals. */
+  blocks?: unknown[];
+}
+
+export interface PostMessageResponse {
+  ok: true;
+  channel: string;
+  ts: string;
+}
+
+export interface Channel {
+  id: string;
+  name: string;
+  is_channel?: boolean;
+  is_private?: boolean;
+  is_member?: boolean;
+}
+
+export interface SlackUserInfo {
+  id: string;
+  name?: string;
+  real_name?: string;
+}
+
+export class SlackAPI {
+  constructor(private readonly token: string) {
+    if (!token) throw new Error('SlackAPI: token is required');
+  }
+
+  /** Generic Slack API call helper — handles auth, JSON, and ok=false errors. */
+  private async call<T>(method: string, body: Record<string, unknown>): Promise<T> {
+    const res = await fetch(`https://slack.com/api/${method}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.token}`,
+        'Content-Type': 'application/json; charset=utf-8',
+      },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as { ok: boolean; error?: string } & T;
+    if (!json.ok) {
+      throw new Error(`slack ${method}: ${json.error ?? 'unknown error'}`);
+    }
+    return json;
+  }
+
+  async postMessage(req: PostMessageRequest): Promise<PostMessageResponse> {
+    return this.call<PostMessageResponse>('chat.postMessage', req as unknown as Record<string, unknown>);
+  }
+
+  /** Used by SP3b's dispatcher to resolve a display name for the injected header. */
+  async getUserInfo(userId: string): Promise<SlackUserInfo> {
+    const resp = await this.call<{ user: SlackUserInfo }>('users.info', { user: userId });
+    return resp.user;
+  }
+
+  async listChannels(): Promise<Channel[]> {
+    const out: Channel[] = [];
+    let cursor: string | undefined = undefined;
+    do {
+      const body: Record<string, unknown> = { limit: 200, types: 'public_channel,private_channel' };
+      if (cursor) body.cursor = cursor;
+      const resp = await this.call<{
+        channels: Channel[];
+        response_metadata?: { next_cursor?: string };
+      }>('conversations.list', body);
+      out.push(...resp.channels);
+      cursor = resp.response_metadata?.next_cursor || undefined;
+    } while (cursor);
+    return out;
+  }
+}

--- a/src/slack/dispatcher.ts
+++ b/src/slack/dispatcher.ts
@@ -1,0 +1,118 @@
+/**
+ * SP3b bus dispatcher — routes one inbound Slack message to every agent
+ * whose slack.json says it should receive it, exactly mirroring how
+ * fast-checker.ts injects Telegram messages into an agent's PTY (see
+ * queueTelegramMessage / formatTelegramTextMessage).
+ *
+ * Two independent gates, both required (fail-closed — see identity.ts's
+ * isSlackUserAllowed docblock for why channel membership alone isn't
+ * enough):
+ *   1. channel gate — event.channel is in the agent's slack.json
+ *      allowed_channels.
+ *   2. user gate — event.user is in the agent's slack.json allowed_users.
+ *
+ * Channels are N:1 (many agents can watch the same channel, unlike
+ * Telegram's inherent 1:1 bot-per-chat), so this delivers to EVERY matching
+ * agent, not just the first.
+ */
+import { FastChecker } from '../daemon/fast-checker.js';
+import { loadSlackConfig, isSlackUserAllowed } from './identity.js';
+import type { SlackSocketMessageEvent } from './socket-mode.js';
+
+export interface DispatchTarget {
+  name: string;
+  checker: FastChecker;
+}
+
+/** Resolves a Slack user id to a display name for the injected header. Cacheable — see resolveUserName. */
+export type UserNameResolver = (userId: string) => Promise<string>;
+
+export interface DispatchResult {
+  delivered: string[]; // agent names the message was queued to
+  skippedNoChannelMatch: boolean; // no agent has this channel in allowed_channels
+  skippedUserNotAllowed: string[]; // agent names that matched on channel but rejected on user
+}
+
+/**
+ * Route one normalized Slack event to every agent configured for it.
+ *
+ * `frameworkRoot`/`org` are passed straight to loadSlackConfig per target —
+ * callers already have these from the daemon's agent registry, so this
+ * function stays a pure router rather than re-deriving them.
+ */
+export async function dispatchSlackMessage(
+  event: SlackSocketMessageEvent,
+  targets: DispatchTarget[],
+  frameworkRoot: string,
+  org: string,
+  resolveUserName: UserNameResolver,
+): Promise<DispatchResult> {
+  const result: DispatchResult = {
+    delivered: [],
+    skippedNoChannelMatch: false,
+    skippedUserNotAllowed: [],
+  };
+
+  const matchingChannel = targets.filter((t) => {
+    const cfg = loadSlackConfig(frameworkRoot, org, t.name);
+    return !!cfg && cfg.allowed_channels.includes(event.channel);
+  });
+
+  if (matchingChannel.length === 0) {
+    result.skippedNoChannelMatch = true;
+    return result;
+  }
+
+  const displayName = await resolveUserName(event.user);
+
+  for (const target of matchingChannel) {
+    const cfg = loadSlackConfig(frameworkRoot, org, target.name);
+    // cfg is guaranteed non-null here (filtered above), but re-check
+    // narrows the type without a non-null assertion.
+    if (!cfg) continue;
+
+    if (!isSlackUserAllowed(cfg, event.team, event.user)) {
+      result.skippedUserNotAllowed.push(target.name);
+      continue;
+    }
+
+    const formatted = FastChecker.formatSlackTextMessage(
+      displayName,
+      event.channel,
+      event.text,
+      target.name,
+    );
+
+    if (target.checker.isDuplicate(formatted)) continue;
+    target.checker.queueSlackMessage(formatted);
+    result.delivered.push(target.name);
+  }
+
+  return result;
+}
+
+/**
+ * TTL-cached users.info lookup — avoids one Slack API call per message for
+ * frequently-messaging users. Not exported as a class: the daemon holds one
+ * closure-captured cache per SlackAPI instance, same lifetime as the
+ * connection itself.
+ */
+export function makeUserNameResolver(
+  fetchUserInfo: (userId: string) => Promise<{ real_name?: string; name?: string } | null>,
+  ttlMs = 10 * 60 * 1000,
+): UserNameResolver {
+  const cache = new Map<string, { name: string; expiresAt: number }>();
+  return async (userId: string): Promise<string> => {
+    const cached = cache.get(userId);
+    if (cached && cached.expiresAt > Date.now()) return cached.name;
+    let name = userId; // fall back to the raw id if the lookup fails
+    try {
+      const info = await fetchUserInfo(userId);
+      if (info) name = info.real_name || info.name || userId;
+    } catch {
+      /* fall back to raw id — never block delivery on a display-name lookup */
+    }
+    cache.set(userId, { name, expiresAt: Date.now() + ttlMs });
+    return name;
+  };
+}

--- a/src/slack/identity.ts
+++ b/src/slack/identity.ts
@@ -1,0 +1,115 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+
+/** Resolves the on-disk directory for an agent: `orgs/<org>/agents/<name>`. */
+function resolveAgentDir(frameworkRoot: string, org: string, agentName: string): string {
+  return join(frameworkRoot, 'orgs', org, 'agents', agentName);
+}
+
+/**
+ * Per-agent Slack identity override — applied to every chat.postMessage.
+ * Either icon_emoji OR icon_url, not both (Slack honors the first present).
+ */
+export interface SlackIdentity {
+  username: string;
+  icon_emoji?: string;
+  icon_url?: string;
+}
+
+/** Schema of `agents/<name>/slack.json`. */
+export interface SlackConfig {
+  display_name: string;
+  icon_emoji?: string;
+  icon_url?: string;
+  /** Map of purpose ("recap", "ops", "approvals", ...) → channel id (Cxxx). */
+  channels: Record<string, string>;
+  /** Channel ids the agent is allowed to read from (SP3b uses this). */
+  allowed_channels: string[];
+  /**
+   * `"<team_id>:<user_id>"` composite keys allowed to message this agent
+   * (SP3b's fail-closed gate — mirrors Telegram's ALLOWED_USER). Channel
+   * membership alone is too weak a gate: channels are N-member and
+   * membership can change after setup, so an unrecognized identity posting
+   * in an allowed channel is IGNORED, not processed, exactly like an
+   * unrecognized Telegram user id is rejected before ever reaching the
+   * agent. Required (not optional) — a slack.json with an empty or missing
+   * list means the agent accepts messages from NO one, matching Telegram's
+   * fail-closed default when ALLOWED_USER is unset.
+   *
+   * team_id is part of the key, not just user_id: Slack user ids are
+   * workspace-scoped, not globally unique, so user_id alone is not a safe
+   * security key (warden review, SP3b) — this matters most if the Slack app
+   * is ever installed org-wide across an Enterprise Grid (multiple
+   * workspaces can then fan events into one Socket Mode connection).
+   *
+   * NOTE — this list is a single flat allowlist across ALL of this agent's
+   * allowed_channels, not a per-channel map. Correct for a single-channel
+   * agent (e.g. Beau's); a future multi-channel agent needing different
+   * trust levels per channel would need this reworked into a
+   * Record<channelId, string[]> — do not assume today's flat shape implies
+   * "same channel" or "same trust level" without checking allowed_channels'
+   * length first.
+   */
+  allowed_users: string[];
+}
+
+/**
+ * Load the Slack identity override for an agent. Returns null when the agent
+ * has no slack.json — that's the "Slack-disabled" signal and a normal state.
+ */
+export function loadSlackIdentity(
+  frameworkRoot: string,
+  org: string,
+  agentName: string,
+): SlackIdentity | null {
+  const agentDir = resolveAgentDir(frameworkRoot, org, agentName);
+  const path = join(agentDir, 'slack.json');
+  if (!existsSync(path)) return null;
+  let cfg: SlackConfig;
+  try {
+    cfg = JSON.parse(readFileSync(path, 'utf-8'));
+  } catch (e) {
+    throw new Error(`slack.json parse failed for ${agentName}: ${(e as Error).message}`);
+  }
+  const id: SlackIdentity = { username: cfg.display_name };
+  if (cfg.icon_emoji) id.icon_emoji = cfg.icon_emoji;
+  else if (cfg.icon_url) id.icon_url = cfg.icon_url;
+  return id;
+}
+
+/**
+ * Load the full Slack config for an agent (for routing — SP3a doesn't use this,
+ * but identity.ts is the right home for the loader; SP3b's bus dispatcher
+ * imports it.).
+ */
+export function loadSlackConfig(
+  frameworkRoot: string,
+  org: string,
+  agentName: string,
+): SlackConfig | null {
+  const agentDir = resolveAgentDir(frameworkRoot, org, agentName);
+  const path = join(agentDir, 'slack.json');
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, 'utf-8')) as SlackConfig;
+}
+
+/** Builds the `"<team_id>:<user_id>"` composite key used by allowed_users. */
+export function slackIdentityKey(teamId: string, userId: string): string {
+  return `${teamId}:${userId}`;
+}
+
+/**
+ * Fail-closed allowlist check — mirrors Telegram's ALLOWED_USER gate.
+ * Channel membership alone is not a sufficient gate (channels are N-member
+ * and membership drifts after setup), so this is a second, independent
+ * check the dispatcher applies before an inbound Slack message ever reaches
+ * an agent's PTY. A config with a missing or empty `allowed_users` allows
+ * NO one — matching Telegram's posture when ALLOWED_USER is unset — rather
+ * than silently defaulting to "anyone in the channel."
+ *
+ * Keys on team_id+user_id, not user_id alone — see allowed_users' docblock
+ * for why (Slack user ids are workspace-scoped, not globally unique).
+ */
+export function isSlackUserAllowed(config: SlackConfig, teamId: string, userId: string): boolean {
+  return Array.isArray(config.allowed_users) && config.allowed_users.includes(slackIdentityKey(teamId, userId));
+}

--- a/src/slack/index.ts
+++ b/src/slack/index.ts
@@ -1,0 +1,8 @@
+export { SlackAPI } from './api.js';
+export type { PostMessageRequest, PostMessageResponse, Channel, SlackUserInfo } from './api.js';
+export { loadSlackIdentity, loadSlackConfig, isSlackUserAllowed, slackIdentityKey } from './identity.js';
+export type { SlackIdentity, SlackConfig } from './identity.js';
+export { SlackSocketModeClient, openConnectionUrl } from './socket-mode.js';
+export type { SlackSocketMessageEvent, SlackSocketMessageHandler } from './socket-mode.js';
+export { dispatchSlackMessage, makeUserNameResolver } from './dispatcher.js';
+export type { DispatchTarget, DispatchResult, UserNameResolver } from './dispatcher.js';

--- a/src/slack/socket-mode.ts
+++ b/src/slack/socket-mode.ts
@@ -1,0 +1,308 @@
+/**
+ * Slack Socket Mode client — inbound event delivery over a persistent
+ * WebSocket, no public Request URL needed. Uses Node's native global
+ * `WebSocket` (stable, unflagged since Node 22 — see package.json's
+ * engines.node bump alongside this file). No external dependency: Slack's
+ * wss:// URL from apps.connections.open is a one-time ticketed URL, so no
+ * custom auth header is needed on the socket itself (unlike the REST calls
+ * in api.ts, which do need the Bearer app-level token).
+ *
+ * Protocol shape (Slack's Socket Mode docs):
+ *   1. POST apps.connections.open with the app-level (xapp-) token → a
+ *      short-lived wss:// URL. Must be re-requested on every reconnect; the
+ *      URL is single-use and expires.
+ *   2. Server sends a `hello` frame once connected.
+ *   3. Server sends `events_api` envelopes: `{envelope_id, type, payload}`.
+ *      The client MUST ack by sending `{envelope_id}` back within ~3s or
+ *      Slack redelivers the event (possibly over a new connection) — this is
+ *      a transport-layer requirement, independent of whether the event was
+ *      actually processed successfully downstream.
+ *   4. Server may send a `disconnect` frame (reason: "warning" |
+ *      "refresh_requested" | ...) before closing — the client should open a
+ *      NEW connection proactively rather than wait for the close to avoid a
+ *      gap in delivery.
+ *   5. Ping/pong is handled at the WebSocket protocol level by the runtime;
+ *      no JSON-level heartbeat handling is needed. A silence watchdog still
+ *      guards against a connection that's technically open but stopped
+ *      delivering traffic (network black-hole).
+ */
+
+const CONNECTIONS_OPEN_URL = 'https://slack.com/api/apps.connections.open';
+const SILENCE_TIMEOUT_MS = 45_000; // reconnect if nothing received in this window
+const RECONNECT_BASE_DELAY_MS = 1_000;
+const RECONNECT_MAX_DELAY_MS = 30_000;
+
+export interface SlackSocketMessageEvent {
+  type: 'message' | 'app_mention';
+  /**
+   * Workspace id the event belongs to (payload.team_id). Combined with
+   * `user` as a composite identity key everywhere this event is checked
+   * against an allowlist — Slack user ids are workspace-scoped, not
+   * globally unique, so `user` alone is not a safe security key (warden
+   * review, SP3b). Always present: every Socket Mode events_api envelope
+   * carries team_id at the payload level.
+   */
+  team: string;
+  channel: string;
+  user: string;
+  text: string;
+  ts: string;
+  thread_ts?: string;
+}
+
+export type SlackSocketMessageHandler = (event: SlackSocketMessageEvent) => void;
+
+interface EventsApiEnvelope {
+  envelope_id: string;
+  type: 'events_api';
+  payload: {
+    // team_id lives on the payload, NOT nested inside payload.event — easy
+    // to get wrong since every other field of interest is on payload.event.
+    team_id: string;
+    event: {
+      type: string;
+      subtype?: string;
+      bot_id?: string;
+      channel?: string;
+      user?: string;
+      text?: string;
+      ts?: string;
+      thread_ts?: string;
+    };
+  };
+}
+
+interface DisconnectEnvelope {
+  type: 'disconnect';
+  reason?: string;
+}
+
+interface HelloEnvelope {
+  type: 'hello';
+}
+
+type InboundFrame = EventsApiEnvelope | DisconnectEnvelope | HelloEnvelope | { type: string };
+
+/**
+ * Fetch a fresh Socket Mode WebSocket URL. Exported for tests — the real
+ * connection flow always goes through this before opening a socket.
+ */
+export async function openConnectionUrl(appToken: string): Promise<string> {
+  const res = await fetch(CONNECTIONS_OPEN_URL, {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${appToken}` },
+  });
+  const json = (await res.json()) as { ok: boolean; url?: string; error?: string };
+  if (!json.ok || !json.url) {
+    throw new Error(`slack apps.connections.open: ${json.error ?? 'no url returned'}`);
+  }
+  return json.url;
+}
+
+export class SlackSocketModeClient {
+  private appToken: string;
+  private messageHandlers: SlackSocketMessageHandler[] = [];
+  private ws: WebSocket | null = null;
+  private running = false;
+  private reconnectAttempt = 0;
+  private silenceTimer: ReturnType<typeof setTimeout> | null = null;
+  private log: (msg: string) => void;
+
+  /**
+   * Reconnect-hygiene guard (warden review, SP3b): every socket this client
+   * opens is stamped with the epoch that was current when it was created.
+   * Every one of that socket's handlers re-checks `epoch === this.epoch`
+   * before doing anything. When a replacement connection is opened, `epoch`
+   * increments immediately — so the OLD socket's handlers become no-ops the
+   * instant a newer connection exists, regardless of exactly when the old
+   * socket's underlying 'message'/'close' events actually fire. This is a
+   * positive invariant ("is my epoch still current"), not a "did teardown
+   * run in the right order" assumption — the classic hand-rolled-reconnect
+   * bug class is racing exactly that ordering.
+   */
+  private epoch = 0;
+
+  constructor(appToken: string, options: { log?: (msg: string) => void } = {}) {
+    if (!appToken) throw new Error('SlackSocketModeClient: appToken is required');
+    this.appToken = appToken;
+    this.log = options.log || ((msg) => console.log(`[slack-socket-mode] ${msg}`));
+  }
+
+  onMessage(handler: SlackSocketMessageHandler): void {
+    this.messageHandlers.push(handler);
+  }
+
+  async start(): Promise<void> {
+    this.running = true;
+    await this.connect();
+  }
+
+  stop(): void {
+    this.running = false;
+    this.epoch++; // retire whatever socket is currently open
+    this.clearSilenceTimer();
+    this.ws?.close();
+    this.ws = null;
+  }
+
+  private async connect(): Promise<void> {
+    if (!this.running) return;
+    const myEpoch = ++this.epoch; // retires any previously-open socket immediately
+
+    let url: string;
+    try {
+      url = await openConnectionUrl(this.appToken);
+    } catch (err) {
+      this.log(`connections.open failed: ${(err as Error).message}`);
+      this.scheduleReconnect();
+      return;
+    }
+
+    // The epoch could have advanced again while awaiting the HTTP call above
+    // (e.g. stop() was called, or a second reconnect raced in) — bail rather
+    // than open a socket that would be immediately stale.
+    if (myEpoch !== this.epoch || !this.running) return;
+
+    let socket: WebSocket;
+    try {
+      // `new WebSocket(...)` throws synchronously — most notably a bare
+      // `ReferenceError: WebSocket is not defined` if the runtime predates
+      // Node 22 (analyst review, SP3b: the daemon's actual deployed Node
+      // version isn't guaranteed to match package.json's engines floor).
+      // Uncaught here, that exception propagates out of connect() and up
+      // through start() to whatever awaits it — for the daemon's
+      // orchestrator-only Socket Mode bootstrap, that would otherwise crash
+      // agent startup entirely rather than degrade to "Slack inactive."
+      socket = new WebSocket(url);
+    } catch (err) {
+      this.log(`WebSocket construction failed: ${(err as Error).message} — is this runtime on Node >=22?`);
+      this.scheduleReconnect();
+      return;
+    }
+
+    socket.addEventListener('open', () => {
+      if (myEpoch !== this.epoch) return;
+      this.reconnectAttempt = 0;
+      this.armSilenceTimer();
+      this.log('connected');
+    });
+
+    socket.addEventListener('message', (ev: MessageEvent) => {
+      if (myEpoch !== this.epoch) return; // stale socket — see epoch docblock
+      this.armSilenceTimer();
+      this.handleFrame(socket, String(ev.data));
+    });
+
+    socket.addEventListener('close', () => {
+      if (myEpoch !== this.epoch) return; // already superseded — do not reconnect on its behalf
+      this.clearSilenceTimer();
+      this.ws = null;
+      if (this.running) this.scheduleReconnect();
+    });
+
+    socket.addEventListener('error', () => {
+      // 'close' fires after 'error' for a failed connection — reconnect is
+      // scheduled there (guarded by the same epoch check). This handler
+      // exists only so an unhandled 'error' event doesn't crash the process
+      // (native WebSocket emits Event, not an exception).
+    });
+
+    this.ws = socket;
+  }
+
+  /**
+   * Proactively open a replacement connection ahead of a server-initiated
+   * disconnect. Bumping the epoch here (via connect()'s `++this.epoch`)
+   * retires the current socket's handlers immediately — before the old
+   * socket has actually closed — so a frame that arrives on the dying
+   * connection in the gap between "disconnect requested" and "socket
+   * actually closes" is silently dropped rather than processed twice.
+   */
+  private async reconnect(): Promise<void> {
+    await this.connect();
+  }
+
+  private handleFrame(socket: WebSocket, raw: string): void {
+    let frame: InboundFrame;
+    try {
+      frame = JSON.parse(raw) as InboundFrame;
+    } catch {
+      return; // not JSON — ignore
+    }
+
+    if (frame.type === 'hello') {
+      return;
+    }
+
+    if (frame.type === 'disconnect') {
+      this.log(`disconnect requested (reason: ${(frame as DisconnectEnvelope).reason ?? 'unknown'}) — opening replacement`);
+      void this.reconnect();
+      return;
+    }
+
+    if (frame.type === 'events_api') {
+      const envelope = frame as EventsApiEnvelope;
+      // Ack immediately — transport requirement, independent of downstream
+      // processing outcome.
+      try {
+        socket.send(JSON.stringify({ envelope_id: envelope.envelope_id }));
+      } catch {
+        /* socket may have closed between message and ack — the event will
+           be redelivered on reconnect, nothing further to do here */
+      }
+      this.dispatchEvent(envelope.payload.team_id, envelope.payload.event);
+    }
+  }
+
+  private dispatchEvent(teamId: string, event: EventsApiEnvelope['payload']['event']): void {
+    // Exclude bot-authored messages (subtype/bot_id present) to avoid the
+    // bot reacting to its own or another bot's posts, and message_changed/
+    // message_deleted subtypes which aren't new user input.
+    if (event.subtype || event.bot_id) return;
+    if (event.type !== 'message' && event.type !== 'app_mention') return;
+    if (!event.channel || !event.user || event.text === undefined || !event.ts) return;
+    if (!teamId) return;
+
+    const normalized: SlackSocketMessageEvent = {
+      type: event.type,
+      team: teamId,
+      channel: event.channel,
+      user: event.user,
+      text: event.text,
+      ts: event.ts,
+      thread_ts: event.thread_ts,
+    };
+    for (const handler of this.messageHandlers) {
+      try {
+        handler(normalized);
+      } catch (err) {
+        this.log(`message handler error: ${(err as Error).message}`);
+      }
+    }
+  }
+
+  private armSilenceTimer(): void {
+    this.clearSilenceTimer();
+    this.silenceTimer = setTimeout(() => {
+      this.log(`no traffic for ${SILENCE_TIMEOUT_MS}ms — forcing reconnect`);
+      this.ws?.close();
+    }, SILENCE_TIMEOUT_MS);
+  }
+
+  private clearSilenceTimer(): void {
+    if (this.silenceTimer) {
+      clearTimeout(this.silenceTimer);
+      this.silenceTimer = null;
+    }
+  }
+
+  private scheduleReconnect(): void {
+    if (!this.running) return;
+    const delay = Math.min(
+      RECONNECT_BASE_DELAY_MS * 2 ** this.reconnectAttempt,
+      RECONNECT_MAX_DELAY_MS,
+    );
+    this.reconnectAttempt++;
+    setTimeout(() => void this.connect(), delay);
+  }
+}

--- a/templates/agent/CLAUDE.md
+++ b/templates/agent/CLAUDE.md
@@ -97,6 +97,20 @@ Photos include a `local_file:` path. Callbacks include `callback_data:` and `mes
 
 ---
 
+## Slack Messages
+
+If this agent has a `slack.json` configured, it can also be messaged via Slack, same idea as Telegram — inbound messages arrive real-time via the daemon's Socket Mode connection and are injected the same way:
+
+```
+=== SLACK from [USER: <name>] (channel:<id>) ===
+<text>
+Reply using: cortextos slack send <channel> '<your reply>' --as <agent>
+```
+
+Reply with the exact command shown — it posts under this agent's configured Slack identity (display name/icon from `slack.json`). Slack is optional per-agent: no `slack.json` means Slack is simply not active for this agent, Telegram and everything else works as usual. See `docs/runbook/slack-adapter-setup.md` for setup.
+
+---
+
 ## Agent-to-Agent Messages
 
 ```

--- a/templates/analyst/CLAUDE.md
+++ b/templates/analyst/CLAUDE.md
@@ -91,6 +91,20 @@ Photos include a `local_file:` path. Callbacks include `callback_data:` and `mes
 
 ---
 
+## Slack Messages
+
+If this agent has a `slack.json` configured, it can also be messaged via Slack, same idea as Telegram:
+
+```
+=== SLACK from [USER: <name>] (channel:<id>) ===
+<text>
+Reply using: cortextos slack send <channel> '<your reply>' --as <agent>
+```
+
+Reply with the exact command shown. No `slack.json` means Slack is simply inactive for this agent. See `docs/runbook/slack-adapter-setup.md` for setup.
+
+---
+
 ## Agent-to-Agent Messages
 
 ```

--- a/templates/orchestrator/CLAUDE.md
+++ b/templates/orchestrator/CLAUDE.md
@@ -102,6 +102,20 @@ Photos include a `local_file:` path. Callbacks include `callback_data:` and `mes
 
 ---
 
+## Slack Messages
+
+The orchestrator agent is the one that starts the org's shared Slack Socket Mode connection (one connection per org, at orchestrator boot, when `SLACK_BOT_TOKEN` and `SLACK_APP_TOKEN` are both set). If this or any agent in the org has a `slack.json` configured, it can be messaged via Slack, same idea as Telegram:
+
+```
+=== SLACK from [USER: <name>] (channel:<id>) ===
+<text>
+Reply using: cortextos slack send <channel> '<your reply>' --as <agent>
+```
+
+Reply with the exact command shown. Slack is optional: if the org's tokens aren't set, or an agent has no `slack.json`, Slack is simply inactive there and nothing else — Telegram, cron, task dispatch — is affected. See `docs/runbook/slack-adapter-setup.md` for setup.
+
+---
+
 ## Agent-to-Agent Messages
 
 ```

--- a/tests/unit/cli/slack.test.ts
+++ b/tests/unit/cli/slack.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { runTestSend, slackCommand } from '../../../src/cli/slack';
+
+describe('runTestSend', () => {
+  let root: string;
+  let api: { postMessage: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'sp3a-cli-'));
+    api = { postMessage: vi.fn().mockResolvedValue({ ok: true, channel: 'C1', ts: '1' }) };
+  });
+
+  it('posts a test message under the agent identity', async () => {
+    const agentDir = join(root, 'orgs', 'wyre', 'agents', 'boss');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, 'slack.json'),
+      JSON.stringify({
+        display_name: 'boss',
+        icon_emoji: ':robot_face:',
+        channels: {},
+        allowed_channels: [],
+      }),
+    );
+    await runTestSend(
+      { frameworkRoot: root, org: 'wyre', agent: 'boss', channel: 'C1', text: 'hi' },
+      api as never,
+    );
+    expect(api.postMessage).toHaveBeenCalledWith({
+      channel: 'C1',
+      text: 'hi',
+      username: 'boss',
+      icon_emoji: ':robot_face:',
+    });
+  });
+
+  it('posts without identity when --as is omitted', async () => {
+    await runTestSend(
+      { frameworkRoot: root, org: 'wyre', channel: 'C1', text: 'plain' },
+      api as never,
+    );
+    expect(api.postMessage).toHaveBeenCalledWith({ channel: 'C1', text: 'plain' });
+  });
+});
+
+describe('slack send subcommand (SP3b reply path)', () => {
+  it('registers a stable "send" subcommand alongside test-send', () => {
+    const names = slackCommand.commands.map((c) => c.name());
+    expect(names).toContain('send');
+    expect(names).toContain('test-send'); // unchanged — send is additive, not a replacement
+  });
+});

--- a/tests/unit/slack/api.test.ts
+++ b/tests/unit/slack/api.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SlackAPI } from '../../../src/slack/api';
+
+describe('SlackAPI', () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    global.fetch = fetchMock as any;
+  });
+
+  describe('postMessage', () => {
+    it('POSTs to chat.postMessage with the bot token and json body', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: true, channel: 'C1', ts: '1.0' }),
+      });
+      const api = new SlackAPI('xoxb-abc');
+      const res = await api.postMessage({ channel: 'C1', text: 'hello' });
+      expect(res).toEqual({ ok: true, channel: 'C1', ts: '1.0' });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://slack.com/api/chat.postMessage',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer xoxb-abc',
+            'Content-Type': 'application/json; charset=utf-8',
+          }),
+          body: JSON.stringify({ channel: 'C1', text: 'hello' }),
+        }),
+      );
+    });
+
+    it('throws on Slack API error (ok=false)', async () => {
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => ({ ok: false, error: 'channel_not_found' }),
+      });
+      const api = new SlackAPI('xoxb-abc');
+      await expect(api.postMessage({ channel: 'C1', text: 'x' })).rejects.toThrow(
+        /channel_not_found/,
+      );
+    });
+
+    it('passes through username and icon_emoji overrides', async () => {
+      fetchMock.mockResolvedValue({ ok: true, json: async () => ({ ok: true, channel: 'C1', ts: '1' }) });
+      const api = new SlackAPI('xoxb-abc');
+      await api.postMessage({
+        channel: 'C1', text: 'hi', username: 'boss', icon_emoji: ':robot_face:',
+      });
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      expect(body.username).toBe('boss');
+      expect(body.icon_emoji).toBe(':robot_face:');
+    });
+  });
+
+  describe('listChannels', () => {
+    it('paginates with next_cursor until empty', async () => {
+      fetchMock
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            channels: [{ id: 'C1', name: 'general' }],
+            response_metadata: { next_cursor: 'CURSOR' },
+          }),
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            ok: true,
+            channels: [{ id: 'C2', name: 'random' }],
+            response_metadata: { next_cursor: '' },
+          }),
+        });
+      const api = new SlackAPI('xoxb-abc');
+      const channels = await api.listChannels();
+      expect(channels.map((c) => c.id)).toEqual(['C1', 'C2']);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/tests/unit/slack/dispatcher.test.ts
+++ b/tests/unit/slack/dispatcher.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { dispatchSlackMessage, makeUserNameResolver, type DispatchTarget } from '../../../src/slack/dispatcher';
+import type { SlackSocketMessageEvent } from '../../../src/slack/socket-mode';
+import { FastChecker } from '../../../src/daemon/fast-checker';
+
+// A minimal fake standing in for FastChecker — the dispatcher only calls
+// isDuplicate() and queueSlackMessage() on its targets, so a real FastChecker
+// (which needs a real AgentProcess + BusPaths) would be unnecessary
+// machinery for testing pure routing logic.
+class FakeChecker {
+  queued: string[] = [];
+  private seen = new Set<string>();
+  isDuplicate(text: string): boolean {
+    if (this.seen.has(text)) return true;
+    this.seen.add(text);
+    return false;
+  }
+  queueSlackMessage(formatted: string): void {
+    this.queued.push(formatted);
+  }
+}
+
+function makeAgent(root: string, name: string, slackJson: object): void {
+  const dir = join(root, 'orgs', 'wyre', 'agents', name);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'slack.json'), JSON.stringify(slackJson));
+}
+
+const noopResolver = async (userId: string) => `name-${userId}`;
+
+describe('dispatchSlackMessage', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'sp3b-dispatch-'));
+  });
+
+  const baseEvent: SlackSocketMessageEvent = {
+    type: 'message',
+    team: 'T1',
+    channel: 'C1',
+    user: 'U1',
+    text: 'hello',
+    ts: '1.1',
+  };
+
+  it('delivers to a single agent whose slack.json matches both channel and user', async () => {
+    makeAgent(root, 'boss', {
+      display_name: 'boss', channels: {}, allowed_channels: ['C1'], allowed_users: ['T1:U1'],
+    });
+    const checker = new FakeChecker();
+    const targets: DispatchTarget[] = [{ name: 'boss', checker: checker as unknown as FastChecker }];
+
+    const result = await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+
+    expect(result.delivered).toEqual(['boss']);
+    expect(checker.queued).toHaveLength(1);
+    expect(checker.queued[0]).toContain('=== SLACK from [USER: name-U1] (channel:C1) ===');
+  });
+
+  it('delivers to ALL matching agents when multiple agents watch the same channel (N:1)', async () => {
+    makeAgent(root, 'boss', { display_name: 'boss', channels: {}, allowed_channels: ['C1'], allowed_users: ['T1:U1'] });
+    makeAgent(root, 'dev', { display_name: 'dev', channels: {}, allowed_channels: ['C1'], allowed_users: ['T1:U1'] });
+    const bossChecker = new FakeChecker();
+    const devChecker = new FakeChecker();
+    const targets: DispatchTarget[] = [
+      { name: 'boss', checker: bossChecker as unknown as FastChecker },
+      { name: 'dev', checker: devChecker as unknown as FastChecker },
+    ];
+
+    const result = await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+
+    expect(result.delivered.sort()).toEqual(['boss', 'dev']);
+    expect(bossChecker.queued).toHaveLength(1);
+    expect(devChecker.queued).toHaveLength(1);
+  });
+
+  it('skips an agent whose slack.json does not include the channel', async () => {
+    makeAgent(root, 'boss', { display_name: 'boss', channels: {}, allowed_channels: ['C-OTHER'], allowed_users: ['T1:U1'] });
+    const checker = new FakeChecker();
+    const targets: DispatchTarget[] = [{ name: 'boss', checker: checker as unknown as FastChecker }];
+
+    const result = await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+
+    expect(result.delivered).toEqual([]);
+    expect(result.skippedNoChannelMatch).toBe(true);
+    expect(checker.queued).toHaveLength(0);
+  });
+
+  it('fail-closed: skips an agent whose channel matches but user is NOT in allowed_users', async () => {
+    makeAgent(root, 'boss', { display_name: 'boss', channels: {}, allowed_channels: ['C1'], allowed_users: ['T1:U-SOMEONE-ELSE'] });
+    const checker = new FakeChecker();
+    const targets: DispatchTarget[] = [{ name: 'boss', checker: checker as unknown as FastChecker }];
+
+    const result = await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+
+    expect(result.delivered).toEqual([]);
+    expect(result.skippedUserNotAllowed).toEqual(['boss']);
+    expect(checker.queued).toHaveLength(0);
+  });
+
+  it('fail-closed: the SAME user_id from a DIFFERENT team is rejected (composite key)', async () => {
+    makeAgent(root, 'boss', { display_name: 'boss', channels: {}, allowed_channels: ['C1'], allowed_users: ['T-DIFFERENT:U1'] });
+    const checker = new FakeChecker();
+    const targets: DispatchTarget[] = [{ name: 'boss', checker: checker as unknown as FastChecker }];
+
+    // baseEvent.team is 'T1', not 'T-DIFFERENT' — same user id, wrong workspace.
+    const result = await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+
+    expect(result.delivered).toEqual([]);
+    expect(result.skippedUserNotAllowed).toEqual(['boss']);
+  });
+
+  it('respects per-agent dedup — the same event queued twice for one agent is queued once', async () => {
+    makeAgent(root, 'boss', { display_name: 'boss', channels: {}, allowed_channels: ['C1'], allowed_users: ['T1:U1'] });
+    const checker = new FakeChecker();
+    const targets: DispatchTarget[] = [{ name: 'boss', checker: checker as unknown as FastChecker }];
+
+    await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+    const second = await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+
+    expect(checker.queued).toHaveLength(1);
+    expect(second.delivered).toEqual([]); // deduped, not "delivered" a second time
+  });
+
+  it('skips an agent with no slack.json entirely', async () => {
+    // no makeAgent() call for 'dev' — no slack.json on disk
+    const checker = new FakeChecker();
+    const targets: DispatchTarget[] = [{ name: 'dev', checker: checker as unknown as FastChecker }];
+
+    const result = await dispatchSlackMessage(baseEvent, targets, root, 'wyre', noopResolver);
+
+    expect(result.delivered).toEqual([]);
+    expect(checker.queued).toHaveLength(0);
+  });
+});
+
+describe('makeUserNameResolver', () => {
+  it('resolves and caches a user name, calling the underlying fetch only once', async () => {
+    let calls = 0;
+    const resolver = makeUserNameResolver(async (userId) => {
+      calls++;
+      return { real_name: `Real ${userId}` };
+    });
+
+    const first = await resolver('U1');
+    const second = await resolver('U1');
+
+    expect(first).toBe('Real U1');
+    expect(second).toBe('Real U1');
+    expect(calls).toBe(1);
+  });
+
+  it('falls back to name when real_name is absent', async () => {
+    const resolver = makeUserNameResolver(async () => ({ name: 'shortname' }));
+    expect(await resolver('U1')).toBe('shortname');
+  });
+
+  it('falls back to the raw user id when the lookup throws', async () => {
+    const resolver = makeUserNameResolver(async () => {
+      throw new Error('users.info failed');
+    });
+    expect(await resolver('U1')).toBe('U1');
+  });
+
+  it('falls back to the raw user id when the lookup returns null', async () => {
+    const resolver = makeUserNameResolver(async () => null);
+    expect(await resolver('U1')).toBe('U1');
+  });
+});

--- a/tests/unit/slack/identity.test.ts
+++ b/tests/unit/slack/identity.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { loadSlackIdentity, isSlackUserAllowed, slackIdentityKey, type SlackConfig } from '../../../src/slack/identity';
+
+function makeAgent(root: string, name: string, slackJson?: object): string {
+  const dir = join(root, 'orgs', 'wyre', 'agents', name);
+  mkdirSync(dir, { recursive: true });
+  if (slackJson) writeFileSync(join(dir, 'slack.json'), JSON.stringify(slackJson));
+  return dir;
+}
+
+describe('loadSlackIdentity', () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'sp3a-id-'));
+  });
+
+  it('returns display_name + icon_emoji from slack.json', () => {
+    makeAgent(root, 'boss', {
+      display_name: 'boss',
+      icon_emoji: ':robot_face:',
+      channels: { recap: 'C01' },
+      allowed_channels: ['C01'],
+    });
+    const id = loadSlackIdentity(root, 'wyre', 'boss');
+    expect(id).toEqual({ username: 'boss', icon_emoji: ':robot_face:' });
+  });
+
+  it('returns icon_url when slack.json has it instead of icon_emoji', () => {
+    makeAgent(root, 'analyst', {
+      display_name: 'analyst',
+      icon_url: 'https://example.com/a.png',
+      channels: {},
+      allowed_channels: [],
+    });
+    const id = loadSlackIdentity(root, 'wyre', 'analyst');
+    expect(id).toEqual({ username: 'analyst', icon_url: 'https://example.com/a.png' });
+  });
+
+  it('returns null when slack.json is absent (agent is Slack-disabled)', () => {
+    makeAgent(root, 'dev'); // no slack.json
+    expect(loadSlackIdentity(root, 'wyre', 'dev')).toBeNull();
+  });
+
+  it('throws on malformed slack.json', () => {
+    const dir = makeAgent(root, 'broken');
+    writeFileSync(join(dir, 'slack.json'), '{ not json');
+    expect(() => loadSlackIdentity(root, 'wyre', 'broken')).toThrow(/parse/i);
+  });
+});
+
+describe('slackIdentityKey', () => {
+  it('composes team_id and user_id into a single key', () => {
+    expect(slackIdentityKey('T123', 'U456')).toBe('T123:U456');
+  });
+
+  it('does not collide across teams for the same user_id (the bug the composite key prevents)', () => {
+    expect(slackIdentityKey('T-A', 'U-SAME')).not.toBe(slackIdentityKey('T-B', 'U-SAME'));
+  });
+});
+
+describe('isSlackUserAllowed', () => {
+  const baseConfig: SlackConfig = {
+    display_name: 'test',
+    channels: {},
+    allowed_channels: ['C1'],
+    allowed_users: ['T1:U1', 'T1:U2'],
+  };
+
+  it('true for a team_id+user_id pair in allowed_users', () => {
+    expect(isSlackUserAllowed(baseConfig, 'T1', 'U1')).toBe(true);
+  });
+
+  it('false for a user_id not in allowed_users', () => {
+    expect(isSlackUserAllowed(baseConfig, 'T1', 'U999')).toBe(false);
+  });
+
+  it('false when the user_id matches but the team_id does not (cross-workspace collision guard)', () => {
+    expect(isSlackUserAllowed(baseConfig, 'T-OTHER', 'U1')).toBe(false);
+  });
+
+  it('fail-closed: false when allowed_users is empty', () => {
+    expect(isSlackUserAllowed({ ...baseConfig, allowed_users: [] }, 'T1', 'U1')).toBe(false);
+  });
+
+  it('fail-closed: false when allowed_users is missing entirely', () => {
+    const cfg = { ...baseConfig } as Partial<SlackConfig>;
+    delete cfg.allowed_users;
+    expect(isSlackUserAllowed(cfg as SlackConfig, 'T1', 'U1')).toBe(false);
+  });
+});

--- a/tests/unit/slack/socket-mode.test.ts
+++ b/tests/unit/slack/socket-mode.test.ts
@@ -1,0 +1,302 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { SlackSocketModeClient, openConnectionUrl } from '../../../src/slack/socket-mode';
+
+/**
+ * Minimal fake matching the subset of the native WebSocket API socket-mode.ts
+ * uses (addEventListener for open/message/close/error, send, close). Each
+ * `new WebSocket(url)` call in the client under test produces one of these;
+ * tests drive its lifecycle explicitly via the emit* helpers.
+ */
+class FakeWebSocket {
+  static instances: FakeWebSocket[] = [];
+  url: string;
+  sent: string[] = [];
+  closed = false;
+  private listeners: Record<string, Array<(ev: unknown) => void>> = {};
+
+  constructor(url: string) {
+    this.url = url;
+    FakeWebSocket.instances.push(this);
+  }
+
+  addEventListener(type: string, handler: (ev: unknown) => void): void {
+    (this.listeners[type] ??= []).push(handler);
+  }
+
+  send(data: string): void {
+    if (this.closed) throw new Error('socket is closed');
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.closed = true;
+    this.emit('close', {});
+  }
+
+  emit(type: string, ev: unknown): void {
+    for (const h of this.listeners[type] ?? []) h(ev);
+  }
+
+  emitMessage(data: unknown): void {
+    this.emit('message', { data: JSON.stringify(data) });
+  }
+}
+
+function resetFakes(): void {
+  FakeWebSocket.instances = [];
+}
+
+/** Flush the pending microtask chain (a real macrotask tick flushes all queued microtasks first). */
+function flushAsync(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+describe('openConnectionUrl', () => {
+  beforeEach(() => {
+    global.fetch = vi.fn() as unknown as typeof fetch;
+  });
+
+  it('POSTs to apps.connections.open with the app-level token and returns the url', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: async () => ({ ok: true, url: 'wss://example.com/link' }),
+    });
+    const url = await openConnectionUrl('xapp-1');
+    expect(url).toBe('wss://example.com/link');
+    expect(global.fetch).toHaveBeenCalledWith(
+      'https://slack.com/api/apps.connections.open',
+      expect.objectContaining({
+        method: 'POST',
+        headers: { Authorization: 'Bearer xapp-1' },
+      }),
+    );
+  });
+
+  it('throws when Slack returns ok:false', async () => {
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValue({
+      json: async () => ({ ok: false, error: 'invalid_auth' }),
+    });
+    await expect(openConnectionUrl('xapp-bad')).rejects.toThrow(/invalid_auth/);
+  });
+});
+
+describe('SlackSocketModeClient', () => {
+  beforeEach(() => {
+    resetFakes();
+    global.fetch = vi.fn().mockResolvedValue({
+      json: async () => ({ ok: true, url: 'wss://example.com/link' }),
+    }) as unknown as typeof fetch;
+    global.WebSocket = FakeWebSocket as unknown as typeof WebSocket;
+  });
+
+  it('acks an events_api envelope immediately, before dispatching', async () => {
+    const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+    const received: unknown[] = [];
+    client.onMessage((e) => received.push(e));
+    await client.start();
+
+    const socket = FakeWebSocket.instances[0];
+    socket.emitMessage({
+      envelope_id: 'env-1',
+      type: 'events_api',
+      payload: {
+        team_id: 'T1',
+        event: { type: 'message', channel: 'C1', user: 'U1', text: 'hi', ts: '1.1' },
+      },
+    });
+
+    expect(socket.sent).toEqual([JSON.stringify({ envelope_id: 'env-1' })]);
+    expect(received).toEqual([
+      { type: 'message', team: 'T1', channel: 'C1', user: 'U1', text: 'hi', ts: '1.1', thread_ts: undefined },
+    ]);
+  });
+
+  it('excludes bot-authored messages (bot_id present)', async () => {
+    const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+    const received: unknown[] = [];
+    client.onMessage((e) => received.push(e));
+    await client.start();
+
+    FakeWebSocket.instances[0].emitMessage({
+      envelope_id: 'env-1',
+      type: 'events_api',
+      payload: {
+        team_id: 'T1',
+        event: { type: 'message', channel: 'C1', user: 'U1', text: 'hi', ts: '1.1', bot_id: 'B1' },
+      },
+    });
+
+    expect(received).toEqual([]);
+  });
+
+  it('excludes message subtypes (edits, joins, etc.)', async () => {
+    const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+    const received: unknown[] = [];
+    client.onMessage((e) => received.push(e));
+    await client.start();
+
+    FakeWebSocket.instances[0].emitMessage({
+      envelope_id: 'env-1',
+      type: 'events_api',
+      payload: {
+        team_id: 'T1',
+        event: { type: 'message', channel: 'C1', user: 'U1', text: 'hi', ts: '1.1', subtype: 'message_changed' },
+      },
+    });
+
+    expect(received).toEqual([]);
+  });
+
+  it('accepts app_mention events', async () => {
+    const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+    const received: unknown[] = [];
+    client.onMessage((e) => received.push(e));
+    await client.start();
+
+    FakeWebSocket.instances[0].emitMessage({
+      envelope_id: 'env-1',
+      type: 'events_api',
+      payload: {
+        team_id: 'T1',
+        event: { type: 'app_mention', channel: 'C1', user: 'U1', text: '<@BOT> hi', ts: '1.1' },
+      },
+    });
+
+    expect(received).toHaveLength(1);
+  });
+
+  it('ignores non-message/app_mention event types', async () => {
+    const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+    const received: unknown[] = [];
+    client.onMessage((e) => received.push(e));
+    await client.start();
+
+    FakeWebSocket.instances[0].emitMessage({
+      envelope_id: 'env-1',
+      type: 'events_api',
+      payload: { team_id: 'T1', event: { type: 'reaction_added', channel: 'C1', user: 'U1' } },
+    });
+
+    expect(received).toEqual([]);
+  });
+
+  it('ignores a hello frame without error', async () => {
+    const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+    await client.start();
+    expect(() => FakeWebSocket.instances[0].emitMessage({ type: 'hello' })).not.toThrow();
+  });
+
+  it('ignores non-JSON frames without error', async () => {
+    const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+    await client.start();
+    const socket = FakeWebSocket.instances[0];
+    expect(() => socket.emit('message', { data: 'not json' })).not.toThrow();
+  });
+
+  describe('reconnect hygiene (warden review)', () => {
+    it('on a disconnect frame, opens a replacement connection', async () => {
+      const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+      await client.start();
+      expect(FakeWebSocket.instances).toHaveLength(1);
+
+      FakeWebSocket.instances[0].emitMessage({ type: 'disconnect', reason: 'refresh_requested' });
+      // connect() awaits openConnectionUrl (a resolved-immediately mock
+      // here) before constructing the new socket — flush the pending
+      // microtask chain via a real macrotask tick.
+      await flushAsync();
+
+      expect(FakeWebSocket.instances).toHaveLength(2);
+    });
+
+    it('a frame arriving on the OLD socket after a new connection is active is dropped, not processed', async () => {
+      const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+      const received: unknown[] = [];
+      client.onMessage((e) => received.push(e));
+      await client.start();
+
+      const oldSocket = FakeWebSocket.instances[0];
+      oldSocket.emitMessage({ type: 'disconnect', reason: 'refresh_requested' });
+      await flushAsync();
+      expect(FakeWebSocket.instances).toHaveLength(2);
+
+      // The old (now-superseded) socket receives one more frame before it
+      // actually finishes closing — exactly the race warden flagged. This
+      // MUST be dropped by the epoch guard, not delivered to handlers.
+      oldSocket.emitMessage({
+        envelope_id: 'stale-env',
+        type: 'events_api',
+        payload: {
+          team_id: 'T1',
+          event: { type: 'message', channel: 'C1', user: 'U1', text: 'stale', ts: '1.1' },
+        },
+      });
+
+      expect(received).toEqual([]);
+      // And it must not have even sent an ack — the frame was dropped
+      // before doing anything, including the transport-level ack.
+      expect(oldSocket.sent).toEqual([]);
+
+      // The NEW socket, meanwhile, is fully live and processes normally.
+      const newSocket = FakeWebSocket.instances[1];
+      newSocket.emitMessage({
+        envelope_id: 'live-env',
+        type: 'events_api',
+        payload: {
+          team_id: 'T1',
+          event: { type: 'message', channel: 'C1', user: 'U1', text: 'live', ts: '1.2' },
+        },
+      });
+      expect(received).toHaveLength(1);
+    });
+
+    it("a close event on the OLD (superseded) socket does not trigger a second reconnect", async () => {
+      const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+      await client.start();
+
+      const oldSocket = FakeWebSocket.instances[0];
+      oldSocket.emitMessage({ type: 'disconnect', reason: 'refresh_requested' });
+      await flushAsync();
+      expect(FakeWebSocket.instances).toHaveLength(2);
+
+      // Slack now actually closes the old socket. Its close handler is
+      // epoch-guarded and must NOT schedule yet another reconnect.
+      oldSocket.close();
+      // If a spurious reconnect were scheduled it would be via a real
+      // setTimeout (reconnectAttempt backoff) — nothing to await
+      // synchronously, but no THIRD socket should ever appear from this.
+      expect(FakeWebSocket.instances).toHaveLength(2);
+    });
+
+    it('stop() retires the current socket and no reconnect follows its close', async () => {
+      const client = new SlackSocketModeClient('xapp-1', { log: () => {} });
+      await client.start();
+      const socket = FakeWebSocket.instances[0];
+
+      client.stop();
+      expect(socket.closed).toBe(true);
+      expect(FakeWebSocket.instances).toHaveLength(1); // no reconnect socket appeared
+    });
+  });
+
+  describe('WebSocket construction failure (analyst review — Node<22 has no global WebSocket)', () => {
+    it('a throwing WebSocket constructor (e.g. ReferenceError: WebSocket is not defined) does not propagate out of start()', async () => {
+      global.WebSocket = class {
+        constructor() {
+          throw new ReferenceError('WebSocket is not defined');
+        }
+      } as unknown as typeof WebSocket;
+
+      const logs: string[] = [];
+      const client = new SlackSocketModeClient('xapp-1', { log: (m) => logs.push(m) });
+
+      // The whole point: start() must resolve, not reject/throw, even though
+      // the underlying WebSocket constructor is fatal on this runtime.
+      await expect(client.start()).resolves.toBeUndefined();
+      expect(logs.some((l) => l.includes('WebSocket construction failed'))).toBe(true);
+      expect(logs.some((l) => l.includes('Node >=22'))).toBe(true);
+
+      // The failure path scheduled a real reconnect setTimeout — stop() so
+      // it doesn't fire against a later test's global.WebSocket.
+      client.stop();
+    });
+  });
+});


### PR DESCRIPTION
Adds Slack as a second messaging surface for cortextOS agents, alongside the existing Telegram integration.

## What this adds

- **Socket Mode inbound + Web API outbound** (`src/slack/`): one shared WebSocket connection per org (Slack apps are workspace-scoped, unlike Telegram's per-agent bot), fail-closed `allowed_users` gate keyed on `team_id:user_id` composite identity (Slack user IDs are workspace-scoped, not globally unique — plain `user_id` alone is not a safe allowlist key).
- **Non-blocking startup**: a Slack outage, bad token, or Socket Mode failure can never block orchestrator boot — construction and `.start()` are both wrapped defensively, matching the existing `maybeStartActivityChannelPoller` isolation contract.
- **CLI**: `cortextos slack send`, `test-send`, `discover-channels`.
- **Bus entry point**: `bus/send-slack.sh`, so the injected "Reply using:" line can post back to Slack the same way it does for Telegram.
- **Daemon wiring**: `queueSlackMessage`/`formatSlackTextMessage` in `fast-checker.ts` (parallel queue to Telegram's, same dedup logic reused unmodified) and `maybeStartSlackSocketMode` in `agent-manager.ts` (org-level singleton, orchestrator-only start).
- **Setup runbook**: `docs/runbook/slack-adapter-setup.md` — creating a Slack app with Socket Mode, required bot scopes, per-agent `slack.json` schema, env vars, verification via `test-send`/`discover-channels`.
- **Agent Awareness Standard compliance** (per CONTRIBUTING.md): `templates/agent/CLAUDE.md`, `templates/orchestrator/CLAUDE.md`, and `templates/analyst/CLAUDE.md` all document the new Slack messaging path with usage examples.
- **`engines.node` bumped `>=20` → `>=22`**: Socket Mode uses Node's native `WebSocket` global, stable and unflagged since Node 22 (confirmed `typeof WebSocket === 'undefined'` on Node 18.x/20.x). No new runtime dependency for the WebSocket transport itself.

## Design notes

- Channels are N:1 (multiple members can message an agent's channel), unlike Telegram's 1:1 bot relationship — the dispatcher delivers to every agent whose `slack.json` matches both the channel and the sender's identity, not just the first match.
- `allowed_users` is a flat allowlist across all of an agent's `allowed_channels`, not a per-channel map — documented as a known limitation in `identity.ts`'s docblock for a future multi-channel-with-different-trust-levels agent to revisit.
- A missing or empty `allowed_users` list allows **no one** — matches Telegram's fail-closed default when `ALLOWED_USER` is unset, rather than silently trusting anyone in the channel.

## Testing

- `npx tsc --noEmit` — clean.
- New Slack-specific tests: 43/43 passing (`tests/unit/slack/*`, `tests/unit/cli/slack.test.ts`).
- Daemon wiring coverage: 88/88 passing (`tests/unit/daemon/agent-manager.test.ts`, `tests/unit/daemon/fast-checker.test.ts`).
- Full suite: 2072 passing. Two pre-existing failures (`tests/unit/lifecycle/status-schema.test.ts` — missing `ajv` devDependency; one symlink-hardening case in `tests/unit/hooks/hooks.test.ts`) reproduce identically on a clean `main` checkout with none of this PR's changes applied — unrelated to this change, noting for visibility rather than silently leaving unmentioned.
- `npm run build` — succeeds.

## Not in scope for this PR

Matches Telegram's original MVP scope rather than shipping every Slack feature at once: no Block Kit / interactive components, no file uploads, no reactions/threading beyond what's needed for basic message delivery. Can follow in a subsequent PR if there's interest.
