### PR TITLE
fix(bus): gate usage-api alerts + derive Codex window labels by seconds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Run codex parity tests
         run: npm run test:codex
 
+      - name: Usage API alert routing + window tests
+        run: bash tests/check-usage-api-alert.test.sh
+
   dashboard-build:
     name: Dashboard Build
     runs-on: ubuntu-latest

--- a/bus/check-usage-api.sh
+++ b/bus/check-usage-api.sh
@@ -7,12 +7,19 @@
 #
 # Usage:
 #   cortextos bus check-usage-api [--warn-7day N] [--warn-5h N] [--chat-id ID]
+#                                 [--no-telegram]
 #
 # Options:
-#   --warn-7day N   Warn (via Telegram) if 7-day utilization >= N% (default: 80)
-#   --warn-5h N     Warn (via Telegram) if 5-hour utilization >= N% (default: 90)
+#   --warn-7day N   Warn if 7-day utilization >= N% (default: 80)
+#   --warn-5h N     Warn if 5-hour utilization >= N% (default: 90)
 #   --chat-id ID    Telegram chat ID to send alerts to (uses CTX_TELEGRAM_CHAT_ID if omitted)
+#   --no-telegram   Suppress direct Telegram alerts (alias: --suppress). Alerts still
+#                   route to CTX_USAGE_ALERT_AGENT if that env var is set.
 #   --force         Bypass the 3-minute result cache
+#
+# Env:
+#   CTX_USAGE_ALERT_AGENT   If set, every alert is also routed to this agent via
+#                           `bus send-message`. Default empty (Telegram-only).
 #
 # Output: JSON with utilization fields + codex plan info, or exits 1 on error.
 #
@@ -29,14 +36,17 @@ source "$SCRIPT_DIR/_ctx-env.sh"
 WARN_7DAY=80
 WARN_5H=90
 CHAT_ID="${CTX_TELEGRAM_CHAT_ID:-}"
+ALERT_AGENT="${CTX_USAGE_ALERT_AGENT:-}"
+SUPPRESS_TELEGRAM=false
 FORCE=false
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
-    --warn-7day) WARN_7DAY="$2"; shift 2 ;;
-    --warn-5h)   WARN_5H="$2";   shift 2 ;;
-    --chat-id)   CHAT_ID="$2";   shift 2 ;;
-    --force)     FORCE=true;     shift   ;;
+    --warn-7day)   WARN_7DAY="$2"; shift 2 ;;
+    --warn-5h)     WARN_5H="$2";   shift 2 ;;
+    --chat-id)     CHAT_ID="$2";   shift 2 ;;
+    --no-telegram|--suppress) SUPPRESS_TELEGRAM=true; shift ;;
+    --force)       FORCE=true;     shift   ;;
     *) echo "Unknown option: $1" >&2; exit 1 ;;
   esac
 done
@@ -111,6 +121,49 @@ except:
   echo "$result"
 }
 
+# ── Codex usage windows: THE single derive-by-seconds source of truth ────────
+# Reads wham/usage JSON on stdin. Assigns each window to its slot by
+# limit_window_seconds (18000 -> 5h, 604800 -> 7d), NEVER by position. Emits one
+# eval-able line of shell assignments. Empty/absent wham or an absent window is
+# graceful (-1 / empty); an UNRECOGNIZED limit_window_seconds fails loud (stderr
+# + exit 1) so a schema change can never be silently mislabeled.
+_codex_windows() {
+  python3 -c '
+import sys, json
+raw = sys.stdin.read().strip()
+slots = {"5h": {}, "7d": {}}
+if raw:
+    try:
+        wham = json.loads(raw)
+    except Exception:
+        wham = {}
+    rl = wham.get("rate_limit", {}) or {}
+    for key in ("primary_window", "secondary_window"):
+        w = rl.get(key)
+        if not w:
+            continue
+        lws = w.get("limit_window_seconds")
+        if lws == 18000:
+            slots["5h"] = w
+        elif lws == 604800:
+            slots["7d"] = w
+        else:
+            sys.stderr.write("unrecognized limit_window_seconds=%r in %s\n" % (lws, key))
+            sys.exit(1)
+def pct(w):
+    v = w.get("used_percent")
+    return v if v is not None else -1
+def num(w, k):
+    v = w.get(k)
+    return v if v is not None else ""
+w5, w7 = slots["5h"], slots["7d"]
+print("CODEX_5H=%s CODEX_7D=%s CODEX_5H_SECS=%s CODEX_7D_SECS=%s CODEX_5H_RESET_SECS=%s CODEX_7D_RESET_SECS=%s" % (
+    pct(w5), pct(w7),
+    num(w5, "limit_window_seconds"), num(w7, "limit_window_seconds"),
+    num(w5, "reset_after_seconds"), num(w7, "reset_after_seconds")))
+'
+}
+
 # ── Codex plan helper (JWT decode + wham/usage live % + SQLite token counts) ──
 _codex_json() {
   local auth_file="$HOME/.codex/auth.json"
@@ -120,7 +173,17 @@ _codex_json() {
   local wham_json=""
   wham_json=$(_codex_wham_usage 2>/dev/null) || true
 
-  CODEX_AUTH="$auth_file" CODEX_DB="$db_file" WHAM_JSON="$wham_json" python3 -c "
+  # Derive windows ONCE by seconds. A non-zero exit (unrecognized window) has
+  # already printed to stderr; propagate it so `set -e` exits loudly.
+  local WINS
+  WINS=$(printf '%s' "$wham_json" | _codex_windows) || return 1
+  eval "$WINS"
+
+  CODEX_AUTH="$auth_file" CODEX_DB="$db_file" WHAM_JSON="$wham_json" \
+  CODEX_5H="${CODEX_5H:--1}" CODEX_7D="${CODEX_7D:--1}" \
+  CODEX_5H_SECS="${CODEX_5H_SECS:-}" CODEX_7D_SECS="${CODEX_7D_SECS:-}" \
+  CODEX_5H_RESET_SECS="${CODEX_5H_RESET_SECS:-}" CODEX_7D_RESET_SECS="${CODEX_7D_RESET_SECS:-}" \
+  python3 -c "
 import json, base64, time, os, re, sqlite3
 from datetime import datetime, timezone
 
@@ -141,20 +204,34 @@ except Exception as e:
     result['token_expires_in_hours'] = None
     result['jwt_error'] = str(e)
 
-# Live usage % from wham/usage API
+# Live usage %: consume ONLY the env values _codex_windows already derived
+# by seconds. No positional derivation happens here.
+def _env_num(name):
+    v = os.environ.get(name, '')
+    if v in ('', '-1'):
+        return None
+    try:
+        return int(v)
+    except ValueError:
+        try:
+            return float(v)
+        except ValueError:
+            return None
+result['utilization_5h']         = _env_num('CODEX_5H')
+result['utilization_7d']         = _env_num('CODEX_7D')
+result['reset_5h_seconds']       = _env_num('CODEX_5H_RESET_SECS')
+result['reset_7d_seconds']       = _env_num('CODEX_7D_RESET_SECS')
+result['limit_window_seconds_5h'] = _env_num('CODEX_5H_SECS')
+result['limit_window_seconds_7d'] = _env_num('CODEX_7D_SECS')
+
+# limit_reached / allowed are top-level flags (positional-independent).
 wham_raw = os.environ.get('WHAM_JSON', '')
 if wham_raw:
     try:
         wham = json.loads(wham_raw)
         rl = wham.get('rate_limit', {})
-        pw = rl.get('primary_window', {})
-        sw = rl.get('secondary_window', {})
-        result['utilization_5h']  = pw.get('used_percent')
-        result['utilization_7d']  = sw.get('used_percent')
-        result['reset_5h_seconds'] = pw.get('reset_after_seconds')
-        result['reset_7d_seconds'] = sw.get('reset_after_seconds')
-        result['limit_reached']   = rl.get('limit_reached', False)
-        result['allowed']         = rl.get('allowed', True)
+        result['limit_reached'] = rl.get('limit_reached', False)
+        result['allowed']       = rl.get('allowed', True)
     except Exception:
         pass
 
@@ -273,10 +350,25 @@ fi
 # Cache the result
 echo "$RESPONSE" > "$CACHE_FILE"
 
-# ── Threshold checks + Telegram alerts ──────────────────────────────────────
+# ── Threshold checks + alerts ────────────────────────────────────────────────
 ALERT_SENT=false
 
-if [[ -n "$CHAT_ID" ]]; then
+# _alert <message> [priority] — the ONE routing sink. Routes to a configured
+# orchestrator agent (if CTX_USAGE_ALERT_AGENT set) AND/OR Telegram (unless
+# --no-telegram / no chat id). Public default (agent empty) is Telegram-only.
+_alert() {
+  local msg="$1"; local priority="${2:-normal}"
+  if [[ -n "$ALERT_AGENT" ]]; then
+    node "$SCRIPT_DIR/../dist/cli.js" bus send-message "$ALERT_AGENT" "$priority" "$msg" >/dev/null 2>&1 || true
+  fi
+  if [[ "$SUPPRESS_TELEGRAM" == "false" && -n "$CHAT_ID" && -f "$SCRIPT_DIR/send-telegram.sh" ]]; then
+    bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$msg" 2>/dev/null || true
+  fi
+  echo "$msg" >&2
+  ALERT_SENT=true
+}
+
+if [[ -n "$CHAT_ID" || -n "$ALERT_AGENT" ]]; then
   FIVE_H=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('five_hour',{}).get('utilization'); print(v if v is not None else -1)" 2>/dev/null || echo -1)
   SEVEN_D=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); v=d.get('seven_day',{}).get('utilization'); print(v if v is not None else -1)" 2>/dev/null || echo -1)
   SEVEN_D_RESET=$(echo "$RESPONSE" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('seven_day',{}).get('resets_at','unknown'))" 2>/dev/null || echo "unknown")
@@ -285,39 +377,37 @@ if [[ -n "$CHAT_ID" ]]; then
   # 7-day critical threshold
   if python3 -c "import sys; v=float('${SEVEN_D}'); sys.exit(0 if v >= ${WARN_7DAY} else 1)" 2>/dev/null; then
     SEND_MSG="CODE RED: Claude Max 7-day usage at ${SEVEN_D}%. Resets: ${SEVEN_D_RESET}. Agents will hit hard limit soon. Action needed: reduce agent frequency or pause non-critical crons."
-    # Use send-telegram if available
-    if [[ -f "$SCRIPT_DIR/send-telegram.sh" ]]; then
-      bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
-    fi
-    ALERT_SENT=true
-    echo "$SEND_MSG" >&2
+    _alert "$SEND_MSG" high
   fi
 
   # 5-hour warning threshold
   if python3 -c "import sys; v=float('${FIVE_H}'); sys.exit(0 if v >= ${WARN_5H} else 1)" 2>/dev/null; then
     SEND_MSG="Warning: Claude Max 5-hour window at ${FIVE_H}%. Resets: ${FIVE_H_RESET}."
-    if [[ -f "$SCRIPT_DIR/send-telegram.sh" ]]; then
-      bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
-    fi
-    echo "$SEND_MSG" >&2
+    _alert "$SEND_MSG" normal
   fi
 
-  # Codex usage threshold checks (from wham/usage)
+  # Codex usage threshold checks (from wham/usage). Windows derived by seconds,
+  # NEVER positionally.
   CODEX_WHAM=$(_codex_wham_usage 2>/dev/null || echo "")
   if [[ -n "$CODEX_WHAM" ]]; then
-    CODEX_5H=$(echo "$CODEX_WHAM" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('rate_limit',{}).get('primary_window',{}).get('used_percent',-1))" 2>/dev/null || echo -1)
-    CODEX_7D=$(echo "$CODEX_WHAM" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('rate_limit',{}).get('secondary_window',{}).get('used_percent',-1))" 2>/dev/null || echo -1)
+    if ! WINS="$(printf '%s' "$CODEX_WHAM" | _codex_windows)"; then
+      echo "check-usage-api: unrecognized codex usage window; aborting" >&2
+      exit 1
+    fi
+    eval "$WINS"
+    CODEX_5H="${CODEX_5H:--1}"
+    CODEX_7D="${CODEX_7D:--1}"
     CODEX_LIMIT=$(echo "$CODEX_WHAM" | python3 -c "import sys,json; d=json.load(sys.stdin); print(d.get('rate_limit',{}).get('limit_reached',False))" 2>/dev/null || echo "False")
 
     if [[ "$CODEX_LIMIT" == "True" ]]; then
       SEND_MSG="CODE RED: Codex rate limit reached. Sessions blocked until window resets."
-      [[ -f "$SCRIPT_DIR/send-telegram.sh" ]] && bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
+      _alert "$SEND_MSG" high
     elif python3 -c "import sys; v=float('${CODEX_7D}'); sys.exit(0 if v >= ${WARN_7DAY} else 1)" 2>/dev/null; then
       SEND_MSG="Warning: Codex 7-day usage at ${CODEX_7D}%."
-      [[ -f "$SCRIPT_DIR/send-telegram.sh" ]] && bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
+      _alert "$SEND_MSG" normal
     elif python3 -c "import sys; v=float('${CODEX_5H}'); sys.exit(0 if v >= ${WARN_5H} else 1)" 2>/dev/null; then
       SEND_MSG="Warning: Codex 5-hour window at ${CODEX_5H}%."
-      [[ -f "$SCRIPT_DIR/send-telegram.sh" ]] && bash "$SCRIPT_DIR/send-telegram.sh" "$CHAT_ID" "$SEND_MSG" 2>/dev/null || true
+      _alert "$SEND_MSG" normal
     fi
   fi
 fi

--- a/tests/check-usage-api-alert.test.sh
+++ b/tests/check-usage-api-alert.test.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# Unit harness for check-usage-api.sh — DEFECT 1 (alert gating + generic routing)
+# and DEFECT 2 (Codex usage-window labels derived by seconds, never positionally).
+# Extracts the REAL _alert / _codex_windows / _codex_json functions from the
+# script (no drift), mocks node + send-telegram + _codex_wham_usage, and asserts
+# routing + by-value window correctness. Several assertions are DISCRIMINATING:
+# they go RED against the pre-fix positional code (see tests 7, 9, 10).
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT="$TEST_DIR/../bus/check-usage-api.sh"
+PASS=0; FAIL=0
+ok()   { PASS=$((PASS+1)); echo "  ok   - $1"; }
+nope() { FAIL=$((FAIL+1)); echo "  FAIL - $1"; }
+check(){ if eval "$2"; then ok "$1"; else nope "$1 :: [$2]"; fi; }
+
+TMP="$(mktemp -d)"; trap 'rm -rf "$TMP"' EXIT
+
+# ── Mocks + globals the extracted functions reference ────────────────────────
+NODE_LOG="$TMP/node.log"; : > "$NODE_LOG"
+TG_LOG="$TMP/tg.log";     : > "$TG_LOG"
+
+# Mock node -> capture the bus invocation instead of sending.
+node() { echo "$*" >> "$NODE_LOG"; }
+
+# Mock SCRIPT_DIR so _alert resolves a FAKE send-telegram.sh that just logs.
+SCRIPT_DIR="$TMP/bin"; mkdir -p "$SCRIPT_DIR"
+cat > "$SCRIPT_DIR/send-telegram.sh" <<'TG'
+#!/usr/bin/env bash
+echo "TG: $*" >> "$TG_LOG"
+TG
+chmod +x "$SCRIPT_DIR/send-telegram.sh"
+export TG_LOG   # the fake send-telegram.sh runs in a child bash and needs this
+
+ALERT_AGENT=""
+SUPPRESS_TELEGRAM=false
+CHAT_ID=""
+ALERT_SENT=false
+
+# Extract the real functions from the script and eval them here (no drift).
+eval "$(sed -n '/^_alert() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^_codex_windows() {/,/^}/p' "$SCRIPT")"
+eval "$(sed -n '/^_codex_json() {/,/^}/p' "$SCRIPT")"
+
+# ═══════════════════════ DEFECT 1 — gating + routing ════════════════════════
+echo "== DEFECT 1: generic gating + routing =="
+
+# (1) agent from env (generic, NOT hardcoded) routed at the given priority
+ALERT_AGENT="someorch"; SUPPRESS_TELEGRAM=false; CHAT_ID="12345"
+: > "$NODE_LOG"; : > "$TG_LOG"
+_alert "CODE RED body" high
+check "1: env agent routed via bus at high" 'grep -q "bus send-message someorch high CODE RED body" "$NODE_LOG"'
+
+# (2) --no-telegram suppresses Telegram but bus routing still fires
+ALERT_AGENT="someorch"; SUPPRESS_TELEGRAM=true; CHAT_ID="12345"
+: > "$NODE_LOG"; : > "$TG_LOG"
+_alert "warn body" normal
+check "2: suppress -> Telegram NOT called"   '[[ ! -s "$TG_LOG" ]]'
+check "2: suppress -> bus still routes"        'grep -q "bus send-message someorch normal warn body" "$NODE_LOG"'
+
+# (3) not suppressed + CHAT_ID set -> Telegram IS called
+ALERT_AGENT=""; SUPPRESS_TELEGRAM=false; CHAT_ID="12345"
+: > "$NODE_LOG"; : > "$TG_LOG"
+_alert "warn body" normal
+check "3: not suppressed -> Telegram called"   '[[ -s "$TG_LOG" ]]'
+
+# (4) CODE-RED routed high; with suppress on it sends NO Telegram
+ALERT_AGENT="someorch"; SUPPRESS_TELEGRAM=true; CHAT_ID="12345"
+: > "$NODE_LOG"; : > "$TG_LOG"
+_alert "CODE RED: Codex rate limit reached." high
+check "4: CODE-RED routed high"                'grep -q "send-message someorch high" "$NODE_LOG"'
+check "4: CODE-RED + suppress -> no Telegram"  '[[ ! -s "$TG_LOG" ]]'
+
+# (5) PII gate: zero hardcoded agent names / owners in the source
+check "5: PII gate (no paul/james)" '[[ "$(grep -icE "paul|james" "$SCRIPT")" -eq 0 ]]'
+
+# ═══════════════════ DEFECT 2 — windows derived by seconds ══════════════════
+echo "== DEFECT 2: _codex_windows derive-by-seconds =="
+
+W_POS='{"rate_limit":{"primary_window":{"used_percent":30,"limit_window_seconds":18000,"reset_after_seconds":100},"secondary_window":{"used_percent":70,"limit_window_seconds":604800,"reset_after_seconds":200}}}'
+W_SWAP='{"rate_limit":{"primary_window":{"used_percent":70,"limit_window_seconds":604800},"secondary_window":{"used_percent":30,"limit_window_seconds":18000}}}'
+W_INC='{"rate_limit":{"primary_window":{"used_percent":100,"limit_window_seconds":604800},"secondary_window":null}}'
+W_BAD='{"rate_limit":{"primary_window":{"used_percent":50,"limit_window_seconds":999}}}'
+
+# (6) positive control: canonical order maps correctly
+OUT6=$(printf '%s' "$W_POS" | _codex_windows)
+check "6: pos control 5h=30" 'echo "$OUT6" | grep -q "CODEX_5H=30 "'
+check "6: pos control 7d=70" 'echo "$OUT6" | grep -q "CODEX_7D=70 "'
+
+# (7) DISCRIMINATING: swapped order still maps by seconds (RED vs positional code)
+OUT7=$(printf '%s' "$W_SWAP" | _codex_windows)
+check "7: swap still 5h=30 (discriminating)" 'echo "$OUT7" | grep -q "CODEX_5H=30 "'
+check "7: swap still 7d=70 (discriminating)" 'echo "$OUT7" | grep -q "CODEX_7D=70 "'
+
+# (8) incident shape: 7d=100, 5h absent
+OUT8=$(printf '%s' "$W_INC" | _codex_windows)
+check "8: incident 7d=100"     'echo "$OUT8" | grep -q "CODEX_7D=100 "'
+check "8: incident 5h absent"  'echo "$OUT8" | grep -q "CODEX_5H=-1 "'
+
+# (9) fail-loud on unrecognized window (must NOT be swallowed)
+ERR9=$(printf '%s' "$W_BAD" | _codex_windows 2>&1); RC9=$?
+check "9: unrecognized -> non-zero exit"     '[[ $RC9 -ne 0 ]]'
+check "9: unrecognized -> error on stderr"   'echo "$ERR9" | grep -q "unrecognized limit_window_seconds"'
+
+# (10) BY-VALUE output path: _codex_json labels swapped windows correctly
+_codex_wham_usage() {
+  printf '%s' '{"rate_limit":{"limit_reached":false,"allowed":true,"primary_window":{"used_percent":70,"limit_window_seconds":604800,"reset_after_seconds":200},"secondary_window":{"used_percent":30,"limit_window_seconds":18000,"reset_after_seconds":100}}}'
+}
+FAKE_HOME="$TMP/home"; mkdir -p "$FAKE_HOME/.codex"
+echo '{"tokens":{"access_token":"x.y.z"}}' > "$FAKE_HOME/.codex/auth.json"
+OUT10=$(HOME="$FAKE_HOME" _codex_json)
+check "10: output utilization_5h==30 (by value)"        'echo "$OUT10" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get(\"utilization_5h\")==30, d"'
+check "10: output utilization_7d==70 (by value)"        'echo "$OUT10" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get(\"utilization_7d\")==70, d"'
+check "10: output limit_window_seconds_7d==604800"      'echo "$OUT10" | python3 -c "import sys,json; d=json.load(sys.stdin); assert d.get(\"limit_window_seconds_7d\")==604800, d"'
+
+echo ""
+echo "RESULT: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Fixes two defects in `bus/check-usage-api.sh` in one focused change.

**DEFECT 1 — ungated direct alert sends.** All five alert branches sent Telegram directly to a single hardcoded owner chat with no opt-out, including the threshold-independent CODE-RED branch. This adds one generic routing sink (`_alert`): a `--no-telegram`/`--suppress` flag that every branch respects, plus an env-configurable orchestrator route (`CTX_USAGE_ALERT_AGENT`) over the bus. No hardcoded agent names or chat ids; the public default (Telegram-to-owner when `CHAT_ID` is set) is unchanged.

**DEFECT 2 — backwards Codex window labels.** Codex usage windows were labelled positionally, producing swapped 5h/7d readings whenever the API window ordering differed (observed: a 7d window reported as the 5h figure). Labels are now derived from `limit_window_seconds` (18000 → 5h, 604800 → 7d) in a single source of truth (`_codex_windows`) consumed by both the alert path and the JSON output builder. It fails loud on an unrecognized window and surfaces `limit_window_seconds_5h`/`_7d` in the output.

## Test Plan

- New `tests/check-usage-api-alert.test.sh` — 18 assertions across gating/routing and derive-by-seconds, wired into CI.
- `bash tests/check-usage-api-alert.test.sh` → 18 passed, 0 failed.
- Discrimination proven: reverting to the positional/non-gating logic turns 11 assertions RED (including a by-value output-path swap test that catches the exact mislabel).
- `bash -n bus/check-usage-api.sh` clean; `tsc --noEmit` EXIT=0 (no TypeScript touched).
- Full vitest suite: failure name-set identical branch-vs-base (zero new failures).

Supersedes #622 (which removed Telegram entirely and hardcoded a personal route); that PR will be closed.
