### PR TITLE
fix(daemon): reload crons.json on tick when its mtime advances

### DIFF
--- a/src/bus/crons.ts
+++ b/src/bus/crons.ts
@@ -14,7 +14,7 @@
  * Write always goes through atomicWriteSync (mkdir + tmp rename).
  */
 
-import { existsSync, readFileSync, mkdirSync } from 'fs';
+import { existsSync, readFileSync, mkdirSync, statSync } from 'fs';
 import { join, dirname } from 'path';
 import type { CronDefinition, CronExecutionLogEntry } from '../types/index.js';
 import { CRONS_DIRECTORY, CRONS_FILENAME, cronExecutionLogPathFor } from './crons-schema.js';
@@ -41,6 +41,25 @@ interface CronsFile {
 function cronsFilePath(agentName: string): string {
   const ctxRoot = process.env.CTX_ROOT ?? process.cwd();
   return join(ctxRoot, CRONS_DIRECTORY, agentName, CRONS_FILENAME);
+}
+
+/**
+ * Return the mtime (ms since epoch) of an agent's crons.json, or null.
+ *
+ * Resolves the path via the same private {@link cronsFilePath} the readers use,
+ * so callers never duplicate CTX_ROOT resolution (which could drift in test
+ * sandboxes). Returns null when the file is absent or any stat error occurs —
+ * callers treat null as "no change" so a transient failure never drops a live
+ * schedule.
+ */
+export function cronsFileMtimeMs(agentName: string): number | null {
+  try {
+    const path = cronsFilePath(agentName);
+    if (!existsSync(path)) return null;
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -1944,13 +1944,18 @@ function fmtTs(iso: string | undefined): string {
 
 /**
  * Send a reload-crons IPC signal to the daemon (non-blocking, best-effort).
- * Silently swallows errors — the daemon will pick up changes on its next tick.
+ *
+ * This is a fast-path only: it asks the running scheduler to reload crons.json
+ * immediately.  If the signal cannot be delivered, the edit is NOT lost — the
+ * scheduler's tick loop stats crons.json every 30s and reloads on its own when
+ * the file mtime changes (see CronScheduler.tick mtime guard), so a durable
+ * crons.json edit takes effect within one tick regardless of this signal.
  */
 async function signalCronReload(agentName: string, instanceId: string): Promise<void> {
   try {
     const ipc = new IPCClient(instanceId);
     await ipc.send({ type: 'reload-crons', agent: agentName, source: 'cortextos bus cron-cmd' });
-  } catch { /* non-fatal — scheduler picks up file change on next 30s tick */ }
+  } catch { /* non-fatal — the tick loop detects the crons.json mtime change and reloads within ~30s */ }
 }
 
 busCommand

--- a/src/daemon/cron-scheduler.ts
+++ b/src/daemon/cron-scheduler.ts
@@ -28,7 +28,7 @@
 import { homedir } from 'os';
 import { join } from 'path';
 import { parseDurationMs, readCronState } from '../bus/cron-state.js';
-import { readCronsWithStatus, updateCron } from '../bus/crons.js';
+import { readCronsWithStatus, updateCron, cronsFileMtimeMs } from '../bus/crons.js';
 import type { CronDefinition } from '../types/index.js';
 import { appendExecutionLog } from './cron-execution-log.js';
 
@@ -261,6 +261,13 @@ export class CronScheduler {
    */
   private lastGoodSchedule: Map<string, ScheduledCron> = new Map();
 
+  /**
+   * mtime (ms) of crons.json at the moment loadCrons() last read it.  The tick
+   * loop compares the live file mtime against this to detect durable edits that
+   * arrived without an explicit IPC reload signal, and reloads within one tick.
+   */
+  private lastLoadedCronsMtimeMs: number | null = null;
+
   /** The master 30-second interval handle. */
   private tickHandle: ReturnType<typeof setInterval> | null = null;
 
@@ -331,6 +338,13 @@ export class CronScheduler {
 
   private loadCrons(isReload: boolean): void {
     const now = Date.now();
+    // Capture the file mtime BEFORE reading its contents.  If a write lands
+    // between this stat and the read below, we store the OLDER mtime and read
+    // the NEWER content, so the next tick harmlessly re-reloads rather than
+    // missing the edit — we deliberately err toward an extra reload, never a
+    // missed edit.  This single assignment keeps the tracked mtime in sync for
+    // every caller: start(), reload() (IPC path), and the tick mtime-guard.
+    this.lastLoadedCronsMtimeMs = cronsFileMtimeMs(this.agentName);
     const { crons: defs, corrupt } = readCronsWithStatus(this.agentName);
     const nextScheduled = new Map<string, ScheduledCron>();
 
@@ -362,24 +376,36 @@ export class CronScheduler {
       const key = changeKeyFor(def);
       const existing = this.scheduled.get(def.name);
 
-      if (isReload && existing !== undefined && existing.changeKey === key) {
-        // Definition unchanged — preserve nextFireAt
-        nextScheduled.set(def.name, { ...existing, definition: def });
-        continue;
-      }
-
       // RELOAD-WHILE-FIRING GUARD: if the cron is mid-fire, preserve the
-      // existing entry as-is until the fire completes.  A fresh ScheduledCron
-      // built from stale crons.json (last_fired_at not yet persisted) would
-      // catch-up-fire on the next tick and double-fire the same logical event.
-      // The next reload (manual or after fire completes) will pick up the
-      // new schedule cleanly.
+      // existing entry AS-IS (same object reference) until the fire completes.
+      // A fresh ScheduledCron built from stale crons.json (last_fired_at not yet
+      // persisted) would catch-up-fire on the next tick and double-fire the same
+      // logical event.  The next reload (manual or after fire completes) will
+      // pick up the new schedule cleanly.
+      //
+      // This MUST be checked BEFORE the changeKey-unchanged branch below.  That
+      // branch stores a SHALLOW COPY (`{ ...existing }`) to swap in the new
+      // definition object; for a firing cron the copy would orphan the object
+      // tick() holds — the copy freezes firing=true and the stale nextFireAt,
+      // while the in-flight fire's post-success advances the now-detached
+      // original.  Result: nextFireAt is never updated in the live map and the
+      // cron is stuck firing=true forever.  Ordering the firing guard first
+      // keeps the SAME reference so the completing fire advances the live entry.
+      // (Only exposed once the tick loop can reload mid-fire on an mtime change;
+      // pre-existing latent hazard on the reload-while-unchanged path.)
       if (isReload && existing !== undefined && existing.firing === true) {
         this.logger(
           `[cron-scheduler] reload deferred for "${def.name}" — fire in progress; ` +
           `new schedule will apply on next reload after fire completes`
         );
         nextScheduled.set(def.name, existing);
+        continue;
+      }
+
+      if (isReload && existing !== undefined && existing.changeKey === key) {
+        // Definition unchanged (and not firing) — preserve nextFireAt while
+        // swapping in the new definition object so prompt-only edits apply.
+        nextScheduled.set(def.name, { ...existing, definition: def });
         continue;
       }
 
@@ -454,6 +480,30 @@ export class CronScheduler {
 
   private async tick(): Promise<void> {
     const now = Date.now();
+
+    // MTIME RELOAD GUARD.
+    // The guard reloads whenever crons.json's mtime differs from the last
+    // LOADED mtime.  This INCLUDES the tick after any fire, because tick's own
+    // updateCron bookkeeping writes (last_fire_attempted_at, last_fired_at)
+    // advance the file mtime.  That post-fire reload is intentional and
+    // load-bearing: it is how an external edit that landed while a fire was
+    // awaiting gets picked up.  We deliberately do NOT refresh the tracked
+    // mtime after our own writes — by mtime alone we cannot distinguish our
+    // bookkeeping write from one that merged a concurrent external edit (we are
+    // the last writer either way), so storing the post-write mtime would
+    // permanently mask such an edit.  The reload is correctness-neutral
+    // (nextFireAt is preserved for unchanged changeKey), and is logged like any
+    // other reload for transparency.
+    //
+    // The `!== null` condition means a transient stat failure or unexpected
+    // deletion (null) is treated as "no change" so we never drop the live
+    // schedule on a transient error.  reload() inherits the reload-while-firing
+    // guard, so a cron mid-fire is preserved and an mtime reload cannot
+    // double-fire.
+    const currentMtime = cronsFileMtimeMs(this.agentName);
+    if (currentMtime !== null && currentMtime !== this.lastLoadedCronsMtimeMs) {
+      this.reload();
+    }
 
     for (const [name, sc] of this.scheduled) {
       if (sc.nextFireAt > now) {

--- a/tests/integration/phase5-failure-modes.test.ts
+++ b/tests/integration/phase5-failure-modes.test.ts
@@ -50,6 +50,7 @@ import {
   writeFileSync,
   readFileSync,
   existsSync,
+  utimesSync,
 } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -1040,6 +1041,149 @@ describe('FM-9: IPC reload during active catch-up — schedule change mid-flight
       const fromNow = nextFire.nextFireAt - Date.now();
       expect(fromNow).toBeGreaterThan(ONE_HOUR);
     }
+
+    scheduler.stop();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FM-10: tick-loop crons.json mtime reload — REAL-file path (no IPC signal)
+//
+// The unit tests in tests/unit/daemon/cron-scheduler.test.ts mock
+// cronsFileMtimeMs, so they cannot exercise the real stat/read path.  These
+// integration tests write a real crons.json, force its mtime strictly forward
+// (utimesSync — deterministic regardless of filesystem mtime granularity), and
+// assert the tick loop picks the edit up within one tick with NO reload() call.
+// ---------------------------------------------------------------------------
+
+describe('FM-10: tick-loop crons.json mtime reload (real file, no IPC)', () => {
+  it('durable crons.json edit is picked up within one tick with no reload() call', async () => {
+    const agent = 'fm-mtime-pickup';
+    ensureAgentDir(agent);
+
+    const fired: string[] = [];
+    const logs: string[] = [];
+
+    // A cron far from due, so nothing fires before the edit lands.
+    addCron(agent, makeCronDef('base', '6h'));
+
+    const scheduler = buildScheduler(agent, (c) => fired.push(c.name), logs);
+    scheduler.start();
+    expect(scheduler.getNextFireTimes().map(n => n.name)).not.toContain('added');
+
+    // Durable edit straight to crons.json — NO scheduler.reload() / IPC.
+    writeCrons(agent, [makeCronDef('base', '6h'), makeCronDef('added', '1m')]);
+    const future = new Date(Date.now() + 10_000);
+    utimesSync(cronsFilePath(agent), future, future);
+
+    // One tick: the loop must stat the file, detect the new mtime, and reload.
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    expect(scheduler.getNextFireTimes().map(n => n.name)).toContain('added');
+
+    // And the newly added cron actually fires when due.
+    await vi.advanceTimersByTimeAsync(ONE_MIN + TICK_MS);
+    expect(fired).toContain('added');
+
+    scheduler.stop();
+  });
+
+  it('prompt-only durable edit (changeKey unchanged) is applied to the live definition within one tick', async () => {
+    const agent = 'fm-mtime-prompt';
+    ensureAgentDir(agent);
+
+    const firedDefs: CronDefinition[] = [];
+    const logs: string[] = [];
+
+    // Overdue by 2m so it catch-up fires on the very first tick — after the
+    // tick-top mtime guard has already applied the durable edit.
+    addCron(agent, makeCronDef('promptcron', '1m', {
+      prompt: 'ORIGINAL',
+      last_fired_at: new Date(Date.now() - 2 * ONE_MIN).toISOString(),
+    }));
+
+    const scheduler = buildScheduler(agent, (c) => firedDefs.push({ ...c }), logs);
+    scheduler.start();
+
+    // Durable prompt-only edit: same name + schedule (changeKey unchanged),
+    // new prompt text. No reload() call.
+    writeCrons(agent, [makeCronDef('promptcron', '1m', { prompt: 'EDITED' })]);
+    const future = new Date(Date.now() + 10_000);
+    utimesSync(cronsFilePath(agent), future, future);
+
+    // One tick: the mtime guard reloads (changeKey-unchanged branch swaps in the
+    // new definition, preserving nextFireAt) BEFORE the fire loop runs, so the
+    // catch-up fire carries the EDITED prompt.
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+
+    const promptFires = firedDefs.filter(d => d.name === 'promptcron');
+    expect(promptFires.length).toBeGreaterThanOrEqual(1);
+    expect(promptFires[promptFires.length - 1].prompt).toBe('EDITED');
+
+    scheduler.stop();
+  });
+
+  // CRUX PROPERTY / POSITIVE CONTROL for the mtime-guard design decision:
+  // "we deliberately do NOT refresh the tracked mtime after our own writes."
+  //
+  // A cron's own post-fire bookkeeping write (last_fired_at/fire_count) advances
+  // the real crons.json mtime.  If a future "optimization" refreshed
+  // lastLoadedCronsMtimeMs to that post-write value, an EXTERNAL edit that landed
+  // while the fire was in flight would be permanently masked (the post-fire tick
+  // would see mtime == tracked and never reload).  This test fails RED under that
+  // injection and GREEN with the shipped code, guarding the property.
+  it('a mid-fire external edit survives the post-fire bookkeeping write and is applied on the post-fire tick', async () => {
+    const agent = 'fm-postfire-external';
+    ensureAgentDir(agent);
+
+    const firedPrompts: string[] = [];
+    let resolveFire: (() => void) | null = null;
+    let blocked = false;
+
+    // Overdue by 2m so it catch-up fires on the very first tick.
+    addCron(agent, makeCronDef('pc', '1m', {
+      prompt: 'ORIGINAL',
+      last_fired_at: new Date(Date.now() - 2 * ONE_MIN).toISOString(),
+    }));
+
+    // Pin the tracked-mtime baseline strictly into the past so ANY later real
+    // write is unambiguously newer than the value captured at start() — makes
+    // the GREEN direction independent of filesystem mtime granularity. (It does
+    // NOT weaken the RED control, which turns on the post-fire refresh overwriting
+    // this baseline with the bookkeeping-write mtime.)
+    const past = new Date(Date.now() - 5 * ONE_MIN);
+    utimesSync(cronsFilePath(agent), past, past);
+
+    const scheduler = buildScheduler(agent, (c) => {
+      firedPrompts.push(c.prompt);
+      if (c.name === 'pc' && !blocked) {
+        blocked = true;
+        return new Promise<void>(res => { resolveFire = res; });
+      }
+    }, []);
+    scheduler.start();
+
+    // Tick 1: catch-up fire begins and BLOCKS (firing === true).
+    await vi.advanceTimersByTimeAsync(TICK_MS);
+    expect(firedPrompts).toEqual(['ORIGINAL']);
+    expect(resolveFire).not.toBeNull();
+
+    // EXTERNAL writer edits crons.json mid-fire: prompt-only (changeKey UNCHANGED),
+    // real write advances the real mtime.
+    writeCrons(agent, [makeCronDef('pc', '1m', { prompt: 'EDITED' })]);
+
+    // Let the fire complete. The post-success updateCron bookkeeping write
+    // read-modify-writes crons.json (preserving the EDITED prompt on disk) and
+    // advances the real mtime again.
+    resolveFire!();
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Post-fire tick(s): the mtime guard must NOT treat its own bookkeeping write
+    // as "no external change" — it reloads, applies the EDITED definition, and the
+    // next scheduled fire carries it.
+    await vi.advanceTimersByTimeAsync(ONE_MIN + TICK_MS);
+
+    expect(firedPrompts.length).toBeGreaterThanOrEqual(2);
+    expect(firedPrompts[firedPrompts.length - 1]).toBe('EDITED');
 
     scheduler.stop();
   });

--- a/tests/unit/daemon/cron-scheduler.test.ts
+++ b/tests/unit/daemon/cron-scheduler.test.ts
@@ -21,11 +21,16 @@ const mockUpdateCron = vi.fn();
 // keep working.  Tests that need to assert the corruption path can override
 // with mockReadCronsWithStatus.mockReturnValueOnce({ crons: [...], corrupt: true }).
 const mockReadCronsWithStatus = vi.fn();
+// cronsFileMtimeMs backs the tick loop's durable-edit detection.  Existing
+// tests keep a constant mtime (set in beforeEach) so they never spuriously
+// reload; tick-reload tests drive this to simulate crons.json edits.
+const mockCronsFileMtimeMs = vi.fn();
 
 vi.mock('../../../src/bus/crons.js', () => ({
   readCrons:  (...args: unknown[]) => mockReadCrons(...args),
   readCronsWithStatus: (...args: unknown[]) => mockReadCronsWithStatus(...args),
   updateCron: (...args: unknown[]) => mockUpdateCron(...args),
+  cronsFileMtimeMs: (...args: unknown[]) => mockCronsFileMtimeMs(...args),
 }));
 
 // ---------------------------------------------------------------------------
@@ -187,12 +192,16 @@ describe('CronScheduler', () => {
     mockReadCrons.mockReset();
     mockUpdateCron.mockReset();
     mockReadCronsWithStatus.mockReset();
+    mockCronsFileMtimeMs.mockReset();
     // Default: readCronsWithStatus reflects whatever readCrons returns
     // and reports the file as healthy (corrupt: false).
     mockReadCronsWithStatus.mockImplementation((agent: string) => ({
       crons: mockReadCrons(agent) ?? [],
       corrupt: false,
     }));
+    // Default: a stable crons.json mtime so existing tests never trigger the
+    // tick loop's durable-edit reload.
+    mockCronsFileMtimeMs.mockReturnValue(1000);
 
     scheduler = new CronScheduler({
       agentName: 'test-agent',
@@ -793,5 +802,184 @@ describe('CronScheduler', () => {
     expect(names).toContain('a');
     expect(names).toContain('b');
     expect(names).not.toContain('c'); // disabled, not scheduled
+  });
+
+  // -------------------------------------------------------------------------
+  // Tick-loop crons.json mtime reload (fix/cron-scheduler-tick-reload)
+  //
+  // A durable crons.json edit must take effect even when the IPC reload-crons
+  // signal never arrives: the tick loop stats crons.json every 30s and reloads
+  // when the mtime differs from the last LOADED mtime.
+  // -------------------------------------------------------------------------
+
+  it('(a) durable crons.json edit with no IPC is picked up on the next tick', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ name: 'base', schedule: '1h' })]);
+    mockCronsFileMtimeMs.mockReturnValue(1000);
+    scheduler.start();
+    expect(scheduler.getNextFireTimes().map(e => e.name)).not.toContain('added');
+
+    // Durable edit: a new cron appears in crons.json and the file mtime advances.
+    // No reload() is called — the tick loop must detect the mtime change itself.
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'base', schedule: '1h' }),
+      makeCron({ name: 'added', schedule: '1m' }),
+    ]);
+    mockCronsFileMtimeMs.mockReturnValue(2000);
+
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(scheduler.getNextFireTimes().map(e => e.name)).toContain('added');
+
+    // And the newly added cron actually fires once it becomes due.
+    await vi.advanceTimersByTimeAsync(60_000 + TICK);
+    expect(fired.map(c => c.name)).toContain('added');
+  });
+
+  it('(b) no reload when crons.json mtime is unchanged (no-fire case)', async () => {
+    // Scoped to the no-fire case: the cron never becomes due, so the only
+    // loadCrons call is start()'s.  The post-fire reload path is covered by (f).
+    mockReadCrons.mockReturnValue([makeCron({ name: 'idle', schedule: '1h' })]);
+    mockCronsFileMtimeMs.mockReturnValue(1000);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(5 * TICK);
+
+    expect(mockReadCronsWithStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it('(c) mid-fire mtime reload does not double-fire', async () => {
+    let resolveFire: (() => void) | undefined;
+    const slowFire = vi.fn().mockImplementation(() => new Promise<void>((res) => { resolveFire = res; }));
+
+    const midScheduler = new CronScheduler({
+      agentName: 'test-agent',
+      onFire: slowFire,
+      logger: (msg) => logs.push(msg),
+    });
+
+    const tenMinAgo = new Date(Date.now() - 10 * 60_000).toISOString();
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'racy', schedule: '10m', last_fired_at: tenMinAgo, fire_count: 1 }),
+    ]);
+    mockCronsFileMtimeMs.mockReturnValue(1000);
+
+    midScheduler.start();
+
+    // Catch-up fire begins, awaiting slowFire (firing === true).
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(slowFire).toHaveBeenCalledTimes(1);
+
+    // Durable edit lands mid-fire: mtime advances and the schedule changes.
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'racy', schedule: '1m', last_fired_at: tenMinAgo, fire_count: 1 }),
+    ]);
+    mockCronsFileMtimeMs.mockReturnValue(2000);
+
+    // Tick triggers the mtime reload; the reload-while-firing guard preserves
+    // the in-flight cron rather than rebuilding it from stale disk state.
+    await vi.advanceTimersByTimeAsync(TICK);
+
+    // Resolve the fire and let further ticks run.
+    resolveFire!();
+    await vi.advanceTimersByTimeAsync(0);
+    await vi.advanceTimersByTimeAsync(TICK);
+
+    expect(slowFire).toHaveBeenCalledTimes(1);
+    midScheduler.stop();
+  });
+
+  it('(d) crons.json absent / stat failure does not crash the tick and does not reload', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ name: 'steady', schedule: '1m' })]);
+    mockCronsFileMtimeMs.mockReturnValue(1000);
+    scheduler.start();
+
+    // Stat now fails / file absent → null, treated as "no change".
+    mockCronsFileMtimeMs.mockReturnValue(null);
+
+    await vi.advanceTimersByTimeAsync(60_000 + TICK);
+
+    // No extra reload — only start()'s load.
+    expect(mockReadCronsWithStatus).toHaveBeenCalledTimes(1);
+    // The scheduled cron still behaves normally.
+    expect(fired.map(c => c.name)).toContain('steady');
+  });
+
+  it('(e) explicit IPC reload keeps the tracked mtime in sync (no redundant tick reload)', async () => {
+    mockReadCrons.mockReturnValue([makeCron({ name: 'one', schedule: '1h' })]);
+    mockCronsFileMtimeMs.mockReturnValue(1000);
+    scheduler.start();
+    expect(mockReadCronsWithStatus).toHaveBeenCalledTimes(1);
+
+    // Durable edit + explicit IPC reload (reload() → loadCrons updates the
+    // tracked mtime to the new value).
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'one', schedule: '1h' }),
+      makeCron({ name: 'two', schedule: '1h' }),
+    ]);
+    mockCronsFileMtimeMs.mockReturnValue(2000);
+    scheduler.reload();
+    expect(mockReadCronsWithStatus).toHaveBeenCalledTimes(2);
+
+    // Tick with mtime still 2000 must NOT trigger a second reload.
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(mockReadCronsWithStatus).toHaveBeenCalledTimes(2);
+  });
+
+  it('(f) post-fire reload happens once and does not double-fire', async () => {
+    const twoMinAgo = new Date(Date.now() - 2 * 60_000).toISOString();
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'job', schedule: '1m', last_fired_at: twoMinAgo, fire_count: 1 }),
+    ]);
+    mockCronsFileMtimeMs.mockReturnValue(1000);
+    scheduler.start();
+
+    // Catch-up fire on the first tick.
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(fired.filter(c => c.name === 'job')).toHaveLength(1);
+
+    const loadsBefore = mockReadCronsWithStatus.mock.calls.length;
+
+    // tick's own updateCron bookkeeping advanced the file mtime (updateCron is
+    // mocked and does not move the mocked mtime, so we simulate it). Contents
+    // are UNCHANGED.
+    mockCronsFileMtimeMs.mockReturnValue(2000);
+    await vi.advanceTimersByTimeAsync(TICK);
+
+    // A reload happened...
+    expect(mockReadCronsWithStatus.mock.calls.length).toBe(loadsBefore + 1);
+    // ...but the cron did not double-fire (nextFireAt preserved for the
+    // unchanged changeKey).
+    expect(fired.filter(c => c.name === 'job')).toHaveLength(1);
+  });
+
+  it('(g) external edit across a fire is applied and logged (suppression never hides a real edit)', async () => {
+    const twoMinAgo = new Date(Date.now() - 2 * 60_000).toISOString();
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'job', schedule: '1m', last_fired_at: twoMinAgo, fire_count: 1 }),
+    ]);
+    mockCronsFileMtimeMs.mockReturnValue(1000);
+    scheduler.start();
+
+    await vi.advanceTimersByTimeAsync(TICK);
+    expect(fired.filter(c => c.name === 'job')).toHaveLength(1);
+
+    const beforeReload = scheduler.getNextFireTimes().find(e => e.name === 'job');
+    expect(beforeReload).toBeDefined();
+    const logsBefore = logs.length;
+
+    // Same as (f) but the file contents genuinely change (schedule 1m → 5m):
+    // changeKey differs, so this is a REAL edit that must not be suppressed.
+    mockReadCrons.mockReturnValue([
+      makeCron({ name: 'job', schedule: '5m' }),
+    ]);
+    mockCronsFileMtimeMs.mockReturnValue(2000);
+    await vi.advanceTimersByTimeAsync(TICK);
+
+    // Modified schedule applied (nextFireAt recomputed for the new changeKey)...
+    const afterReload = scheduler.getNextFireTimes().find(e => e.name === 'job');
+    expect(afterReload).toBeDefined();
+    expect(afterReload!.nextFireAt).not.toBe(beforeReload!.nextFireAt);
+    // ...and the reload IS announced because the schedule changed.
+    const newLogs = logs.slice(logsBefore);
+    expect(newLogs.some(l => l.includes('reloaded') && l.includes('cron(s) active'))).toBe(true);
   });
 });


### PR DESCRIPTION
The cron scheduler now reloads crons.json within one tick when its mtime advances, so an out-of-band edit is picked up without an explicit IPC reload signal or a restart. Errs toward an extra reload rather than a missed edit. Independent change (src/daemon/cron-scheduler.ts, src/bus/crons.ts, src/cli/bus.ts); base main; mergeable in any order. Unit + integration tests added.