### PR TITLE
fix(bus): make heartbeat refresh opt-in so on-behalf events cannot spoof liveness

### DIFF
--- a/src/bus/event.ts
+++ b/src/bus/event.ts
@@ -11,14 +11,19 @@ import { validateEventCategory, validateEventSeverity, isValidJson } from '../ut
  *
  * Events are stored at: {analyticsDir}/events/{agent}/{YYYY-MM-DD}.jsonl
  *
- * Side-effect: if this agent has an existing heartbeat.json, refresh its
- * `last_heartbeat` timestamp. Activity is liveness — if the agent is
- * logging events, it is by definition alive, so the stale-heartbeat
- * monitor should not page on it. Other fields (status, mode, etc.) are
- * preserved from the last explicit update-heartbeat call. Best-effort:
- * a failing heartbeat refresh never blocks the event write itself.
- * If no heartbeat file exists yet we do nothing — the first
- * update-heartbeat call creates it with full field values.
+ * Optional side-effect: when the caller opts in via `opts.refreshHeartbeat`
+ * and this agent has an existing heartbeat.json, refresh its
+ * `last_heartbeat` timestamp. "Activity is liveness" holds ONLY for an
+ * agent logging its OWN in-session activity, so opt-in is reserved for
+ * those call sites. Daemon-on-behalf writes (e.g. delivering an inbound
+ * message to another agent) must never opt in — otherwise a wedged
+ * agent's heartbeat would be spoofed fresh by traffic it did not act on.
+ * The default is off (fail-safe): a caller that says nothing never
+ * touches the heartbeat. Other fields (status, mode, etc.) are preserved
+ * from the last explicit update-heartbeat call. Best-effort: a failing
+ * heartbeat refresh never blocks the event write itself. If no heartbeat
+ * file exists yet we do nothing — the first update-heartbeat call creates
+ * it with full field values.
  */
 export function logEvent(
   paths: BusPaths,
@@ -28,6 +33,7 @@ export function logEvent(
   eventName: string,
   severity: EventSeverity,
   metadata?: Record<string, unknown> | string,
+  opts?: { refreshHeartbeat?: boolean },
 ): void {
   validateEventCategory(category);
   validateEventSeverity(severity);
@@ -64,8 +70,11 @@ export function logEvent(
 
   appendFileSync(join(eventsDir, `${today}.jsonl`), eventLine + '\n', 'utf-8');
 
-  // Refresh heartbeat timestamp as a side-effect. See doc comment above.
-  refreshHeartbeatTimestamp(paths, timestamp);
+  // Refresh heartbeat timestamp only when the caller opts in (in-session
+  // self-logging). Default off is fail-safe. See doc comment above.
+  if (opts?.refreshHeartbeat) {
+    refreshHeartbeatTimestamp(paths, timestamp);
+  }
 }
 
 /**

--- a/src/bus/task.ts
+++ b/src/bus/task.ts
@@ -510,7 +510,7 @@ export function completeTask(
       logEvent(eventPaths, assignee, taskOrg, 'task', 'task_completed', 'info', {
         task_id: taskId,
         ...(result ? { result } : {}),
-      });
+      }, { refreshHeartbeat: true });
     } catch {
       // Never let observability break task completion.
     }

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -117,7 +117,7 @@ busCommand
 
     const msgId = sendMessage(paths, env.agentName, to, priority as Priority, text, effectiveReplyTo);
     try {
-      logEvent(paths, env.agentName, env.org, 'message', 'agent_message_sent', 'info', JSON.stringify({ to, priority, msg_id: msgId, reply_to: effectiveReplyTo ?? null }));
+      logEvent(paths, env.agentName, env.org, 'message', 'agent_message_sent', 'info', JSON.stringify({ to, priority, msg_id: msgId, reply_to: effectiveReplyTo ?? null }), { refreshHeartbeat: true });
     } catch { /* non-fatal */ }
     console.log(msgId);
   });
@@ -139,7 +139,7 @@ busCommand
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
     ackInbox(paths, id);
     try {
-      logEvent(paths, env.agentName, env.org, 'message', 'inbox_ack', 'info', JSON.stringify({ msg_id: id }));
+      logEvent(paths, env.agentName, env.org, 'message', 'inbox_ack', 'info', JSON.stringify({ msg_id: id }), { refreshHeartbeat: true });
     } catch { /* non-fatal */ }
     console.log(`ACK'd ${id}`);
   });
@@ -429,7 +429,7 @@ busCommand
     }
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
-    logEvent(paths, env.agentName, env.org, category as EventCategory, event, severity as EventSeverity, opts.meta);
+    logEvent(paths, env.agentName, env.org, category as EventCategory, event, severity as EventSeverity, opts.meta, { refreshHeartbeat: true });
     console.log(`Logged ${category}/${event} (${severity})`);
   });
 
@@ -490,7 +490,7 @@ busCommand
     // even if the agent itself forgets to call log-event. This makes the
     // dashboard "agents" list derive from heartbeats, not just explicit events.
     try {
-      logEvent(paths, env.agentName, env.org, 'heartbeat', 'heartbeat', 'info', JSON.stringify({ status, task: opts.task ?? '' }));
+      logEvent(paths, env.agentName, env.org, 'heartbeat', 'heartbeat', 'info', JSON.stringify({ status, task: opts.task ?? '' }), { refreshHeartbeat: true });
     } catch {
       // Non-fatal: heartbeat write already succeeded
     }
@@ -1049,7 +1049,7 @@ busCommand
         try {
           const paths = resolvePaths(env.agentName, env.instanceId, env.org);
           const preview = message.length > 120 ? message.slice(0, 120) + '…' : message;
-          logEvent(paths, env.agentName, env.org, 'message', 'telegram_sent', 'info', JSON.stringify({ chat_id: chatId, message_id: sentMessageId, preview }));
+          logEvent(paths, env.agentName, env.org, 'message', 'telegram_sent', 'info', JSON.stringify({ chat_id: chatId, message_id: sentMessageId, preview }), { refreshHeartbeat: true });
         } catch { /* non-fatal */ }
       }
 
@@ -2722,7 +2722,7 @@ busCommand
                 line: trimmed,
                 session: sessionName,
                 high_signal: isHighSignal,
-              });
+              }, { refreshHeartbeat: true });
             } catch { /* Never fail the stream */ }
           } else {
             logLine(`[event] ${trimmed}`);

--- a/src/pty/codex-app-server-pty.ts
+++ b/src/pty/codex-app-server-pty.ts
@@ -795,6 +795,8 @@ export class CodexAppServerPTY {
   private emitUnsupportedRequestEvent(method: string): void {
     try {
       const paths = resolvePaths(this._env.agentName, this._env.instanceId, this._env.org);
+      // Error/runtime event: deliberately does not refresh heartbeat —
+      // emitting an error does not prove the reasoning loop is alive.
       logEvent(
         paths,
         this._env.agentName,

--- a/src/telegram/logging.ts
+++ b/src/telegram/logging.ts
@@ -113,6 +113,9 @@ export function recordInboundTelegram(
 
   const hasMedia = !!(msg.photo || msg.document || msg.voice || msg.audio || msg.video || msg.video_note);
   try {
+    // Daemon-on-behalf delivery write: deliberately does NOT opt into
+    // heartbeat refresh, so a wedged agent's heartbeat cannot be spoofed
+    // fresh by inbound traffic it never acted on.
     logEvent(paths, agentName, org, 'message', 'telegram_received', 'info', {
       chat_id: String(msg.chat?.id ?? ''),
       message_id: msg.message_id,

--- a/tests/unit/bus/event.test.ts
+++ b/tests/unit/bus/event.test.ts
@@ -6,11 +6,13 @@ import { logEvent } from '../../../src/bus/event';
 import type { BusPaths, Heartbeat } from '../../../src/types';
 
 /**
- * Tests for the heartbeat-refresh side-effect on logEvent. The data
- * point that motivated this behavior: 76.4% of fleet activity events
- * landed while the agent's heartbeat was >5min stale — every event
- * implies the agent is alive, so the stale-monitor should never fire
- * on an agent that is actively logging activity.
+ * Tests for the opt-in heartbeat-refresh side-effect on logEvent. The
+ * refresh now happens ONLY when the caller passes
+ * `{ refreshHeartbeat: true }`, which is reserved for an agent logging
+ * its OWN in-session activity. The default is off (fail-safe): a
+ * daemon-on-behalf write (e.g. delivering an inbound message to another
+ * agent) never opts in, so a wedged agent's heartbeat cannot be spoofed
+ * fresh by traffic it did not act on.
  */
 describe('Bus events', () => {
   let testDir: string;
@@ -57,7 +59,7 @@ describe('Bus events', () => {
   });
 
   describe('heartbeat refresh side-effect', () => {
-    it('bumps last_heartbeat on an existing heartbeat.json without overwriting other fields', async () => {
+    it('bumps last_heartbeat on an existing heartbeat.json without overwriting other fields when the caller opts in', async () => {
       const oldHeartbeat: Heartbeat = {
         agent: 'spark',
         org: 'eros-os',
@@ -71,7 +73,9 @@ describe('Bus events', () => {
 
       // Let one millisecond tick so the new timestamp is strictly newer.
       await new Promise((resolve) => setTimeout(resolve, 2));
-      logEvent(paths, 'spark', 'eros-os', 'action', 'activity_tick', 'info');
+      logEvent(paths, 'spark', 'eros-os', 'action', 'activity_tick', 'info', undefined, {
+        refreshHeartbeat: true,
+      });
 
       const refreshed = JSON.parse(
         readFileSync(join(paths.stateDir, 'heartbeat.json'), 'utf-8'),
@@ -88,6 +92,26 @@ describe('Bus events', () => {
       expect(refreshed.loop_interval).toBe('4h');
       expect(refreshed.agent).toBe('spark');
       expect(refreshed.org).toBe('eros-os');
+    });
+
+    it('leaves last_heartbeat byte-identical when the caller does not opt in (default off, spoof-safe)', () => {
+      const oldHeartbeat: Heartbeat = {
+        agent: 'spark',
+        org: 'eros-os',
+        status: 'online',
+        current_task: 'wedged',
+        mode: 'day',
+        last_heartbeat: '2026-04-23T12:00:00Z',
+        loop_interval: '4h',
+      };
+      const raw = JSON.stringify(oldHeartbeat);
+      writeFileSync(join(paths.stateDir, 'heartbeat.json'), raw);
+
+      // Daemon-on-behalf-style write: no opts, so no refresh.
+      logEvent(paths, 'spark', 'eros-os', 'message', 'telegram_received', 'info', { text_chars: 3 });
+
+      const after = readFileSync(join(paths.stateDir, 'heartbeat.json'), 'utf-8');
+      expect(after).toBe(raw);
     });
 
     it('is a no-op when no heartbeat.json exists yet', () => {
@@ -109,9 +133,11 @@ describe('Bus events', () => {
       // Write a corrupt heartbeat.json to exercise the error path.
       writeFileSync(join(paths.stateDir, 'heartbeat.json'), '{not valid json');
 
-      // Must not throw.
+      // Must not throw. Opt in so the refresh path is actually exercised.
       expect(() =>
-        logEvent(paths, 'spark', 'eros-os', 'action', 'after_corrupt_hb', 'info'),
+        logEvent(paths, 'spark', 'eros-os', 'action', 'after_corrupt_hb', 'info', undefined, {
+          refreshHeartbeat: true,
+        }),
       ).not.toThrow();
 
       // Event still written.

--- a/tests/unit/telegram/logging.test.ts
+++ b/tests/unit/telegram/logging.test.ts
@@ -128,6 +128,44 @@ describe('Telegram Logging', () => {
       });
     });
 
+    it('does NOT refresh last_heartbeat — inbound traffic cannot spoof a wedged agent alive', () => {
+      const paths = buildPaths(testDir, 'spark');
+      mkdirSync(paths.stateDir, { recursive: true });
+
+      // Wedged agent with a stale heartbeat on disk.
+      const staleHeartbeat = JSON.stringify({
+        agent: 'spark',
+        org: 'eros-os',
+        status: 'online',
+        current_task: 'wedged',
+        mode: 'day',
+        last_heartbeat: '2026-04-23T12:00:00Z',
+        loop_interval: '4h',
+      });
+      writeFileSync(join(paths.stateDir, 'heartbeat.json'), staleHeartbeat);
+
+      const msg: TelegramMessage = {
+        message_id: 12345,
+        date: 1714214400,
+        from: { id: 6595584963, is_bot: false, first_name: 'Eros' },
+        chat: { id: 6595584963, type: 'private' },
+        text: 'Doe maar',
+      };
+
+      recordInboundTelegram(paths, testDir, 'spark', 'eros-os', 'Eros', msg);
+
+      // The telegram_received event WAS written…
+      const today = new Date().toISOString().split('T')[0];
+      const eventPath = join(testDir, 'analytics', 'events', 'spark', `${today}.jsonl`);
+      const eventEntry = JSON.parse(readFileSync(eventPath, 'utf-8').trim());
+      expect(eventEntry.event).toBe('telegram_received');
+
+      // …but last_heartbeat is byte-identical: the daemon-on-behalf write
+      // did not opt into the refresh.
+      const after = readFileSync(join(paths.stateDir, 'heartbeat.json'), 'utf-8');
+      expect(after).toBe(staleHeartbeat);
+    });
+
     it('marks has_media=true and uses caption length when the message carries a photo', () => {
       const paths = buildPaths(testDir, 'bolt');
       mkdirSync(paths.stateDir, { recursive: true });


### PR DESCRIPTION
## Summary
`logEvent()` refreshed the target agent's `last_heartbeat` as an **unconditional side-effect** of every event write. When the daemon logs an event on another agent's behalf — delivering an inbound Telegram via `recordInboundTelegram` → `logEvent('telegram_received')` — it refreshed that agent's heartbeat even if the agent's session was wedged. This **spoofs liveness**: any stale-heartbeat detector reading this signal fails open, because a wedged agent that keeps receiving messages never looks stale. (Observed live: an agent with a silently-hung backend kept a fresh heartbeat purely from inbound message traffic.)

## Change
Make the heartbeat refresh **opt-in** via a new `opts?: { refreshHeartbeat?: boolean }` parameter on `logEvent`, **default OFF (fail-safe)**.

- The **7 in-session / agent-own** call sites opt in (`{ refreshHeartbeat: true }`) — these are the agent logging its own activity (task complete, message sent, inbox ack, tool_call, explicit heartbeat, telegram_sent, generic `log-event`).
- The **2 on-behalf writers do NOT opt in**: `recordInboundTelegram` (daemon delivering an inbound message to another agent — the actual former spoof vector) and the pty runtime-error event (emitting an error does not prove the reasoning loop is alive).
- Default-off means any **future** daemon-side `logEvent` site is safe by construction — it cannot silently reopen the hole.

The `refreshHeartbeatTimestamp` implementation is unchanged; only the call is gated. `update-heartbeat` sets `last_heartbeat` directly and does not depend on the side-effect, so explicit heartbeats are unaffected.

## Tests
- Updated the existing `event.test.ts` cases that asserted the old unconditional-refresh behavior.
- Added a spoof-guard: a default-off `logEvent` leaves `last_heartbeat` byte-identical.
- Added a spoof-guard in `logging.test.ts`: `recordInboundTelegram` writes the `telegram_received` event but does NOT refresh the target's `last_heartbeat`.

## Test Plan
- `./node_modules/.bin/tsc --noEmit` → exit 0.
- `vitest run` on the two changed test files → 19/19 pass.
- Full suite failure set identical to base (pre-existing failures unrelated to `event.ts`/`logging.ts`).
- Positive controls: forcing the refresh unconditionally fails the two spoof-safe tests; forcing it always-off fails the opt-in test — confirming the guards are load-bearing.

## Note for reviewers
An agent that only *receives* and never *emits* any in-session event will now correctly let its heartbeat go stale — that is the intended fix. Healthy agents emit `tool_call` continuously and are unaffected. This unblocks a separate silent-dormancy detector (held) which reads heartbeat staleness and can now rely on a truthful signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)