### PR TITLE
fix(daemon): suppress futile context-handoff when resume baseline exceeds threshold

### DIFF
--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -1,10 +1,10 @@
 import { readdirSync, readFileSync, existsSync, writeFileSync, unlinkSync, statSync } from 'fs';
 import { execFile } from 'child_process';
-import { join } from 'path';
+import { join, dirname, basename } from 'path';
 import { createHash } from 'crypto';
 import { hardRestart } from '../bus/system.js';
 import type { InboxMessage, BusPaths, TelegramMessage, TelegramCallbackQuery } from '../types/index.js';
-import { checkInbox, ackInbox } from '../bus/message.js';
+import { checkInbox, ackInbox, sendMessage } from '../bus/message.js';
 import { updateApproval } from '../bus/approval.js';
 import { AgentProcess } from './agent-process.js';
 import type { TelegramAPI } from '../telegram/api.js';
@@ -26,6 +26,14 @@ export function handoffGraceMs(runtime: string | undefined): number {
   if (runtime === 'codex-app-server' || runtime === 'opencode') return 600_000;
   return 120_000;
 }
+
+/**
+ * Percentage points of context growth beyond the session baseline that count as
+ * real work-fill. Below this margin, a session born at/above the handoff
+ * threshold has done no meaningful work, so a handoff is futile — the fresh
+ * session would be reborn at the same baseline and re-fire.
+ */
+const WORKFILL_MARGIN = 10;
 
 /**
  * Fast message checker for a single agent.
@@ -88,6 +96,15 @@ export class FastChecker {
   private ctxCircuitBrokenAt: number | null = null; // when circuit tripped (null = healthy)
   // Persisted to disk so --continue restarts don't reset the circuit breaker
   private ctxCircuitFile: string = '';
+  // Per-session (NOT persisted): first trustworthy ctx reading of this session,
+  // captured once the post-start grace window has expired. null = not yet captured.
+  private ctxSessionBaselinePct: number | null = null;
+  // Per-session (NOT persisted): once-per-session throttle for the futile-handoff alert.
+  private ctxBaselineAlertFiredAt: number = 0;
+  // Accepted edge: on the null-session_id restart path the new-session block is skipped,
+  // so these two fields (like the other per-session ctx fields) can carry a prior session's
+  // value across a cooperative restart. forceContextRestart resets them, and the guard is
+  // inert whenever ctxSessionStartedAt is 0, so this is no worse than the existing fields.
 
   constructor(
     agent: AgentProcess,
@@ -1046,6 +1063,26 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
   }
 
   /**
+   * Resolve the org's configured orchestrator agent name, or null if none is
+   * configured / resolvable. Mirrors how the daemon reads it elsewhere
+   * (agent-manager.maybeStartSlackSocketMode, AgentProcess.buildDeliverablesBlock):
+   * the `orchestrator` field lives in orgs/<org>/context.json under the framework
+   * root. The org is derived from the agent directory, whose canonical layout is
+   * <root>/orgs/<org>/agents/<name> (see add-agent.ts / resolvePaths). Returns null
+   * on any failure so the caller degrades to log-only.
+   */
+  private resolveOrchestratorName(): string | null {
+    try {
+      const org = basename(dirname(dirname(this.agent.getAgentDir())));
+      const contextPath = join(this.frameworkRoot, 'orgs', org, 'context.json');
+      const orchestrator = JSON.parse(readFileSync(contextPath, 'utf-8')).orchestrator;
+      return typeof orchestrator === 'string' && orchestrator ? orchestrator : null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
    * Context monitor — called on every poll cycle.
    * Reads context_status.json written by the statusLine bridge hook and takes
    * action when thresholds are crossed.
@@ -1100,6 +1137,8 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
           this.ctxHandoffFiredAt = 0;
           this.ctxHandoffDeadlineAt = 0;
           this.ctxWarningFiredAt = 0;
+          this.ctxSessionBaselinePct = null;
+          this.ctxBaselineAlertFiredAt = 0;
           this.log(`New session detected (${incomingSessionId.slice(0, 8)}…) — per-session ctx state reset`);
         }
         this.ctxLastSessionId = incomingSessionId;
@@ -1188,6 +1227,14 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
       return;
     }
 
+    // Capture the session baseline: the first trustworthy reading once the post-start
+    // grace window has expired. Gated on ctxSessionStartedAt > 0 — only when we actually
+    // observed this session's birth can we distinguish baseline-fill from work-fill.
+    // Without an anchor the guard stays inert and legacy handoff behavior is preserved.
+    if (this.ctxSessionStartedAt > 0 && !withinHandoffGrace && this.ctxSessionBaselinePct === null) {
+      this.ctxSessionBaselinePct = effectivePct;
+    }
+
     // Tier 1: warning — PTY injection only, no Telegram ping (context management is internal)
     if (effectivePct >= warn && !withinHandoffGrace && now - this.ctxWarningFiredAt > 15 * 60_000) {
       this.ctxWarningFiredAt = now;
@@ -1199,6 +1246,41 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
 
     // Tier 2: handoff (fires once per session lifecycle)
     if (effectivePct >= handoff && this.ctxHandoffFiredAt === 0 && !withinHandoffGrace) {
+      // Futile-handoff guard. A session BORN at/above the handoff threshold cannot be
+      // helped by a handoff — the fresh session inherits the same heavy resume baseline
+      // and re-fires immediately, thrashing in ~3-min clusters until the 3-fire breaker
+      // pauses auto-handoff. Suppress ONLY when the captured baseline itself meets/exceeds
+      // threshold AND almost no work-fill has accumulated on top of it. A born-low session
+      // that grows into the threshold (baseline < handoff) is the healthy path and reaches
+      // the normal handoff below untouched. Returning here means no lease is acquired, no
+      // fire is counted toward the 3-fire breaker, no Tier-3 deadline is armed, and no
+      // .force-fresh is pre-written — the handoff simply idles until real work-fill lands.
+      if (
+        this.ctxSessionBaselinePct !== null
+        && this.ctxSessionBaselinePct >= handoff
+        && effectivePct - this.ctxSessionBaselinePct < WORKFILL_MARGIN
+      ) {
+        if (this.ctxBaselineAlertFiredAt === 0) {
+          this.ctxBaselineAlertFiredAt = now;
+          const msg = `Context handoff SUPPRESSED for ${this.agent.name}: resume baseline `
+            + `${Math.round(this.ctxSessionBaselinePct)}% already meets/exceeds the ${handoff}% handoff `
+            + `threshold. A handoff cannot reduce a baseline it did not create — the fresh session would `
+            + `be born at the same level and re-fire. Review ctx_handoff_threshold or trim this agent's `
+            + `bootstrap. Auto-handoff idle until real work-fill accumulates.`;
+          this.log(msg);
+          // Route to the org's configured orchestrator as an internal bus message (agent
+          // inbox), NOT to the human's Telegram — this is an infra event, not a user ping.
+          // Best-effort: skip if no orchestrator is configured or it would be self-messaging,
+          // and swallow any bus failure — the this.log line above is the durable audit trail.
+          const orchestrator = this.resolveOrchestratorName();
+          if (orchestrator && orchestrator !== this.agent.name) {
+            try {
+              sendMessage(this.paths, this.agent.name, orchestrator, 'normal', msg);
+            } catch { /* non-fatal — bus send is best-effort */ }
+          }
+        }
+        return;
+      }
       const lease = requestContextHandoffLease({
         ctxRoot: this.paths.ctxRoot,
         agentName: this.agent.name,
@@ -1312,6 +1394,8 @@ Reply using: cortextos bus send-telegram ${chatId} '<your reply>'
     this.ctxHandoffFiredAt = 0;
     this.ctxHandoffDeadlineAt = 0;
     this.ctxWarningFiredAt = 0;
+    this.ctxSessionBaselinePct = null;
+    this.ctxBaselineAlertFiredAt = 0;
 
     // Release this dying session's context-handoff lease on teardown. This restart is
     // IN-PROCESS — sessionRefresh() below does stop()+start() on the same AgentProcess

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 vi.mock('child_process', () => ({ execFile: vi.fn() }));
-import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, mkdirSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { FastChecker } from '../../../src/daemon/fast-checker';
@@ -1038,6 +1038,190 @@ describe('FastChecker', () => {
       const handoffPrompts = injected(agent).filter(m => m.includes('CONTEXT HANDOFF REQUIRED'));
       expect(handoffPrompts.length).toBe(2); // 3rd fire tripped the breaker instead of handing off
       expect((checker as any).ctxCircuitBrokenAt).not.toBeNull();
+    });
+  });
+
+  // Futile-baseline guard: a session BORN at/above the handoff threshold (heavy
+  // resume baseline) cannot be helped by a handoff — the fresh session inherits the
+  // same baseline and re-fires. The guard captures the first post-grace reading as
+  // the session baseline and suppresses the Tier-2 handoff when that baseline already
+  // meets/exceeds threshold AND ~no work-fill has accumulated, routing a single
+  // once-per-session alert to the org's orchestrator (a bus inbox message, NOT the
+  // human's Telegram). These exercise the REAL checkContextStatus flow.
+  describe('context-handoff futile-baseline guard', () => {
+    const ORCH = 'orchestrator';
+    const ORG = 'testorg';
+    let frameworkRoot: string;
+    let agentDir: string;
+
+    beforeEach(() => {
+      frameworkRoot = mkdtempSync(join(tmpdir(), 'cortextos-fw-'));
+      // Canonical agent-dir layout <root>/orgs/<org>/agents/<name> so the guard can
+      // derive the org and read orgs/<org>/context.json for the orchestrator name.
+      agentDir = join(frameworkRoot, 'orgs', ORG, 'agents', 'ctx-agent');
+      mkdirSync(agentDir, { recursive: true });
+      writeFileSync(
+        join(frameworkRoot, 'orgs', ORG, 'context.json'),
+        JSON.stringify({ orchestrator: ORCH }),
+        'utf-8',
+      );
+    });
+
+    afterEach(() => {
+      rmSync(frameworkRoot, { recursive: true, force: true });
+      vi.useRealTimers();
+    });
+
+    function makeCtxAgent(name = 'ctx-agent') {
+      const config: any = {};
+      return {
+        name,
+        isBootstrapped: vi.fn().mockReturnValue(true),
+        injectMessage: vi.fn().mockReturnValue(true),
+        write: vi.fn(),
+        getAgentDir: () => agentDir,
+        getConfig: () => config,
+        getOutputBuffer: () => ({ getRecent: () => '' }),
+        sessionRefresh: vi.fn().mockResolvedValue(undefined),
+      } as any;
+    }
+
+    function writeConfig(cfg: Record<string, unknown>) {
+      writeFileSync(join(agentDir, 'config.json'), JSON.stringify(cfg), 'utf-8');
+    }
+
+    // Optional session_id: writing one drives the new-session detection that sets
+    // ctxSessionStartedAt (the guard's anchor). Omitting it leaves the session
+    // un-anchored — the legacy, guard-inert path.
+    function writeCtxStatus(pct: number, sessionId?: string) {
+      const data: any = {
+        used_percentage: pct,
+        exceeds_200k_tokens: false,
+        written_at: new Date().toISOString(),
+      };
+      if (sessionId !== undefined) data.session_id = sessionId;
+      writeFileSync(join(paths.stateDir, 'context_status.json'), JSON.stringify(data), 'utf-8');
+    }
+
+    function injected(agent: any): string[] {
+      return agent.injectMessage.mock.calls.map((c: any[]) => c[0] as string);
+    }
+
+    // The actual mechanism the alert uses: a bus message dropped in the
+    // orchestrator's inbox under ctxRoot (sendMessage), NOT a telegram call.
+    function orchestratorMessages(): any[] {
+      const dir = join(paths.ctxRoot, 'inbox', ORCH);
+      if (!existsSync(dir)) return [];
+      return readdirSync(dir)
+        .filter(f => f.endsWith('.json'))
+        .map(f => JSON.parse(readFileSync(join(dir, f), 'utf-8')));
+    }
+
+    // Default (claude) runtime grace window is 120_000ms — advance past it.
+    const GRACE_MS = 120_000;
+
+    it('A: heavy-baseline idle session is suppressed and alerts the orchestrator exactly once', async () => {
+      vi.useFakeTimers();
+      const t0 = new Date('2026-06-01T00:00:00Z').getTime();
+      vi.setSystemTime(t0);
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, frameworkRoot);
+      writeConfig({});
+
+      // Birth an anchored session already above the 60% handoff threshold.
+      writeCtxStatus(72, 'sess-heavy');
+      await (checker as any).checkContextStatus(); // within grace — no baseline, no action
+
+      // Past grace, still ~idle at the same baseline: capture baseline + suppress.
+      vi.setSystemTime(t0 + GRACE_MS + 60_000);
+      writeCtxStatus(72, 'sess-heavy');
+      await (checker as any).checkContextStatus();
+
+      // A further idle tick must NOT emit a second alert (once-per-session throttle).
+      vi.setSystemTime(t0 + GRACE_MS + 120_000);
+      writeCtxStatus(72, 'sess-heavy');
+      await (checker as any).checkContextStatus();
+
+      expect(injected(agent).some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(false);
+      expect((checker as any).ctxHandoffFiredAt).toBe(0);
+      expect((checker as any).ctxHandoffFires.length).toBe(0);
+      expect((checker as any).ctxCircuitBrokenAt).toBeNull();
+      expect((checker as any).ctxSessionBaselinePct).toBe(72);
+
+      const msgs = orchestratorMessages();
+      expect(msgs.length).toBe(1);
+      expect(msgs[0].from).toBe('ctx-agent');
+      expect(msgs[0].to).toBe(ORCH);
+      expect(msgs[0].text).toMatch(/baseline/i);
+      expect(msgs[0].text).toMatch(/threshold/i);
+    });
+
+    it('B: low-baseline session that grows into the threshold still hands off (no alert)', async () => {
+      vi.useFakeTimers();
+      const t0 = new Date('2026-06-01T00:00:00Z').getTime();
+      vi.setSystemTime(t0);
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, frameworkRoot);
+      writeConfig({});
+
+      writeCtxStatus(20, 'sess-grow');
+      await (checker as any).checkContextStatus(); // within grace
+
+      vi.setSystemTime(t0 + GRACE_MS + 60_000);
+      writeCtxStatus(20, 'sess-grow');
+      await (checker as any).checkContextStatus(); // post-grace: baseline = 20 (< handoff)
+
+      vi.setSystemTime(t0 + GRACE_MS + 180_000);
+      writeCtxStatus(65, 'sess-grow'); // real work-fill grew it into the threshold
+      await (checker as any).checkContextStatus();
+
+      expect((checker as any).ctxSessionBaselinePct).toBe(20);
+      expect(injected(agent).some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(true);
+      expect((checker as any).ctxHandoffFiredAt).toBeGreaterThan(0);
+      expect(orchestratorMessages().length).toBe(0);
+    });
+
+    it('C: session born above threshold still hands off once work-fill exceeds the margin', async () => {
+      vi.useFakeTimers();
+      const t0 = new Date('2026-06-01T00:00:00Z').getTime();
+      vi.setSystemTime(t0);
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, frameworkRoot);
+      writeConfig({});
+
+      writeCtxStatus(62, 'sess-margin');
+      await (checker as any).checkContextStatus(); // within grace
+
+      vi.setSystemTime(t0 + GRACE_MS + 60_000);
+      writeCtxStatus(62, 'sess-margin');
+      await (checker as any).checkContextStatus(); // baseline = 62, suppressed (62-62 < 10)
+
+      expect((checker as any).ctxSessionBaselinePct).toBe(62);
+      expect((checker as any).ctxHandoffFiredAt).toBe(0); // still suppressed while idle
+
+      // Accumulate real work-fill beyond WORKFILL_MARGIN (10): 78 - 62 = 16.
+      vi.setSystemTime(t0 + GRACE_MS + 180_000);
+      writeCtxStatus(78, 'sess-margin');
+      await (checker as any).checkContextStatus();
+
+      expect(injected(agent).some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(true);
+      expect((checker as any).ctxHandoffFiredAt).toBeGreaterThan(0);
+    });
+
+    it('D: an un-anchored session (no session_id) still hands off at threshold — legacy path', async () => {
+      const agent = makeCtxAgent();
+      const checker = new FastChecker(agent, paths, frameworkRoot);
+      writeConfig({});
+
+      // No session_id → ctxSessionStartedAt never set → baseline never captured.
+      writeCtxStatus(65);
+      await (checker as any).checkContextStatus();
+
+      expect((checker as any).ctxSessionStartedAt).toBe(0);
+      expect((checker as any).ctxSessionBaselinePct).toBeNull();
+      expect(injected(agent).some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(true);
+      expect((checker as any).ctxHandoffFiredAt).toBeGreaterThan(0);
+      expect(orchestratorMessages().length).toBe(0);
     });
   });
 });


### PR DESCRIPTION
## Summary
Agents with a heavy resume baseline restart at the context-handoff threshold, come back already at/above it, and re-fire in a loop until the 3-fire circuit breaker pauses them for 30 min — each restart accomplishing nothing, since a handoff cannot reduce a baseline it did not create.

This adds a futile-handoff guard to the context watchdog (`src/daemon/fast-checker.ts`):
- Capture a per-session baseline at the first post-grace context reading (gated on an observed session birth).
- In Tier 2, when that baseline is already >= the handoff threshold **and** context has grown less than `WORKFILL_MARGIN` (10 points) since, suppress the futile handoff and alert the configured orchestrator **once** instead of thrashing. The suppression returns before lease acquisition, the fire-count increment, deadline arming, and the force-fresh pre-arm, so a born-high session never advances the circuit breaker.
- A session that starts below threshold and grows into it, or starts high and accumulates real work-fill (> margin), still hands off normally.
- Genuine exhaustion stays caught by the ungated hard-overflow path, which runs before suppression.

The alert recipient is derived from the org's configured `orchestrator` field (no hardcoded identity); it degrades to log-only when unset or self-directed.

## Test Plan
- `tsc --noEmit`: clean.
- `vitest run tests/unit/daemon/fast-checker.test.ts`: 63 passed (4 new).
- New tests cover: heavy-baseline suppression + single alert, low-baseline grow-into-threshold still hands off, born-high-then-real-work still hands off, and the unanchored legacy path unchanged.
- Full-suite name-set diff vs base: zero newly-failing tests.