### PR TITLE
fix(opencode): auto-recover exit-0 --continue wedge and confirm-dead stale reap

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -15,6 +15,16 @@ import { resolvePaths } from '../utils/paths.js';
 
 type LogFn = (msg: string) => void;
 
+// opencode --continue wedge auto-recovery thresholds. A wedged session exits
+// code 0 almost immediately on every `--continue` re-attach, so a "wedge exit"
+// is an exit_code=0 that arrives within FAST_EXIT_MS of the spawn. After
+// WEDGE_THRESHOLD consecutive such exits we stop trusting the session marker and
+// force a fresh boot. 3 mirrors the codex thread-resume crash-loop signature
+// (see shouldContinue()); the fast-exit gate keeps a genuinely long, cleanly
+// exited session from ever counting.
+const OPENCODE_CONTINUE_WEDGE_THRESHOLD = 3;
+const OPENCODE_CONTINUE_WEDGE_FAST_EXIT_MS = 60_000;
+
 /**
  * Manages a single agent's lifecycle.
  * Replaces agent-wrapper.sh for one agent.
@@ -69,6 +79,13 @@ export class AgentProcess {
   // a handoff doc marker. start() reads this after spawn to decide whether the
   // daemon should fire runtime-owned lifecycle Telegram directly.
   private lastSpawnWasHandoff = false;
+  // opencode --continue wedge auto-recovery state (see the OPENCODE_CONTINUE_WEDGE_*
+  // constants). lastSpawnMode/lastStartAtMs let handleExit tell an immediate
+  // exit-0-on-continue (wedge) apart from a normal exit; the counter tracks the
+  // consecutive streak and is reset by any non-wedge exit.
+  private lastSpawnMode: 'fresh' | 'continue' | null = null;
+  private lastStartAtMs = 0;
+  private opencodeContinueWedgeCount = 0;
 
   constructor(name: string, env: CtxEnv, config: AgentConfig, log?: LogFn) {
     this.name = name;
@@ -108,6 +125,10 @@ export class AgentProcess {
 
     // Determine start mode
     const mode = this.shouldContinue() ? 'continue' : 'fresh';
+    // Record the mode/time this lifecycle spawned in so handleExit can detect an
+    // immediate exit-0-on-continue wedge (opencode --continue re-attach loop).
+    this.lastSpawnMode = mode;
+    this.lastStartAtMs = Date.now();
     const prompt = mode === 'fresh'
       ? this.buildStartupPrompt()
       : this.buildContinuePrompt();
@@ -619,6 +640,54 @@ export class AgentProcess {
       return;
     }
 
+    // opencode --continue wedge auto-recovery (companion to the image-poison
+    // block above; same shape, different signature). shouldContinue() passes
+    // `opencode --continue` whenever the session marker is present, with no
+    // wedge-awareness — so a session wedged on the bootstrap splash re-attaches
+    // on every crash-recovery restart and exits code 0 almost immediately,
+    // producing a self-perpetuating exit_code=0 loop that drains max_crashes and
+    // halts the agent (measured live 2026-08-12: opencode crashed 10x with
+    // exit_code=0 across 22min, then HALTED). The marker is trusted as "safe to
+    // continue" without confirming the prior session is not wedged. Detect the
+    // signature — an opencode agent, spawned in continue mode, exiting 0 within
+    // FAST_EXIT_MS — and after THRESHOLD consecutive such exits arm .force-fresh
+    // so the next boot discards the wedged session (shouldContinue() honors
+    // .force-fresh for all runtimes). This automates an operator's manual
+    // stop -> drop-marker -> fresh recovery. Like image-poison, a recovery
+    // restart is not charged against max_crashes_per_day — it is a self-inflicted
+    // continuity artifact, not an agent malfunction.
+    if (
+      exitCode === 0 &&
+      this.config.runtime === 'opencode' &&
+      this.lastSpawnMode === 'continue' &&
+      Date.now() - this.lastStartAtMs < OPENCODE_CONTINUE_WEDGE_FAST_EXIT_MS
+    ) {
+      this.opencodeContinueWedgeCount++;
+      if (this.opencodeContinueWedgeCount >= OPENCODE_CONTINUE_WEDGE_THRESHOLD) {
+        this.log(
+          `opencode --continue wedge: ${this.opencodeContinueWedgeCount} consecutive fast exit_code=0 continues — arming .force-fresh and restarting fresh (not counted toward max_crashes_per_day).`,
+        );
+        this.armForceFresh('opencode --continue wedge auto-recovery');
+        this.appendCrashToRestartsLog(exitCode, 5000, 'OPENCODE_CONTINUE_WEDGE_RECOVERY');
+        this.opencodeContinueWedgeCount = 0;
+        this.status = 'crashed';
+        this.notifyStatusChange();
+        setTimeout(() => {
+          if (this.status === 'crashed') {
+            this.start().catch(err => this.log(`opencode wedge recovery restart failed: ${err}`));
+          }
+        }, 5000);
+        return;
+      }
+      // Below threshold: fall through to normal crash recovery (still counted +
+      // backoff). The next restart re-continues; if it wedges again the streak
+      // grows until the threshold trips the force-fresh above.
+    } else {
+      // Any non-wedge exit — nonzero code, fresh mode, or a session that stayed
+      // up past the fast-exit window — breaks the consecutive streak.
+      this.opencodeContinueWedgeCount = 0;
+    }
+
     // CrashLoopPauser (instar-inspired): if a sliding window is configured,
     // check whether the agent is crash-looping before falling through to
     // the legacy daily counter. The window is a more precise signal than
@@ -1021,7 +1090,7 @@ export class AgentProcess {
   private appendCrashToRestartsLog(
     exitCode: number,
     backoffMs: number,
-    kind: 'CRASH' | 'HALTED' | 'CRASH_LOOP' | 'IMAGE_POISON_RECOVERY',
+    kind: 'CRASH' | 'HALTED' | 'CRASH_LOOP' | 'IMAGE_POISON_RECOVERY' | 'OPENCODE_CONTINUE_WEDGE_RECOVERY',
   ): void {
     try {
       const logDir = join(this.env.ctxRoot, 'logs', this.name);
@@ -1030,7 +1099,7 @@ export class AgentProcess {
       const details =
         kind === 'HALTED'
           ? `exit_code=${exitCode} crash_count=${this.crashCount} max_crashes=${this.maxCrashesPerDay}`
-          : kind === 'IMAGE_POISON_RECOVERY'
+          : kind === 'IMAGE_POISON_RECOVERY' || kind === 'OPENCODE_CONTINUE_WEDGE_RECOVERY'
             ? `exit_code=${exitCode} backoff_s=${backoffMs / 1000} (not counted toward max_crashes)`
             : `exit_code=${exitCode} crash_count=${this.crashCount} backoff_s=${backoffMs / 1000}`;
       const logLine = `[${timestamp}] ${kind}: ${details}\n`;

--- a/src/pty/opencode-pty.ts
+++ b/src/pty/opencode-pty.ts
@@ -29,6 +29,31 @@ const SHELL_DETECT_TAIL_LINES = 20;
 // markers are ruled out.
 const SHELL_PROMPT_TAIL_PATTERN = /[%$#]$/;
 const TELEGRAM_HEADER_PATTERN = /^=== TELEGRAM(?:\s+\w+)?\s+from[^\n]*\(chat_id:(-?\d+)\)/;
+// Stale-process reap tuning. A fire-and-forget SIGTERM (the previous behavior)
+// unlinked the marker and moved on without confirming the orphan actually died,
+// so a wedged prior session could survive and keep re-holding its --continue
+// state. We now poll for exit, escalate to SIGKILL, and confirm-dead before
+// treating the process as reaped.
+const REAP_POLL_INTERVAL_MS = 200;
+const REAP_SIGTERM_GRACE_MS = 2000;
+const REAP_SIGKILL_GRACE_MS = 2000;
+
+const reapSleep = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+// OS-level pid liveness probe using the signal-0 idiom (mirrors the isPidAlive
+// helper in src/daemon/agent-manager.ts): signal 0 sends nothing, it only tests
+// existence + our permission to signal. ESRCH => the process is gone (dead);
+// EPERM => it exists but is owned elsewhere (alive). These are our own child
+// processes, so EPERM is not expected, but we honor the same semantics.
+function isReapTargetAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
 
 /**
  * PTY wrapper for OpenCode agents.
@@ -128,7 +153,7 @@ export class OpencodePTY extends AgentPTY {
     // `opencode run <message>`). Cortext agents must stay alive for future
     // Telegram, inbox, and cron injections, so start the persistent TUI first
     // and inject the startup prompt through the normal PTY input path.
-    this.cleanupStaleProcessMarker();
+    await this.cleanupStaleProcessMarker();
     this.spawnStartedAtMs = Date.now();
     await super.spawn(mode, '');
     this.writeSessionMarker(mode);
@@ -409,23 +434,60 @@ If it instructs you to send Telegram or bus output, run the required terminal co
     }
   }
 
-  private cleanupStaleProcessMarker(): void {
+  private async cleanupStaleProcessMarker(): Promise<void> {
     try {
       const markerPath = this.processMarkerPath();
       if (!existsSync(markerPath)) return;
       const parsed = JSON.parse(readFileSync(markerPath, 'utf-8')) as { pid?: unknown };
       const pid = typeof parsed.pid === 'number' ? parsed.pid : null;
       if (pid && pid > 0 && pid !== process.pid) {
-        try {
-          process.kill(pid, 'SIGTERM');
-        } catch {
-          // Missing process or permission failure; either way do not block boot.
-        }
+        await this.terminateStaleProcess(pid);
       }
       unlinkSync(markerPath);
     } catch {
       // A corrupt marker must not block the agent from starting.
     }
+  }
+
+  /**
+   * Terminate a recorded stale OpenCode process and CONFIRM it is dead before
+   * returning: SIGTERM -> poll for exit -> SIGKILL escalation -> poll again.
+   * A bare fire-and-forget SIGTERM could leave a wedged prior session alive
+   * while its marker was already unlinked, so the next spawn ran alongside an
+   * orphan still holding the agent's session/state root. Bounded and best-effort:
+   * a target that survives even SIGKILL is logged, not allowed to block boot.
+   */
+  private async terminateStaleProcess(pid: number): Promise<void> {
+    if (!isReapTargetAlive(pid)) return;
+    try {
+      process.kill(pid, 'SIGTERM');
+    } catch {
+      // ESRCH (already gone) or EPERM — nothing more we can do; treat as reaped.
+      return;
+    }
+    if (await this.waitForProcessExit(pid, REAP_SIGTERM_GRACE_MS)) return;
+
+    try {
+      process.kill(pid, 'SIGKILL');
+    } catch {
+      return;
+    }
+    if (await this.waitForProcessExit(pid, REAP_SIGKILL_GRACE_MS)) return;
+
+    // Still alive after SIGKILL — do not block boot, but leave a breadcrumb.
+    this.getOutputBuffer().push(
+      `[opencode-pty] stale process ${pid} survived SIGKILL during reap; continuing boot\n`,
+    );
+  }
+
+  /** Poll until the pid is gone or the grace window elapses. Returns true if dead. */
+  private async waitForProcessExit(pid: number, graceMs: number): Promise<boolean> {
+    const deadline = Date.now() + graceMs;
+    while (Date.now() < deadline) {
+      if (!isReapTargetAlive(pid)) return true;
+      await reapSleep(REAP_POLL_INTERVAL_MS);
+    }
+    return !isReapTargetAlive(pid);
   }
 }
 

--- a/tests/unit/daemon/agent-process-opencode-wedge.test.ts
+++ b/tests/unit/daemon/agent-process-opencode-wedge.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, readFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// opencode --continue wedge auto-recovery (agent-process.ts handleExit).
+//
+// This suite deliberately uses REAL fs + the REAL exit-code path (the captured
+// onExit closure drives the real handleExit) and only stubs the PTY classes so
+// no real `opencode` binary is spawned. A sibling PR this week regressed because
+// a heavily mocked unit test hid a real-file-path bug, so the assertions here
+// are made against files actually written to a temp ctxRoot: the .force-fresh
+// marker, restarts.log, and the real opencode-session.json that shouldContinue()
+// reads to decide fresh vs --continue.
+
+let capturedOnExit: ((exitCode: number, signal?: number) => void) | null = null;
+
+const mockOpencodePty = {
+  spawn: vi.fn().mockResolvedValue(undefined),
+  kill: vi.fn(),
+  write: vi.fn(),
+  getPid: vi.fn().mockReturnValue(13579),
+  isAlive: vi.fn().mockReturnValue(true),
+  onExit: vi.fn().mockImplementation((cb: (exitCode: number, signal?: number) => void) => {
+    capturedOnExit = cb;
+  }),
+  getOutputBuffer: vi.fn().mockReturnValue({
+    isBootstrapped: vi.fn().mockReturnValue(true),
+    getRecent: vi.fn().mockReturnValue(''),
+    push: vi.fn(),
+  }),
+};
+
+vi.mock('../../../src/pty/agent-pty.js', () => ({
+  AgentPTY: function AgentPTY() { return mockOpencodePty; },
+}));
+vi.mock('../../../src/pty/codex-app-server-pty.js', () => ({
+  CodexAppServerPTY: function CodexAppServerPTY() { return mockOpencodePty; },
+}));
+vi.mock('../../../src/pty/hermes-pty.js', () => ({
+  HermesPTY: function HermesPTY() { return mockOpencodePty; },
+  hermesDbExists: vi.fn().mockReturnValue(false),
+}));
+
+// Keep the REAL opencodeSessionExists (it reads the real marker on disk) and
+// only replace the class so no `opencode` process is spawned.
+vi.mock('../../../src/pty/opencode-pty.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../../src/pty/opencode-pty.js')>();
+  return { ...actual, OpencodePTY: function OpencodePTY() { return mockOpencodePty; } };
+});
+
+vi.mock('../../../src/pty/inject.js', () => ({
+  injectMessage: vi.fn(),
+  MessageDedup: class { isDuplicate() { return false; } },
+}));
+
+const { AgentProcess } = await import('../../../src/daemon/agent-process.js');
+
+let ctxRoot: string;
+const AGENT = 'opencode-agent';
+
+function stateDir(): string { return join(ctxRoot, 'state', AGENT); }
+function forceFreshPath(): string { return join(stateDir(), '.force-fresh'); }
+function restartsLogPath(): string { return join(ctxRoot, 'logs', AGENT, 'restarts.log'); }
+function writeSessionMarker(): void {
+  mkdirSync(stateDir(), { recursive: true });
+  writeFileSync(
+    join(stateDir(), 'opencode-session.json'),
+    JSON.stringify({ runtime: 'opencode', mode: 'continue' }),
+    'utf-8',
+  );
+}
+
+function makeEnv() {
+  return {
+    instanceId: 'test',
+    ctxRoot,
+    frameworkRoot: join(ctxRoot, 'fw'),
+    agentName: AGENT,
+    agentDir: join(ctxRoot, 'fw', 'agents', AGENT),
+    org: 'acme',
+    projectRoot: join(ctxRoot, 'fw'),
+  };
+}
+
+beforeEach(() => {
+  capturedOnExit = null;
+  ctxRoot = mkdtempSync(join(tmpdir(), 'oc-wedge-'));
+  mkdirSync(join(ctxRoot, 'fw', 'agents', AGENT), { recursive: true });
+  mockOpencodePty.spawn.mockClear();
+  mockOpencodePty.onExit.mockClear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  try { rmSync(ctxRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('opencode --continue wedge auto-recovery', () => {
+  it('arms .force-fresh after N consecutive fast exit-0 continues and reboots fresh', async () => {
+    vi.useFakeTimers();
+    writeSessionMarker();
+    const ap = new AgentProcess(AGENT, makeEnv(), { runtime: 'opencode', telegram_polling: false });
+
+    // First boot: session marker present -> --continue.
+    await ap.start();
+    expect(mockOpencodePty.spawn).toHaveBeenLastCalledWith('continue', expect.any(String));
+
+    // Wedge exit #1 (immediate exit_code=0). Below threshold -> normal crash
+    // recovery reschedules a --continue restart.
+    capturedOnExit!(0);
+    expect(existsSync(forceFreshPath())).toBe(false);
+    await vi.advanceTimersByTimeAsync(5000); // crash #1 backoff -> restart
+    expect(mockOpencodePty.spawn).toHaveBeenLastCalledWith('continue', expect.any(String));
+
+    // Wedge exit #2. Still below threshold.
+    capturedOnExit!(0);
+    expect(existsSync(forceFreshPath())).toBe(false);
+    await vi.advanceTimersByTimeAsync(10000); // crash #2 backoff -> restart
+    expect(mockOpencodePty.spawn).toHaveBeenLastCalledWith('continue', expect.any(String));
+
+    // Wedge exit #3 -> threshold reached -> arm .force-fresh (real file) and log.
+    capturedOnExit!(0);
+    expect(existsSync(forceFreshPath())).toBe(true);
+    expect(readFileSync(restartsLogPath(), 'utf-8'))
+      .toContain('OPENCODE_CONTINUE_WEDGE_RECOVERY');
+
+    // Recovery restart: shouldContinue() reads the real .force-fresh -> fresh boot,
+    // and the marker is consumed.
+    await vi.advanceTimersByTimeAsync(5000);
+    expect(mockOpencodePty.spawn).toHaveBeenLastCalledWith('fresh', expect.any(String));
+    expect(existsSync(forceFreshPath())).toBe(false);
+  });
+
+  it('does not arm .force-fresh when a continue session exits cleanly after the fast-exit window', async () => {
+    vi.useFakeTimers();
+    writeSessionMarker();
+    const ap = new AgentProcess(AGENT, makeEnv(), { runtime: 'opencode', telegram_polling: false });
+
+    await ap.start();
+    expect(mockOpencodePty.spawn).toHaveBeenLastCalledWith('continue', expect.any(String));
+
+    // A long, healthy session that later exits 0 is NOT a wedge — the fast-exit
+    // gate must keep the streak from ever incrementing, even after several such
+    // exits.
+    for (let i = 0; i < 4; i++) {
+      await vi.advanceTimersByTimeAsync(120_000); // uptime well past FAST_EXIT_MS
+      capturedOnExit!(0);
+      expect(existsSync(forceFreshPath())).toBe(false);
+      await vi.advanceTimersByTimeAsync(300_000); // backoff -> restart (continue)
+    }
+    expect(existsSync(forceFreshPath())).toBe(false);
+  });
+
+  it('does not count exit-0 in fresh mode toward the wedge streak', async () => {
+    vi.useFakeTimers();
+    // No session marker -> fresh boot.
+    const ap = new AgentProcess(AGENT, makeEnv(), { runtime: 'opencode', telegram_polling: false });
+
+    await ap.start();
+    expect(mockOpencodePty.spawn).toHaveBeenLastCalledWith('fresh', expect.any(String));
+
+    capturedOnExit!(0);
+    capturedOnExit!(0);
+    capturedOnExit!(0);
+    expect(existsSync(forceFreshPath())).toBe(false);
+  });
+});

--- a/tests/unit/pty/opencode-pty-reap.test.ts
+++ b/tests/unit/pty/opencode-pty-reap.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { spawn, type ChildProcess } from 'child_process';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { OpencodePTY } from '../../../src/pty/opencode-pty.js';
+
+// Face #2 — confirm-dead reap. These tests exercise the REAL kill path against
+// REAL OS processes and a REAL marker file (no process.kill mocks), because the
+// whole point of the fix is to prove the orphan is actually gone, not merely
+// that a signal was sent. cleanupStaleProcessMarker() is driven directly so no
+// `opencode` binary is spawned.
+
+const AGENT = 'opencode-agent';
+let ctxRoot: string;
+const children: ChildProcess[] = [];
+
+function isAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+function stateDir(): string { return join(ctxRoot, 'state', AGENT); }
+function markerPath(): string { return join(stateDir(), 'opencode-process.json'); }
+
+function writeProcessMarker(pid: number): void {
+  mkdirSync(stateDir(), { recursive: true });
+  writeFileSync(
+    markerPath(),
+    JSON.stringify({ runtime: 'opencode', pid, updated_at: new Date().toISOString() }),
+    'utf-8',
+  );
+}
+
+function makePty(): OpencodePTY {
+  const env = {
+    instanceId: 'test',
+    ctxRoot,
+    frameworkRoot: join(ctxRoot, 'fw'),
+    agentName: AGENT,
+    agentDir: join(ctxRoot, 'fw', 'agents', AGENT),
+    org: 'acme',
+    projectRoot: join(ctxRoot, 'fw'),
+  };
+  return new OpencodePTY(env, {}, join(ctxRoot, 'logs', AGENT, 'stdout.log'));
+}
+
+/** Wait until a pid is dead or the timeout elapses. */
+async function waitDead(pid: number, timeoutMs = 5000): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!isAlive(pid)) return true;
+    await new Promise((r) => setTimeout(r, 50));
+  }
+  return !isAlive(pid);
+}
+
+beforeEach(() => {
+  ctxRoot = mkdtempSync(join(tmpdir(), 'oc-reap-'));
+});
+
+afterEach(() => {
+  for (const c of children) {
+    if (c.pid && isAlive(c.pid)) {
+      try { process.kill(c.pid, 'SIGKILL'); } catch { /* already gone */ }
+    }
+  }
+  children.length = 0;
+  try { rmSync(ctxRoot, { recursive: true, force: true }); } catch { /* ignore */ }
+});
+
+describe('OpencodePTY.cleanupStaleProcessMarker confirm-dead reap', () => {
+  it('SIGTERMs a stale process, confirms it is dead, and removes the marker', async () => {
+    // A plain sleep dies on SIGTERM (default disposition).
+    const child = spawn('sleep', ['30'], { stdio: 'ignore' });
+    children.push(child);
+    const pid = child.pid!;
+    expect(isAlive(pid)).toBe(true);
+    writeProcessMarker(pid);
+
+    const pty = makePty();
+    await (pty as unknown as { cleanupStaleProcessMarker(): Promise<void> }).cleanupStaleProcessMarker();
+
+    // Reaped for real: the process is gone and the marker is unlinked.
+    expect(isAlive(pid)).toBe(false);
+    expect(existsSync(markerPath())).toBe(false);
+  });
+
+  it('escalates to SIGKILL when a stale process ignores SIGTERM', async () => {
+    // This child installs a no-op SIGTERM handler, so only SIGKILL can end it —
+    // proving the escalation path actually confirms death rather than giving up
+    // after the ignored SIGTERM.
+    const child = spawn(
+      process.execPath,
+      ['-e', 'process.on("SIGTERM", () => {}); setInterval(() => {}, 1e9);'],
+      { stdio: 'ignore' },
+    );
+    children.push(child);
+    const pid = child.pid!;
+    // Give node a moment to install the handler before we reap.
+    await new Promise((r) => setTimeout(r, 300));
+    expect(isAlive(pid)).toBe(true);
+    writeProcessMarker(pid);
+
+    const pty = makePty();
+    await (pty as unknown as { cleanupStaleProcessMarker(): Promise<void> }).cleanupStaleProcessMarker();
+
+    expect(await waitDead(pid)).toBe(true);
+    expect(existsSync(markerPath())).toBe(false);
+  }, 10000);
+
+  it('removes a marker for an already-dead pid without error', async () => {
+    const child = spawn('sleep', ['30'], { stdio: 'ignore' });
+    const pid = child.pid!;
+    child.kill('SIGKILL');
+    expect(await waitDead(pid)).toBe(true);
+    writeProcessMarker(pid);
+
+    const pty = makePty();
+    await (pty as unknown as { cleanupStaleProcessMarker(): Promise<void> }).cleanupStaleProcessMarker();
+
+    expect(existsSync(markerPath())).toBe(false);
+  });
+});

--- a/tests/unit/pty/opencode-pty.test.ts
+++ b/tests/unit/pty/opencode-pty.test.ts
@@ -538,8 +538,22 @@ describe('OpencodePTY', () => {
     }
   });
 
-  it('cleans up a stale recorded OpenCode process before spawning a replacement', async () => {
-    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true);
+  it('SIGTERMs a stale recorded OpenCode process, confirms dead, and removes the marker', async () => {
+    // Simulate a process that exits on SIGTERM: signal-0 probes report alive
+    // until SIGTERM lands, then ESRCH (gone). No SIGKILL escalation is needed.
+    let terminated = false;
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, sig?: string | number) => {
+      if (sig === 'SIGTERM') { terminated = true; return true; }
+      if (sig === 0) {
+        if (terminated) {
+          const err = new Error('ESRCH') as NodeJS.ErrnoException;
+          err.code = 'ESRCH';
+          throw err;
+        }
+        return true;
+      }
+      return true;
+    }) as typeof process.kill);
     fsMocks.existsSync.mockImplementation((path: string) =>
       path === '/tmp/ctx/state/opencode-agent/opencode-process.json');
     fsMocks.readFileSync.mockImplementation((path: string) => {
@@ -555,11 +569,50 @@ describe('OpencodePTY', () => {
       await pty.spawn('fresh', '');
 
       expect(killSpy).toHaveBeenCalledWith(24680, 'SIGTERM');
+      expect(killSpy).not.toHaveBeenCalledWith(24680, 'SIGKILL');
       expect(fsMocks.unlinkSync).toHaveBeenCalledWith('/tmp/ctx/state/opencode-agent/opencode-process.json');
     } finally {
       killSpy.mockRestore();
     }
   });
+
+  it('escalates to SIGKILL when the stale process survives SIGTERM', async () => {
+    // signal-0 always reports alive until SIGKILL lands — the reap must escalate
+    // and still remove the marker after confirming death.
+    let killed = false;
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(((pid: number, sig?: string | number) => {
+      if (sig === 'SIGKILL') { killed = true; return true; }
+      if (sig === 0) {
+        if (killed) {
+          const err = new Error('ESRCH') as NodeJS.ErrnoException;
+          err.code = 'ESRCH';
+          throw err;
+        }
+        return true; // survives the SIGTERM window
+      }
+      return true; // SIGTERM is a no-op for this process
+    }) as typeof process.kill);
+    fsMocks.existsSync.mockImplementation((path: string) =>
+      path === '/tmp/ctx/state/opencode-agent/opencode-process.json');
+    fsMocks.readFileSync.mockImplementation((path: string) => {
+      if (path === '/tmp/ctx/state/opencode-agent/opencode-process.json') {
+        return JSON.stringify({ pid: 24680 });
+      }
+      return '';
+    });
+
+    try {
+      const pty = new OpencodePTY(mockEnv, {});
+      installSpawnMock(pty);
+      await pty.spawn('fresh', '');
+
+      expect(killSpy).toHaveBeenCalledWith(24680, 'SIGTERM');
+      expect(killSpy).toHaveBeenCalledWith(24680, 'SIGKILL');
+      expect(fsMocks.unlinkSync).toHaveBeenCalledWith('/tmp/ctx/state/opencode-agent/opencode-process.json');
+    } finally {
+      killSpy.mockRestore();
+    }
+  }, 10000);
 
   it('removes the recorded OpenCode process marker on explicit kill', async () => {
     const pty = new OpencodePTY(mockEnv, {});


### PR DESCRIPTION
Detects the opencode `--continue` wedge (repeated fast exit-0 relaunches) and arms a force-fresh reboot to recover automatically, plus reaps a confirmed-dead stale PTY. Independent change (touches src/daemon/agent-process.ts and src/pty/opencode-pty.ts); base main; mergeable in any order. Unit tests added for the wedge-recovery and reap paths.