### PR TITLE
fix(telegram): exponential backoff on poller transient errors

### DIFF
--- a/src/telegram/poller.ts
+++ b/src/telegram/poller.ts
@@ -9,6 +9,45 @@ export type CallbackHandler = (query: TelegramCallbackQuery) => void;
 export type ReactionHandler = (reaction: TelegramMessageReaction) => void;
 
 /**
+ * Ceiling (ms) on an honored Telegram 429 `retry after N` hint.
+ *
+ * The retry_after hint is honored directly and is deliberately NOT subject to the
+ * 30s exponential `capMs` — a real Telegram flood-control wait can legitimately
+ * exceed 30s, and truncating it to 30s would ignore the server's instruction and
+ * risk a tighter flood ban. But the hint must still be bounded: an uncapped
+ * honor path lets a hostile or buggy `retry after 3600` sleep the poller ~1h and
+ * freeze the agent's Telegram lifeline.
+ *
+ * 5 minutes is a generous ceiling. Real Telegram flood-control waits run from
+ * seconds to at most low minutes, so a legitimate hint is honored unchanged,
+ * while an absurd value is clamped so the poller resumes within minutes rather
+ * than being frozen for an hour.
+ */
+export const RETRY_AFTER_CEILING_MS = 300_000;
+
+/**
+ * Compute the base backoff delay (in ms) after a transient poll failure.
+ *
+ * Pure and jitter-free — the caller adds any jitter and owns 409 handling.
+ *
+ * @param message The error message from the failed getUpdates call.
+ * @param attempt Consecutive-transient-error count (>=1).
+ * @param baseMs Base delay for the exponential curve (the normal poll interval).
+ * @param capMs Maximum backoff delay.
+ * @returns Honors a `retry after N` hint from a Telegram 429 (short-circuits the
+ *   curve), clamped to {@link RETRY_AFTER_CEILING_MS}; otherwise an
+ *   exponential-with-cap delay: min(capMs, baseMs * 2^(attempt-1)).
+ */
+export function computePollBackoffMs(message: string, attempt: number, baseMs: number, capMs: number): number {
+  const retryMatch = message.match(/retry after (\d+)/i);
+  if (retryMatch) {
+    const honored = Math.max(1, parseInt(retryMatch[1], 10)) * 1000;
+    return Math.min(RETRY_AFTER_CEILING_MS, honored);
+  }
+  return Math.min(capMs, baseMs * 2 ** (attempt - 1));
+}
+
+/**
  * Telegram polling loop. Replaces the Telegram portion of fast-checker.sh.
  * Polls getUpdates every 1 second and routes messages/callbacks to handlers.
  */
@@ -22,6 +61,8 @@ export class TelegramPoller {
   private callbackHandlers: CallbackHandler[] = [];
   private reactionHandlers: ReactionHandler[] = [];
   private pollInterval: number;
+  private consecutiveErrors = 0;
+  private readonly backoffCapMs = 30_000;
   /**
    * Why the poll loop last exited. Read by AgentManager's poller-supervisor
    * (#459 supervision-gap fix) to decide whether to restart:
@@ -88,9 +129,13 @@ export class TelegramPoller {
   async start(): Promise<void> {
     this.running = true;
     this.lastExitReason = '';
+    this.consecutiveErrors = 0;
     while (this.running) {
       try {
         await this.pollOnce();
+        // Success — clear the backoff counter and poll again at the normal interval.
+        this.consecutiveErrors = 0;
+        await sleep(this.pollInterval);
       } catch (err) {
         if (!this.running) {
           this.lastExitReason = 'stopped-externally';
@@ -106,10 +151,14 @@ export class TelegramPoller {
           this.running = false;
           return;
         }
-        // Other errors are transient — log and continue polling.
-        console.error('[telegram-poller] Poll error:', err);
+        // Other errors are transient — back off exponentially (honoring a 429
+        // retry_after hint) so a persistent failure does not hot-loop the API.
+        this.consecutiveErrors++;
+        const base = computePollBackoffMs(msg, this.consecutiveErrors, this.pollInterval, this.backoffCapMs);
+        const delay = base + Math.random() * this.pollInterval;
+        console.error(`[telegram-poller] Poll error (retry in ${Math.round(delay)}ms, attempt ${this.consecutiveErrors}):`, err);
+        await sleep(delay);
       }
-      await sleep(this.pollInterval);
     }
   }
 

--- a/tests/unit/telegram/poller.test.ts
+++ b/tests/unit/telegram/poller.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { TelegramPoller } from '../../../src/telegram/poller';
+import { TelegramPoller, computePollBackoffMs, RETRY_AFTER_CEILING_MS } from '../../../src/telegram/poller';
 import type { TelegramAPI } from '../../../src/telegram/api';
 import type { TelegramUpdate } from '../../../src/types/index';
 
@@ -315,5 +315,152 @@ describe('TelegramPoller — start() re-entry (LINK A for the map-entry-race pol
 
     poller.stop();
     await second;
+  });
+});
+
+describe('TelegramPoller — poll backoff', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'cortextos-poller-backoff-'));
+    // Silence the diagnostic error logging the backoff path emits.
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  // Group A — pure function, no timers.
+  it('grows exponentially then caps at capMs', () => {
+    const delays = [1, 2, 3, 4, 5, 6, 7].map((n) =>
+      computePollBackoffMs('Telegram API request timed out after 15s: getUpdates', n, 1000, 30000),
+    );
+    expect(delays).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+  });
+
+  it('honors a 429 retry_after hint regardless of attempt', () => {
+    const msg = 'Telegram API error: Too Many Requests: retry after 7';
+    expect(computePollBackoffMs(msg, 1, 1000, 30000)).toBe(7000);
+    expect(computePollBackoffMs(msg, 5, 1000, 30000)).toBe(7000);
+  });
+
+  it('floors a retry_after of 0 to 1000ms', () => {
+    expect(computePollBackoffMs('retry after 0', 3, 1000, 30000)).toBe(1000);
+  });
+
+  it('falls back to the exponential curve when there is no retry_after', () => {
+    expect(computePollBackoffMs('Telegram API request failed: boom', 3, 1000, 30000)).toBe(4000);
+  });
+
+  it('clamps a retry_after above the ceiling and honors one below it unchanged', () => {
+    const ceilingSecs = RETRY_AFTER_CEILING_MS / 1000;
+    // Above the ceiling (e.g. a hostile "retry after 3600") is clamped down to it.
+    const aboveSecs = ceilingSecs + 300;
+    expect(computePollBackoffMs(`retry after ${aboveSecs}`, 1, 1000, 30000)).toBe(RETRY_AFTER_CEILING_MS);
+    // Below the ceiling (a realistic flood-control wait that still exceeds the 30s
+    // exponential cap) is honored as-is — proving the honor path does not reuse capMs.
+    const belowSecs = ceilingSecs - 60;
+    expect(computePollBackoffMs(`retry after ${belowSecs}`, 1, 1000, 30000)).toBe(belowSecs * 1000);
+  });
+
+  // Group B — loop integration under fake timers.
+  function backoffApi(impl: () => Promise<unknown>): TelegramAPI {
+    return { getUpdates: vi.fn(impl) } as unknown as TelegramAPI;
+  }
+
+  it('backs off exponentially and caps during a sustained error storm', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const delays = () => setTimeoutSpy.mock.calls.map((c) => Number(c[1]));
+
+    const api = backoffApi(async () => {
+      throw new Error('Telegram API request timed out after 15s: getUpdates');
+    });
+    const poller = new TelegramPoller(api, stateDir);
+    const running = poller.start();
+
+    // Flush the first pollOnce rejection microtask so the first backoff sleep is scheduled.
+    await vi.advanceTimersByTimeAsync(0);
+    for (let i = 1; i < 7; i++) {
+      const d = delays();
+      await vi.advanceTimersByTimeAsync(d[d.length - 1]);
+    }
+
+    expect(delays()).toEqual([1000, 2000, 4000, 8000, 16000, 30000, 30000]);
+
+    poller.stop();
+    const d = delays();
+    await vi.advanceTimersByTimeAsync(d[d.length - 1]);
+    await running;
+  });
+
+  it('honors a 429 retry_after for the first backoff in the loop', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const delays = () => setTimeoutSpy.mock.calls.map((c) => Number(c[1]));
+
+    const api = backoffApi(async () => {
+      throw new Error('Telegram API error: Too Many Requests: retry after 5');
+    });
+    const poller = new TelegramPoller(api, stateDir);
+    const running = poller.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    expect(delays()[0]).toBe(5000);
+
+    poller.stop();
+    await vi.advanceTimersByTimeAsync(5000);
+    await running;
+  });
+
+  it('resets the backoff counter after a successful poll', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    const delays = () => setTimeoutSpy.mock.calls.map((c) => Number(c[1]));
+
+    let call = 0;
+    const api = backoffApi(async () => {
+      call++;
+      if (call === 3) return { result: [] }; // third poll succeeds
+      throw new Error('Telegram API request timed out after 15s: getUpdates');
+    });
+    const poller = new TelegramPoller(api, stateDir);
+    const running = poller.start();
+
+    await vi.advanceTimersByTimeAsync(0); // call1 fail -> 1000
+    await vi.advanceTimersByTimeAsync(1000); // call2 fail -> 2000
+    await vi.advanceTimersByTimeAsync(2000); // call3 success -> reset -> sleep 1000
+    await vi.advanceTimersByTimeAsync(1000); // call4 fail -> attempt 1 again -> 1000
+
+    // fail(1000), fail(2000), success(1000 interval), fail(1000 — NOT 4000)
+    expect(delays()).toEqual([1000, 2000, 1000, 1000]);
+
+    poller.stop();
+    await vi.advanceTimersByTimeAsync(1000);
+    await running;
+  });
+
+  it('still self-dies on a 409 Conflict without scheduling a backoff', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(Math, 'random').mockReturnValue(0);
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+
+    const api = backoffApi(async () => {
+      throw new Error('Telegram API error: Conflict: terminated by other getUpdates request');
+    });
+    const poller = new TelegramPoller(api, stateDir);
+    const running = poller.start();
+
+    await vi.advanceTimersByTimeAsync(0);
+    await running;
+
+    expect(poller.lastExitReason).toBe('conflict-self-die');
+    expect(setTimeoutSpy).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
The Telegram poll loop retried every transient `getUpdates` error (timeout, 429, 5xx) after a fixed 1s interval, hammering the API on persistent failures and ignoring Telegram's 429 `retry_after` hint.

This adds exponential backoff with additive jitter on transient poll errors:
- Honors a Telegram 429 `retry_after` hint, bounded by a 5-minute ceiling so an absurd/hostile value cannot freeze the poller (the agent's Telegram lifeline).
- Caps the exponential curve at 30s; resets to baseline on a successful poll.
- The 409 Conflict self-die and intentional-stop paths are unchanged.
- `computePollBackoffMs` is a pure exported helper (unit-testable without timers).

## Test Plan
- `npx tsc --noEmit` clean.
- `tests/unit/telegram/poller.test.ts`: 18 tests (9 new) — pure-function backoff curve + 30s cap + `retry_after` honor + ceiling clamp + reset-on-success, plus fake-timer loop tests proving backoff engages/grows/caps under an error storm, honors 429, resets after success, and 409 still self-dies with no backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)