### PR TITLE
feat(daemon): replay missed Telegram + stale-task/downtime warnings on session start (theta 63)

### DIFF
--- a/docs/architecture/telegram-replay-session-start.md
+++ b/docs/architecture/telegram-replay-session-start.md
@@ -121,17 +121,18 @@ Does NOT auto-reopen, auto-complete, or auto-drop. Only signals.
 
 ### Part 3 — Downtime detection helper
 
-New file `state/<agent>/last-alive.txt` — single ISO timestamp, updated by fast-checker on every successful tick (piggyback on existing heartbeat/tick).
+Reuse the **existing** liveness signal `state/<agent>/heartbeat.json` (`last_heartbeat`, an ISO timestamp already refreshed on every `logEvent` and on `update-heartbeat`) rather than introducing a new `last-alive.txt` written on every fast-checker tick. This avoids a redundant ~1 Hz write path and a second liveness source that could drift from the canonical one.
 
-Read on session start; if `now - last_alive > 4h`, we're recovering from real downtime. Feeds Part 1's downtime warning and can be reused for future observability.
+Read `last_heartbeat` on session start; if `now - last_heartbeat > 4h`, we're recovering from real downtime. Feeds Part 1's downtime warning. Missing/unparseable heartbeat → treat downtime as 0 (no false alarm).
 
 ---
 
 ## Edge cases
 
 - **Cross-chat ordering:** sort by `archived_at` ASC preserves chronology across chats.
-- **Media messages:** existing formatter (`formatTelegramForInjection`) handles photo/voice/document/video — replay reuses it. No new code path.
-- **Double-inject on crash mid-cursor-flush:** atomic write via `atomicWriteSync`. If the process still crashes after inject and before flush, next replay resurfaces the same message — agent should treat message_id as idempotency key (see `agent.injectMessage` dedup path).
+- **Media messages:** the live FastChecker media formatters need the *downloaded local file path*, but the archive stores only `file_id`/`file_name`/`mime_type` — the downloaded file is fetched live and is likely gone after a downtime window. So replay uses a dedicated `[REPLAYED]` formatter that surfaces media as a note (type + file name + caption + "not re-downloaded — ask sender to resend"). Text messages replay in full. There is no reuse of the live media formatters.
+- **Dedup bypass (salt):** replayed injects are prefixed `[REPLAYED <archived_at>]`. This is required — a byte-identical re-inject would be silently swallowed by BOTH dedup layers (`AgentProcess` in-memory `MessageDedup` + FastChecker's persistent SHA-256 `.message-dedup-hashes`). The per-message `archived_at` also makes each replayed line unique.
+- **Double-inject on crash mid-cursor-flush:** atomic write via `atomicWriteSync`. On a write failure (e.g. ENOSPC) replay halts after the current inject and does NOT advance the cursor; the next start re-processes from the last durable watermark — agent should treat `message_id` as idempotency key.
 - **PTY not ready:** replay only fires AFTER PTY spawn-ready signal. If PTY dies mid-replay, cursor advances only for successfully-injected entries; next restart resumes.
 - **Chat_id types:** JSON key normalization — always cast `chat_id` to string when reading/writing cursor to avoid `-100...` int drift.
 - **First-time boot:** no cursor file, no archive → skip both replay and warn (both no-op cleanly).

--- a/docs/architecture/telegram-replay-session-start.md
+++ b/docs/architecture/telegram-replay-session-start.md
@@ -1,0 +1,272 @@
+# Telegram Replay + Stale-Task Warning on Session Start
+
+**Status:** Design — not yet implemented
+**Priority:** High (silent message loss with real client impact; theta 63 primary deliverable)
+**Owner:** develop (implementation), analyst (design), gc-admin (first live-verify target)
+**Last updated:** 2026-08-13
+**Related:** theta 63, `project_telegram_loss_on_restart`
+
+---
+
+## Problem
+
+`fast-checker` injects Telegram messages into the agent's live PTY as they arrive. Every inbound message is durably archived to `logs/<agent>/inbound-messages.jsonl` via `recordInboundTelegram()` (`src/telegram/logging.ts:89`). But if the PTY is not alive at inject time — during a stop/restart/crash-recovery window — the archive lands and the injection is dropped. There is no replay on session start.
+
+`check-inbox` covers agent-to-agent bus messages only, not Telegram.
+
+**Live impact — 2026-08-13, gc-admin:** during a ~1h downtime window, 2 HelpDesk manager requests + 3 David DMs were archived but never surfaced. Discovered post-restart by manual heartbeat-cycle scan. Two of the requests had delivery-delay before response: 3.7h and 1.8h.
+
+**Adjacent problem — orphaned in_progress tasks:** the same restart can leave a task in `in_progress` with artifacts on disk and no reply to the requester. There is no session-start signal to the agent about stale in-progress work.
+
+---
+
+## Root cause
+
+1. `fast-checker.ts` polls Telegram and injects on arrival — pure push model, no persistent watermark.
+2. `inbound-messages.jsonl` exists purely as an audit log; nothing reads it back.
+3. Task state carries `updated_at`, but no reminder mechanism surfaces stale in-progress items on session start.
+
+---
+
+## Proposed fix — three parts, one PR
+
+### Part 1 — Watermark replay of missed Telegram messages
+
+New persistence:
+```
+state/<agent>/telegram-cursor.json
+{
+  "<chat_id_str>": <last_processed_message_id>,
+  ...
+}
+```
+
+New session-start hook (fires after PTY is spawn-ready but before first Telegram poll):
+
+```typescript
+async function replayMissedTelegram(agent: AgentContext): Promise<void> {
+  const cursor = readCursor(agent);                             // {} if missing
+  const now = Date.now();
+  const window24hAgo = now - 24 * 3600 * 1000;
+  const perChatCap = 100;
+
+  const entries = tailScanInbound(agent);                        // parsed jsonl objects
+  const missed = entries
+    .filter(e => (cursor[String(e.chat_id)] ?? 0) < e.message_id)
+    .filter(e => Date.parse(e.archived_at) >= window24hAgo)
+    .sort((a, b) => a.archived_at.localeCompare(b.archived_at));
+
+  // Per-chat cap: keep the LAST `perChatCap` entries per chat_id (freshest).
+  const capped = capPerChat(missed, perChatCap);
+
+  if (capped.length === 0) {
+    initCursorIfMissing(agent, entries);                         // start-from-now
+    return;
+  }
+
+  // Downtime detection: if the gap between now and last-alive marker > 4h, emit
+  // one warning BEFORE replay so the agent sees the scope.
+  const downtimeH = detectDowntime(agent, now);
+  if (downtimeH > 4) {
+    agent.injectMessage(
+      `[STARTUP] Detected ${downtimeH.toFixed(1)}h downtime. Replaying ${capped.length} missed Telegram message(s) (bounded to last 24h, ${perChatCap}/chat).`
+    );
+  }
+
+  for (const entry of capped) {
+    const formatted = formatTelegramForInjection(entry);         // reuse existing formatter
+    if (agent.injectMessage(formatted)) {
+      cursor[String(entry.chat_id)] = entry.message_id;
+      writeCursorAtomic(agent, cursor);
+      emitEvent('telegram_replayed', {
+        chat_id: entry.chat_id,
+        message_id: entry.message_id,
+        archived_at: entry.archived_at,
+      });
+    }
+  }
+}
+```
+
+Bounds:
+- **Time cap:** entries older than 24h are skipped. Prevents avalanche after multi-day downtime.
+- **Count cap:** at most 100 per `chat_id`. Prevents avalanche when one chat has a huge burst backlog.
+- **First run:** no cursor file → treat as "start-from-now"; write current max message_id per chat, skip replay.
+
+Live-inject path (unchanged) also updates the cursor on each successful inject so live and replay use the same source of truth.
+
+### Part 2 — Stale in-progress task warning
+
+New session-start hook (fires alongside Part 1):
+
+```typescript
+async function warnStaleTasks(agent: AgentContext, thresholdHours = 2): Promise<void> {
+  const cutoff = Date.now() - thresholdHours * 3600 * 1000;
+  const inProg = listTasks(agent, { status: 'in_progress' });
+  const stale = inProg.filter(t => Date.parse(t.updated_at) < cutoff);
+  if (stale.length === 0) return;
+
+  const ids = stale.slice(0, 10).map(t => t.id).join(', ');
+  const more = stale.length > 10 ? ` (+${stale.length - 10} more)` : '';
+  agent.injectMessage(
+    `[STALE-TASKS] ${stale.length} in-progress task(s) with updated_at > ${thresholdHours}h ago: ${ids}${more}. Review — decide to resume, complete, or drop.`
+  );
+  emitEvent('stale_tasks_warned', { count: stale.length });
+}
+```
+
+Threshold `thresholdHours` is a config knob per agent, defaulting to 2 (tuneable if false-positives on long-running work).
+
+Does NOT auto-reopen, auto-complete, or auto-drop. Only signals.
+
+### Part 3 — Downtime detection helper
+
+New file `state/<agent>/last-alive.txt` — single ISO timestamp, updated by fast-checker on every successful tick (piggyback on existing heartbeat/tick).
+
+Read on session start; if `now - last_alive > 4h`, we're recovering from real downtime. Feeds Part 1's downtime warning and can be reused for future observability.
+
+---
+
+## Edge cases
+
+- **Cross-chat ordering:** sort by `archived_at` ASC preserves chronology across chats.
+- **Media messages:** existing formatter (`formatTelegramForInjection`) handles photo/voice/document/video — replay reuses it. No new code path.
+- **Double-inject on crash mid-cursor-flush:** atomic write via `atomicWriteSync`. If the process still crashes after inject and before flush, next replay resurfaces the same message — agent should treat message_id as idempotency key (see `agent.injectMessage` dedup path).
+- **PTY not ready:** replay only fires AFTER PTY spawn-ready signal. If PTY dies mid-replay, cursor advances only for successfully-injected entries; next restart resumes.
+- **Chat_id types:** JSON key normalization — always cast `chat_id` to string when reading/writing cursor to avoid `-100...` int drift.
+- **First-time boot:** no cursor file, no archive → skip both replay and warn (both no-op cleanly).
+- **Retention:** `inbound-messages.jsonl` at 695KB after ~5 months growth ≈ 1.7MB/year. Tail-scan of that size is <20ms. Log rotation is orthogonal, not blocking. Track as future hygiene item.
+
+---
+
+## Test spec (for develop)
+
+New tests in `tests/daemon/telegram-replay.test.ts` (or matching file). Use a fake agent context + in-memory JSONL fixture.
+
+### Test 1 — no cursor, entries present → start-from-now
+
+```
+given: cursor file absent, inbound-messages.jsonl has 5 entries
+when:  replayMissedTelegram runs on session start
+then:  cursor is initialized with max message_id per chat
+       agent.injectMessage NOT called (no replay on first run)
+```
+
+### Test 2 — cursor stale, entries newer, within 24h → replay in order
+
+```
+given: cursor = {chat_A: 100, chat_B: 200}
+       jsonl has entries 101-105 (chat_A) and 201-203 (chat_B), all within 24h
+when:  replay runs
+then:  agent.injectMessage called 8 times in archived_at ASC order
+       cursor updated to {chat_A: 105, chat_B: 203}
+```
+
+### Test 3 — entries older than 24h → skipped
+
+```
+given: cursor = {chat_A: 100}, jsonl has entry 101 with archived_at = 25h ago
+when:  replay runs
+then:  agent.injectMessage NOT called
+       cursor stays at 100 (nothing to advance)
+```
+
+### Test 4 — per-chat cap enforced
+
+```
+given: cursor = {chat_A: 0}, jsonl has 150 entries for chat_A within 24h
+when:  replay runs
+then:  agent.injectMessage called 100 times (last 100 by archived_at DESC)
+       cursor advances to the newest message_id
+```
+
+### Test 5 — downtime warning emitted when gap > 4h
+
+```
+given: last-alive.txt = 6h ago, missed entries present
+when:  replay runs
+then:  first injected message is [STARTUP] downtime warning
+       subsequent injects are the replayed entries
+```
+
+### Test 6 — no downtime warning when gap < 4h
+
+```
+given: last-alive.txt = 30min ago, missed entries present
+when:  replay runs
+then:  agent.injectMessage called only for the entries (no [STARTUP] prefix)
+```
+
+### Test 7 — stale-task warning fires
+
+```
+given: 3 in-progress tasks with updated_at 3h ago
+when:  warnStaleTasks runs (threshold = 2h)
+then:  agent.injectMessage called once with [STALE-TASKS] warning containing 3 task ids
+```
+
+### Test 8 — stale-task warning suppressed when fresh
+
+```
+given: 3 in-progress tasks with updated_at 30min ago
+when:  warnStaleTasks runs (threshold = 2h)
+then:  agent.injectMessage NOT called
+```
+
+### Test 9 — atomic cursor write survives partial failure
+
+```
+given: writeCursorAtomic throws ENOSPC after first inject
+when:  replay runs on 3 entries
+then:  first inject completes, cursor advance fails, error logged
+       next replay re-processes entries 1..3 (idempotent from agent side)
+```
+
+### Test 10 — chat_id string normalization
+
+```
+given: cursor stored with "-1003928420107" as string key
+when:  entry arrives with chat_id: -1003928420107 (int)
+then:  cursor lookup succeeds (no double-inject due to key type mismatch)
+```
+
+---
+
+## Telemetry additions
+
+- Event `telegram_replayed` on each replayed message: `{chat_id, message_id, archived_at}`
+- Event `stale_tasks_warned`: `{count}`
+- Event `downtime_detected` on gap > 4h: `{downtime_hours, missed_count}`
+
+Feeds nightly-metrics and downstream ratio computations. `KBRetryMetrics`-shape unchanged (this is a different subsystem).
+
+---
+
+## Rollout
+
+1. develop implements (worktree off upstream/main, same method as #900/#901/#902/#903)
+2. Design doc `git add -f` in the same PR commit (past `docs/.gitignore:47`)
+3. capitan reviews, merges
+4. **Deploy note — daemon-side TypeScript: PR merge ≠ live.** Unlike the Python
+   mmrag.py path (executes from source → working-tree edit is live immediately),
+   this is compiled daemon code: production runs from built `dist/`. Going live
+   requires `npm run build` + `pm2 restart cortextos-daemon` (capitan zone per
+   prod-config-ownership). Coordinate deployment separately after merge — merged
+   upstream and live-in-daemon are distinct states.
+5. **Live-verify:** gc-admin is the first target — has the concrete missing-message case from 2026-08-13. Trigger a controlled restart, confirm archived messages replay + cursor updates + events emit.
+6. Retro after 1 week: check `telegram_replayed` and `stale_tasks_warned` event counts fleet-wide; validate false-positive rate on stale-task threshold (2h default).
+
+---
+
+## Out of scope
+
+- Log rotation for `inbound-messages.jsonl` (track as future hygiene item)
+- Auto-resolution of stale tasks (only signal, never auto-act)
+- Cross-agent replay coordination (each agent replays its own archive only)
+- Bulk archive replay CLI (`bus replay-telegram --agent <name> --window 7d`) — nice-to-have, defer
+- Deduplication across multiple sessions of same message (idempotency at agent memory layer)
+
+## Non-goals
+
+- Perfect delivery guarantee. This is at-least-once + best-effort ordering, bounded by 24h/100-per-chat cap.
+- Replacing check-inbox for a2a messages — this is Telegram-specific.

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -13,6 +13,7 @@ import { SlackAPI } from '../slack/api.js';
 import { SlackSocketModeClient } from '../slack/socket-mode.js';
 import { dispatchSlackMessage, makeUserNameResolver, type DispatchTarget } from '../slack/dispatcher.js';
 import { resolvePaths } from '../utils/paths.js';
+import { replayMissedTelegram, warnStaleTasks, advanceCursorLive } from './telegram-replay.js';
 import { resolveEnv } from '../utils/env.js';
 import { recordInboundTelegram, cacheLastSent, logOutboundMessage, buildRecentHistory } from '../telegram/logging.js';
 import { collectTelegramCommands, registerTelegramCommands } from '../bus/metrics.js';
@@ -526,6 +527,35 @@ export class AgentManager {
       console.error(`[${name}] Fast checker error:`, err);
     });
 
+    // theta 63: session-start Telegram replay + stale-task / downtime warnings.
+    // Fire-and-forget after the PTY is bootstrapped so a recovery restart
+    // resurfaces Telegram messages archived while the PTY was down (and warns
+    // about in-progress tasks orphaned by the restart). Never throws into
+    // startAgent — a replay failure must not block the agent coming up.
+    void (async () => {
+      try {
+        for (let i = 0; i < 60 && !agentProcess.isBootstrapped(); i++) {
+          await new Promise((r) => setTimeout(r, 500));
+        }
+        if (!agentProcess.isBootstrapped()) {
+          log('[telegram-replay] PTY not bootstrapped within 30s — skipping session-start replay');
+          return;
+        }
+        const inject = (content: string) => agentProcess.injectMessage(content);
+        const now = Date.now();
+        const res = replayMissedTelegram({
+          stateDir: paths.stateDir, logDir: paths.logDir, paths,
+          agentName: name, org: resolvedOrg, inject, now, log,
+        });
+        if (res.replayed > 0 || res.downtimeHours > 4) {
+          log(`[telegram-replay] replayed ${res.replayed} message(s); downtime ${res.downtimeHours.toFixed(1)}h`);
+        }
+        warnStaleTasks({ paths, agentName: name, org: resolvedOrg, inject, now, log });
+      } catch (err) {
+        log(`[telegram-replay] session-start replay error: ${err}`);
+      }
+    })();
+
     // Register Telegram slash commands at startup (fix for issue #1)
     if (telegramApi && botToken) {
       const scanDirs = [agentDir, this.frameworkRoot].filter(Boolean);
@@ -602,6 +632,15 @@ export class AgentManager {
         // agents — the JSONL had the data but it never reached the
         // event log.
         recordInboundTelegram(paths, this.ctxRoot, name, resolvedOrg, from, msg, log);
+
+        // theta 63: advance the replay cursor for messages handled while the PTY
+        // is live+bootstrapped, so session-start replay only resurfaces messages
+        // archived during a down window — not everything seen since boot. A rare
+        // crash between here and inject at worst re-replays idempotently.
+        if (typeof msg.message_id === 'number' && msgChatId != null &&
+            agentProcess.getStatus().status === 'running' && agentProcess.isBootstrapped()) {
+          advanceCursorLive(stateDir, msgChatId, msg.message_id);
+        }
 
         // Check for media messages (photo, document, voice, audio, video, video_note)
         const isMedia = !!(msg.photo || msg.document || msg.voice || msg.audio || msg.video || msg.video_note);

--- a/src/daemon/telegram-replay.ts
+++ b/src/daemon/telegram-replay.ts
@@ -1,0 +1,424 @@
+/**
+ * Telegram replay + stale-task warning + downtime detection on session start.
+ *
+ * theta 63 — see docs/architecture/telegram-replay-session-start.md.
+ *
+ * `fast-checker` injects inbound Telegram into the live PTY as messages arrive,
+ * and every inbound is archived to `{ctxRoot}/logs/<agent>/inbound-messages.jsonl`
+ * by `recordInboundTelegram()`. But if the PTY is not alive at inject time
+ * (stop / restart / crash-recovery window) the archive lands and the injection
+ * is dropped — silent message loss. `check-inbox` only covers a2a bus messages.
+ *
+ * This module replays the archive on session start, bounded by a per-chat
+ * watermark cursor + a 24h time window + a per-chat count cap, and separately
+ * warns about stale in-progress tasks and multi-hour downtime.
+ *
+ * The core selection logic (`selectMissed`) is pure and dependency-injected so
+ * it is unit-testable without a live daemon; the orchestrators take an `inject`
+ * callback (mirroring `AgentProcess.injectMessage(content): boolean`).
+ */
+
+import { join } from 'node:path';
+import { readFileSync, existsSync } from 'node:fs';
+import { atomicWriteSync } from '../utils/atomic.js';
+import { listTasks } from '../bus/task.js';
+import { logEvent } from '../bus/event.js';
+import type { BusPaths, EventCategory, EventSeverity } from '../types/index.js';
+
+// ---------------------------------------------------------------------------
+// Constants (tuneable; some are exposed as knobs on the deps objects)
+// ---------------------------------------------------------------------------
+
+export const CURSOR_FILE = 'telegram-cursor.json';
+const HEARTBEAT_FILE = 'heartbeat.json';
+const INBOUND_FILE = 'inbound-messages.jsonl';
+
+export const REPLAY_WINDOW_MS = 24 * 60 * 60 * 1000; // 24h time cap
+export const REPLAY_PER_CHAT_CAP = 100; // freshest N per chat
+export const DOWNTIME_WARN_HOURS = 4; // gap > this → [STARTUP] warning
+export const STALE_TASK_HOURS = 2; // in_progress older than this → warn
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/**
+ * The subset of the inbound JSONL schema this module reads. The archive also
+ * carries `from`, `has_media`, `file_id`, `file_size`, `mime_type`, `timestamp`,
+ * `agent` — see src/telegram/logging.ts. We tolerate extra/missing fields.
+ */
+export interface InboundEntry {
+  message_id: number;
+  chat_id: number | string;
+  from_name?: string;
+  text?: string;
+  has_media?: boolean;
+  media_type?: string | null;
+  file_name?: string;
+  duration?: number;
+  transcript?: string;
+  archived_at: string; // ISO 8601
+}
+
+/** chat_id (as string key) -> last processed message_id. */
+export type TelegramCursor = Record<string, number>;
+
+type Emit = (category: EventCategory, event: string, severity: EventSeverity, meta: Record<string, unknown>) => void;
+
+export interface ReplayDeps {
+  stateDir: string;
+  logDir: string;
+  paths: BusPaths;
+  agentName: string;
+  org: string;
+  /** Injects into the live PTY; returns true on success (dedup/PTY-down → false). */
+  inject: (content: string) => boolean;
+  /** Injectable clock (ms since epoch). */
+  now: number;
+  windowMs?: number;
+  perChatCap?: number;
+  downtimeThresholdH?: number;
+  /** Defaults to a `logEvent` wrapper; injectable for tests. */
+  emit?: Emit;
+  log?: (m: string) => void;
+}
+
+export interface WarnStaleDeps {
+  paths: BusPaths;
+  agentName: string;
+  org: string;
+  inject: (content: string) => boolean;
+  now: number;
+  thresholdHours?: number;
+  emit?: Emit;
+  log?: (m: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// chat_id normalization — JSON object keys are always strings, and Telegram
+// group ids look like -1003928420107. Casting on every read/write avoids the
+// int-vs-string key mismatch that would double-inject (design test 10).
+// ---------------------------------------------------------------------------
+
+export function chatKey(chatId: number | string): string {
+  return String(chatId);
+}
+
+// ---------------------------------------------------------------------------
+// Cursor persistence
+// ---------------------------------------------------------------------------
+
+export function cursorPath(stateDir: string): string {
+  return join(stateDir, CURSOR_FILE);
+}
+
+export function readCursor(stateDir: string): TelegramCursor {
+  const p = cursorPath(stateDir);
+  if (!existsSync(p)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(p, 'utf-8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    // Normalize values to numbers; drop anything non-numeric.
+    const out: TelegramCursor = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      const n = typeof v === 'number' ? v : Number(v);
+      if (Number.isFinite(n)) out[k] = n;
+    }
+    return out;
+  } catch {
+    return {};
+  }
+}
+
+/** Atomic write. May throw (e.g. ENOSPC) — callers decide how to degrade. */
+export function writeCursorAtomic(stateDir: string, cursor: TelegramCursor): void {
+  atomicWriteSync(cursorPath(stateDir), JSON.stringify(cursor, null, 2));
+}
+
+/**
+ * Advance the live cursor for a message the live pipeline handled. Called from
+ * the daemon's Telegram handler after a successful queue while the PTY is up,
+ * so that the same message is not re-surfaced by replay on the next start.
+ * Best-effort: swallows write errors (a missed advance only risks one idempotent
+ * double-replay, never a lost message).
+ */
+export function advanceCursorLive(stateDir: string, chatId: number | string, messageId: number): void {
+  if (!Number.isFinite(messageId)) return;
+  const cursor = readCursor(stateDir);
+  const k = chatKey(chatId);
+  if ((cursor[k] ?? 0) >= messageId) return;
+  cursor[k] = messageId;
+  try {
+    writeCursorAtomic(stateDir, cursor);
+  } catch {
+    /* best-effort; replay + idempotency cover a missed advance */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Archive scan + selection (pure core)
+// ---------------------------------------------------------------------------
+
+export function tailScanInbound(logDir: string): InboundEntry[] {
+  const p = join(logDir, INBOUND_FILE);
+  if (!existsSync(p)) return [];
+  let raw: string;
+  try {
+    raw = readFileSync(p, 'utf-8');
+  } catch {
+    return [];
+  }
+  const out: InboundEntry[] = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      const e = JSON.parse(line);
+      if (e == null || typeof e.message_id !== 'number' || e.chat_id == null || typeof e.archived_at !== 'string') {
+        continue; // skip malformed / non-message lines
+      }
+      out.push(e as InboundEntry);
+    } catch {
+      continue;
+    }
+  }
+  return out;
+}
+
+/** Max message_id per chat over all entries — used to seed the first-run cursor. */
+export function maxPerChat(entries: InboundEntry[]): TelegramCursor {
+  const out: TelegramCursor = {};
+  for (const e of entries) {
+    const k = chatKey(e.chat_id);
+    if ((out[k] ?? 0) < e.message_id) out[k] = e.message_id;
+  }
+  return out;
+}
+
+/**
+ * Pure selection: entries strictly newer than the cursor for their chat, within
+ * the time window, capped to the freshest `perChatCap` per chat, returned in
+ * global archived_at ASC order (chronological across chats).
+ */
+export function selectMissed(
+  entries: InboundEntry[],
+  cursor: TelegramCursor,
+  nowMs: number,
+  windowMs: number = REPLAY_WINDOW_MS,
+  perChatCap: number = REPLAY_PER_CHAT_CAP,
+): InboundEntry[] {
+  const windowStart = nowMs - windowMs;
+  const eligible = entries.filter((e) => {
+    const seen = cursor[chatKey(e.chat_id)] ?? 0;
+    if (e.message_id <= seen) return false;
+    const t = Date.parse(e.archived_at);
+    return Number.isFinite(t) && t >= windowStart;
+  });
+
+  // Per-chat cap: keep the freshest `perChatCap` by (archived_at, message_id).
+  const byChat = new Map<string, InboundEntry[]>();
+  for (const e of eligible) {
+    const k = chatKey(e.chat_id);
+    const arr = byChat.get(k) ?? [];
+    arr.push(e);
+    byChat.set(k, arr);
+  }
+  const capped: InboundEntry[] = [];
+  for (const arr of byChat.values()) {
+    arr.sort(cmpChrono);
+    // freshest N = tail after ASC sort
+    capped.push(...(arr.length > perChatCap ? arr.slice(arr.length - perChatCap) : arr));
+  }
+  capped.sort(cmpChrono);
+  return capped;
+}
+
+function cmpChrono(a: InboundEntry, b: InboundEntry): number {
+  const ta = Date.parse(a.archived_at);
+  const tb = Date.parse(b.archived_at);
+  if (ta !== tb) return ta - tb;
+  return a.message_id - b.message_id; // stable tiebreak
+}
+
+// ---------------------------------------------------------------------------
+// Downtime detection (reuses heartbeat.json last_heartbeat — the existing
+// liveness signal — rather than a new last-alive.txt written on every tick)
+// ---------------------------------------------------------------------------
+
+export function getLastAliveMs(stateDir: string): number | null {
+  const p = join(stateDir, HEARTBEAT_FILE);
+  if (!existsSync(p)) return null;
+  try {
+    const hb = JSON.parse(readFileSync(p, 'utf-8'));
+    const t = Date.parse(hb?.last_heartbeat ?? '');
+    return Number.isFinite(t) ? t : null;
+  } catch {
+    return null;
+  }
+}
+
+export function detectDowntimeHours(lastAliveMs: number | null, nowMs: number): number {
+  if (lastAliveMs == null) return 0; // unknown liveness → don't cry downtime
+  const gapMs = nowMs - lastAliveMs;
+  return gapMs > 0 ? gapMs / (60 * 60 * 1000) : 0;
+}
+
+// ---------------------------------------------------------------------------
+// Replay formatter — a dedicated, self-contained formatter marked [REPLAYED].
+// We do NOT reuse the FastChecker media formatters: the archive stores file_id
+// / file_name / mime_type but NOT the downloaded local path (media is fetched
+// live and may be gone after a downtime window), so media replays surface as a
+// note. The [REPLAYED archived_at] prefix also salts the content past the two
+// dedup layers (AgentProcess MessageDedup + FastChecker SHA-256) that would
+// otherwise swallow a byte-identical re-inject.
+// ---------------------------------------------------------------------------
+
+export function formatReplayEntry(entry: InboundEntry): string {
+  const from = entry.from_name || 'Unknown';
+  const chatId = entry.chat_id;
+  let body: string;
+  if (entry.has_media && entry.media_type) {
+    const parts = [`[media: ${entry.media_type}]`];
+    if (entry.file_name) parts.push(`file: ${entry.file_name}`);
+    if (entry.text) parts.push(`caption: ${entry.text}`);
+    if (entry.transcript) parts.push(`transcript: ${entry.transcript}`);
+    parts.push('(archived during downtime; file not re-downloaded — ask sender to resend if you need it)');
+    body = parts.join(' ');
+  } else {
+    body = entry.text || '(empty message)';
+  }
+  return `=== TELEGRAM (REPLAYED ${entry.archived_at}) from ${from} (chat_id:${chatId}) ===
+${body}
+Reply using: cortextos bus send-telegram ${chatId} "<reply>"
+
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Default event emitter
+// ---------------------------------------------------------------------------
+
+function defaultEmit(paths: BusPaths, agentName: string, org: string): Emit {
+  return (category, event, severity, meta) => {
+    try {
+      logEvent(paths, agentName, org, category, event, severity, meta);
+    } catch {
+      /* telemetry must never break the replay path */
+    }
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrators
+// ---------------------------------------------------------------------------
+
+export interface ReplayResult {
+  replayed: number;
+  downtimeHours: number;
+  firstRun: boolean;
+}
+
+/**
+ * Replay missed Telegram messages on session start. Fires after the PTY is
+ * bootstrapped, before/around the first live Telegram poll.
+ */
+export function replayMissedTelegram(deps: ReplayDeps): ReplayResult {
+  const {
+    stateDir, logDir, paths, agentName, org, inject, now,
+    windowMs = REPLAY_WINDOW_MS,
+    perChatCap = REPLAY_PER_CHAT_CAP,
+    downtimeThresholdH = DOWNTIME_WARN_HOURS,
+    log = () => {},
+  } = deps;
+  const emit = deps.emit ?? defaultEmit(paths, agentName, org);
+
+  const entries = tailScanInbound(logDir);
+  const cursorExists = existsSync(cursorPath(stateDir));
+
+  // First run: no cursor → establish the watermark at the current max per chat
+  // and skip replay ("start-from-now"). Prevents replaying the entire archive
+  // the first time the feature ships.
+  if (!cursorExists) {
+    try {
+      writeCursorAtomic(stateDir, maxPerChat(entries));
+    } catch (e) {
+      log(`[telegram-replay] first-run cursor init failed: ${e}`);
+    }
+    return { replayed: 0, downtimeHours: 0, firstRun: true };
+  }
+
+  const cursor = readCursor(stateDir);
+  const missed = selectMissed(entries, cursor, now, windowMs, perChatCap);
+  if (missed.length === 0) {
+    return { replayed: 0, downtimeHours: 0, firstRun: false };
+  }
+
+  const downtimeHours = detectDowntimeHours(getLastAliveMs(stateDir), now);
+  if (downtimeHours > downtimeThresholdH) {
+    inject(
+      `[STARTUP] Detected ${downtimeHours.toFixed(1)}h downtime. Replaying ${missed.length} missed Telegram message(s) (bounded to last 24h, ${perChatCap}/chat).`,
+    );
+    emit('action', 'downtime_detected', 'warning', { downtime_hours: downtimeHours, missed_count: missed.length });
+  }
+
+  let replayed = 0;
+  for (const entry of missed) {
+    const formatted = formatReplayEntry(entry);
+    if (!inject(formatted)) continue; // PTY down / deduped — leave cursor, retry next start
+    const k = chatKey(entry.chat_id);
+    cursor[k] = Math.max(cursor[k] ?? 0, entry.message_id);
+    try {
+      writeCursorAtomic(stateDir, cursor);
+    } catch (e) {
+      // Cursor advance failed (e.g. ENOSPC). The message was injected but the
+      // watermark did not persist; stop here so we don't inject a burst we
+      // cannot checkpoint. Next start re-processes from the last durable cursor
+      // (agent side is idempotent on message_id).
+      log(`[telegram-replay] cursor write failed after inject, halting replay: ${e}`);
+      break;
+    }
+    emit('message', 'telegram_replayed', 'info', {
+      chat_id: entry.chat_id,
+      message_id: entry.message_id,
+      archived_at: entry.archived_at,
+    });
+    replayed++;
+  }
+
+  return { replayed, downtimeHours, firstRun: false };
+}
+
+export interface WarnStaleResult {
+  stale: number;
+}
+
+/**
+ * Warn (do not act) about in-progress tasks whose `updated_at` is older than
+ * `thresholdHours`. Surfaces work orphaned by a restart. Signal only — never
+ * auto-resumes, auto-completes, or auto-drops.
+ */
+export function warnStaleTasks(deps: WarnStaleDeps): WarnStaleResult {
+  const { paths, agentName, org, inject, now, thresholdHours = STALE_TASK_HOURS, log = () => {} } = deps;
+  const emit = deps.emit ?? defaultEmit(paths, agentName, org);
+
+  let inProg;
+  try {
+    inProg = listTasks(paths, { status: 'in_progress' });
+  } catch (e) {
+    log(`[stale-tasks] listTasks failed: ${e}`);
+    return { stale: 0 };
+  }
+  const cutoff = now - thresholdHours * 60 * 60 * 1000;
+  const stale = inProg.filter((t) => {
+    const u = Date.parse(t.updated_at);
+    return Number.isFinite(u) && u < cutoff;
+  });
+  if (stale.length === 0) return { stale: 0 };
+
+  const ids = stale.slice(0, 10).map((t) => t.id).join(', ');
+  const more = stale.length > 10 ? ` (+${stale.length - 10} more)` : '';
+  inject(
+    `[STALE-TASKS] ${stale.length} in-progress task(s) with updated_at > ${thresholdHours}h ago: ${ids}${more}. Review — resume, complete, or drop.`,
+  );
+  emit('task', 'stale_tasks_warned', 'warning', { count: stale.length });
+  return { stale: stale.length };
+}

--- a/tests/unit/daemon/telegram-replay.test.ts
+++ b/tests/unit/daemon/telegram-replay.test.ts
@@ -1,0 +1,251 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { BusPaths } from '../../../src/types';
+import {
+  replayMissedTelegram,
+  warnStaleTasks,
+  readCursor,
+  selectMissed,
+  chatKey,
+  type InboundEntry,
+} from '../../../src/daemon/telegram-replay';
+
+// Fixed clock for deterministic windows.
+const NOW = Date.parse('2026-08-13T12:00:00Z');
+const H = 60 * 60 * 1000;
+
+function isoAgo(ms: number): string {
+  return new Date(NOW - ms).toISOString();
+}
+
+function entry(message_id: number, chat_id: number | string, agoMs: number, extra: Partial<InboundEntry> = {}): InboundEntry {
+  return { message_id, chat_id, archived_at: isoAgo(agoMs), from_name: 'Tester', text: `msg ${message_id}`, ...extra };
+}
+
+function writeInbound(logDir: string, entries: InboundEntry[]): void {
+  const lines = entries.map((e) => JSON.stringify(e)).join('\n') + '\n';
+  writeFileSync(join(logDir, 'inbound-messages.jsonl'), lines, 'utf-8');
+}
+
+function writeCursorFile(stateDir: string, cursor: Record<string, number>): void {
+  writeFileSync(join(stateDir, 'telegram-cursor.json'), JSON.stringify(cursor), 'utf-8');
+}
+
+function writeHeartbeat(stateDir: string, lastAliveAgoMs: number): void {
+  writeFileSync(join(stateDir, 'heartbeat.json'), JSON.stringify({ last_heartbeat: isoAgo(lastAliveAgoMs) }), 'utf-8');
+}
+
+function writeTask(taskDir: string, id: string, status: string, updatedAgoMs: number): void {
+  const t = {
+    id,
+    title: `task ${id}`,
+    description: '',
+    status,
+    priority: 'normal',
+    agent: 'test-agent',
+    created_at: isoAgo(updatedAgoMs + H),
+    updated_at: isoAgo(updatedAgoMs),
+  };
+  writeFileSync(join(taskDir, `${id}.json`), JSON.stringify(t), 'utf-8');
+}
+
+/** archived_at extracted from a formatted [REPLAYED ...] block, for order assertions. */
+function replayedAts(calls: string[]): string[] {
+  return calls
+    .map((c) => c.match(/REPLAYED ([^)]+)\)/)?.[1])
+    .filter((x): x is string => !!x);
+}
+
+describe('telegram-replay', () => {
+  let testDir: string;
+  let paths: BusPaths;
+  let inject: ReturnType<typeof vi.fn>;
+  let emit: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-tg-replay-'));
+    paths = {
+      ctxRoot: testDir,
+      inbox: join(testDir, 'inbox'),
+      inflight: join(testDir, 'inflight'),
+      processed: join(testDir, 'processed'),
+      logDir: join(testDir, 'logs', 'test-agent'),
+      stateDir: join(testDir, 'state', 'test-agent'),
+      taskDir: join(testDir, 'tasks'),
+      approvalDir: join(testDir, 'approvals'),
+      analyticsDir: join(testDir, 'analytics'),
+      deliverablesDir: join(testDir, 'deliverables'),
+    } as BusPaths;
+    for (const d of Object.values(paths)) {
+      if (typeof d === 'string' && d !== testDir) mkdirSync(d, { recursive: true });
+    }
+    inject = vi.fn().mockReturnValue(true);
+    emit = vi.fn();
+  });
+
+  afterEach(() => {
+    try { chmodSync(paths.stateDir, 0o700); } catch { /* ignore */ }
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  function deps(overrides: Record<string, unknown> = {}) {
+    return {
+      stateDir: paths.stateDir,
+      logDir: paths.logDir,
+      paths,
+      agentName: 'test-agent',
+      org: 'testorg',
+      inject,
+      now: NOW,
+      emit,
+      ...overrides,
+    };
+  }
+
+  // Test 1 — no cursor, entries present → start-from-now
+  it('no cursor file + entries present → initializes cursor to max/chat, no replay', () => {
+    writeInbound(paths.logDir, [
+      entry(101, 'chatA', 1 * H), entry(102, 'chatA', 0.5 * H),
+      entry(201, 'chatB', 2 * H), entry(202, 'chatB', 1 * H), entry(203, 'chatB', 0.2 * H),
+    ]);
+    const res = replayMissedTelegram(deps());
+    expect(res.firstRun).toBe(true);
+    expect(inject).not.toHaveBeenCalled();
+    const cursor = readCursor(paths.stateDir);
+    expect(cursor).toEqual({ chatA: 102, chatB: 203 });
+  });
+
+  // Test 2 — cursor stale, entries newer within 24h → replay in ASC order
+  it('stale cursor + newer entries within 24h → replays all in archived_at ASC order, advances cursor', () => {
+    writeCursorFile(paths.stateDir, { chatA: 100, chatB: 200 });
+    writeInbound(paths.logDir, [
+      entry(101, 'chatA', 5 * H), entry(102, 'chatA', 4 * H), entry(103, 'chatA', 3 * H),
+      entry(104, 'chatA', 2 * H), entry(105, 'chatA', 1 * H),
+      entry(201, 'chatB', 4.5 * H), entry(202, 'chatB', 2.5 * H), entry(203, 'chatB', 0.5 * H),
+    ]);
+    const res = replayMissedTelegram(deps());
+    expect(res.replayed).toBe(8);
+    expect(inject).toHaveBeenCalledTimes(8);
+    const ats = replayedAts(inject.mock.calls.map((c) => c[0] as string));
+    const sorted = [...ats].sort();
+    expect(ats).toEqual(sorted); // ASC chronological
+    expect(readCursor(paths.stateDir)).toEqual({ chatA: 105, chatB: 203 });
+  });
+
+  // Test 3 — entries older than 24h → skipped
+  it('entry older than 24h → skipped, cursor unchanged', () => {
+    writeCursorFile(paths.stateDir, { chatA: 100 });
+    writeInbound(paths.logDir, [entry(101, 'chatA', 25 * H)]);
+    const res = replayMissedTelegram(deps());
+    expect(res.replayed).toBe(0);
+    expect(inject).not.toHaveBeenCalled();
+    expect(readCursor(paths.stateDir)).toEqual({ chatA: 100 });
+  });
+
+  // Test 4 — per-chat cap enforced (freshest 100)
+  it('150 entries in one chat within 24h → replays freshest 100, cursor to newest', () => {
+    writeCursorFile(paths.stateDir, { chatA: 0 });
+    const entries: InboundEntry[] = [];
+    for (let i = 1; i <= 150; i++) {
+      // higher id = fresher (smaller agoMs); all within 24h
+      entries.push(entry(i, 'chatA', (151 - i) * 0.1 * H));
+    }
+    writeInbound(paths.logDir, entries);
+    const res = replayMissedTelegram(deps());
+    expect(res.replayed).toBe(100);
+    expect(inject).toHaveBeenCalledTimes(100);
+    // freshest 100 = ids 51..150; cursor advances to 150
+    expect(readCursor(paths.stateDir)).toEqual({ chatA: 150 });
+  });
+
+  // Test 5 — downtime warning when gap > 4h
+  it('gap > 4h → first inject is [STARTUP] downtime warning, then entries', () => {
+    writeCursorFile(paths.stateDir, { chatA: 100 });
+    writeHeartbeat(paths.stateDir, 6 * H);
+    writeInbound(paths.logDir, [entry(101, 'chatA', 2 * H), entry(102, 'chatA', 1 * H)]);
+    const res = replayMissedTelegram(deps());
+    expect(res.downtimeHours).toBeCloseTo(6, 1);
+    expect((inject.mock.calls[0][0] as string).startsWith('[STARTUP]')).toBe(true);
+    expect(inject).toHaveBeenCalledTimes(3); // 1 warning + 2 entries
+    expect(emit).toHaveBeenCalledWith('action', 'downtime_detected', 'warning', expect.objectContaining({ missed_count: 2 }));
+  });
+
+  // Test 6 — no downtime warning when gap < 4h
+  it('gap < 4h → no [STARTUP] warning, only entries', () => {
+    writeCursorFile(paths.stateDir, { chatA: 100 });
+    writeHeartbeat(paths.stateDir, 0.5 * H);
+    writeInbound(paths.logDir, [entry(101, 'chatA', 0.4 * H), entry(102, 'chatA', 0.2 * H)]);
+    replayMissedTelegram(deps());
+    expect(inject).toHaveBeenCalledTimes(2);
+    for (const c of inject.mock.calls) expect((c[0] as string).startsWith('[STARTUP]')).toBe(false);
+  });
+
+  // Test 7 — stale-task warning fires
+  it('3 in-progress tasks updated 3h ago (threshold 2h) → one [STALE-TASKS] warning with 3 ids', () => {
+    writeTask(paths.taskDir, 'task_a', 'in_progress', 3 * H);
+    writeTask(paths.taskDir, 'task_b', 'in_progress', 3 * H);
+    writeTask(paths.taskDir, 'task_c', 'in_progress', 3 * H);
+    const res = warnStaleTasks({ paths, agentName: 'test-agent', org: 'testorg', inject, now: NOW, thresholdHours: 2, emit });
+    expect(res.stale).toBe(3);
+    expect(inject).toHaveBeenCalledTimes(1);
+    const msg = inject.mock.calls[0][0] as string;
+    expect(msg.startsWith('[STALE-TASKS]')).toBe(true);
+    for (const id of ['task_a', 'task_b', 'task_c']) expect(msg).toContain(id);
+    expect(emit).toHaveBeenCalledWith('task', 'stale_tasks_warned', 'warning', { count: 3 });
+  });
+
+  // Test 8 — stale-task warning suppressed when fresh
+  it('in-progress tasks updated 30min ago (threshold 2h) → no warning', () => {
+    writeTask(paths.taskDir, 'task_a', 'in_progress', 0.5 * H);
+    writeTask(paths.taskDir, 'task_b', 'in_progress', 0.5 * H);
+    const res = warnStaleTasks({ paths, agentName: 'test-agent', org: 'testorg', inject, now: NOW, thresholdHours: 2, emit });
+    expect(res.stale).toBe(0);
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  // Test 9 — atomic cursor write survives partial failure
+  it('cursor write failure after first inject → first inject done, replay halts, next run re-processes', () => {
+    writeCursorFile(paths.stateDir, { chatA: 100 });
+    writeInbound(paths.logDir, [
+      entry(101, 'chatA', 3 * H), entry(102, 'chatA', 2 * H), entry(103, 'chatA', 1 * H),
+    ]);
+    // Make the state dir unwritable so atomicWriteSync (tmp write) throws, but
+    // the existing cursor file stays readable.
+    chmodSync(paths.stateDir, 0o500);
+    const res = replayMissedTelegram(deps());
+    // First entry injected; cursor write throws → loop breaks.
+    expect(inject).toHaveBeenCalledTimes(1);
+    expect(res.replayed).toBe(0); // replayed counter only increments after a durable cursor write
+    // Restore writability; cursor never advanced → next run re-processes all 3.
+    chmodSync(paths.stateDir, 0o700);
+    inject.mockClear();
+    const res2 = replayMissedTelegram(deps());
+    expect(inject).toHaveBeenCalledTimes(3);
+    expect(res2.replayed).toBe(3);
+    expect(readCursor(paths.stateDir)).toEqual({ chatA: 103 });
+  });
+
+  // Test 10 — chat_id string normalization (int in archive, string key in cursor)
+  it('int chat_id in archive matches string cursor key → no double-inject', () => {
+    const groupId = -1003928420107;
+    writeCursorFile(paths.stateDir, { [String(groupId)]: 500 });
+    writeInbound(paths.logDir, [
+      entry(500, groupId, 2 * H), // already seen (== cursor) → skip
+      entry(501, groupId, 1 * H), // new → replay
+    ]);
+    // Sanity: pure selection respects the string/int key equivalence.
+    const missed = selectMissed(
+      [entry(500, groupId, 2 * H), entry(501, groupId, 1 * H)],
+      { [chatKey(groupId)]: 500 },
+      NOW,
+    );
+    expect(missed.map((m) => m.message_id)).toEqual([501]);
+
+    const res = replayMissedTelegram(deps());
+    expect(res.replayed).toBe(1);
+    expect(inject).toHaveBeenCalledTimes(1);
+    expect(readCursor(paths.stateDir)).toEqual({ [String(groupId)]: 501 });
+  });
+});


### PR DESCRIPTION
Clean PR off `upstream/main` (worktree method, same as #900–#903).

## Problem
`fast-checker` injects inbound Telegram into the live PTY as it arrives; every message is archived to `logs/<agent>/inbound-messages.jsonl`. But if the PTY is down at inject time (stop / restart / crash-recovery) the archive lands and the injection is **dropped** — silent message loss. `check-inbox` covers only a2a bus messages, not Telegram.

**Live impact (gc-admin, 2026-08-13):** during a ~1h window, 2 HelpDesk requests + 3 David DMs were archived but never surfaced; two replies delayed 3.7h / 1.8h.

## Fix — one module, three parts
`src/daemon/telegram-replay.ts` (pure core + dependency-injected → unit-testable without a live daemon):

1. **Watermark replay** — `state/<agent>/telegram-cursor.json` (`{chat_id: last_message_id}`). On session start, replay archived entries with `message_id > cursor`, bounded to the last **24h** and the freshest **100/chat**, in `archived_at` ASC order. First run (no cursor) = start-from-now (seed watermark, no replay). The cursor advances on the **live inject path** (gated on PTY running + bootstrapped) so replay only resurfaces messages archived during a down window — not everything since boot.
2. **Stale-task warn** — one `[STALE-TASKS]` inject for `in_progress` tasks with `updated_at` older than 2h (config knob). Signal only, never auto-acts.
3. **Downtime detect** — liveness gap > 4h → a `[STARTUP]` warning before replay.

Wired into `AgentManager.startAgent` as a fire-and-forget step after PTY bootstrap (never throws into startup). Telemetry: `telegram_replayed`, `stale_tasks_warned`, `downtime_detected`.

## Deviations from the design doc (flagged for analyst reconcile)
- **Downtime** reuses `heartbeat.json` `last_heartbeat` (existing liveness signal) instead of a new `last-alive.txt` written every 1s tick — avoids a redundant 1Hz write path.
- **Media** replays surface as a `[REPLAYED]` note, not via the FastChecker media formatters: the archive stores `file_id`/`file_name` but **not** the downloaded local path (media is fetched live, likely gone after downtime). Text replays in full.
- The `[REPLAYED archived_at]` prefix salts content past the two dedup layers (`AgentProcess` MessageDedup + FastChecker SHA-256) that would otherwise swallow a byte-identical re-inject.

## Deploy note
Daemon-side TypeScript: **PR merge ≠ live.** Production runs from built `dist/` — going live needs `npm run build` + `pm2 restart cortextos-daemon` (capitan zone). Coordinate deployment separately after merge.

## Tests
`tests/unit/daemon/telegram-replay.test.ts` — **10 scenarios, all pass** (first-run, stale-cursor ASC replay, 24h skip, per-chat cap, downtime warn on/off, stale-task fire/suppress, atomic-write partial-failure, chat_id string normalization). Module typechecks clean; `tsup` build succeeds.

_Note: a pre-existing `@noble/hashes` resolution issue in the merged #907 buzz adapter breaks `agent-manager.test.ts` collection in a stale-node_modules environment — identical with and without this change; CI with a fresh `npm ci` is unaffected._

Design doc `docs/architecture/telegram-replay-session-start.md` force-added past `docs/.gitignore:47`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)