### PR TITLE
fix(daemon): detect silent agent dormancy on `cortextos status` with per-agent cadence threshold

### DIFF
--- a/src/cli/status.ts
+++ b/src/cli/status.ts
@@ -95,10 +95,12 @@ export function displayStatuses(statuses: AgentStatus[]): void {
   console.log(separator);
 
   let anyAwaiting = false;
+  let anyDormant = false;
   for (const s of statuses) {
     const name = s.name.padEnd(18);
     let label: string = s.status;
     if (s.awaitingConfirmation) { label = 'unhealthy*'; anyAwaiting = true; }
+    if (s.dormant) { label = 'dormant†'; anyDormant = true; }
     const status = label.padEnd(12);
     const pid = (s.pid?.toString() || '-').padEnd(10);
     const uptime = s.uptime ? formatUptime(s.uptime).padEnd(12) : '-'.padEnd(12);
@@ -107,6 +109,7 @@ export function displayStatuses(statuses: AgentStatus[]): void {
   }
 
   if (anyAwaiting) console.log('  * awaiting interactive confirmation (first-run prompt not accepted)\n');
+  if (anyDormant) console.log('  † enabled but heartbeat stale relative to liveness baseline (possible silent dormancy)\n');
 
   console.log('');
 }

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -20,7 +20,8 @@ import { stripControlChars } from '../utils/validate.js';
 import { processMediaMessage } from '../telegram/media.js';
 import { stripBom } from '../utils/strip-bom.js';
 import { BuzzRelayClient, BuzzDispatcher, loadBuzzConfig, type NostrEvent } from '../buzz/index.js';
-import { computeDormancy } from '../utils/dormancy.js';
+import { computeDormancy, parseHeartbeatIntervalMs } from '../utils/dormancy.js';
+import { CRONS_DIRECTORY, CRONS_FILENAME } from '../bus/crons-schema.js';
 
 type LogFn = (msg: string) => void;
 
@@ -1637,6 +1638,7 @@ export class AgentManager {
         lastSeenMs: this.readHeartbeatMs(name),
         uptimeMs: status.uptime != null ? status.uptime * 1000 : null,
         daemonUptimeMs,
+        expectedIntervalMs: this.readHeartbeatIntervalMs(name),
       });
       if (d.dormant) {
         status.dormant = true;
@@ -1658,6 +1660,7 @@ export class AgentManager {
         lastSeenMs: this.readHeartbeatMs(name),
         uptimeMs: null,
         daemonUptimeMs,
+        expectedIntervalMs: this.readHeartbeatIntervalMs(name),
       });
       statuses.push({
         name,
@@ -1683,6 +1686,35 @@ export class AgentManager {
       if (!ts) return null;
       const ms = new Date(ts).getTime();
       return isNaN(ms) ? null : ms;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * silent-dormancy fix: read an agent's expected heartbeat cadence (ms) from
+   * its ENABLED `heartbeat` cron, so computeDormancy derives the staleness
+   * threshold from the agent's OWN configured cadence rather than a fixed
+   * default. Returns null when there is no enabled `heartbeat` cron or its
+   * schedule form is unparseable — best effort, never throws; the caller then
+   * falls back to FALLBACK_INTERVAL_MS (24h).
+   *
+   * Root resolution is load-bearing. We build the crons path directly from
+   * `this.ctxRoot` (mirroring readHeartbeatMs) using CRONS_DIRECTORY/
+   * CRONS_FILENAME — NOT `readCrons()` from bus/crons.ts, whose cronsFilePath
+   * resolves its root from `process.env.CTX_ROOT ?? process.cwd()`
+   * independently of the daemon's own ctxRoot. A wrong root would read zero
+   * crons and silently drop every agent to the 24h fallback.
+   */
+  private readHeartbeatIntervalMs(agent: string): number | null {
+    const cronsPath = join(this.ctxRoot, CRONS_DIRECTORY, agent, CRONS_FILENAME);
+    if (!existsSync(cronsPath)) return null;
+    try {
+      const parsed = JSON.parse(readFileSync(cronsPath, 'utf-8'));
+      const crons: CronDefinition[] = Array.isArray(parsed?.crons) ? parsed.crons : [];
+      const heartbeat = crons.find(c => c.name === 'heartbeat' && c.enabled !== false);
+      if (!heartbeat) return null;
+      return parseHeartbeatIntervalMs(heartbeat.schedule);
     } catch {
       return null;
     }

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -20,6 +20,7 @@ import { stripControlChars } from '../utils/validate.js';
 import { processMediaMessage } from '../telegram/media.js';
 import { stripBom } from '../utils/strip-bom.js';
 import { BuzzRelayClient, BuzzDispatcher, loadBuzzConfig, type NostrEvent } from '../buzz/index.js';
+import { computeDormancy } from '../utils/dormancy.js';
 
 type LogFn = (msg: string) => void;
 
@@ -127,6 +128,12 @@ export class AgentManager {
   // the orchestrator (e.g. a restart) while this daemon process is alive.
   private slackSocketStarted = false;
   private slackSocketClient: SlackSocketModeClient | null = null;
+
+  // silent-dormancy fix: epoch ms of when this AgentManager (i.e. the daemon)
+  // was constructed. Used as the Face-B liveness baseline for enabled agents
+  // that are absent from the mapped set — there is no per-agent uptime for
+  // them, so staleness is measured relative to daemon start.
+  private daemonStartMs: number = Date.now();
 
   constructor(instanceId: string, ctxRoot: string, frameworkRoot: string, org: string) {
     this.instanceId = instanceId;
@@ -1601,8 +1608,17 @@ export class AgentManager {
    * Get status of all agents.
    */
   getAllStatuses(): AgentStatus[] {
+    const nowMs = Date.now();
+    const daemonUptimeMs = nowMs - this.daemonStartMs;
+    // silent-dormancy fix: agents not in enabled-agents.json default to enabled
+    // (matching discoverAndStart's default-on behavior); an explicit
+    // `enabled: false` entry is the only way to be disabled.
+    const enabledList = this.readInstanceEnableList();
+    const isEnabled = (name: string): boolean => enabledList[name]?.enabled !== false;
+
     const statuses: AgentStatus[] = [];
-    for (const [, entry] of this.agents) {
+    const mapped = new Set<string>();
+    for (const [name, entry] of this.agents) {
       const status = entry.process.getStatus();
       // liveness fix: a mapped entry still reporting 'running' whose OS pid is
       // gone is dead, not running. getStatus() returns a fresh object, so
@@ -1610,9 +1626,66 @@ export class AgentManager {
       if (status.status === 'running' && (!status.pid || !isPidAlive(status.pid))) {
         status.status = 'stopped';
       }
+      mapped.add(name);
+      // Face A — staleness relative to the agent's own process uptime.
+      const d = computeDormancy({
+        agent: name,
+        org: enabledList[name]?.org,
+        enabled: isEnabled(name),
+        mapped: true,
+        nowMs,
+        lastSeenMs: this.readHeartbeatMs(name),
+        uptimeMs: status.uptime != null ? status.uptime * 1000 : null,
+        daemonUptimeMs,
+      });
+      if (d.dormant) {
+        status.dormant = true;
+        status.dormancyReason = d.reason;
+      }
       statuses.push(status);
     }
+
+    // Face B — roster-diff: enabled agents absent from the mapped set. There is
+    // no per-agent uptime, so staleness is measured relative to daemon start.
+    for (const name of Object.keys(enabledList)) {
+      if (mapped.has(name) || !isEnabled(name)) continue;
+      const d = computeDormancy({
+        agent: name,
+        org: enabledList[name]?.org,
+        enabled: true,
+        mapped: false,
+        nowMs,
+        lastSeenMs: this.readHeartbeatMs(name),
+        uptimeMs: null,
+        daemonUptimeMs,
+      });
+      statuses.push({
+        name,
+        status: 'stopped',
+        ...(d.dormant ? { dormant: true, dormancyReason: d.reason } : {}),
+      });
+    }
+
     return statuses;
+  }
+
+  /**
+   * silent-dormancy fix: read the epoch ms of an agent's last heartbeat from
+   * its canonical state/<agent>/heartbeat.json. Returns null if missing or
+   * unparseable — best effort, never throws.
+   */
+  private readHeartbeatMs(agent: string): number | null {
+    const hbPath = join(this.ctxRoot, 'state', agent, 'heartbeat.json');
+    if (!existsSync(hbPath)) return null;
+    try {
+      const hb = JSON.parse(readFileSync(hbPath, 'utf-8'));
+      const ts = hb.last_heartbeat || hb.timestamp;
+      if (!ts) return null;
+      const ms = new Date(ts).getTime();
+      return isNaN(ms) ? null : ms;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -830,4 +830,7 @@ export interface AgentStatus {
   model?: string;
   awaitingConfirmation?: boolean; // first-run observability fix: PTY parked on an
   // interactive first-run prompt past the auto-accept backstop (wedged, not bootstrapped)
+  dormant?: boolean; // silent-dormancy fix: enabled agent whose heartbeat is stale
+  // relative to its own liveness baseline (uptime, or daemon uptime if absent-from-map)
+  dormancyReason?: string; // human explanation of the dormancy verdict
 }

--- a/src/utils/dormancy.ts
+++ b/src/utils/dormancy.ts
@@ -21,6 +21,22 @@
  *
  * `mapped` is NEVER part of the predicate — it only selects which baseline
  * applies and is echoed into the reason string.
+ *
+ * Named residuals (advisory-only surface — no action is taken on any of these):
+ *   (a) Agents with no `heartbeat` cron fall to
+ *       the 24h fallback and are effectively not caught — and may not even be
+ *       "dormant": they can be event-driven rather than beat-driven.
+ *   (b) Agents whose `heartbeat` cron uses a schedule form the parser cannot
+ *       read also fall to the 24h fallback.
+ *   (c) Sub-cadence dormancy (a stall shorter than interval + margin) is
+ *       undetectable BY DESIGN at these cadences — the margin is the price of
+ *       not false-flagging normal jitter.
+ *   (d) The 24h fallback is a conservative, UNVALIDATED ceiling (see
+ *       FALLBACK_INTERVAL_MS); durable per-agent cadence measurement is a
+ *       tracked follow-up.
+ *   (e) A genuinely-idle agent stuck in a single >45m turn exactly when its
+ *       beat is due could receive one spurious advisory flag. Status-surface
+ *       only — nothing acts on it.
  */
 
 // ---------------------------------------------------------------------------
@@ -30,11 +46,29 @@
 /** Below this uptime (Face A) / daemon uptime (Face B) an agent is never flagged. */
 export const BOOT_GRACE_MS = 15 * 60 * 1000; // 15 min
 
-/** Heartbeat is stale when its age exceeds MULTIPLIER × expected interval. */
-export const STALENESS_MULTIPLIER = 3;
+/**
+ * Additive slack added to an agent's OWN configured heartbeat cadence to get the
+ * staleness threshold. It is ADDITIVE, not a multiplier, on purpose: the jitter
+ * that delays a beat is ~constant wall-clock (a heartbeat cron whose fire lands
+ * behind a long agent turn is late by roughly one turn, regardless of whether
+ * the cadence is 20m or 4h). A multiplier would scale this fixed slack with the
+ * cadence and silently flag slow-cadence agents for most of every cycle — the
+ * exact defect this fix removes.
+ */
+export const JITTER_MARGIN_MS = 45 * 60 * 1000; // 45 min
 
-/** Fallback expected heartbeat interval when the caller supplies none. */
-export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 60 * 1000; // 30 min
+/**
+ * Fallback expected heartbeat interval, used ONLY when an agent's real cadence
+ * cannot be parsed (no `heartbeat` cron, or a cron form the parser can't read).
+ *
+ * ⚠ CONSERVATIVE, UNVALIDATED best-estimate CEILING — NOT a measured
+ * zero-false-positive number. It is deliberately large so the fallback path
+ * almost never emits a spurious advisory flag; the cost is that a genuinely
+ * dormant agent on this path is caught late (or, if it is purely event-driven
+ * and legitimately heals-idle beyond 24h, not caught at all). Durable
+ * measurement of real per-agent cadences is a tracked follow-up.
+ */
+export const FALLBACK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24 h
 
 // ---------------------------------------------------------------------------
 // Public types
@@ -57,7 +91,7 @@ export interface DormancyInput {
   uptimeMs: number | null;
   /** Time since daemon start in ms (Face B baseline). */
   daemonUptimeMs: number;
-  /** Expected heartbeat interval in ms; falls back to DEFAULT when null/undefined. */
+  /** Expected heartbeat interval in ms; falls back to FALLBACK_INTERVAL_MS when null/undefined. */
   expectedIntervalMs?: number | null;
 }
 
@@ -87,8 +121,8 @@ export interface DormancyResult {
  * baseline and staleness measure. The `mapped` flag selects the face.
  */
 export function computeDormancy(input: DormancyInput): DormancyResult {
-  const interval = input.expectedIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
-  const thresholdMs = Math.max(BOOT_GRACE_MS, STALENESS_MULTIPLIER * interval);
+  const interval = input.expectedIntervalMs ?? FALLBACK_INTERVAL_MS;
+  const thresholdMs = Math.max(BOOT_GRACE_MS, interval + JITTER_MARGIN_MS);
 
   if (input.mapped) {
     // Face A — baseline is the agent's own uptime. Staleness is clamped to
@@ -126,4 +160,51 @@ function formatMs(ms: number): string {
   if (ms >= 3_600_000)  return `${Math.round(ms / 3_600_000)}h`;
   if (ms >= 60_000)     return `${Math.round(ms / 60_000)}m`;
   return `${ms}ms`;
+}
+
+// ---------------------------------------------------------------------------
+// Heartbeat schedule parser — pure, no I/O
+// ---------------------------------------------------------------------------
+
+//
+// Parse a cron `schedule` string into an expected interval in ms, or null when
+// the cadence cannot be determined (caller then falls back to
+// FALLBACK_INTERVAL_MS).
+//
+// Recognized forms — deliberately narrow so an ambiguous schedule fails to
+// `null` rather than yielding a wrong (and silently trusted) cadence:
+//   - Interval shorthand: "Nh" / "Nm" / "Nd"  (e.g. "4h" -> 14_400_000).
+//   - Every-N-hours 5-field cron "<min> [star][slash]N [star] [star] [star]"
+//     (fixed minute, stepped hour, wildcard day/month/dow) -> N x 3_600_000.
+//
+// Everything else — arbitrary cron expressions (specific hour lists,
+// day-of-week schedules, minute steps), unrecognized text, empty,
+// null/undefined — returns null. A schedule the parser cannot read is a named
+// residual: the agent falls to the 24h fallback and is not caught at its true
+// cadence.
+//
+export function parseHeartbeatIntervalMs(schedule: string | null | undefined): number | null {
+  if (schedule == null) return null;
+  const s = schedule.trim();
+  if (s === '') return null;
+
+  // Interval shorthand: Nh / Nm / Nd.
+  const shorthand = /^(\d+)([hmd])$/.exec(s);
+  if (shorthand) {
+    const n = Number(shorthand[1]);
+    if (n <= 0) return null;
+    const unit = shorthand[2];
+    const mult = unit === 'h' ? 3_600_000 : unit === 'm' ? 60_000 : 86_400_000;
+    return n * mult;
+  }
+
+  // Every-N-hours 5-field cron: "<min> */N * * *" — a fixed minute, a stepped
+  // hour, and wildcard day-of-month / month / day-of-week.
+  const everyNHours = /^\d+\s+\*\/(\d+)\s+\*\s+\*\s+\*$/.exec(s);
+  if (everyNHours) {
+    const n = Number(everyNHours[1]);
+    if (n > 0) return n * 3_600_000;
+  }
+
+  return null;
 }

--- a/src/utils/dormancy.ts
+++ b/src/utils/dormancy.ts
@@ -1,0 +1,129 @@
+/**
+ * dormancy.ts — Pure silent-dormancy predicate for the agent status surface.
+ *
+ * Silent dormancy = an ENABLED agent whose activity signal (heartbeat) is stale
+ * RELATIVE TO its own liveness baseline, while nothing surfaces it.
+ *
+ * This module is intentionally side-effect-free and has no I/O dependencies so
+ * it can be unit-tested exhaustively with an injected `nowMs`. It mirrors the
+ * shape of cron-health.ts.
+ *
+ * One defect, two faces — the ONLY difference is which liveness baseline applies:
+ *
+ *   Face A — mapped agent (present in getAllStatuses)
+ *     baseline = the agent's own process uptime. Staleness is clamped to uptime
+ *     so a fleet bounce cannot flag the whole fleet.
+ *
+ *   Face B — enabled agent ABSENT from the mapped set (roster-diff)
+ *     no agent uptime exists, so baseline = time since DAEMON start. Catches the
+ *     never-spawned / dropped-from-map case. Daemon-start grace is the bounce
+ *     guard for this face.
+ *
+ * `mapped` is NEVER part of the predicate — it only selects which baseline
+ * applies and is echoed into the reason string.
+ */
+
+// ---------------------------------------------------------------------------
+// Constants — all review-tunable proposals, NOT final.
+// ---------------------------------------------------------------------------
+
+/** Below this uptime (Face A) / daemon uptime (Face B) an agent is never flagged. */
+export const BOOT_GRACE_MS = 15 * 60 * 1000; // 15 min
+
+/** Heartbeat is stale when its age exceeds MULTIPLIER × expected interval. */
+export const STALENESS_MULTIPLIER = 3;
+
+/** Fallback expected heartbeat interval when the caller supplies none. */
+export const DEFAULT_HEARTBEAT_INTERVAL_MS = 30 * 60 * 1000; // 30 min
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export interface DormancyInput {
+  /** Agent name (for the result/reason only). */
+  agent: string;
+  /** Org the agent belongs to (optional; echoed through). */
+  org?: string;
+  /** Whether the agent is enabled. A disabled agent is never dormant. */
+  enabled: boolean;
+  /** True = mapped (Face A, uptime baseline); false = enabled-but-absent (Face B). */
+  mapped: boolean;
+  /** Epoch ms for "now" (injectable for deterministic tests). */
+  nowMs: number;
+  /** Epoch ms of the last heartbeat; null if never seen. */
+  lastSeenMs: number | null;
+  /** Agent process uptime in ms (Face A baseline); null when unmapped. */
+  uptimeMs: number | null;
+  /** Time since daemon start in ms (Face B baseline). */
+  daemonUptimeMs: number;
+  /** Expected heartbeat interval in ms; falls back to DEFAULT when null/undefined. */
+  expectedIntervalMs?: number | null;
+}
+
+export interface DormancyResult {
+  agent: string;
+  org?: string;
+  dormant: boolean;
+  mapped: boolean;
+  /** Human string containing the mapped/unmapped word + the age/threshold numbers. */
+  reason: string;
+  /** Staleness threshold used (ms). */
+  thresholdMs: number;
+  /** The staleness age measured against the baseline (ms). */
+  ageMs: number;
+  /** The liveness baseline used: uptime (Face A) or daemon uptime (Face B) (ms). */
+  baselineMs: number;
+}
+
+// ---------------------------------------------------------------------------
+// Core helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute silent-dormancy for a single agent. Pure — no I/O.
+ *
+ * Both faces derive their threshold identically; they differ only in the
+ * baseline and staleness measure. The `mapped` flag selects the face.
+ */
+export function computeDormancy(input: DormancyInput): DormancyResult {
+  const interval = input.expectedIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS;
+  const thresholdMs = Math.max(BOOT_GRACE_MS, STALENESS_MULTIPLIER * interval);
+
+  if (input.mapped) {
+    // Face A — baseline is the agent's own uptime. Staleness is clamped to
+    // uptime (the min(., uptimeMs) below) so a fleet bounce, where every
+    // agent's uptime is small, cannot report the whole fleet as stale.
+    const uptimeMs = input.uptimeMs;
+    const baselineMs = uptimeMs ?? 0;
+    const sinceLastBeat = input.lastSeenMs == null
+      ? baselineMs
+      : Math.min(input.nowMs - input.lastSeenMs, baselineMs);
+    const dormant =
+      input.enabled && uptimeMs != null && uptimeMs > BOOT_GRACE_MS && sinceLastBeat > thresholdMs;
+    const reason = `mapped agent, heartbeat ${formatMs(sinceLastBeat)} stale vs ${formatMs(thresholdMs)} threshold (uptime ${formatMs(baselineMs)})`;
+    return { agent: input.agent, org: input.org, dormant, mapped: true, reason, thresholdMs, ageMs: sinceLastBeat, baselineMs };
+  }
+
+  // Face B — baseline is time since daemon start. A never-heartbeating absent
+  // agent is treated as stale for the whole daemon uptime. The daemon-start
+  // grace is the bounce guard: an agent briefly absent-from-map mid-bounce
+  // (daemon uptime still under grace) must NOT flag.
+  const daemonUptimeMs = input.daemonUptimeMs;
+  const heartbeatAgeMs = input.lastSeenMs == null ? daemonUptimeMs : input.nowMs - input.lastSeenMs;
+  const dormant = input.enabled && daemonUptimeMs > BOOT_GRACE_MS && heartbeatAgeMs > thresholdMs;
+  const reason = `unmapped agent (enabled but absent from map), heartbeat ${formatMs(heartbeatAgeMs)} stale vs ${formatMs(thresholdMs)} threshold (daemon up ${formatMs(daemonUptimeMs)})`;
+  return { agent: input.agent, org: input.org, dormant, mapped: false, reason, thresholdMs, ageMs: heartbeatAgeMs, baselineMs: daemonUptimeMs };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/** Format a duration in ms as a compact human string: "3h", "45m", "2d". */
+function formatMs(ms: number): string {
+  if (ms >= 86_400_000) return `${Math.round(ms / 86_400_000)}d`;
+  if (ms >= 3_600_000)  return `${Math.round(ms / 3_600_000)}h`;
+  if (ms >= 60_000)     return `${Math.round(ms / 60_000)}m`;
+  return `${ms}ms`;
+}

--- a/tests/unit/utils/dormancy.test.ts
+++ b/tests/unit/utils/dormancy.test.ts
@@ -1,0 +1,167 @@
+/**
+ * tests/unit/utils/dormancy.test.ts
+ *
+ * Unit tests for computeDormancy() — the pure silent-dormancy predicate.
+ * No I/O — all inputs (including `nowMs`) are injected. Every numeric input is
+ * DERIVED from the exported constants so the tests stay valid if the tunable
+ * proposals change.
+ *
+ * Coverage:
+ *  - Face A: mapped + frozen heartbeat + enabled + past grace ⇒ dormant
+ *  - Face B: unmapped/absent + stale heartbeat + enabled + past daemon grace ⇒
+ *    dormant (proves the gate ignores `mapped` and Face B works)
+ *  - Face A bounce guard: fresh mapped agent, uptime < grace ⇒ NOT dormant
+ *  - Face B bounce guard: fresh daemon (uptime < grace) + absent stale agent ⇒
+ *    NOT dormant (the fleet-bounce false-positive killer)
+ *  - disabled ⇒ never dormant (both faces)
+ *  - healthy recent heartbeat ⇒ NOT dormant
+ *  - staleness locked to the baseline (uptime), not wall-clock
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  computeDormancy,
+  BOOT_GRACE_MS,
+  STALENESS_MULTIPLIER,
+  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  type DormancyInput,
+} from '../../../src/utils/dormancy';
+
+// Fixed injected "now". Value is arbitrary — nothing reads the wall clock.
+const NOW = 1_000_000_000_000;
+
+// Default threshold the helper derives when no expectedIntervalMs is given.
+const THRESHOLD = Math.max(BOOT_GRACE_MS, STALENESS_MULTIPLIER * DEFAULT_HEARTBEAT_INTERVAL_MS);
+
+// Sanity: with the default interval the multiplier term dominates the grace,
+// so the threshold is strictly greater than the grace. Several tests below rely
+// on this ordering to separate "past grace" from "past threshold".
+const ONE_MIN = 60 * 1000;
+
+function base(overrides: Partial<DormancyInput>): DormancyInput {
+  return {
+    agent: 'agent-x',
+    org: 'testorg',
+    enabled: true,
+    mapped: true,
+    nowMs: NOW,
+    lastSeenMs: NOW, // fresh by default
+    uptimeMs: THRESHOLD + 10 * ONE_MIN, // well past grace by default
+    daemonUptimeMs: THRESHOLD + 10 * ONE_MIN,
+    ...overrides,
+  };
+}
+
+describe('computeDormancy — Face A (mapped, uptime baseline)', () => {
+  it('threshold is strictly greater than the boot grace under the default interval', () => {
+    expect(THRESHOLD).toBeGreaterThan(BOOT_GRACE_MS);
+  });
+
+  it('mapped + frozen heartbeat + enabled + past grace ⇒ dormant', () => {
+    const r = computeDormancy(base({
+      mapped: true,
+      lastSeenMs: NOW - (THRESHOLD + ONE_MIN), // stale beyond threshold
+      uptimeMs: THRESHOLD + 10 * ONE_MIN,      // up long enough to see the staleness
+    }));
+    expect(r.dormant).toBe(true);
+    expect(r.mapped).toBe(true);
+    expect(r.reason).toContain('mapped');
+  });
+
+  it('fresh mapped agent with uptime below grace ⇒ NOT dormant (Face-A bounce guard)', () => {
+    const r = computeDormancy(base({
+      mapped: true,
+      uptimeMs: BOOT_GRACE_MS - ONE_MIN,        // still inside boot grace
+      lastSeenMs: NOW - (THRESHOLD + ONE_MIN),  // heartbeat would otherwise be stale
+    }));
+    expect(r.dormant).toBe(false);
+  });
+
+  it('healthy recent heartbeat ⇒ NOT dormant', () => {
+    const r = computeDormancy(base({
+      mapped: true,
+      lastSeenMs: NOW - ONE_MIN, // one minute ago, well within threshold
+      uptimeMs: THRESHOLD + 10 * ONE_MIN,
+    }));
+    expect(r.dormant).toBe(false);
+  });
+
+  it('staleness is locked to the baseline (uptime), not wall-clock', () => {
+    // Heartbeat is ancient in wall-clock terms, but the agent has only been up
+    // a little past grace (still under threshold). Clamping to uptime keeps it
+    // healthy — proves the min(., uptimeMs) mechanism.
+    const r = computeDormancy(base({
+      mapped: true,
+      lastSeenMs: NOW - 10 * THRESHOLD,      // wall-clock age >> threshold
+      uptimeMs: BOOT_GRACE_MS + ONE_MIN,     // past grace but under threshold
+    }));
+    expect(r.dormant).toBe(false);
+    // The reported age is clamped to uptime, not the raw wall-clock gap.
+    expect(r.ageMs).toBe(BOOT_GRACE_MS + ONE_MIN);
+  });
+
+  it('disabled mapped agent ⇒ never dormant', () => {
+    const r = computeDormancy(base({
+      mapped: true,
+      enabled: false,
+      lastSeenMs: NOW - (THRESHOLD + ONE_MIN),
+      uptimeMs: THRESHOLD + 10 * ONE_MIN,
+    }));
+    expect(r.dormant).toBe(false);
+  });
+
+  it('mapped agent with no uptime yet ⇒ NOT dormant', () => {
+    const r = computeDormancy(base({
+      mapped: true,
+      uptimeMs: null,
+      lastSeenMs: null,
+    }));
+    expect(r.dormant).toBe(false);
+  });
+});
+
+describe('computeDormancy — Face B (unmapped/absent, daemon-uptime baseline)', () => {
+  it('unmapped + stale heartbeat + enabled + past daemon grace ⇒ dormant (gate ignores mapped)', () => {
+    const r = computeDormancy(base({
+      mapped: false,
+      uptimeMs: null, // no agent uptime — it is absent from the map
+      lastSeenMs: NOW - (THRESHOLD + ONE_MIN),
+      daemonUptimeMs: THRESHOLD + 10 * ONE_MIN,
+    }));
+    expect(r.dormant).toBe(true);
+    expect(r.mapped).toBe(false);
+    expect(r.reason).toContain('unmapped');
+  });
+
+  it('never-heartbeating absent agent past daemon grace ⇒ dormant', () => {
+    // null last-seen is treated as "stale for the whole daemon uptime".
+    const r = computeDormancy(base({
+      mapped: false,
+      uptimeMs: null,
+      lastSeenMs: null,
+      daemonUptimeMs: THRESHOLD + ONE_MIN, // exceeds threshold
+    }));
+    expect(r.dormant).toBe(true);
+  });
+
+  it('fresh daemon (uptime below grace) + absent stale agent ⇒ NOT dormant (fleet-bounce guard)', () => {
+    const r = computeDormancy(base({
+      mapped: false,
+      uptimeMs: null,
+      lastSeenMs: NOW - (THRESHOLD + ONE_MIN), // heartbeat is genuinely stale
+      daemonUptimeMs: BOOT_GRACE_MS - ONE_MIN, // but the daemon just started
+    }));
+    expect(r.dormant).toBe(false);
+  });
+
+  it('disabled absent agent ⇒ never dormant', () => {
+    const r = computeDormancy(base({
+      mapped: false,
+      enabled: false,
+      uptimeMs: null,
+      lastSeenMs: NOW - (THRESHOLD + ONE_MIN),
+      daemonUptimeMs: THRESHOLD + 10 * ONE_MIN,
+    }));
+    expect(r.dormant).toBe(false);
+  });
+});

--- a/tests/unit/utils/dormancy.test.ts
+++ b/tests/unit/utils/dormancy.test.ts
@@ -1,42 +1,45 @@
 /**
  * tests/unit/utils/dormancy.test.ts
  *
- * Unit tests for computeDormancy() — the pure silent-dormancy predicate.
- * No I/O — all inputs (including `nowMs`) are injected. Every numeric input is
- * DERIVED from the exported constants so the tests stay valid if the tunable
- * proposals change.
+ * Unit tests for computeDormancy() and parseHeartbeatIntervalMs() — the pure
+ * silent-dormancy predicate and its schedule parser. No I/O — all inputs
+ * (including `nowMs`) are injected. Every numeric expectation is DERIVED from
+ * the exported constants so the tests stay valid if the constants change.
  *
- * Coverage:
- *  - Face A: mapped + frozen heartbeat + enabled + past grace ⇒ dormant
- *  - Face B: unmapped/absent + stale heartbeat + enabled + past daemon grace ⇒
- *    dormant (proves the gate ignores `mapped` and Face B works)
- *  - Face A bounce guard: fresh mapped agent, uptime < grace ⇒ NOT dormant
- *  - Face B bounce guard: fresh daemon (uptime < grace) + absent stale agent ⇒
- *    NOT dormant (the fleet-bounce false-positive killer)
- *  - disabled ⇒ never dormant (both faces)
- *  - healthy recent heartbeat ⇒ NOT dormant
- *  - staleness locked to the baseline (uptime), not wall-clock
+ * The staleness threshold is now ADDITIVE and cadence-relative:
+ *   thresholdMs = max(BOOT_GRACE_MS, interval + JITTER_MARGIN_MS)
+ * where `interval` is the agent's OWN configured heartbeat cadence, or
+ * FALLBACK_INTERVAL_MS when it cannot be determined.
  */
 
 import { describe, it, expect } from 'vitest';
 import {
   computeDormancy,
+  parseHeartbeatIntervalMs,
   BOOT_GRACE_MS,
-  STALENESS_MULTIPLIER,
-  DEFAULT_HEARTBEAT_INTERVAL_MS,
+  JITTER_MARGIN_MS,
+  FALLBACK_INTERVAL_MS,
   type DormancyInput,
 } from '../../../src/utils/dormancy';
 
 // Fixed injected "now". Value is arbitrary — nothing reads the wall clock.
 const NOW = 1_000_000_000_000;
 
-// Default threshold the helper derives when no expectedIntervalMs is given.
-const THRESHOLD = Math.max(BOOT_GRACE_MS, STALENESS_MULTIPLIER * DEFAULT_HEARTBEAT_INTERVAL_MS);
-
-// Sanity: with the default interval the multiplier term dominates the grace,
-// so the threshold is strictly greater than the grace. Several tests below rely
-// on this ordering to separate "past grace" from "past threshold".
 const ONE_MIN = 60 * 1000;
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+// A representative real multi-hour cadence (heartbeat = "4h").
+const INTERVAL_4H = 4 * HOUR;
+
+/** The threshold the helper derives for a given interval (null ⇒ fallback). */
+function thresholdFor(intervalMs: number | null): number {
+  const interval = intervalMs ?? FALLBACK_INTERVAL_MS;
+  return Math.max(BOOT_GRACE_MS, interval + JITTER_MARGIN_MS);
+}
+
+// Default threshold used by the base() fixture (4h cadence).
+const THRESHOLD = thresholdFor(INTERVAL_4H);
 
 function base(overrides: Partial<DormancyInput>): DormancyInput {
   return {
@@ -46,17 +49,81 @@ function base(overrides: Partial<DormancyInput>): DormancyInput {
     mapped: true,
     nowMs: NOW,
     lastSeenMs: NOW, // fresh by default
-    uptimeMs: THRESHOLD + 10 * ONE_MIN, // well past grace by default
+    uptimeMs: THRESHOLD + 10 * ONE_MIN, // well past grace + threshold by default
     daemonUptimeMs: THRESHOLD + 10 * ONE_MIN,
+    expectedIntervalMs: INTERVAL_4H,
     ...overrides,
   };
 }
 
-describe('computeDormancy — Face A (mapped, uptime baseline)', () => {
-  it('threshold is strictly greater than the boot grace under the default interval', () => {
-    expect(THRESHOLD).toBeGreaterThan(BOOT_GRACE_MS);
+describe('computeDormancy — threshold derivation (additive, cadence-relative)', () => {
+  it('threshold is interval + JITTER_MARGIN_MS (additive, not a multiplier)', () => {
+    const r = computeDormancy(base({ expectedIntervalMs: INTERVAL_4H }));
+    expect(r.thresholdMs).toBe(INTERVAL_4H + JITTER_MARGIN_MS);
   });
 
+  it('a longer cadence widens the threshold by exactly the same fixed margin', () => {
+    const shortR = computeDormancy(base({ expectedIntervalMs: HOUR }));
+    const longR = computeDormancy(base({ expectedIntervalMs: 8 * HOUR }));
+    // Additive: the gap between the two thresholds equals the gap between the
+    // two cadences (7h), NOT a multiplied blow-up. A multiplier would make the
+    // difference scale as MULTIPLIER × 7h.
+    expect(longR.thresholdMs - shortR.thresholdMs).toBe(7 * HOUR);
+    expect(longR.thresholdMs).toBe(8 * HOUR + JITTER_MARGIN_MS);
+  });
+
+  it('the JITTER margin is exactly 45 minutes', () => {
+    expect(JITTER_MARGIN_MS).toBe(45 * ONE_MIN);
+  });
+
+  it('null interval falls back to FALLBACK_INTERVAL_MS (24h) + margin', () => {
+    const r = computeDormancy(base({ expectedIntervalMs: null }));
+    expect(r.thresholdMs).toBe(FALLBACK_INTERVAL_MS + JITTER_MARGIN_MS);
+    expect(FALLBACK_INTERVAL_MS).toBe(24 * HOUR);
+  });
+
+  it('undefined interval falls back to FALLBACK_INTERVAL_MS + margin', () => {
+    const r = computeDormancy(base({ expectedIntervalMs: undefined }));
+    expect(r.thresholdMs).toBe(FALLBACK_INTERVAL_MS + JITTER_MARGIN_MS);
+  });
+
+  it('POSITIVE CONTROL: the 45m margin is load-bearing — a within-margin stale beat is NOT dormant', () => {
+    // Heartbeat is stale by interval + 44min — a HARDCODED age (deliberately NOT
+    // derived from JITTER_MARGIN_MS, so it does not move if the constant is
+    // mutated). With the real 45m margin the threshold is interval + 45m and this
+    // age (interval + 44m) is inside it ⇒ healthy. If JITTER_MARGIN_MS were
+    // removed (threshold collapsed to `interval`), interval + 44m would exceed
+    // the threshold and this assertion would flip to dormant.
+    const interval = HOUR;
+    const r = computeDormancy(base({
+      expectedIntervalMs: interval,
+      lastSeenMs: NOW - (interval + 44 * ONE_MIN),
+      uptimeMs: 10 * DAY,
+    }));
+    expect(r.dormant).toBe(false);
+  });
+
+  it('boundary is strict `>`: heartbeat stale by exactly the threshold is NOT dormant', () => {
+    const r = computeDormancy(base({
+      expectedIntervalMs: INTERVAL_4H,
+      lastSeenMs: NOW - THRESHOLD, // exactly at threshold
+      uptimeMs: 10 * DAY,          // uptime far past threshold so the clamp is inert
+    }));
+    expect(r.ageMs).toBe(THRESHOLD);
+    expect(r.dormant).toBe(false);
+  });
+
+  it('one ms past the threshold IS dormant', () => {
+    const r = computeDormancy(base({
+      expectedIntervalMs: INTERVAL_4H,
+      lastSeenMs: NOW - (THRESHOLD + 1),
+      uptimeMs: 10 * DAY,
+    }));
+    expect(r.dormant).toBe(true);
+  });
+});
+
+describe('computeDormancy — Face A (mapped, uptime baseline)', () => {
   it('mapped + frozen heartbeat + enabled + past grace ⇒ dormant', () => {
     const r = computeDormancy(base({
       mapped: true,
@@ -68,7 +135,7 @@ describe('computeDormancy — Face A (mapped, uptime baseline)', () => {
     expect(r.reason).toContain('mapped');
   });
 
-  it('fresh mapped agent with uptime below grace ⇒ NOT dormant (Face-A bounce guard)', () => {
+  it('fresh mapped agent with uptime below grace ⇒ NOT dormant (boot-grace floor / Face-A bounce guard)', () => {
     const r = computeDormancy(base({
       mapped: true,
       uptimeMs: BOOT_GRACE_MS - ONE_MIN,        // still inside boot grace
@@ -154,6 +221,17 @@ describe('computeDormancy — Face B (unmapped/absent, daemon-uptime baseline)',
     expect(r.dormant).toBe(false);
   });
 
+  it('Face B uses the daemon-uptime baseline in its reason string', () => {
+    const r = computeDormancy(base({
+      mapped: false,
+      uptimeMs: null,
+      lastSeenMs: NOW - (THRESHOLD + ONE_MIN),
+      daemonUptimeMs: THRESHOLD + 10 * ONE_MIN,
+    }));
+    expect(r.baselineMs).toBe(THRESHOLD + 10 * ONE_MIN);
+    expect(r.reason).toContain('daemon up');
+  });
+
   it('disabled absent agent ⇒ never dormant', () => {
     const r = computeDormancy(base({
       mapped: false,
@@ -163,5 +241,73 @@ describe('computeDormancy — Face B (unmapped/absent, daemon-uptime baseline)',
       daemonUptimeMs: THRESHOLD + 10 * ONE_MIN,
     }));
     expect(r.dormant).toBe(false);
+  });
+});
+
+describe('parseHeartbeatIntervalMs — interval shorthand', () => {
+  it('Nh → hours', () => {
+    expect(parseHeartbeatIntervalMs('4h')).toBe(4 * HOUR);
+    expect(parseHeartbeatIntervalMs('1h')).toBe(HOUR);
+  });
+
+  it('Nm → minutes', () => {
+    expect(parseHeartbeatIntervalMs('20m')).toBe(20 * ONE_MIN);
+    expect(parseHeartbeatIntervalMs('30m')).toBe(30 * ONE_MIN);
+  });
+
+  it('Nd → days', () => {
+    expect(parseHeartbeatIntervalMs('1d')).toBe(DAY);
+    expect(parseHeartbeatIntervalMs('2d')).toBe(2 * DAY);
+  });
+
+  it('leading/trailing whitespace is tolerated', () => {
+    expect(parseHeartbeatIntervalMs('  4h  ')).toBe(4 * HOUR);
+  });
+
+  it('zero and non-numeric shorthand → null', () => {
+    expect(parseHeartbeatIntervalMs('0h')).toBeNull();
+    expect(parseHeartbeatIntervalMs('h')).toBeNull();
+  });
+});
+
+describe('parseHeartbeatIntervalMs — every-N-hours cron', () => {
+  it('"<min> */N * * *" → N hours', () => {
+    expect(parseHeartbeatIntervalMs('0 */6 * * *')).toBe(6 * HOUR);
+    expect(parseHeartbeatIntervalMs('30 */4 * * *')).toBe(4 * HOUR);
+    expect(parseHeartbeatIntervalMs('0 */1 * * *')).toBe(HOUR);
+  });
+
+  it('POSITIVE CONTROL: */N cron yields the tight parsed threshold — breaking the parse drops to the 24h fallback and flips dormancy', () => {
+    // A 4h-stepped cron parses to a 4h cadence ⇒ threshold 4h45m. A heartbeat
+    // stale by just over that IS dormant. If the every-N-hours parse regressed
+    // to null, the interval would fall to FALLBACK_INTERVAL_MS (24h) ⇒ threshold
+    // 24h45m, the same ~4h46m age would be well within it, and this assertion
+    // would flip to false.
+    const interval = parseHeartbeatIntervalMs('0 */4 * * *');
+    expect(interval).toBe(4 * HOUR); // guard: the parse must be tight
+    const r = computeDormancy(base({
+      expectedIntervalMs: interval,
+      lastSeenMs: NOW - (4 * HOUR + JITTER_MARGIN_MS + ONE_MIN), // just past 4h45m
+      uptimeMs: 10 * DAY,
+    }));
+    expect(r.dormant).toBe(true);
+  });
+});
+
+describe('parseHeartbeatIntervalMs — unparseable ⇒ null (caller falls back)', () => {
+  it('specific-hour and day-of-week cron expressions → null', () => {
+    expect(parseHeartbeatIntervalMs('0 8 * * *')).toBeNull();       // daily at 08:00
+    expect(parseHeartbeatIntervalMs('0 0,6,12,18 * * *')).toBeNull(); // hour list
+    expect(parseHeartbeatIntervalMs('0 16 * * 1')).toBeNull();      // Mondays
+    expect(parseHeartbeatIntervalMs('*/5 * * * *')).toBeNull();     // every 5 min (not every-N-hours)
+  });
+
+  it('weeks shorthand (unsupported), garbage, empty, null, undefined → null', () => {
+    expect(parseHeartbeatIntervalMs('2w')).toBeNull();
+    expect(parseHeartbeatIntervalMs('garbage')).toBeNull();
+    expect(parseHeartbeatIntervalMs('')).toBeNull();
+    expect(parseHeartbeatIntervalMs('   ')).toBeNull();
+    expect(parseHeartbeatIntervalMs(null)).toBeNull();
+    expect(parseHeartbeatIntervalMs(undefined)).toBeNull();
   });
 });


### PR DESCRIPTION
Detects a silent/dormant enabled agent (heartbeat stale beyond an additive, per-agent-cadence-derived threshold) and surfaces it on `cortextos status`. Threshold = the agent's own heartbeat cadence + a fixed jitter margin (additive, not multiplicative). Touches src/utils/dormancy.ts, src/daemon/agent-manager.ts, src/cli/status.ts, src/types/index.ts + tests.

STACKED on #923 (`fix/startagent-idempotent-start`), which is stacked on #895 (`fix/daemon-map-entry-race`) — all three modify agent-manager.ts in a dependency order. Base auto-retargets to main as its parents merge. Do NOT merge before #923 and #895.