### PR TITLE
fix(daemon): death-confirmed stop closes duplicate-PTY windows

### DIFF
--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -46,6 +46,13 @@ export class AgentProcess {
   private sessionStart: Date | null = null;
   private status: AgentStatus['status'] = 'stopped';
   private stopping: boolean = false;
+  // Change B (join-in-flight re-entry): the single in-flight teardown promise.
+  // A stop() that arrives while a teardown is already running awaits THIS
+  // instead of returning immediately. The only re-entrant caller is the
+  // manager's eviction path (`await stale.process.stop()`), which must block
+  // until the real, death-confirmed teardown completes rather than racing a
+  // fresh spawn against a still-alive predecessor (the duplicate-PTY defect).
+  private stopInFlight: Promise<void> | null = null;
   // BUG-040 fix: persists across stop() return until handleExit clears it.
   // Required because BUG-032's CRLF + 5s wait can cause graceful shutdown to
   // exceed the 5s Promise.race timeout in stop(), which would otherwise reset
@@ -227,9 +234,28 @@ export class AgentProcess {
 
   /**
    * Stop the agent gracefully.
+   *
+   * Change B (join-in-flight): a re-entrant stop() awaits the in-flight teardown
+   * instead of the previous silent early no-op (`if (this.stopping) return;`).
+   * The only re-entrant caller is the manager's eviction path
+   * (`await stale.process.stop()`), which WANTS to block until the predecessor
+   * is truly dead before spawning fresh — the previous no-op let it return
+   * immediately and spawn a second live PTY alongside the still-alive first one.
    */
   async stop(): Promise<void> {
-    if (this.stopping) return;
+    if (this.stopping) {
+      if (this.stopInFlight) await this.stopInFlight;
+      return;
+    }
+    this.stopInFlight = this.runStop();
+    try {
+      await this.stopInFlight;
+    } finally {
+      this.stopInFlight = null;
+    }
+  }
+
+  private async runStop(): Promise<void> {
     this.stopping = true;
     // BUG-040 fix: stopRequested persists ACROSS stop()'s return until
     // handleExit clears it. This is the safety net for the case where the
@@ -285,6 +311,11 @@ export class AgentProcess {
       } catch {
         // Ignore write errors during shutdown
       }
+      // Change A (death-confirmed stop): capture the OS child pid BEFORE
+      // pty.kill(). node-pty's kill() can invalidate the handle, so getPid()
+      // is unreliable afterward — we need the pid to confirm death below.
+      const childPid = pty.getPid();
+
       // BUG-032 follow-up: only kill the PTY if the process is still alive.
       // After /exit + 5s wait, the child has usually exited cleanly. Calling
       // pty.kill() on an already-exited PTY tears down the file descriptor,
@@ -306,6 +337,33 @@ export class AgentProcess {
       // timeout reduces "Ignoring late exit from previous lifecycle" log noise.
       if (exitPromise) {
         await Promise.race([exitPromise, sleep(15000)]);
+      }
+
+      // Change A (death-confirmed stop): node-pty's kill() sends SIGHUP with no
+      // escalation, so a child that traps/ignores SIGHUP (or is simply slow to
+      // unwind) outlives the graceful window above. stop() would then return
+      // with the OS child still alive and untracked — free to co-emit alongside
+      // the next spawn under this agent name (the duplicate-PTY defect). If the
+      // child is still alive after the bounded race, escalate to SIGKILL and
+      // poll until the OS confirms it is gone before returning. This branch runs
+      // ONLY when the child survived the graceful window, so a normal fast exit
+      // adds ZERO latency and never sees a SIGKILL (no false kills).
+      if (childPid && isChildAlive(childPid)) {
+        this.log(`Graceful stop timed out — escalating to SIGKILL (pid ${childPid})`);
+        try {
+          process.kill(childPid, 'SIGKILL');
+        } catch {
+          // ESRCH: exited between the liveness check and the kill — fine.
+        }
+        // Bounded poll: 5s deadline / 100ms interval (hardcoded — a stop must
+        // not block the daemon indefinitely on a wedged, unkillable child).
+        const deadline = Date.now() + 5000;
+        while (isChildAlive(childPid) && Date.now() < deadline) {
+          await sleep(100);
+        }
+        if (isChildAlive(childPid)) {
+          this.log(`WARNING: pid ${childPid} still alive 5s after SIGKILL — proceeding anyway`);
+        }
       }
     }
 
@@ -1135,4 +1193,18 @@ export class AgentProcess {
 
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// Change A: OS-level pid liveness probe using the signal-0 idiom. Local copy of
+// the same helper duplicated in agent-manager.ts (isPidAlive), utils/lock.ts,
+// and pty/opencode-pty.ts: signal 0 sends nothing, it only tests process
+// existence + our permission to signal it. A process owned by another user
+// (EPERM) is alive; only ESRCH (process gone) counts as dead.
+function isChildAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'EPERM';
+  }
 }

--- a/tests/unit/daemon/agent-manager-dup-pty-window2.test.ts
+++ b/tests/unit/daemon/agent-manager-dup-pty-window2.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+// Window 2 duplicate-PTY race, the manager-boundary half of
+// the fix whose AgentProcess half is covered by agent-process.test.ts (W1/W2).
+//
+// The defect, read from source: `stopAgent()` (agent-manager.ts:1367) awaits
+// `entry.process.stop()` at :1409, but `AgentProcess.stop()` nulls its PTY handle
+// synchronously before any await, so getStatus().pid goes undefined the instant a
+// stop begins while status is still 'running'. isAgentActuallyAlive() (:332) then
+// reads `!!undefined && ...` === false for the whole stop duration. A start racing
+// the stop (the fire-and-forget `stop-agent`+`start-agent` IPC pair) therefore
+// SKIPS the alive-branch (and its stoppingAgents queue guard) and falls into the
+// eviction path, whose `await stale.process.stop()` (:487) — a RE-ENTRANT stop() —
+// used to be a silent no-op (`if (this.stopping) return;`). Eviction then deleted
+// the map entry and spawned a fresh PTY while the predecessor's OS child was still
+// alive: two live PTYs under one agent name, near-zero gap.
+//
+// This test drives that exact manager race through the real startAgent/stopAgent
+// code paths, with AgentProcess mocked to model the stop() CONTRACT two ways:
+//   - 'current'  — re-entrant stop() is a synchronous no-op and the graceful
+//                  window returns WITHOUT confirming the OS child died.
+//   - 'fixed'    — re-entrant stop() JOINS the in-flight teardown (Change B) and
+//                  the teardown reaps the OS child before returning (Change A).
+// The 'current' contract is the positive control: it reproduces two coexisting
+// live children (RED). The 'fixed' contract is what the shipped AgentProcess.stop()
+// now honors (verified directly by the W1/W2 tests in agent-process.test.ts), and
+// it must leave exactly one live child at rest with the agent UP.
+//
+// Harness cloned from agent-manager-eviction-race-round4.test.ts (same FastChecker/
+// Telegram/Cron/Worker/metrics mocks, same agentsOf/procAt accessors).
+
+type ProcStatus = 'stopped' | 'starting' | 'running' | 'crashed' | 'halted';
+type StopContract = 'current' | 'fixed';
+
+const h = vi.hoisted(() => ({
+  /** Every AgentProcess the manager constructed, in construction order. */
+  procs: [] as unknown[],
+  /** Every FastChecker the manager constructed, in construction order. */
+  checkers: [] as unknown[],
+  /** Which stop() contract the mock AgentProcess models this run. */
+  stopContract: 'fixed' as StopContract,
+}));
+
+vi.mock('../../../src/daemon/agent-process.js', () => ({
+  AgentProcess: class {
+    name: string;
+    index: number;
+    status: ProcStatus = 'stopped';
+    pid: number | undefined;
+    /**
+     * Models the real OS child process — the thing the duplicate-PTY defect is
+     * about. Set true by start(); cleared to false ONLY when a teardown actually
+     * confirms death (Change A). The 'current' contract deliberately leaves it
+     * true after its bounded wait, mirroring a SIGHUP-immune child that outlived
+     * the 15s Promise.race with no SIGKILL escalation.
+     */
+    childAlive = false;
+
+    private stopping = false;
+    private stopInFlight: Promise<void> | null = null;
+    /** Resolved by the test (finishStop) to stand in for the graceful window +
+     *  death confirmation completing. */
+    private releaseGate!: () => void;
+    private gate: Promise<void>;
+
+    constructor(name: string) {
+      this.name = name;
+      this.index = h.procs.length;
+      h.procs.push(this);
+      let release!: () => void;
+      this.gate = new Promise<void>((r) => { release = r; });
+      this.releaseGate = release;
+    }
+
+    async start() {
+      if (this.status === 'running') return;   // agent-process.ts:109-112
+      this.status = 'starting';                // agent-process.ts:137 — SYNC
+      this.status = 'running';
+      this.pid = 4000 + this.index;
+      this.childAlive = true;
+    }
+
+    async stop() {
+      return h.stopContract === 'current' ? this.stopCurrent() : this.stopFixed();
+    }
+
+    /** Pre-fix contract: re-entry is a synchronous no-op, and the graceful
+     *  window returns without confirming the OS child died. */
+    private async stopCurrent() {
+      if (this.stopping) return;               // agent-process.ts:232 (pre-fix)
+      this.stopping = true;
+      this.pid = undefined;                    // PTY handle nulled synchronously
+      await this.gate;                         // bounded graceful window
+      this.status = 'stopped';
+      this.stopping = false;
+      // childAlive INTENTIONALLY left true — no SIGKILL escalation existed.
+    }
+
+    /** Post-fix contract: Change B (join-in-flight) + Change A (death-confirmed). */
+    private async stopFixed() {
+      if (this.stopping) {                     // Change B
+        if (this.stopInFlight) await this.stopInFlight;
+        return;
+      }
+      this.stopInFlight = this.runStopFixed();
+      try {
+        await this.stopInFlight;
+      } finally {
+        this.stopInFlight = null;
+      }
+    }
+
+    private async runStopFixed() {
+      this.stopping = true;
+      this.pid = undefined;                    // PTY handle nulled synchronously
+      await this.gate;                         // graceful window + SIGKILL poll
+      this.childAlive = false;                 // Change A: death confirmed
+      this.status = 'stopped';
+      this.stopping = false;
+    }
+
+    /** Test-only: release the parked teardown. */
+    finishStop() { this.releaseGate(); }
+
+    getStatus() { return { name: this.name, status: this.status, pid: this.pid }; }
+
+    onExit() { /* no-op */ }
+    onStatusChanged() { /* no-op */ }
+    setTelegramHandle() { /* no-op */ }
+  },
+}));
+
+vi.mock('../../../src/daemon/fast-checker.js', () => ({
+  FastChecker: class {
+    process: unknown;
+    startCount = 0;
+    stopCount = 0;
+    constructor(agentProcess: unknown) {
+      this.process = agentProcess;
+      h.checkers.push(this);
+    }
+    async start() { this.startCount++; }
+    stop() { this.stopCount++; }
+    wake() { /* no-op */ }
+    isDuplicate() { return false; }
+    queueTelegramMessage() { /* no-op */ }
+    async handleActivityCallback() { /* no-op */ }
+  },
+}));
+
+vi.mock('../../../src/telegram/api.js', () => ({
+  TelegramAPI: class { async sendMessage() { /* no-op */ } },
+}));
+vi.mock('../../../src/telegram/poller.js', () => ({
+  TelegramPoller: class {
+    lastExitReason: string | undefined;
+    start() { return new Promise<void>(() => {}); }
+    stop() { this.lastExitReason = 'stopped-externally'; }
+    onMessage() { /* no-op */ }
+    onCallback() { /* no-op */ }
+    onReaction() { /* no-op */ }
+  },
+}));
+vi.mock('../../../src/daemon/cron-scheduler.js', () => ({
+  CronScheduler: class {
+    agentName: string;
+    constructor(opts: { agentName: string }) { this.agentName = opts.agentName; }
+    start() { /* no-op */ }
+    stop() { /* no-op */ }
+    reload() { /* no-op */ }
+    getNextFireTimes() { return []; }
+  },
+}));
+vi.mock('../../../src/daemon/worker-process.js', () => ({
+  WorkerProcess: class {
+    name: string;
+    constructor(name: string) { this.name = name; }
+    async spawn() { /* no-op */ }
+    async terminate() { /* no-op */ }
+    onDone() { /* no-op */ }
+    isFinished() { return true; }
+    getStatus() { return { name: this.name }; }
+  },
+}));
+vi.mock('../../../src/bus/metrics.js', () => ({
+  collectTelegramCommands: () => [],
+  registerTelegramCommands: async () => ({ status: 'empty' as const, count: 0 }),
+}));
+
+const { AgentManager } = await import('../../../src/daemon/agent-manager.js');
+
+type EntryLike = { process: { index: number; childAlive: boolean; status: ProcStatus; finishStop(): void }; stopped?: boolean };
+const agentsOf = (am: unknown) => (am as { agents: Map<string, EntryLike> }).agents;
+const procAt = (i: number) => h.procs[i] as { index: number; childAlive: boolean; status: ProcStatus; finishStop(): void };
+const liveChildren = () => h.procs.filter((p) => (p as { childAlive: boolean }).childAlive).length;
+
+describe('AgentManager Window-2 duplicate-PTY race — stop/start reap-before-spawn', () => {
+  let testDir: string;
+  let agentDir: string;
+  let am: InstanceType<typeof AgentManager>;
+  let killSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    h.procs.length = 0;
+    h.checkers.length = 0;
+    h.stopContract = 'fixed';
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-dup-pty-w2-'));
+    agentDir = join(testDir, 'framework', 'orgs', 'acme', 'agents', 'alice');
+    mkdirSync(agentDir, { recursive: true });
+    writeFileSync(
+      join(agentDir, 'config.json'),
+      JSON.stringify({ name: 'alice', runtime: 'claude-code' }),
+    );
+    am = new AgentManager('test-instance', join(testDir, 'instance'), join(testDir, 'framework'), 'acme');
+    // isPidAlive/isChildAlive never see a real pid here (pid is undefined during
+    // stop), but stub process.kill defensively so nothing signals a real pid.
+    killSpy = vi.spyOn(process, 'kill').mockImplementation((() => true) as typeof process.kill);
+  });
+
+  afterEach(() => {
+    killSpy.mockRestore();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('CONTROL (current stop contract): a start racing an in-flight stop spawns a SECOND live child — the defect', async () => {
+    h.stopContract = 'current';
+
+    await am.startAgent('alice', agentDir);
+    expect(h.procs.length).toBe(1);
+    const proc0 = procAt(0);
+    expect(proc0.childAlive).toBe(true);
+    expect(liveChildren()).toBe(1);
+
+    // Fire-and-forget stop: it parks in proc0.stop() on the graceful gate, with
+    // pid already nulled (so isAgentActuallyAlive reads dead) but the OS child
+    // still alive.
+    const stopP = am.stopAgent('alice', false);
+    await Promise.resolve();
+
+    // A start races in while the stop is parked. isAgentActuallyAlive === false
+    // -> eviction path -> `await stale.process.stop()` re-enters stop(), which
+    // under the current contract returns immediately (no-op) WITHOUT reaping the
+    // child. Eviction then deletes the entry and spawns a fresh child.
+    await am.startAgent('alice', agentDir);
+
+    expect(h.procs.length).toBe(2);
+    // BOTH children are alive at the same instant — coexisting live PTYs under
+    // one agent name. This is the reproduced defect (positive control).
+    expect(liveChildren()).toBe(2);
+    expect(procAt(0).childAlive).toBe(true);
+    expect(procAt(1).childAlive).toBe(true);
+
+    // Release the parked first stop so no promise is left dangling.
+    proc0.finishStop();
+    await stopP;
+  });
+
+  it('FIX (death-confirmed + join-in-flight contract): eviction blocks until the predecessor dies — exactly one live child at rest, agent UP', async () => {
+    h.stopContract = 'fixed';
+
+    await am.startAgent('alice', agentDir);
+    expect(h.procs.length).toBe(1);
+    const proc0 = procAt(0);
+    expect(proc0.childAlive).toBe(true);
+
+    // Fire-and-forget stop parks on the gate (pid nulled, child still alive).
+    const stopP = am.stopAgent('alice', false);
+    await Promise.resolve();
+
+    // Racing start -> eviction -> `await stale.process.stop()` re-enters and, under
+    // the fixed contract, JOINS the in-flight teardown. It is now blocked on the
+    // same gate: the fresh spawn CANNOT happen until the predecessor is confirmed
+    // dead. No second child exists yet.
+    const startP = am.startAgent('alice', agentDir);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(h.procs.length).toBe(1);          // fresh spawn is gated, not yet created
+    expect(liveChildren()).toBe(1);          // never two alive at once
+    expect(proc0.childAlive).toBe(true);     // predecessor not yet reaped
+
+    // Release the death gate: the teardown reaps the OS child (Change A), the
+    // joined eviction unblocks, deletes the entry, and only THEN spawns fresh.
+    proc0.finishStop();
+    await Promise.all([stopP, startP]);
+
+    expect(h.procs.length).toBe(2);          // the fresh child was spawned
+    expect(procAt(0).childAlive).toBe(false);// predecessor reaped before the spawn
+    expect(procAt(1).childAlive).toBe(true); // newcomer is the live one
+    expect(liveChildren()).toBe(1);          // exactly one live child at rest
+
+    // The agent ends UP, mapped to the newcomer (a stop+start, not a stop).
+    const entry = agentsOf(am).get('alice');
+    expect(entry?.process).toBe(procAt(1));
+    expect(procAt(1).status).toBe('running');
+  });
+});

--- a/tests/unit/daemon/agent-process-stop-width-round4c.test.ts
+++ b/tests/unit/daemon/agent-process-stop-width-round4c.test.ts
@@ -66,6 +66,14 @@ function makeStubPty() {
     write(s: string) { writes.push(s); },
     isAlive() { return false; },   // false ⇒ kill() is skipped, per :272
     kill() { /* unreachable while isAlive() is false */ },
+    // Change A (death-confirmed stop) added an unconditional `pty.getPid()` read
+    // to stop() before the kill, to identify the OS child for a possible SIGKILL
+    // escalation. getPid() is a real method on every PTY subclass (AgentPTY etc.,
+    // used by getStatus()/start()); this stub predates that read. undefined here
+    // means "no live child" — consistent with isAlive()===false — so stop()'s
+    // `if (childPid && ...)` SIGKILL branch stays skipped and the measured floors
+    // and write assertions below are unchanged.
+    getPid() { return undefined; },
   };
 }
 

--- a/tests/unit/daemon/agent-process.test.ts
+++ b/tests/unit/daemon/agent-process.test.ts
@@ -277,6 +277,139 @@ describe('AgentProcess - BUG-011 fix (stop awaits PTY exit)', () => {
   });
 });
 
+describe('AgentProcess - duplicate-PTY fix (death-confirmed + join-in-flight stop)', () => {
+  // Model a SIGHUP-immune child: node-pty's kill() sends SIGHUP with no
+  // escalation, so a wedged child never fires onExit and stays alive to the
+  // signal-0 liveness probe until a real SIGKILL is delivered. The spy answers
+  // both the signal-0 probes (isChildAlive) and the SIGKILL escalation.
+  function installKillSpy() {
+    let killed = false;
+    let sigkillCount = 0;
+    const spy = vi.spyOn(process, 'kill').mockImplementation(((_pid: number, sig?: string | number) => {
+      if (sig === 'SIGKILL') {
+        killed = true;
+        sigkillCount++;
+        return true;
+      }
+      // signal-0 liveness probe (isChildAlive)
+      if (killed) {
+        const e = new Error('ESRCH') as NodeJS.ErrnoException;
+        e.code = 'ESRCH';
+        throw e;
+      }
+      return true; // still alive
+    }) as unknown as typeof process.kill);
+    return { spy, sigkills: () => sigkillCount };
+  }
+
+  it('W1: stop() escalates to SIGKILL and reaps a SIGHUP-immune child before resolving', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+    expect(ap.getStatus().status).toBe('running');
+
+    const { spy, sigkills } = installKillSpy();
+    vi.useFakeTimers();
+    try {
+      let resolved = false;
+      const stopP = ap.stop().then(() => { resolved = true; });
+
+      // Advance through stop()'s graceful window: 1s (Ctrl-C) + 5s (/exit) +
+      // 15s (Promise.race bound). capturedOnExit is never fired — the child is
+      // wedged — so the sleep(15000) wins the race. stop() must NOT be resolved
+      // yet: the child is still alive and the SIGKILL escalation has to run.
+      await vi.advanceTimersByTimeAsync(1000 + 5000 + 14000);
+      expect(resolved).toBe(false);
+      expect(spy).not.toHaveBeenCalledWith(12345, 'SIGKILL');
+
+      // Cross the 15s race boundary. Now the graceful window has elapsed with the
+      // child still alive -> SIGKILL is delivered, the bounded poll observes death
+      // (signal-0 now throws ESRCH), and stop() resolves to 'stopped'.
+      await vi.advanceTimersByTimeAsync(2000);
+      await stopP;
+
+      expect(resolved).toBe(true);
+      expect(spy).toHaveBeenCalledWith(12345, 'SIGKILL');
+      expect(sigkills()).toBe(1);
+      expect(ap.getStatus().status).toBe('stopped');
+    } finally {
+      vi.useRealTimers();
+      spy.mockRestore();
+    }
+  });
+
+  it('W2: a re-entrant stop() joins the death-confirmed teardown (one SIGKILL, both resolve together)', async () => {
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    const { spy, sigkills } = installKillSpy();
+    vi.useFakeTimers();
+    try {
+      let p1done = false;
+      let p2done = false;
+      const p1 = ap.stop().then(() => { p1done = true; });
+      // Re-enter stop() while the first teardown is parked in its graceful
+      // window. Before Change B this returned immediately (silent no-op),
+      // letting the manager's eviction path spawn a fresh PTY alongside the
+      // still-alive predecessor. Now it must JOIN the in-flight teardown.
+      const p2 = ap.stop().then(() => { p2done = true; });
+
+      // Through the graceful window: neither resolves — the re-entrant stop is
+      // waiting on the SAME teardown, not short-circuiting out early.
+      await vi.advanceTimersByTimeAsync(1000 + 5000 + 14000);
+      expect(p1done).toBe(false);
+      expect(p2done).toBe(false);
+
+      // Cross the race boundary -> single SIGKILL -> death confirmed -> BOTH
+      // callers unblock at the same time off the shared teardown promise.
+      await vi.advanceTimersByTimeAsync(2000);
+      await Promise.all([p1, p2]);
+
+      expect(p1done).toBe(true);
+      expect(p2done).toBe(true);
+      // Exactly one teardown ran: the join shares it, so SIGKILL fires once.
+      expect(sigkills()).toBe(1);
+      expect(ap.getStatus().status).toBe('stopped');
+    } finally {
+      vi.useRealTimers();
+      spy.mockRestore();
+    }
+  });
+
+  it('fast-exit path adds no SIGKILL and no added latency (Change A false-kill guard)', async () => {
+    // Regression control: when the child exits cleanly inside the graceful
+    // window, the SIGKILL escalation must NOT run. This proves Change A is
+    // scoped to the timed-out case only — a normal stop is unchanged.
+    const ap = new AgentProcess('alice', mockEnv, {});
+    await ap.start();
+
+    let killed = false;
+    const spy = vi.spyOn(process, 'kill').mockImplementation(((_pid: number, sig?: string | number) => {
+      if (sig === 'SIGKILL') { killed = true; return true; }
+      // Child already exited (onExit fired): signal-0 reports dead.
+      const e = new Error('ESRCH') as NodeJS.ErrnoException;
+      e.code = 'ESRCH';
+      throw e;
+    }) as unknown as typeof process.kill);
+    // The PTY also reports not-alive after the exit, so pty.kill() is skipped.
+    mockPty.isAlive.mockReturnValue(false);
+
+    try {
+      const stopP = ap.stop();
+      // Fire the exit promptly — the child exits within the graceful window,
+      // winning the Promise.race well before the 15s bound.
+      await new Promise((r) => setTimeout(r, 50));
+      capturedOnExit!(0, 0);
+      await stopP;
+
+      expect(ap.getStatus().status).toBe('stopped');
+      expect(spy).not.toHaveBeenCalledWith(expect.anything(), 'SIGKILL');
+      expect(killed).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  }, 10000);
+});
+
 describe('AgentProcess - disable-resurrection fix (.user-disable gate)', () => {
   it('disabled agent force-exit does NOT trigger crash recovery', async () => {
     // A disabled agent that force-exits/crashes arrives at handleExit with


### PR DESCRIPTION
## Summary

Fixes a daemon defect where two live PTYs could coexist under one agent name and both emit (user-visible symptom: duplicate Telegram sends) across a restart or stop+start cycle.

Root cause: `AgentProcess.stop()` reported completion without confirming the OS child died — the 15s grace `Promise.race` resolves on timeout, node-pty `kill()` is SIGHUP-only with no SIGKILL escalation, and re-entrant `stop()` was a silent no-op. Two triggers, one root cause (guards key on map-entry identity, not process liveness):
- **Window 1** (restartAgent / soft-restart): `stop()` times out with the child alive, the map entry is deleted, the successor-race guard finds no rival, and `startAgent` spawns a second PTY.
- **Window 2** (stop-agent + start-agent IPC pair): the racing `startAgent` reads the entry as pid-less (handle nulled synchronously), takes the eviction path whose re-entrant `stop()` was a no-op, and spawns.

Fix, entirely within `AgentProcess.stop()` (`agent-manager.ts` and `ipc-server.ts` unchanged):
- **Death-confirmed stop:** capture the child pid before `kill()`, and after the grace race escalate to SIGKILL and bounded-poll liveness until the process is confirmed dead before returning. Gated so a child that exits within the grace window never sees SIGKILL (no added latency).
- **Join-in-flight re-entry:** a re-entrant `stop()` awaits the same death-confirmed teardown instead of returning immediately, so the eviction path's `await` blocks the fresh spawn until the predecessor is dead.

## Test Plan

- `tsc --noEmit` clean.
- New positive-control unit tests (fail on unmodified `stop()`, pass with the fix): `agent-process.test.ts` W1 (SIGHUP-immune child reaped by SIGKILL before `stop()` resolves), W2 (re-entrant stop joins the same teardown; one SIGKILL, both resolve together), plus a fast-exit no-false-kill guard.
- `agent-manager-dup-pty-window2.test.ts` drives the manager-level stop+start race (control vs fixed contract).
- Full suite: zero new failures vs base (name-set compared both directions).

## Notes (non-blocking)

- SIGKILL escalation has a theoretical pid-reuse window (same accepted pattern as the existing `isPidAlive` liveness checks).
- If a child survives SIGKILL past the bounded poll (D-state/zombie), `stop()` proceeds with a warning rather than hanging the daemon — a deliberate bounded-liveness tradeoff, strictly better than the prior no-escalation behavior.
- `agent-manager-dup-pty-window2.test.ts` is model-based (mocks `AgentProcess`); production coverage of `stop()` rests on the genuine `agent-process.test.ts` W1/W2 positive controls.

## Known residual

SIGKILL reaps the pty session leader, not a detached grandchild tree (process-group kill deferred as a broader change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)