### PR TITLE
fix(fleet): skip intentionally-disabled agents in fleet-health-check.sh

### DIFF
--- a/docs/architecture/fleet-health-check-skip-disabled.md
+++ b/docs/architecture/fleet-health-check-skip-disabled.md
@@ -1,0 +1,154 @@
+# fleet-health-check.sh — Skip Agents With enabled=false
+
+**Status:** Design — not yet implemented
+**Priority:** Medium (noise reduction, no functional bug)
+**Owner:** develop (implementation), analyst (design), capitan (approval)
+**Last updated:** 2026-08-15
+**Related:** theta 65, `project_fb_communicator_disabled`, `feedback_stale_heartbeat_not_crash`
+
+---
+
+## Problem
+
+`scripts/fleet-health-check.sh` classifies fb-communicator as `stale_verified` on every run (currently ~163h stale, heartbeat + process both dead). fb-communicator is **intentionally disabled** — its `config.json` has `enabled: false`. Analyst has to filter it out mentally on every heartbeat cycle.
+
+Same script emits a `stale_verified` warning event each time it runs → noise in the analytics stream and false-positive stale entries that must be re-explained in memory (`project_fb_communicator_disabled`).
+
+## Root cause
+
+Line 46-101 in `scripts/fleet-health-check.sh` iterates every agent returned by `cortextos bus list-agents`. It checks `.running` and `last_heartbeat` but has no notion of "intentionally disabled." An agent with `config.json` `enabled: false` looks identical to a crashed one from the script's perspective.
+
+Note also: `list-agents` returns `enabled: true` for fb-communicator (probably from an in-memory roster), while `config.json` `enabled: false` is the ground truth for intent-to-run. The script should trust `config.json`, not `list-agents`.
+
+## Proposed fix
+
+Add a **pre-loop skip** on `config.json` `enabled: false`:
+
+```bash
+# Once, near the other path vars (after EVENTS_DIR):
+# config.json is in the REPO tree, not under CTX_ROOT (state/analytics only).
+REPO_ROOT="${CTX_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# Inside the while-loop, immediately after NAME is extracted:
+CONFIG_PATH="${REPO_ROOT}/orgs/${ORG}/agents/${NAME}/config.json"
+if [[ -f "$CONFIG_PATH" ]]; then
+  CONFIG_ENABLED=$(jq -r '.enabled' "$CONFIG_PATH" 2>/dev/null)
+  [[ "$CONFIG_ENABLED" == "false" ]] && continue  # intentionally disabled
+fi
+```
+
+Placement: right after the `NAME=` extraction, before `RUNNING=`/`LAST_HB=`/the
+age check and — crucially — before the `CHECKED=` increment, so disabled agents
+don't count toward `.checked` in the JSON summary.
+
+**Two corrections vs the original draft (both verified empirically, 2026-08-15):**
+
+- **Path base is `CTX_PROJECT_ROOT`, not `CTX_ROOT`.** `CTX_ROOT`
+  (`~/.cortextos/<instance>`) holds only runtime state (`state/`) and analytics
+  (`orgs/<org>/analytics/events`) — it has no `orgs/<org>/agents` tree. The
+  agent `config.json` (ground truth for enable/disable intent) lives in the repo
+  checkout at `${CTX_PROJECT_ROOT}/orgs/<org>/agents/<name>/config.json`. We fall
+  back to deriving the repo root from `BASH_SOURCE` so the script also works when
+  `CTX_PROJECT_ROOT` is unset.
+- **Use plain `jq -r '.enabled'`, NOT `.enabled // true`.** jq's `//` is the
+  *alternative* operator: it treats `false` **and** `null` as "absent", so
+  `false // true` evaluates to `true` and the skip would never fire. Plain
+  `.enabled` yields `"false"` (skip), `"true"` (proceed), `"null"` when the field
+  is missing (proceed → default-enabled), and empty on malformed JSON
+  (proceed → fail-open). All four cases fall out of a single `== "false"` test.
+
+## Blast radius
+
+- **Reduces noise:** fb-communicator (and any future intentionally-disabled agent) no longer surfaces as stale.
+- **No false negatives:** disabled agents by definition should not be flagged as unhealthy. They are supposed to be dead.
+- **No behavior change on running agents:** all other paths untouched.
+- **Cost:** 6 bash lines, 1 file read per agent per invocation.
+
+## Edge cases
+
+- **Config file missing:** treat as enabled (current behavior). Don't fail the whole script on a missing config; log-only in a future iteration if noise persists.
+- **Malformed JSON:** `jq` returns empty; the `[[ ... == "false" ]]` check fails; agent proceeds through normal stale detection. Fail-open.
+- **Agent enabled but PM2 process dead:** correctly flagged as `stale_verified` (unchanged).
+- **Agent disabled and later re-enabled mid-day:** next fleet-health-check run reads fresh `config.json` and re-includes it. No cache.
+
+## Test spec (for develop)
+
+Implemented as `tests/scripts/fleet-health-check.test.ts` — a vitest suite that
+shells out to the real script with a stub `cortextos` (canned `bus list-agents`,
+no-op `bus log-event`) and temp `CTX_PROJECT_ROOT` config fixtures.
+
+**Darwin-gated (`describe.skipIf(process.platform !== 'darwin')`).** The script
+parses timestamps with BSD `date -u -j -f`, absent on GNU/Linux; CI runs on
+ubuntu-latest, where the age computation fails for every agent (`HB_TS=0` → early
+`continue`) and the non-skip cases can't be exercised. The suite runs on the
+fleet Mac (where the script actually executes) and is skipped, not failed, on CI.
+Same `skipIf` pattern already used elsewhere in the repo.
+
+### Test 1 — enabled: false is skipped
+```
+given: fixture agent with config.json {enabled: false}, last_heartbeat 200h ago, running: false
+when:  fleet-health-check runs
+then:  agent NOT in verified/suspect/dismissed
+       checked count does NOT include this agent
+       no log-event emitted for this agent
+```
+
+### Test 2 — enabled: true still classified normally
+```
+given: fixture agent config.json {enabled: true}, last_heartbeat 200h ago, running: false
+when:  fleet-health-check runs
+then:  agent in verified list
+       stale_verified event emitted
+```
+
+### Test 3 — missing enabled field treated as enabled
+```
+given: fixture agent config.json without enabled field, last_heartbeat 200h ago, running: false
+when:  fleet-health-check runs
+then:  agent in verified list (default-enabled)
+```
+
+### Test 4 — malformed config.json fails open
+```
+given: fixture agent config.json is invalid JSON, last_heartbeat 200h ago, running: false
+when:  fleet-health-check runs
+then:  agent in verified list (safe default)
+       no script crash
+```
+
+### Test 5 — fresh agent (heartbeat recent) with enabled: false still skipped
+```
+given: fixture agent config.json {enabled: false}, last_heartbeat 10min ago
+when:  fleet-health-check runs
+then:  agent NOT counted in checked (skipped before the age-check)
+```
+
+---
+
+## Rollout
+
+1. develop implements + tests. Simple bash change; no daemon-side compile.
+2. Design doc `git add -f` in the same PR (past `docs/.gitignore:47`).
+3. capitan reviews, merges.
+4. **Deploy note — the script is currently UNTRACKED.** `scripts/fleet-health-check.sh`
+   was never committed to any branch (local working-tree file only), so this PR
+   *adds* the whole script (with the fix baked in) rather than diffing 6 lines.
+   Consequence: merging upstream does **not** by itself make the fix live on the
+   fleet Mac — the running copy is the untracked working-tree file, and a `git
+   pull` of the merged branch would even conflict with it ("untracked working
+   tree files would be overwritten"). Going live is a separate step: apply the
+   same skip to the working-tree copy (live on the next cron, no restart) and
+   then reconcile the working tree with the now-tracked file. Ownership of that
+   working-tree/prod step is capitan's call (see Out of scope).
+5. Live-verify: run fleet-health-check.sh, confirm fb-communicator is absent from all three lists AND `.checked` count drops by 1 (from 11 to 10).
+6. Remove `project_fb_communicator_disabled` from analyst memory as obsolete after verify (or condense to «was noise-suppressed 2026-08-15 in fleet-health-check.sh»).
+
+## Out of scope
+
+- Fixing the `list-agents` inconsistency (returns `enabled: true` for an agent whose config says `false`). Separate concern — the daemon's in-memory roster is not the source of truth for intent.
+- Cleaning up fb-communicator's `runtime: codex-app-server` leftover from decommissioned codex (theta 65-candidate: codex code removal is separately deferred).
+- Auto-disabling agents based on crash counts.
+
+## Non-goals
+
+- Perfect fidelity between config and roster. This fix trusts `config.json` for intent; other tools may still show the roster state.

--- a/scripts/fleet-health-check.sh
+++ b/scripts/fleet-health-check.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# fleet-health-check.sh — smart stale-heartbeat detector for analyst
+#
+# Reduces false "stale" alerts on idle-but-alive agents.
+#
+# Old rule (analyst CLAUDE.md): flag if heartbeat age > 2x loop_interval.
+# Problem: idle agents legitimately quiet for hours, producing noise capitan
+# manually dismissed every cycle.
+#
+# New rule:
+#   1. Base threshold = 6h (fallback) or 5x loop_interval when set numeric.
+#   2. Heartbeat age <= threshold → skip.
+#   3. Heartbeat age > threshold + running=false (per `bus list-agents`)
+#      → STALE_VERIFIED (agent process actually gone).
+#   4. Heartbeat age > threshold + running=true, no event log entries in the
+#      last 1h → STALE_SUSPECT (alive but silent; worth surfacing but not urgent).
+#   5. Heartbeat age > threshold + running=true + fresh events → DISMISSED
+#      (agent is doing work, just not writing heartbeat.json).
+#
+# Emits log-events per agent evaluated as stale-candidate:
+#   stale_verified  (warning) — process gone, needs attention
+#   stale_suspect   (info)    — alive but silent, watch next cycle
+#   stale_dismissed (info)    — fresh events, no alert needed
+#
+# Output: JSON summary on stdout.
+#   {"verified":[...], "suspect":[...], "dismissed":[...], "checked":N}
+
+set -u
+
+DEFAULT_THRESHOLD_SEC=$(( 6 * 3600 ))
+EVENT_FRESH_WINDOW_SEC=$(( 60 * 60 ))
+NOW_TS=$(date -u +%s)
+TODAY=$(date -u +%Y-%m-%d)
+
+AGENTS_JSON=$(cortextos bus list-agents 2>/dev/null)
+[[ -z "$AGENTS_JSON" ]] && echo '{"error":"list-agents failed"}' && exit 1
+
+VERIFIED='[]'
+SUSPECT='[]'
+DISMISSED='[]'
+CHECKED=0
+
+ORG="${CTX_ORG:-fitnessmama}"
+EVENTS_DIR="${CTX_ROOT}/orgs/${ORG}/analytics/events"
+
+# Agent config.json (source of truth for enabled/disabled intent) lives in the
+# repo tree, NOT under CTX_ROOT (which holds runtime state + analytics only).
+# Prefer CTX_PROJECT_ROOT; fall back to deriving repo root from this script's path.
+REPO_ROOT="${CTX_PROJECT_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+while read -r line; do
+  [[ -z "$line" ]] && continue
+  NAME=$(echo "$line" | jq -r '.name')
+
+  # Skip intentionally-disabled agents (config.json enabled=false). A disabled
+  # agent is supposed to be dead, so it must not surface as stale. Placed before
+  # the age check and the CHECKED increment so disabled agents don't count toward
+  # the `checked` total. jq '.enabled' (NOT '.enabled // true' — jq's // treats
+  # false as absent, so `false // true` => true and the skip would never fire).
+  # Only an explicit "false" skips; true / null(missing) / malformed all proceed
+  # (fail-open — a config we can't parse must not silently hide an agent).
+  CONFIG_PATH="${REPO_ROOT}/orgs/${ORG}/agents/${NAME}/config.json"
+  if [[ -f "$CONFIG_PATH" ]]; then
+    CONFIG_ENABLED=$(jq -r '.enabled' "$CONFIG_PATH" 2>/dev/null)
+    [[ "$CONFIG_ENABLED" == "false" ]] && continue
+  fi
+
+  RUNNING=$(echo "$line" | jq -r '.running')
+  LAST_HB=$(echo "$line" | jq -r '.last_heartbeat // ""')
+  [[ -z "$LAST_HB" || "$LAST_HB" == "null" ]] && continue
+
+  HB_TS=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$LAST_HB" +%s 2>/dev/null || echo 0)
+  [[ "$HB_TS" -eq 0 ]] && continue
+  AGE_SEC=$(( NOW_TS - HB_TS ))
+  AGE_H=$(( AGE_SEC / 3600 ))
+
+  LI_RAW=$(jq -r '.loop_interval // ""' "${CTX_ROOT}/state/${NAME}/heartbeat.json" 2>/dev/null)
+  THRESHOLD=$DEFAULT_THRESHOLD_SEC
+  if [[ "$LI_RAW" =~ ^[0-9]+$ ]] && [[ "$LI_RAW" -gt 0 ]]; then
+    THRESHOLD=$(( LI_RAW * 5 ))
+    [[ $THRESHOLD -lt $DEFAULT_THRESHOLD_SEC ]] && THRESHOLD=$DEFAULT_THRESHOLD_SEC
+  fi
+
+  CHECKED=$(( CHECKED + 1 ))
+  (( AGE_SEC <= THRESHOLD )) && continue
+
+  # Fresh event log entries in last hour?
+  EVENT_FILE="${EVENTS_DIR}/${NAME}/${TODAY}.jsonl"
+  FRESH_EVENTS=0
+  if [[ -f "$EVENT_FILE" ]]; then
+    CUTOFF=$(( NOW_TS - EVENT_FRESH_WINDOW_SEC ))
+    FRESH_EVENTS=$(awk -v c="$CUTOFF" '
+      {
+        # extract "timestamp":"ISO"
+        if (match($0, /"timestamp":"[^"]+"/)) {
+          ts_str = substr($0, RSTART+13, RLENGTH-14)
+          cmd = "date -u -j -f %Y-%m-%dT%H:%M:%SZ \"" ts_str "\" +%s 2>/dev/null"
+          cmd | getline ts
+          close(cmd)
+          if (ts+0 >= c) count++
+        }
+      }
+      END { print count+0 }
+    ' "$EVENT_FILE")
+  fi
+
+  if [[ "$RUNNING" != "true" ]]; then
+    VERIFIED=$(echo "$VERIFIED" | jq -c --arg n "$NAME" --arg h "$AGE_H" '. + [{agent:$n, age_h:($h|tonumber)}]')
+    cortextos bus log-event action stale_verified warning \
+      --meta "{\"agent\":\"$NAME\",\"age_h\":$AGE_H,\"running\":false}" >/dev/null 2>&1
+  elif [[ "$FRESH_EVENTS" -gt 0 ]]; then
+    DISMISSED=$(echo "$DISMISSED" | jq -c --arg n "$NAME" --arg h "$AGE_H" --arg e "$FRESH_EVENTS" '. + [{agent:$n, age_h:($h|tonumber), fresh_events:($e|tonumber)}]')
+    cortextos bus log-event action stale_dismissed info \
+      --meta "{\"agent\":\"$NAME\",\"age_h\":$AGE_H,\"running\":true,\"fresh_events\":$FRESH_EVENTS}" >/dev/null 2>&1
+  else
+    SUSPECT=$(echo "$SUSPECT" | jq -c --arg n "$NAME" --arg h "$AGE_H" '. + [{agent:$n, age_h:($h|tonumber)}]')
+    cortextos bus log-event action stale_suspect info \
+      --meta "{\"agent\":\"$NAME\",\"age_h\":$AGE_H,\"running\":true,\"fresh_events\":0}" >/dev/null 2>&1
+  fi
+done < <(echo "$AGENTS_JSON" | jq -c '.[]')
+
+jq -n --argjson v "$VERIFIED" --argjson s "$SUSPECT" --argjson d "$DISMISSED" --arg c "$CHECKED" \
+  '{verified:$v, suspect:$s, dismissed:$d, checked:($c|tonumber)}'

--- a/tests/scripts/fleet-health-check.test.ts
+++ b/tests/scripts/fleet-health-check.test.ts
@@ -1,0 +1,163 @@
+/**
+ * tests/scripts/fleet-health-check.test.ts
+ *
+ * Covers the "skip intentionally-disabled agents" behaviour added to
+ * scripts/fleet-health-check.sh (theta 65). See
+ * docs/architecture/fleet-health-check-skip-disabled.md for the 5 test cases.
+ *
+ * The suite shells out to the real script with:
+ *   - a stub `cortextos` on PATH (canned `bus list-agents`, no-op `bus log-event`)
+ *   - a temp CTX_PROJECT_ROOT holding orgs/<org>/agents/<name>/config.json fixtures
+ *   - a temp CTX_ROOT (runtime state root; heartbeat/events fixtures are optional
+ *     because last_heartbeat comes from `list-agents`, not heartbeat.json)
+ *
+ * DARWIN-ONLY: the script parses timestamps with BSD `date -u -j -f`, which does
+ * not exist on GNU/Linux. CI runs on ubuntu-latest, where the age computation
+ * would fail for every agent (HB_TS=0 → early `continue`) and the non-skip cases
+ * could not be exercised. We therefore gate the whole suite on darwin — the same
+ * skipIf pattern used elsewhere in the repo — and run it on the fleet Mac where
+ * the script actually executes.
+ */
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, chmodSync } from 'fs';
+import { join, dirname } from 'path';
+import { tmpdir } from 'os';
+import { fileURLToPath } from 'url';
+import { execFileSync } from 'child_process';
+
+const SCRIPT = join(dirname(fileURLToPath(import.meta.url)), '../../scripts/fleet-health-check.sh');
+const ORG = 'testorg';
+
+function isoAgo(hoursAgo: number): string {
+  // Script format is %Y-%m-%dT%H:%M:%SZ — strip the millisecond component.
+  return new Date(Date.now() - hoursAgo * 3600 * 1000)
+    .toISOString()
+    .replace(/\.\d{3}Z$/, 'Z');
+}
+
+type Agent = { name: string; running: boolean; last_heartbeat: string };
+// config: JSON string to write, 'MALFORMED' for invalid JSON, or null for no file.
+type Configs = Record<string, string | null>;
+
+function run(agents: Agent[], configs: Configs) {
+  const ctxRoot = mkdtempSync(join(tmpdir(), 'fhc-ctxroot-'));
+  const projRoot = mkdtempSync(join(tmpdir(), 'fhc-proj-'));
+  const stubDir = mkdtempSync(join(tmpdir(), 'fhc-stub-'));
+
+  // Config fixtures in the repo tree location the script reads.
+  for (const [name, content] of Object.entries(configs)) {
+    if (content === null) continue;
+    const dir = join(projRoot, 'orgs', ORG, 'agents', name);
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(join(dir, 'config.json'), content === 'MALFORMED' ? '{ not json' : content);
+  }
+
+  // list-agents fixture + stub cortextos.
+  const listFixture = join(stubDir, 'agents.json');
+  writeFileSync(listFixture, JSON.stringify(agents));
+  const stub = join(stubDir, 'cortextos');
+  writeFileSync(
+    stub,
+    `#!/usr/bin/env bash
+if [[ "$1" == "bus" && "$2" == "list-agents" ]]; then cat "${listFixture}"; exit 0; fi
+exit 0
+`,
+  );
+  chmodSync(stub, 0o755);
+
+  try {
+    const out = execFileSync('bash', [SCRIPT], {
+      encoding: 'utf8',
+      env: {
+        ...process.env,
+        PATH: `${stubDir}:${process.env.PATH}`,
+        CTX_ROOT: ctxRoot,
+        CTX_PROJECT_ROOT: projRoot,
+        CTX_ORG: ORG,
+      },
+    });
+    return JSON.parse(out) as { verified: any[]; suspect: any[]; dismissed: any[]; checked: number };
+  } finally {
+    rmSync(ctxRoot, { recursive: true, force: true });
+    rmSync(projRoot, { recursive: true, force: true });
+    rmSync(stubDir, { recursive: true, force: true });
+  }
+}
+
+const names = (list: any[]) => list.map((e) => e.agent);
+
+describe.skipIf(process.platform !== 'darwin')('fleet-health-check.sh — skip disabled agents', () => {
+  it('Test 1: enabled=false + stale + dead is skipped (absent from all lists, not counted)', () => {
+    const r = run(
+      [{ name: 'disabled-agent', running: false, last_heartbeat: isoAgo(200) }],
+      { 'disabled-agent': JSON.stringify({ enabled: false }) },
+    );
+    expect(names(r.verified)).not.toContain('disabled-agent');
+    expect(names(r.suspect)).not.toContain('disabled-agent');
+    expect(names(r.dismissed)).not.toContain('disabled-agent');
+    expect(r.checked).toBe(0);
+  });
+
+  it('Test 2: enabled=true + stale + dead is still classified stale_verified', () => {
+    const r = run(
+      [{ name: 'live-agent', running: false, last_heartbeat: isoAgo(200) }],
+      { 'live-agent': JSON.stringify({ enabled: true }) },
+    );
+    expect(names(r.verified)).toContain('live-agent');
+    expect(r.checked).toBe(1);
+  });
+
+  it('Test 3: missing enabled field is treated as enabled (default-enabled)', () => {
+    const r = run(
+      [{ name: 'no-field-agent', running: false, last_heartbeat: isoAgo(200) }],
+      { 'no-field-agent': JSON.stringify({ some_other_key: 1 }) },
+    );
+    expect(names(r.verified)).toContain('no-field-agent');
+    expect(r.checked).toBe(1);
+  });
+
+  it('Test 4: malformed config.json fails open (agent classified, no crash)', () => {
+    const r = run(
+      [{ name: 'broken-cfg-agent', running: false, last_heartbeat: isoAgo(200) }],
+      { 'broken-cfg-agent': 'MALFORMED' },
+    );
+    expect(names(r.verified)).toContain('broken-cfg-agent');
+    expect(r.checked).toBe(1);
+  });
+
+  it('Test 5: enabled=false with a recent heartbeat is still skipped (before age check)', () => {
+    const r = run(
+      [{ name: 'disabled-fresh', running: true, last_heartbeat: isoAgo(0.17) }],
+      { 'disabled-fresh': JSON.stringify({ enabled: false }) },
+    );
+    expect(r.checked).toBe(0);
+    expect([...names(r.verified), ...names(r.suspect), ...names(r.dismissed)]).not.toContain(
+      'disabled-fresh',
+    );
+  });
+
+  it('gate discriminates: disabled skipped while enabled peer is classified', () => {
+    const r = run(
+      [
+        { name: 'fb-communicator', running: false, last_heartbeat: isoAgo(200) },
+        { name: 'develop', running: false, last_heartbeat: isoAgo(200) },
+      ],
+      {
+        'fb-communicator': JSON.stringify({ enabled: false }),
+        develop: JSON.stringify({ enabled: true }),
+      },
+    );
+    expect(names(r.verified)).toContain('develop');
+    expect(names(r.verified)).not.toContain('fb-communicator');
+    expect(r.checked).toBe(1);
+  });
+
+  it('no config file present is treated as enabled (backward compat)', () => {
+    const r = run(
+      [{ name: 'legacy-agent', running: false, last_heartbeat: isoAgo(200) }],
+      { 'legacy-agent': null },
+    );
+    expect(names(r.verified)).toContain('legacy-agent');
+    expect(r.checked).toBe(1);
+  });
+});


### PR DESCRIPTION
## Problem

`scripts/fleet-health-check.sh` (analyst's stale-heartbeat detector) classifies **fb-communicator** as `stale_verified` on every run — it has `config.json` `enabled: false` (intentionally decommissioned), heartbeat + process both long dead. Each run emits a false `stale_verified` warning event and forces a manual dismissal, adding recurring noise to the analytics stream.

## Fix

A pre-loop skip: agents whose `config.json` has `enabled: false` are intentionally dead and must not surface as stale.

```bash
CONFIG_PATH="${REPO_ROOT}/orgs/${ORG}/agents/${NAME}/config.json"
if [[ -f "$CONFIG_PATH" ]]; then
  CONFIG_ENABLED=$(jq -r '.enabled' "$CONFIG_PATH" 2>/dev/null)
  [[ "$CONFIG_ENABLED" == "false" ]] && continue
fi
```

Placed right after `NAME=` — before the age check and the `CHECKED` increment — so disabled agents don't count toward `.checked`.

### Two subtleties (both verified empirically)

- **Path base is `CTX_PROJECT_ROOT`, not `CTX_ROOT`.** `CTX_ROOT` (`~/.cortextos/<instance>`) holds only runtime state + analytics — no `orgs/*/agents` tree. The `config.json` (ground truth for enable/disable intent) lives in the repo checkout. Falls back to a `BASH_SOURCE`-derived repo root when `CTX_PROJECT_ROOT` is unset.
- **`jq -r '.enabled'`, not `.enabled // true`.** jq's `//` treats `false` **and** `null` as absent, so `false // true` → `true` and the skip would never fire. Plain `.enabled` gives `"false"` (skip), `"true"` (proceed), `"null"` when missing (proceed → default-enabled), empty on malformed JSON (proceed → fail-open) — all handled by one `== "false"` test.

## Note: script was untracked

`scripts/fleet-health-check.sh` was never committed to any branch (local working-tree file only), so this PR **adds** the whole script with the fix baked in. Because the running copy on the fleet host is the untracked working-tree file, merging this PR does not by itself make the fix live there — going live is a separate working-tree reconciliation step (owner: capitan). See the design doc's Rollout section.

## Tests

`tests/scripts/fleet-health-check.test.ts` — vitest suite that shells out to the real script with a stub `cortextos` and temp config fixtures. Covers all 5 spec cases (enabled=false skipped, enabled=true classified, missing field default-enabled, malformed fail-open, disabled+recent-heartbeat still skipped) plus a discriminate-between-peers case and a no-config-file case.

**Darwin-gated** (`describe.skipIf(process.platform !== 'darwin')`): the script parses timestamps with BSD `date -u -j -f`, absent on GNU/Linux; CI runs ubuntu-latest, where the age computation fails for every agent and the non-skip cases can't be exercised. Suite runs on the fleet Mac (where the script executes) and is skipped — not failed — on CI. 7/7 pass locally on darwin.

## Verification on real fleet data

Ran both the current and modified scripts against real `list-agents` output with `log-event` stubbed (no side effects):

| | `.checked` | `verified` |
|---|---|---|
| before | 11 | `[fb-communicator]` |
| after | 10 | `[]` |

fb-communicator absent from all lists, `.checked` drops 11→10 — exactly the design's live-verify criterion.

Design: `docs/architecture/fleet-health-check-skip-disabled.md` (included, force-added past `docs/.gitignore`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)