### PR TITLE
fix(daemon): idempotent startAgent for duplicate live-agent starts

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -89,6 +89,23 @@ export class AgentManager {
   // entry returns instead of double-spawning a PTY (same hazard class BUG-011's
   // pendingRestarts guards for alive entries).
   private evictingAgents: Set<string> = new Set();
+  // idempotency fix: names with a stopAgent() teardown currently in flight.
+  // Claimed synchronously on stopAgent() entry (before its first await), so a
+  // concurrent startAgent() hitting the alive-branch can tell a legit in-flight
+  // restart (queue via pendingRestarts) from a pure duplicate start (no-op).
+  //
+  // ORDERING INVARIANT (relied on by the alive-branch no-op path): for any
+  // coordinated stop+start pair on the same name, stopAgent() must claim
+  // `stoppingAgents` synchronously BEFORE the paired startAgent() runs its
+  // synchronous prefix (the alive-branch check). All CURRENT dispatch paths
+  // satisfy this: restartAgent() and stopAll() are sequential-await (stop is
+  // fully entered — marker claimed — before start begins), and IPC stop/start
+  // messages are processed in arrival order (a restart-all sends stop first).
+  // A hypothetical FUTURE caller that dispatched startAgent() BEFORE stopAgent()
+  // for a coordinated restart would find `stoppingAgents` still empty, take the
+  // idempotent no-op path, and have its start SWALLOWED — so callers MUST keep
+  // stop-before-start ordering for coordinated restarts.
+  private stoppingAgents: Set<string> = new Set();
   private instanceId: string;
   private ctxRoot: string;
   private frameworkRoot: string;
@@ -354,15 +371,14 @@ export class AgentManager {
       // (restart-all could send stop+start simultaneously, and the new
       // start would arrive while the old stop's PTY exit was still in
       // flight). PR #11 closed BUG-011 by making `AgentProcess.stop()`
-      // await the actual PTY exit before resolving — which means this
-      // branch should NEVER fire under normal restart paths.
+      // await the actual PTY exit before resolving.
       //
-      // We log a regression warning here instead of deleting the branch
-      // entirely, so we'll know IMMEDIATELY if BUG-011 ever regresses
-      // (a future change accidentally breaks the exit-await). Phase 4 of
-      // the core stability test plan + cycle 2 of PR #13 both confirmed
-      // this branch is dormant. Once we have weeks of zero-warning
-      // production data, we can delete the queue mechanism entirely.
+      // The idempotency fix then repurposed the queue path: the alive sub-branch
+      // below distinguishes a LEGIT in-flight restart (a stopAgent() teardown is
+      // genuinely in flight — stoppingAgents.has — so we queue via pendingRestarts)
+      // from a pure duplicate start against a healthy agent (idempotent no-op).
+      // The legit-restart case fires on every concurrent restart-all and is logged
+      // at info level, NOT as a regression alarm — see the per-case comments below.
       if (this.isAgentActuallyAlive(name)) {
         // ALIVE entry: preserve the existing BUG-011/031/040 dedup/queue behavior
         // EXACTLY — this is the legitimate in-flight-restart race path.
@@ -375,10 +391,28 @@ export class AgentManager {
           // distinct from the BUG-011 in-flight race PR #11 closed. Log at
           // info level so operators don't think PR #11 has regressed.
           console.log(`[agent-manager] ${name} already in registry (post-crash discovery overlap, expected). Queueing restart.`);
-        } else {
-          console.warn(`[agent-manager] BUG-011 REGRESSION CHECK: ${name} still in registry during startAgent — pendingRestarts queueing engaged. This should not happen with PR #11 in place.`);
+          this.pendingRestarts.add(name);
+          return;
         }
-        this.pendingRestarts.add(name);
+        if (this.stoppingAgents.has(name)) {
+          // LEGIT in-flight restart: a concurrent stopAgent() is tearing this
+          // agent down but hasn't reached its final PTY-exit line yet, so the
+          // entry still reads as alive. Queue the restart so stopAgent()'s honor
+          // path brings the agent back — the real BUG-011/BUG-031 race path.
+          //
+          // Info-level, NOT a regression alarm: after the idempotency fix this
+          // is the EXPECTED legit-restart race (stoppingAgents proves a teardown
+          // is genuinely in flight), so it fires on every concurrent restart-all.
+          // A true BUG-011 regression (start racing a stop WITHOUT a marker) does
+          // NOT reach here — it falls through to the no-op path below instead.
+          console.log(`[agent-manager] ${name} start raced an in-flight stop (expected legit in-flight restart) — queueing via pendingRestarts; stopAgent's honor path will bring it back.`);
+          this.pendingRestarts.add(name);
+          return;
+        }
+        // SPURIOUS pure duplicate start against a healthy agent nobody is
+        // stopping. No teardown is in flight, so a queued restart would cause a
+        // later spurious restart. Idempotent no-op instead — no warn, no queue.
+        console.log(`[agent-manager] ${name} already running and healthy — duplicate start ignored (idempotent no-op).`);
         return;
       }
       // liveness fix: entry exists but is NOT actually alive (halted/crashed/
@@ -1329,114 +1363,129 @@ export class AgentManager {
       return;
     }
 
-    // map-entry-race fix: capture every name-keyed resource we own BEFORE the
-    // await below. entry.process.stop() yields for up to ~21s (BUG-032's
-    // graceful /exit dance plus BUG-040's 15s exit wait), and a NEW instance can
-    // be registered under this same name inside that window (startAgent's
-    // eviction path, or a fire-and-forget IPC start — ipc-server.ts never awaits
-    // startAgent/stopAgent/restartAgent). After the await, `name` is no longer a
-    // reliable handle to us.
-    // RULE: act unconditionally on the objects you captured; act by name only
-    // while the name still resolves to you. See stillMapped().
-    const scheduler = this.cronSchedulers.get(name);
+    // idempotency fix (#923): claim the name synchronously BEFORE the first await
+    // (entry.process.stop() below) so a startAgent() racing this teardown sees
+    // the marker and queues via pendingRestarts instead of taking the no-op
+    // path. finally (NOT catch) so a throw from process.stop() still propagates
+    // to callers while the marker is always released.
+    this.stoppingAgents.add(name);
+    try {
+      // map-entry-race fix (#895): capture every name-keyed resource we own
+      // BEFORE the await below. entry.process.stop() yields for up to ~21s
+      // (BUG-032's graceful /exit dance plus BUG-040's 15s exit wait), and a NEW
+      // instance can be registered under this same name inside that window
+      // (startAgent's eviction path, or a fire-and-forget IPC start —
+      // ipc-server.ts never awaits startAgent/stopAgent/restartAgent). After the
+      // await, `name` is no longer a reliable handle to us.
+      // RULE: act unconditionally on the objects you captured; act by name only
+      // while the name still resolves to you. See stillMapped().
+      const scheduler = this.cronSchedulers.get(name);
 
-    // Round 3 (F5/F2): mark the teardown BEFORE it starts, not after it finishes.
-    // A poller's stop() cannot recall a getUpdates batch that is already open, and
-    // process.stop() yields for up to ~21s — so callbacks and a parked startAgent
-    // both land DURING the teardown, which is exactly when they must not act.
-    entry.stopped = true;
+      // Round 3 (F5/F2): mark the teardown BEFORE it starts, not after it
+      // finishes. A poller's stop() cannot recall a getUpdates batch that is
+      // already open, and process.stop() yields for up to ~21s — so callbacks and
+      // a parked startAgent both land DURING the teardown, which is exactly when
+      // they must not act.
+      entry.stopped = true;
 
-    if (entry.poller) entry.poller.stop();
-    if (entry.activityPoller) entry.activityPoller.stop();
-    // Unregister from every org's Buzz dispatcher — harmless no-op for orgs
-    // this agent was never registered in. We don't track which org this
-    // agent belongs to on the entry itself, so this sweeps all of them
-    // rather than requiring an extra lookup.
-    for (const buzzEntry of this.buzzClients.values()) {
-      buzzEntry.dispatcher.unregister(name);
-    }
-    entry.checker.stop();
-    await entry.process.stop();
-
-    // Our scheduler object: stopping it is always correct (the interval is
-    // ours, and skipping it leaks a setInterval forever). Unmapping it is only
-    // correct while the name still points at it.
-    if (!scheduler && this.stillMapped(name, entry)) {
-      // The capture above has a blind spot the post-await read it replaced did
-      // not: a scheduler wired for US during the await (startAgent's post-start
-      // wiring at the `startAgentCronScheduler` call below, or reloadCrons'
-      // lazy-create) did not exist when we captured. Nothing else ever stops it
-      // — it outlives the agent as a live setInterval whose onFire injects into
-      // a name that is gone, AND it makes the next start's scheduler request hit
-      // the "already running — skipped" guard, so the replacement inherits a
-      // dead scheduler. Acting by name is safe here BECAUSE the name still
-      // resolves to us, so whatever is under it is ours.
-      const late = this.cronSchedulers.get(name);
-      if (late) {
-        late.stop();
-        this.cronSchedulers.delete(name);
+      if (entry.poller) entry.poller.stop();
+      if (entry.activityPoller) entry.activityPoller.stop();
+      // Unregister from every org's Buzz dispatcher — harmless no-op for orgs
+      // this agent was never registered in. We don't track which org this
+      // agent belongs to on the entry itself, so this sweeps all of them
+      // rather than requiring an extra lookup.
+      for (const buzzEntry of this.buzzClients.values()) {
+        buzzEntry.dispatcher.unregister(name);
       }
-    }
+      entry.checker.stop();
+      await entry.process.stop();
 
-    if (scheduler) {
-      scheduler.stop();
-      if (this.cronSchedulers.get(name) === scheduler) {
-        this.cronSchedulers.delete(name);
-        // If a new instance took the name while we were stopping, it may have
-        // been refused a scheduler by startAgentCronScheduler's "already
-        // running" guard because OURS was still mapped. Re-wire now the slot is
-        // free — otherwise the new agent runs with no crons at all. Calling a
-        // start-path helper from the stop path is deliberate: the method is
-        // idempotent and map-driven, and this is the only moment at which the
-        // newcomer's missing scheduler is detectable.
-        if (!this.stillMapped(name, entry)) this.startAgentCronScheduler(name);
+      // Our scheduler object: stopping it is always correct (the interval is
+      // ours, and skipping it leaks a setInterval forever). Unmapping it is only
+      // correct while the name still points at it.
+      if (!scheduler && this.stillMapped(name, entry)) {
+        // The capture above has a blind spot the post-await read it replaced did
+        // not: a scheduler wired for US during the await (startAgent's post-start
+        // wiring at the `startAgentCronScheduler` call below, or reloadCrons'
+        // lazy-create) did not exist when we captured. Nothing else ever stops it
+        // — it outlives the agent as a live setInterval whose onFire injects into
+        // a name that is gone, AND it makes the next start's scheduler request hit
+        // the "already running — skipped" guard, so the replacement inherits a
+        // dead scheduler. Acting by name is safe here BECAUSE the name still
+        // resolves to us, so whatever is under it is ours.
+        const late = this.cronSchedulers.get(name);
+        if (late) {
+          late.stop();
+          this.cronSchedulers.delete(name);
+        }
       }
-    }
 
-    // Round 3 (F4): same conflation as the eviction path — see the F3 comment in
-    // startAgent(). Reachable here via two concurrent stops for one name (ipc-server
-    // never awaits stopAgent): the first to finish deletes the name, and the second
-    // then took this branch, warned about a re-registration that never happened, and
-    // returned BEFORE the pendingRestarts handling below — stranding a queued restart
-    // that later fires against an unrelated stop.
-    if (this.agents.has(name) && !this.stillMapped(name, entry)) {
-      // Superseded: our instance is fully torn down, but the name belongs to
-      // someone else now. Deleting it here would empty the map slot while the
-      // new agent keeps running — an untracked orphan. pendingRestarts is
-      // deliberately left alone: the queue refers to whoever is mapped.
-      console.warn(`[agent-manager] ${name} was re-registered while stopping — old instance fully torn down, new instance left mapped.`);
-      return;
-    }
-
-    this.agents.delete(name);
-
-    // disable-resurrection fix: an explicit user stop/disable must win against a
-    // racing queued restart. Drop the pending entry instead of honoring it.
-    // Internal callers (restartAgent, stopAll) pass userInitiated=false, so the
-    // BUG-011/BUG-031 restart-all honor path below is preserved unchanged.
-    if (userInitiated) {
-      if (this.pendingRestarts.delete(name)) {
-        console.log(`[agent-manager] Dropped queued restart for ${name} — explicit user stop/disable wins.`);
+      if (scheduler) {
+        scheduler.stop();
+        if (this.cronSchedulers.get(name) === scheduler) {
+          this.cronSchedulers.delete(name);
+          // If a new instance took the name while we were stopping, it may have
+          // been refused a scheduler by startAgentCronScheduler's "already
+          // running" guard because OURS was still mapped. Re-wire now the slot is
+          // free — otherwise the new agent runs with no crons at all. Calling a
+          // start-path helper from the stop path is deliberate: the method is
+          // idempotent and map-driven, and this is the only moment at which the
+          // newcomer's missing scheduler is detectable.
+          if (!this.stillMapped(name, entry)) this.startAgentCronScheduler(name);
+        }
       }
-      return;
-    }
 
-    // BUG-031: honor any restart that was queued while we were stopping.
-    // After PR #11 (BUG-011 fix) this branch should never fire — see the
-    // matching warning comment in startAgent(). The honor logic is preserved
-    // as a safety net in case BUG-011 regresses; the warn line tells us
-    // immediately if it ever does.
-    if (this.pendingRestarts.has(name)) {
-      if (this.daemonJustCrashed) {
-        console.log(`[agent-manager] pendingRestarts fired for ${name} (post-crash safety net, expected). Honoring queued restart.`);
-      } else {
-        console.warn(`[agent-manager] BUG-011 REGRESSION CHECK: pendingRestarts fired for ${name} — race condition leaked through. Honoring queued restart as safety net.`);
+      // Round 3 (F4): same conflation as the eviction path — see the F3 comment in
+      // startAgent(). Reachable here via two concurrent stops for one name (ipc-server
+      // never awaits stopAgent): the first to finish deletes the name, and the second
+      // then took this branch, warned about a re-registration that never happened, and
+      // returned BEFORE the pendingRestarts handling below — stranding a queued restart
+      // that later fires against an unrelated stop.
+      if (this.agents.has(name) && !this.stillMapped(name, entry)) {
+        // Superseded: our instance is fully torn down, but the name belongs to
+        // someone else now. Deleting it here would empty the map slot while the
+        // new agent keeps running — an untracked orphan. pendingRestarts is
+        // deliberately left alone: the queue refers to whoever is mapped. The
+        // finally below still releases stoppingAgents.
+        console.warn(`[agent-manager] ${name} was re-registered while stopping — old instance fully torn down, new instance left mapped.`);
+        return;
       }
-      this.pendingRestarts.delete(name);
-      console.log(`[agent-manager] Honoring queued restart for ${name}`);
-      this.startAgent(name, '').catch(err =>
-        console.error(`[agent-manager] Queued restart failed for ${name}:`, err),
-      );
+
+      this.agents.delete(name);
+
+      // disable-resurrection fix: an explicit user stop/disable must win against a
+      // racing queued restart. Drop the pending entry instead of honoring it.
+      // Internal callers (restartAgent, stopAll) pass userInitiated=false, so the
+      // BUG-011/BUG-031 restart-all honor path below is preserved unchanged.
+      if (userInitiated) {
+        if (this.pendingRestarts.delete(name)) {
+          console.log(`[agent-manager] Dropped queued restart for ${name} — explicit user stop/disable wins.`);
+        }
+        return;
+      }
+
+      // BUG-031: honor any restart that was queued while we were stopping.
+      // After the idempotency fix `pendingRestarts` is a NORMAL control-flow
+      // signal, not a BUG-011 canary. Writers enumeration (both `pendingRestarts.add`
+      // sites in this file): (1) startAgent's post-crash branch — guarded by
+      // daemonJustCrashed=true; (2) startAgent's stoppingAgents.has branch — the
+      // legit in-flight restart. So reaching this honor branch with
+      // daemonJustCrashed=false means writer (2): the EXPECTED legit-restart race.
+      // Both cases are info-level; neither is a regression, so honoring is normal.
+      if (this.pendingRestarts.has(name)) {
+        if (this.daemonJustCrashed) {
+          console.log(`[agent-manager] pendingRestarts fired for ${name} (post-crash safety net, expected). Honoring queued restart.`);
+        } else {
+          console.log(`[agent-manager] pendingRestarts fired for ${name} (expected legit in-flight-restart race). Honoring queued restart.`);
+        }
+        this.pendingRestarts.delete(name);
+        console.log(`[agent-manager] Honoring queued restart for ${name}`);
+        this.startAgent(name, '').catch(err =>
+          console.error(`[agent-manager] Queued restart failed for ${name}:`, err),
+        );
+      }
+    } finally {
+      this.stoppingAgents.delete(name);
     }
   }
 

--- a/tests/unit/daemon/agent-manager-liveness.test.ts
+++ b/tests/unit/daemon/agent-manager-liveness.test.ts
@@ -30,6 +30,7 @@ const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
 type AgentsMap = Map<string, unknown>;
 const agentsOf = (am: unknown) => (am as { agents: AgentsMap }).agents;
 const pendingOf = (am: unknown) => (am as { pendingRestarts: Set<string> }).pendingRestarts;
+const stoppingOf = (am: unknown) => (am as { stoppingAgents: Set<string> }).stoppingAgents;
 
 // pids used only inside the process.kill spy — never signalled for real.
 const LIVE_PID = 1234;
@@ -143,7 +144,10 @@ describe('AgentManager liveness — startAgent evicts a dead entry but preserves
     expect(agentsOf(am).has('alice')).toBe(false);
   });
 
-  it('genuinely-alive entry (running, live pid): preserved — queued, not stopped', async () => {
+  it('genuinely-alive entry (running, live pid), no stop in flight: idempotent no-op — not stopped, not queued', async () => {
+    // idempotency fix: a duplicate start against a healthy agent nobody is
+    // stopping must be a pure no-op. No pendingRestarts entry (which would
+    // cause a later spurious restart), no process.stop(), entry preserved.
     const processStop = vi.fn(async () => {});
     const checkerStop = vi.fn();
     const alive = {
@@ -154,9 +158,99 @@ describe('AgentManager liveness — startAgent evicts a dead entry but preserves
 
     await am.startAgent('alice', '');
 
-    expect(pendingOf(am).has('alice')).toBe(true);
+    expect(pendingOf(am).has('alice')).toBe(false);
     expect(processStop).not.toHaveBeenCalled();
     expect(agentsOf(am).has('alice')).toBe(true);
+  });
+
+  it('duplicate start on live agent, no stop in flight: no warn, no pendingRestart', async () => {
+    const processStop = vi.fn(async () => {});
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const alive = {
+      process: { getStatus: () => ({ name: 'alice', status: 'running', pid: LIVE_PID }), stop: processStop },
+      checker: { stop: vi.fn() },
+    };
+    agentsOf(am).set('alice', alive);
+
+    await am.startAgent('alice', '');
+
+    expect(pendingOf(am).has('alice')).toBe(false);
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('BUG-011 REGRESSION CHECK'));
+    expect(processStop).not.toHaveBeenCalled();
+    expect(agentsOf(am).has('alice')).toBe(true);
+    warnSpy.mockRestore();
+  });
+
+  it('start racing a genuine in-flight stop still queues and comes back', async () => {
+    // Deterministic race: stopAgent()'s process.stop() is deferred so the stop
+    // parks mid-teardown with stoppingAgents held. A start racing in sees the
+    // alive entry + the marker → queues via pendingRestarts (real BUG-011 path).
+    // When the stop resolves, its honor path consumes the queue and restarts.
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((r) => { resolveStop = r; });
+    const processStop = vi.fn(() => stopPromise);
+    const alive = {
+      process: { getStatus: () => ({ name: 'alice', status: 'running', pid: LIVE_PID }), stop: processStop },
+      checker: { stop: vi.fn() },
+    };
+    agentsOf(am).set('alice', alive);
+
+    const startSpy = vi.spyOn(am, 'startAgent');
+
+    const stopP = am.stopAgent('alice');       // parks on deferred process.stop()
+    expect(stoppingOf(am).has('alice')).toBe(true);
+
+    await am.startAgent('alice', '');           // races: alive + marker → queues
+    expect(pendingOf(am).has('alice')).toBe(true);
+    expect(agentsOf(am).has('alice')).toBe(true);
+
+    resolveStop();
+    await stopP;                                 // stop finishes: delete entry + honor path
+    await Promise.resolve();                      // flush microtasks for the honored start
+
+    expect(pendingOf(am).has('alice')).toBe(false);  // queue consumed
+    expect(startSpy).toHaveBeenCalledWith('alice', ''); // came back via honor path
+    expect(stoppingOf(am).has('alice')).toBe(false);
+
+    startSpy.mockRestore();
+  });
+
+  it('legit in-flight restart emits NO BUG-011 REGRESSION CHECK warn — softened both sites', async () => {
+    // Item 1: the two softened warns both fire on this one flow — startAgent's
+    // stoppingAgents.has queue branch (site i) and stopAgent's non-crash
+    // pendingRestarts honor branch (site ii). After softening they are info logs,
+    // so console.warn must NEVER be called with the BUG-011 REGRESSION CHECK
+    // string while the agent still queues + comes back (behaviour unchanged).
+    // POSITIVE CONTROL: re-raising either softened site to console.warn(...
+    // 'BUG-011 REGRESSION CHECK' ...) turns this assertion red.
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let resolveStop!: () => void;
+    const stopPromise = new Promise<void>((r) => { resolveStop = r; });
+    const processStop = vi.fn(() => stopPromise);
+    const alive = {
+      process: { getStatus: () => ({ name: 'alice', status: 'running', pid: LIVE_PID }), stop: processStop },
+      checker: { stop: vi.fn() },
+    };
+    agentsOf(am).set('alice', alive);
+
+    const startSpy = vi.spyOn(am, 'startAgent');
+
+    const stopP = am.stopAgent('alice');       // parks on deferred process.stop()
+    await am.startAgent('alice', '');           // site (i): alive + marker → queues
+    expect(pendingOf(am).has('alice')).toBe(true);
+
+    resolveStop();
+    await stopP;                                 // site (ii): honor path fires
+    await Promise.resolve();                      // flush microtasks for honored start
+
+    // behaviour unchanged: queued and came back via the honor path
+    expect(pendingOf(am).has('alice')).toBe(false);
+    expect(startSpy).toHaveBeenCalledWith('alice', '');
+    // neither softened site emitted the regression alarm
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('BUG-011 REGRESSION CHECK'));
+
+    startSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it('concurrent starts on a dead entry evict once (evictingAgents guard, no double-spawn)', async () => {


### PR DESCRIPTION
## Summary
A duplicate `startAgent` against a healthy, running agent queued a `pendingRestarts` entry and logged a spurious `BUG-011 REGRESSION CHECK` warning — causing a later spurious restart on the agent's next stop.

This makes `startAgent` state-sensitive:
- Adds a `stoppingAgents` marker claimed synchronously at `stopAgent` entry (before its first `await`), so the alive-branch distinguishes a legit in-flight restart (queue via `pendingRestarts`) from a pure duplicate start (idempotent no-op).
- Softens the now-stale `BUG-011 REGRESSION CHECK` warnings on the expected legit-restart path to info level (queue/restart behavior byte-identical).
- Documents the stop-before-start ordering invariant the no-op path relies on.

## Test Plan
- `npx tsc --noEmit` clean.
- `tests/unit/daemon/agent-manager-liveness.test.ts`: 14 tests — duplicate start on a healthy agent is a no-op (no warn, no queue, not stopped); a start racing a genuine in-flight stop still queues and the agent comes back; existing evict-path tests preserved.
- `tests/unit/daemon/agent-manager.test.ts` stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)