### PR TITLE
fix(daemon): add unified agent recovery watchdog

### DIFF
--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -22,6 +22,9 @@ import { stripBom } from '../utils/strip-bom.js';
 import { BuzzRelayClient, BuzzDispatcher, loadBuzzConfig, type NostrEvent } from '../buzz/index.js';
 import { computeDormancy, parseHeartbeatIntervalMs } from '../utils/dormancy.js';
 import { CRONS_DIRECTORY, CRONS_FILENAME } from '../bus/crons-schema.js';
+import { hardRestart } from '../bus/system.js';
+import { RecoveryWatchdog, type LivenessVerdict, type MappedAgentSnapshot } from './recovery-watchdog.js';
+import type { Heartbeat } from '../types/index.js';
 
 type LogFn = (msg: string) => void;
 
@@ -136,6 +139,11 @@ export class AgentManager {
   // them, so staleness is measured relative to daemon start.
   private daemonStartMs: number = Date.now();
 
+  // Recovery watchdog: the single agent-recovery authority (one timer, one
+  // circuit-breaker registry, one recover() chokepoint). Owned here; started at
+  // the end of discoverAndStart() and stopped in stopAll().
+  private recoveryWatchdog: RecoveryWatchdog | null = null;
+
   constructor(instanceId: string, ctxRoot: string, frameworkRoot: string, org: string) {
     this.instanceId = instanceId;
     this.ctxRoot = ctxRoot;
@@ -236,6 +244,13 @@ export class AgentManager {
     // are normal operation and should fire the real BUG-011 alarm if a
     // race ever does leak through PR #11's protection.
     this.clearDaemonCrashMarkers();
+
+    // Start the single recovery watchdog once the initial roster is up. Guarded
+    // so a re-entered discoverAndStart never spawns a second timer.
+    if (!this.recoveryWatchdog) {
+      this.recoveryWatchdog = new RecoveryWatchdog(this, (m) => console.log(m));
+      this.recoveryWatchdog.start();
+    }
   }
 
   /**
@@ -1548,6 +1563,8 @@ export class AgentManager {
    * time `pty.kill()` runs, every agent already has its marker on disk.
    */
   async stopAll(): Promise<void> {
+    this.recoveryWatchdog?.stop();
+    this.recoveryWatchdog = null;
     this.slackSocketClient?.stop();
     this.slackSocketClient = null;
     this.slackSocketStarted = false;
@@ -1718,6 +1735,112 @@ export class AgentManager {
     } catch {
       return null;
     }
+  }
+
+  /**
+   * Read and parse an agent's canonical heartbeat.json. Returns null if missing
+   * or unparseable — best effort, never throws. Used by the recovery watchdog's
+   * content-freshness gate (which reads status/current_task, not the timestamp).
+   */
+  private readHeartbeat(agent: string): Heartbeat | null {
+    const hbPath = join(this.ctxRoot, 'state', agent, 'heartbeat.json');
+    if (!existsSync(hbPath)) return null;
+    try {
+      return JSON.parse(readFileSync(hbPath, 'utf-8')) as Heartbeat;
+    } catch {
+      return null;
+    }
+  }
+
+  // ---- RecoveryManager surface (consumed by RecoveryWatchdog) ----
+
+  /**
+   * Snapshot every mapped agent for the frozen-content trigger. Applies the same
+   * pid-liveness status correction as getAllStatuses (a 'running' entry whose pid
+   * is gone is reported 'stopped', so it carries no uptime and is not flagged).
+   */
+  getMappedContentSnapshot(_nowMs: number): MappedAgentSnapshot[] {
+    const enabledList = this.readInstanceEnableList();
+    const isEnabled = (name: string): boolean => enabledList[name]?.enabled !== false;
+    const out: MappedAgentSnapshot[] = [];
+    for (const [name, entry] of this.agents) {
+      const status = entry.process.getStatus();
+      const running = status.status === 'running' && !!status.pid && isPidAlive(status.pid);
+      out.push({
+        name,
+        org: enabledList[name]?.org,
+        enabled: isEnabled(name),
+        uptimeMs: running && status.uptime != null ? status.uptime * 1000 : null,
+        heartbeat: this.readHeartbeat(name),
+      });
+    }
+    return out;
+  }
+
+  /**
+   * Face-B dormant agents: enabled agents absent from the mapped set. Reuses
+   * computeDormancy exactly as getAllStatuses does, so the watchdog and the
+   * status surface agree on who is absent-dormant.
+   */
+  getAbsentDormantAgents(nowMs: number): Array<{ name: string; org?: string }> {
+    const daemonUptimeMs = nowMs - this.daemonStartMs;
+    const enabledList = this.readInstanceEnableList();
+    const isEnabled = (name: string): boolean => enabledList[name]?.enabled !== false;
+    const out: Array<{ name: string; org?: string }> = [];
+    for (const name of Object.keys(enabledList)) {
+      if (this.agents.has(name) || !isEnabled(name)) continue;
+      const d = computeDormancy({
+        agent: name,
+        org: enabledList[name]?.org,
+        enabled: true,
+        mapped: false,
+        nowMs,
+        lastSeenMs: this.readHeartbeatMs(name),
+        uptimeMs: null,
+        daemonUptimeMs,
+        expectedIntervalMs: this.readHeartbeatIntervalMs(name),
+      });
+      if (d.dormant) out.push({ name, org: enabledList[name]?.org });
+    }
+    return out;
+  }
+
+  /** Secondary-liveness verdict for a mapped agent (UNCERTAIN if not mapped). */
+  probeAgentLiveness(name: string): LivenessVerdict {
+    const entry = this.agents.get(name);
+    if (!entry) return 'UNCERTAIN';
+    try {
+      return entry.process.probeLiveness();
+    } catch {
+      return 'UNCERTAIN';
+    }
+  }
+
+  /** state/<agent> dir — for the watchdog's circuit file and .restart-planned probe. */
+  stateDirFor(name: string): string {
+    return join(this.ctxRoot, 'state', name);
+  }
+
+  /**
+   * Force-fresh restart action for the watchdog: writes .force-fresh +
+   * .restart-planned (so the next spawn skips --continue and crash-alert knows
+   * the restart was planned), then does a full teardown+rebuild via restartAgent.
+   * Paths are rooted at this.ctxRoot so stateDir matches readHeartbeat/readHeartbeatMs.
+   */
+  async forceFreshRestart(name: string, reason: string): Promise<void> {
+    const paths: BusPaths = {
+      ...resolvePaths(name, this.instanceId, this.resolveAgentOrg(name)),
+      ctxRoot: this.ctxRoot,
+      stateDir: join(this.ctxRoot, 'state', name),
+      logDir: join(this.ctxRoot, 'logs', name),
+    };
+    hardRestart(paths, name, reason);
+    await this.restartAgent(name);
+  }
+
+  /** Start-absent action for the watchdog: start an enabled-but-absent agent fresh. */
+  async startAbsent(name: string): Promise<void> {
+    await this.startAgent(name, '');
   }
 
   /**

--- a/src/daemon/agent-process.ts
+++ b/src/daemon/agent-process.ts
@@ -6,6 +6,7 @@ import { AgentPTY } from '../pty/agent-pty.js';
 import { CodexAppServerPTY } from '../pty/codex-app-server-pty.js';
 import { HermesPTY, hermesDbExists } from '../pty/hermes-pty.js';
 import { OpencodePTY, opencodeSessionExists } from '../pty/opencode-pty.js';
+import { classifyCodexLiveness, classifyProcStateLiveness, type LivenessVerdict } from './recovery-watchdog.js';
 import { MessageDedup, injectMessage as injectMessageIntoPty } from '../pty/inject.js';
 import type { TelegramAPI } from '../telegram/api.js';
 import { ensureDir } from '../utils/atomic.js';
@@ -473,6 +474,31 @@ export class AgentProcess {
           ? this.pty.isAwaitingInteractiveConfirmation()
           : false,
     };
+  }
+
+  /**
+   * Secondary-liveness verdict for the recovery watchdog's discriminator.
+   * Dispatches by runtime to the PTY's raw signals and runs the fail-safe
+   * classifier. Any missing PTY / uncertainty resolves to UNCERTAIN (veto).
+   */
+  probeLiveness(): LivenessVerdict {
+    if (!this.pty) return 'UNCERTAIN';
+    if (this.config.runtime === 'codex-app-server') {
+      const s = (this.pty as CodexAppServerPTY).probeLiveness();
+      let pidAlive = false;
+      if (s.pid != null) {
+        try {
+          process.kill(s.pid, 0);
+          pidAlive = true;
+        } catch (err) {
+          pidAlive = (err as NodeJS.ErrnoException).code === 'EPERM';
+        }
+      }
+      return classifyCodexLiveness({ socketAlive: s.socketAlive, pid: s.pid, pidAlive, turnInFlight: s.turnInFlight });
+    }
+    // claude-code / hermes / opencode all extend AgentPTY.
+    const s = (this.pty as AgentPTY).probeLiveness();
+    return classifyProcStateLiveness(s);
   }
 
   /**

--- a/src/daemon/recovery-watchdog.ts
+++ b/src/daemon/recovery-watchdog.ts
@@ -1,0 +1,471 @@
+/**
+ * recovery-watchdog.ts — the single agent-recovery authority for the daemon.
+ *
+ * ONE timer (a periodic fleet sweep), ONE circuit-breaker registry, ONE
+ * `recover()` chokepoint. New recovery reasons register as `RecoveryTrigger`
+ * extension points feeding the SAME chokepoint — never their own timer or
+ * restart path — so single-authority is architectural, not convention.
+ *
+ * Two triggers ship here:
+ *   - FrozenContentTrigger — NET-NEW content-freshness detection for MAPPED,
+ *     pid-alive agents. It does NOT consume computeDormancy/`d.dormant`: the
+ *     fast-checker writes its own ~50min idle beat in the daemon, keeping
+ *     `last_heartbeat` fresh even when the agent brain is wedged, so timestamp
+ *     dormancy is blind to a mapped wedge (see C1). Frozen content is also the
+ *     STANDING state of a healthy idle agent (C2), so this trigger deliberately
+ *     over-flags and the liveness discriminator in `recover()` is the ONLY thing
+ *     preventing mass false-restart.
+ *   - AbsentAgentTrigger — reuses computeDormancy Face B (enabled agents absent
+ *     from the mapped set) to START never-spawned / dropped-from-map agents.
+ *
+ * ────────────────────────────────────────────────────────────────────────────
+ * COVERAGE BOUNDARY — READ THIS. A hung-but-ALIVE claude REPL (a wedged claude
+ * brain whose OS process still sleeps normally, state 'S'/'I') is OUT OF SCOPE.
+ * The fail-safe discriminator cannot distinguish it from a healthy idle REPL and
+ * will VETO (UNCERTAIN), which is correct — guessing there would mass-restart
+ * healthy idle agents. That single case is backstopped by human operators and
+ * the next sweep. A dedicated claude-REPL-wedge signal (e.g. a PTY stuck-banner
+ * probe) is possible future work and is NOT implemented here. The watchdog also
+ * announces this boundary in a startup log line so the gap is loud, never
+ * silent.
+ * ────────────────────────────────────────────────────────────────────────────
+ *
+ * All numeric constants below are review-tunable proposals, NOT final.
+ */
+
+import { existsSync, readFileSync, writeFileSync, statSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import type { Heartbeat } from '../types/index.js';
+import { BOOT_GRACE_MS } from '../utils/dormancy.js';
+import { normalizeHeartbeatContent, contentDiffers } from '../utils/heartbeat-content.js';
+
+type LogFn = (msg: string) => void;
+
+// ---------------------------------------------------------------------------
+// Tunable constants
+// ---------------------------------------------------------------------------
+
+/** Fleet sweep cadence. */
+export const SWEEP_INTERVAL_MS = 5 * 60 * 1000; // 5 min
+
+/**
+ * A MAPPED agent whose normalized heartbeat content has not changed for at
+ * least this long (and is past boot grace) is a frozen-content candidate. The
+ * discriminator then decides whether it is actually wedged.
+ */
+export const RECOVERY_FREEZE_MS = 30 * 60 * 1000; // 30 min
+
+/**
+ * Cross-watchdog cooldown: skip an agent whose `.restart-planned` marker was
+ * touched within this window (a context/hard/self restart is already in flight —
+ * do not fight fast-checker.forceContextRestart or a manual restart).
+ */
+export const RESTART_COOLDOWN_MS = 15 * 60 * 1000; // 15 min
+
+/** Circuit-breaker sliding window. Mirrors fast-checker's 15-min window. */
+export const CIRCUIT_WINDOW_MS = 15 * 60 * 1000; // 15 min
+
+/**
+ * Max recoveries allowed inside CIRCUIT_WINDOW_MS before the breaker trips. With
+ * MAX=2 the 1st and 2nd recoveries proceed and the 3rd trips (2 ok / 3rd trips).
+ *
+ * NOTE (flagged): the plan headline says "3/15min, mirror fast-checker", but the
+ * plan's own test spec says "2 ok / 3rd trips" and fast-checker actually allows
+ * 3 (the 4th trips). These disagree. This follows the explicit test spec; the
+ * value is a single named constant so it is trivial to retune.
+ */
+export const CIRCUIT_MAX_RESTARTS = 2;
+
+/** How long the breaker stays tripped once it fires. */
+export const CIRCUIT_PAUSE_MS = 30 * 60 * 1000; // 30 min
+
+const CIRCUIT_FILENAME = '.recovery-circuit.json';
+const RESTART_PLANNED_FILENAME = '.restart-planned';
+
+/** Exact loud startup line (ruling 2a). Also mirrored in the module docstring. */
+export const COVERAGE_BOUNDARY_LINE =
+  '[recovery-watchdog] started. COVERAGE BOUNDARY: a hung-but-alive claude REPL ' +
+  '(a wedged claude brain whose OS process still sleeps normally) is OUT OF SCOPE — ' +
+  'the fail-safe discriminator cannot distinguish it from a healthy idle REPL and will ' +
+  'VETO. That case is backstopped by human operators and the next sweep.';
+
+// ---------------------------------------------------------------------------
+// Liveness discriminator (VETO-first, fail-SAFE) — pure classifiers
+// ---------------------------------------------------------------------------
+
+/** Only WEDGED is ever restarted. Any uncertainty or error resolves to VETO. */
+export type LivenessVerdict = 'WEDGED' | 'ALIVE_IDLE' | 'UNCERTAIN';
+
+/** Raw signals surfaced by CodexAppServerPTY.probeLiveness() + a pid-liveness probe. */
+export interface CodexLivenessSignals {
+  socketAlive: boolean;
+  pid: number | null;
+  pidAlive: boolean;
+  turnInFlight: boolean;
+}
+
+/** Raw signals surfaced by AgentPTY.probeLiveness() (claude/hermes/opencode). */
+export interface ProcStateSignals {
+  pid: number | null;
+  pidAlive: boolean;
+  procState: string | null; // `ps -o stat=` output, or null when unavailable
+}
+
+/**
+ * codex-app-server discriminator. WEDGED only on a positive dead signal (socket
+ * down, or the app-server child pid gone). An idle server (socket up, pid alive,
+ * no turn in flight) is ALIVE_IDLE and MUST be vetoed — this is the exact
+ * motivating case (multiple alive-idle Codex servers flagged at once). A turn in
+ * flight means it is actively working ⇒ UNCERTAIN ⇒ veto.
+ */
+export function classifyCodexLiveness(s: CodexLivenessSignals): LivenessVerdict {
+  if (s.socketAlive === false) return 'WEDGED';
+  if (s.pid == null || s.pidAlive === false) return 'WEDGED';
+  if (s.socketAlive && s.pidAlive && s.turnInFlight === false) return 'ALIVE_IDLE';
+  return 'UNCERTAIN';
+}
+
+/**
+ * Coarse `ps -o stat=` discriminator for claude/hermes/opencode. A sleeping REPL
+ * and a wedged-but-alive REPL are OS-indistinguishable, so every live-process
+ * state fails SAFE to UNCERTAIN. Only an unambiguous dead state is WEDGED:
+ *   - pid confirmed gone (ESRCH) ⇒ WEDGED
+ *   - Z (zombie) / X (dead) ⇒ WEDGED
+ *   - S/I/R/D/T (any live state) ⇒ UNCERTAIN (veto)
+ *   - no pid, or ps missing / unparseable ⇒ UNCERTAIN (veto)
+ */
+export function classifyProcStateLiveness(s: ProcStateSignals): LivenessVerdict {
+  if (s.pid == null) return 'UNCERTAIN';
+  if (s.pidAlive === false) return 'WEDGED'; // confirmed gone
+  const st = (s.procState ?? '').trim();
+  if (st === '') return 'UNCERTAIN'; // ps missing / parse-fail
+  const head = st[0].toUpperCase();
+  if (head === 'Z' || head === 'X') return 'WEDGED';
+  if (head === 'S' || head === 'I' || head === 'R' || head === 'D' || head === 'T') return 'UNCERTAIN';
+  return 'UNCERTAIN'; // unknown code — fail safe
+}
+
+// ---------------------------------------------------------------------------
+// Manager surface + trigger extension point
+// ---------------------------------------------------------------------------
+
+/** One MAPPED agent's snapshot for the frozen-content trigger. */
+export interface MappedAgentSnapshot {
+  name: string;
+  org?: string;
+  enabled: boolean;
+  /** Agent process uptime in ms; null when not running / no session. */
+  uptimeMs: number | null;
+  heartbeat: Partial<Heartbeat> | null;
+}
+
+/**
+ * The narrow slice of AgentManager the watchdog depends on. Kept as an interface
+ * so the watchdog has no import back-edge to agent-manager and is unit-testable
+ * with a fake manager.
+ */
+export interface RecoveryManager {
+  /** Snapshot of every mapped agent for content-freshness detection. */
+  getMappedContentSnapshot(nowMs: number): MappedAgentSnapshot[];
+  /** Face-B dormant agents (enabled but absent from the map) to start. */
+  getAbsentDormantAgents(nowMs: number): Array<{ name: string; org?: string }>;
+  /** Secondary-liveness verdict for a mapped agent. */
+  probeAgentLiveness(name: string): LivenessVerdict;
+  /** Force-fresh restart: writes .force-fresh + .restart-planned, then restarts. */
+  forceFreshRestart(name: string, reason: string): Promise<void>;
+  /** Start an enabled-but-absent agent fresh. */
+  startAbsent(name: string): Promise<void>;
+  /** state/<agent> dir — used for the circuit file and the .restart-planned probe. */
+  stateDirFor(name: string): string;
+}
+
+export interface RecoveryContext {
+  nowMs: number;
+}
+
+export type RecoveryAction = 'force-fresh-restart' | 'start-absent';
+
+export interface RecoveryCandidate {
+  agent: string;
+  org?: string;
+  action: RecoveryAction;
+  reason: string;
+}
+
+/** Extension point: a recovery reason. Registers into the ONE recover() chokepoint. */
+export interface RecoveryTrigger {
+  readonly name: string;
+  evaluate(ctx: RecoveryContext): RecoveryCandidate[];
+}
+
+// ---------------------------------------------------------------------------
+// Trigger: frozen mapped content (net-new)
+// ---------------------------------------------------------------------------
+
+interface FreezeState {
+  content: string; // normalized content first seen at `since`
+  since: number;   // nowMs when this content was first observed unchanged
+}
+
+/**
+ * Flags a mapped agent whose normalized heartbeat content has been frozen for at
+ * least RECOVERY_FREEZE_MS. Genuinely fresh content (per `contentDiffers`) resets
+ * the freeze — that is the recovery-verification use of the content gate.
+ */
+export class FrozenContentTrigger implements RecoveryTrigger {
+  readonly name = 'frozen-content';
+  private states = new Map<string, FreezeState>();
+
+  constructor(private mgr: RecoveryManager) {}
+
+  evaluate(ctx: RecoveryContext): RecoveryCandidate[] {
+    const now = ctx.nowMs;
+    const out: RecoveryCandidate[] = [];
+    const snapshot = this.mgr.getMappedContentSnapshot(now);
+    const live = new Set<string>();
+
+    for (const a of snapshot) {
+      // Only enabled, running agents past boot grace are eligible. A fresh /
+      // stopped / starting agent has no uptime past grace and is skipped — the
+      // Face-A bounce guard, reused from dormancy's BOOT_GRACE_MS.
+      if (!a.enabled) continue;
+      if (a.uptimeMs == null || a.uptimeMs < BOOT_GRACE_MS) continue;
+      live.add(a.name);
+
+      const content = normalizeHeartbeatContent(a.heartbeat);
+      const prev = this.states.get(a.name);
+
+      if (!prev) {
+        this.states.set(a.name, { content, since: now });
+        continue;
+      }
+      if (contentDiffers(content, prev.content)) {
+        // Genuinely fresh content ⇒ healthy / recovered. Reset the freeze.
+        this.states.set(a.name, { content, since: now });
+        continue;
+      }
+      // Content did not change (identical, or collapsed to WATCHDOG_IDLE).
+      if (now - prev.since >= RECOVERY_FREEZE_MS) {
+        out.push({
+          agent: a.name,
+          org: a.org,
+          action: 'force-fresh-restart',
+          reason: `frozen heartbeat content for ${Math.round((now - prev.since) / 60000)}m (mapped wedge candidate)`,
+        });
+      }
+    }
+
+    // Drop state for agents no longer mapped/eligible so it cannot go stale.
+    for (const name of [...this.states.keys()]) {
+      if (!live.has(name)) this.states.delete(name);
+    }
+    return out;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Trigger: absent enabled agent (reuses computeDormancy Face B)
+// ---------------------------------------------------------------------------
+
+export class AbsentAgentTrigger implements RecoveryTrigger {
+  readonly name = 'absent-agent';
+
+  constructor(private mgr: RecoveryManager) {}
+
+  evaluate(ctx: RecoveryContext): RecoveryCandidate[] {
+    return this.mgr.getAbsentDormantAgents(ctx.nowMs).map(({ name, org }) => ({
+      agent: name,
+      org,
+      action: 'start-absent' as const,
+      reason: 'silent dormancy: enabled agent absent from map (Face B)',
+    }));
+  }
+}
+
+// ---------------------------------------------------------------------------
+// The watchdog
+// ---------------------------------------------------------------------------
+
+interface CircuitState {
+  restarts: number[];
+  brokenAt: number | null;
+}
+
+export class RecoveryWatchdog {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private inFlight = false;
+  private triggers: RecoveryTrigger[];
+
+  constructor(
+    private mgr: RecoveryManager,
+    private log: LogFn = (m) => console.log(m),
+  ) {
+    this.triggers = [new FrozenContentTrigger(mgr), new AbsentAgentTrigger(mgr)];
+  }
+
+  /** Start the single fleet-sweep timer. Idempotent. Emits the loud boundary line. */
+  start(): void {
+    // Loud coverage boundary (ruling 2a) — announced every start so the
+    // claude-REPL-wedge gap is never silent.
+    this.log(COVERAGE_BOUNDARY_LINE);
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.sweep();
+    }, SWEEP_INTERVAL_MS);
+    // Never keep the daemon event loop alive on the watchdog alone.
+    if (typeof this.timer.unref === 'function') this.timer.unref();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One fleet sweep. Guarded so a slow sweep never overlaps itself. */
+  async sweep(): Promise<void> {
+    if (this.inFlight) return;
+    this.inFlight = true;
+    try {
+      const now = Date.now();
+      const seen = new Set<string>();
+      for (const trig of this.triggers) {
+        let candidates: RecoveryCandidate[] = [];
+        try {
+          candidates = trig.evaluate({ nowMs: now });
+        } catch (err) {
+          this.log(`[recovery-watchdog] trigger ${trig.name} failed: ${err}`);
+          continue;
+        }
+        for (const c of candidates) {
+          try {
+            await this.recover(c, now, seen);
+          } catch (err) {
+            this.log(`[recovery-watchdog] recover(${c.agent}) failed: ${err}`);
+          }
+        }
+      }
+    } finally {
+      this.inFlight = false;
+    }
+  }
+
+  /**
+   * The single recovery chokepoint. Order (each a hard gate):
+   *   1. single-sweep dedup — one action per agent per sweep
+   *   2. cross-watchdog cooldown — skip if .restart-planned is recent
+   *   3. circuit breaker — CIRCUIT_MAX_RESTARTS per CIRCUIT_WINDOW_MS, pause
+   *   4. discriminator VETO — force-fresh only proceeds on a WEDGED verdict
+   *   5. action
+   * `now` and `seen` are injected so this is deterministic in tests.
+   */
+  async recover(candidate: RecoveryCandidate, now: number, seen: Set<string>): Promise<void> {
+    const { agent, action, reason } = candidate;
+
+    // (1) single-sweep dedup
+    if (seen.has(agent)) return;
+    seen.add(agent);
+
+    // (2) cross-watchdog cooldown
+    if (this.recentRestartPlanned(agent, now)) {
+      this.log(`[recovery-watchdog] ${agent}: skip — .restart-planned within cooldown`);
+      return;
+    }
+
+    // (3) circuit breaker
+    if (!this.circuitAllows(agent, now)) {
+      this.log(`[recovery-watchdog] ${agent}: skip — circuit breaker tripped/paused`);
+      return;
+    }
+
+    // (4) discriminator VETO (force-fresh only; an absent agent has no process to probe)
+    if (action === 'force-fresh-restart') {
+      const verdict = this.mgr.probeAgentLiveness(agent);
+      if (verdict !== 'WEDGED') {
+        this.log(`[recovery-watchdog] ${agent}: VETO — liveness verdict ${verdict} (not WEDGED)`);
+        return;
+      }
+    }
+
+    // (5) action
+    this.recordCircuit(agent, now);
+    if (action === 'force-fresh-restart') {
+      this.log(`[recovery-watchdog] ${agent}: force-fresh restart — ${reason}`);
+      await this.mgr.forceFreshRestart(agent, `RECOVERY-WATCHDOG: ${reason}`);
+    } else {
+      this.log(`[recovery-watchdog] ${agent}: start-absent — ${reason}`);
+      await this.mgr.startAbsent(agent);
+    }
+  }
+
+  // --- cross-watchdog cooldown ---
+
+  private recentRestartPlanned(agent: string, now: number): boolean {
+    const p = join(this.mgr.stateDirFor(agent), RESTART_PLANNED_FILENAME);
+    try {
+      if (!existsSync(p)) return false;
+      return now - statSync(p).mtimeMs < RESTART_COOLDOWN_MS;
+    } catch {
+      return false; // unreadable — do not block recovery on it
+    }
+  }
+
+  // --- circuit breaker (mirrors fast-checker ctxCircuitRestarts, persisted) ---
+
+  private circuitFile(agent: string): string {
+    return join(this.mgr.stateDirFor(agent), CIRCUIT_FILENAME);
+  }
+
+  private loadCircuit(agent: string): CircuitState {
+    try {
+      const raw = JSON.parse(readFileSync(this.circuitFile(agent), 'utf-8'));
+      return {
+        restarts: Array.isArray(raw.restarts) ? raw.restarts : [],
+        brokenAt: typeof raw.brokenAt === 'number' ? raw.brokenAt : null,
+      };
+    } catch {
+      return { restarts: [], brokenAt: null };
+    }
+  }
+
+  private saveCircuit(agent: string, c: CircuitState): void {
+    try {
+      const dir = this.mgr.stateDirFor(agent);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(this.circuitFile(agent), JSON.stringify(c), 'utf-8');
+    } catch {
+      // Non-critical — an unpersisted breaker still works within a sweep.
+    }
+  }
+
+  /**
+   * True if a recovery is permitted now. Filters the window, honors an active
+   * pause, and trips (returns false) when the window is already at capacity.
+   * Does NOT record the restart — recordCircuit() does that only on a real action.
+   */
+  private circuitAllows(agent: string, now: number): boolean {
+    const c = this.loadCircuit(agent);
+    if (c.brokenAt != null) {
+      if (now - c.brokenAt < CIRCUIT_PAUSE_MS) return false; // still paused
+      c.brokenAt = null; // pause expired — reset
+      c.restarts = [];
+    }
+    c.restarts = c.restarts.filter((t) => now - t < CIRCUIT_WINDOW_MS);
+    if (c.restarts.length >= CIRCUIT_MAX_RESTARTS) {
+      c.brokenAt = now;
+      this.saveCircuit(agent, c);
+      this.log(`[recovery-watchdog] ${agent}: circuit breaker TRIPPED (${c.restarts.length} in ${Math.round(CIRCUIT_WINDOW_MS / 60000)}min) — paused ${Math.round(CIRCUIT_PAUSE_MS / 60000)}min`);
+      return false;
+    }
+    this.saveCircuit(agent, c); // persist the filtered window / cleared pause
+    return true;
+  }
+
+  private recordCircuit(agent: string, now: number): void {
+    const c = this.loadCircuit(agent);
+    c.restarts = c.restarts.filter((t) => now - t < CIRCUIT_WINDOW_MS);
+    c.restarts.push(now);
+    this.saveCircuit(agent, c);
+  }
+}

--- a/src/pty/agent-pty.ts
+++ b/src/pty/agent-pty.ts
@@ -1,5 +1,6 @@
 import { join } from 'path';
 import { existsSync, readFileSync, readdirSync } from 'fs';
+import { execFileSync } from 'child_process';
 import { platform } from 'os';
 import type { AgentConfig, CtxEnv } from '../types/index.js';
 import { OutputBuffer } from './output-buffer.js';
@@ -404,6 +405,37 @@ export class AgentPTY {
    */
   getPid(): number | null {
     return this.pty?.pid || null;
+  }
+
+  /**
+   * Raw liveness signals for the recovery watchdog's discriminator
+   * (claude/hermes/opencode). Returns the pid, an OS pid-liveness result, and
+   * the coarse `ps -o stat=` process state — identical flags on macOS and Linux.
+   * pidAlive uses the signal-0 idiom (ESRCH = gone; EPERM = alive, owned by
+   * another user). procState is null when there is no pid or `ps` is
+   * missing/unparseable; the watchdog fails those SAFE to a veto.
+   */
+  probeLiveness(): { pid: number | null; pidAlive: boolean; procState: string | null } {
+    const pid = this.getPid();
+    if (pid == null) return { pid: null, pidAlive: false, procState: null };
+    let pidAlive: boolean;
+    try {
+      process.kill(pid, 0);
+      pidAlive = true;
+    } catch (err) {
+      pidAlive = (err as NodeJS.ErrnoException).code === 'EPERM';
+    }
+    let procState: string | null = null;
+    try {
+      const out = execFileSync('ps', ['-o', 'stat=', '-p', String(pid)], {
+        encoding: 'utf-8',
+        timeout: 2000,
+      });
+      procState = out.trim() || null;
+    } catch {
+      procState = null; // ps missing / pid gone / parse-fail — watchdog vetoes
+    }
+    return { pid, pidAlive, procState };
   }
 
   /**

--- a/src/pty/codex-app-server-pty.ts
+++ b/src/pty/codex-app-server-pty.ts
@@ -211,6 +211,22 @@ export class CodexAppServerPTY {
     return this._appServerPty?.pid ?? null;
   }
 
+  /**
+   * Raw liveness signals for the recovery watchdog's discriminator. Surfaces the
+   * three in-process signals (no lsof/pgrep — app-server transport is known
+   * here): the socket/RPC alive flag, the app-server child pid, and whether a
+   * turn is currently in flight (`_turnCompletion` is non-null only between a
+   * turn's start and its resolve/reject). The watchdog combines these with a
+   * pid-liveness probe to reach a verdict.
+   */
+  probeLiveness(): { socketAlive: boolean; pid: number | null; turnInFlight: boolean } {
+    return {
+      socketAlive: this._alive,
+      pid: this.getPid(),
+      turnInFlight: this._turnCompletion !== null,
+    };
+  }
+
   onExit(handler: (exitCode: number, signal?: number) => void): void {
     this._onExitHandler = handler;
   }

--- a/src/utils/heartbeat-content.ts
+++ b/src/utils/heartbeat-content.ts
@@ -1,0 +1,79 @@
+/**
+ * heartbeat-content.ts — Pure heartbeat-content normalization for the recovery
+ * watchdog's content-freshness gate. Side-effect-free, no I/O, unit-testable
+ * with plain inputs (mirrors the shape of dormancy.ts).
+ *
+ * WHY THIS EXISTS (see recovery-watchdog.ts C1/C2): the fast-checker writes a
+ * daemon-side idle-beat ("[watchdog] <agent> alive — idle session
+ * <ts>") every ~50min regardless of REPL state, so `last_heartbeat` stays fresh
+ * even when the agent brain is wedged. Timestamp-based staleness therefore
+ * cannot see a mapped wedge. The watchdog instead tracks whether the SEMANTIC
+ * content of the heartbeat (status + current_task) is frozen across a window.
+ *
+ * The normalizer strips every field that changes on its own without the agent's
+ * brain doing anything:
+ *   - `last_heartbeat` / `timestamp` / `mode` / `loop_interval` — excluded
+ *     entirely (never read).
+ *   - ISO-8601 timestamps embedded inside `status` / `current_task` — collapsed
+ *     to a constant token, so a spawn that re-stamps the same text does not read
+ *     as fresh content ("spawn-carry").
+ *   - a daemon idle-beat `status` — collapsed to the WATCHDOG_IDLE constant,
+ *     so the ~50min daemon beat (whose only moving part is its timestamp) does
+ *     not read as fresh content either.
+ *
+ * The same normalizer feeds BOTH detection (FrozenContentTrigger: content
+ * unchanged across the freeze window) AND recovery-verification (did a restart
+ * produce genuinely different content — see `contentDiffers`).
+ */
+
+import type { Heartbeat } from '../types/index.js';
+
+/**
+ * Canonical token for a heartbeat whose `status` is the daemon's idle-beat.
+ * Any two idle-beat heartbeats normalize to this SAME value, so an
+ * agent emitting only idle beats reads as "content frozen", not "content
+ * changed each beat". It is NOT treated as genuine fresh content by
+ * `contentDiffers` — recovery is only credited for real, non-idle content.
+ */
+export const WATCHDOG_IDLE = '__WATCHDOG_IDLE__';
+
+/** Constant an embedded ISO-8601 timestamp collapses to. */
+const ISO_TOKEN = '__TS__';
+
+/** ISO-8601 timestamp anywhere inside a field (with or without milliseconds). */
+const ISO_RE = /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z/g;
+
+/**
+ * Daemon idle-beat `status`, written by fast-checker.ts's heartbeatTimer as
+ * `bus update-heartbeat "[watchdog] <agent> alive — idle session <ts>"`. Matched
+ * dash-agnostically (the real string uses an em dash) so the gate does not
+ * hinge on the exact separator glyph.
+ */
+const WATCHDOG_IDLE_RE = /^\[watchdog\].*\balive\b.*idle session/i;
+
+/**
+ * Reduce a heartbeat to a canonical semantic-content string from `status` +
+ * `current_task` only. Pure. Returns '' for a null/missing heartbeat.
+ */
+export function normalizeHeartbeatContent(hb: Partial<Heartbeat> | null | undefined): string {
+  if (!hb) return '';
+  const status = typeof hb.status === 'string' ? hb.status : '';
+  if (WATCHDOG_IDLE_RE.test(status.trim())) return WATCHDOG_IDLE;
+  const task = typeof hb.current_task === 'string' ? hb.current_task : '';
+  const scrub = (s: string) => s.replace(ISO_RE, ISO_TOKEN).trim();
+  // NUL delimiter between the two fields: a byte that cannot occur in real
+  // status/task text, so the fingerprint is unambiguous. Must stay the \0
+  // ESCAPE — a literal NUL char here makes git treat this source as binary
+  // and blinds every text-based diff/review/PII sweep of this file.
+  return `${scrub(status)}\0${scrub(task)}`;
+}
+
+/**
+ * Recovery-verification predicate: does the live normalized content represent
+ * GENUINELY FRESH agent output relative to the content captured before a
+ * restart? True only when it is neither identical to the captured content
+ * (spawn-carry) NOR the daemon idle beat (which no agent brain authored).
+ */
+export function contentDiffers(normalizedLive: string, captured: string): boolean {
+  return normalizedLive !== captured && normalizedLive !== WATCHDOG_IDLE;
+}

--- a/tests/unit/daemon/recovery-watchdog.test.ts
+++ b/tests/unit/daemon/recovery-watchdog.test.ts
@@ -1,0 +1,255 @@
+/**
+ * tests/unit/daemon/recovery-watchdog.test.ts
+ *
+ * Unit tests for the recovery watchdog: the fail-safe liveness discriminator,
+ * the frozen-content trigger, and the recover() chokepoint (single-sweep dedup,
+ * cross-watchdog cooldown, circuit breaker, discriminator VETO). Pure logic and
+ * file-backed state under a tmp dir; `nowMs` and `seen` are injected so every
+ * assertion is deterministic (mirrors dormancy.test.ts).
+ *
+ * Each safety-critical behavior is paired with a discriminating control: the
+ * alive-idle VETO and the spawn-carry no-clear both flip if their guard inverts.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, utimesSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import {
+  RecoveryWatchdog,
+  FrozenContentTrigger,
+  classifyCodexLiveness,
+  classifyProcStateLiveness,
+  RECOVERY_FREEZE_MS,
+  RESTART_COOLDOWN_MS,
+  CIRCUIT_MAX_RESTARTS,
+  CIRCUIT_PAUSE_MS,
+  type RecoveryManager,
+  type MappedAgentSnapshot,
+  type LivenessVerdict,
+  type RecoveryCandidate,
+} from '../../../src/daemon/recovery-watchdog';
+import { BOOT_GRACE_MS } from '../../../src/utils/dormancy';
+import type { Heartbeat } from '../../../src/types/index';
+
+const NOW = 1_000_000_000_000;
+
+// A fake manager: records restart actions, serves a scripted snapshot / verdict,
+// and roots per-agent state dirs under a tmp directory.
+class FakeManager implements RecoveryManager {
+  snapshot: MappedAgentSnapshot[] = [];
+  absent: Array<{ name: string; org?: string }> = [];
+  verdict: LivenessVerdict = 'WEDGED';
+  forceCalls: string[] = [];
+  startCalls: string[] = [];
+
+  constructor(private root: string) {}
+
+  getMappedContentSnapshot(): MappedAgentSnapshot[] {
+    return this.snapshot;
+  }
+  getAbsentDormantAgents(): Array<{ name: string; org?: string }> {
+    return this.absent;
+  }
+  probeAgentLiveness(): LivenessVerdict {
+    return this.verdict;
+  }
+  async forceFreshRestart(name: string): Promise<void> {
+    this.forceCalls.push(name);
+  }
+  async startAbsent(name: string): Promise<void> {
+    this.startCalls.push(name);
+  }
+  stateDirFor(name: string): string {
+    const d = join(this.root, name);
+    mkdirSync(d, { recursive: true });
+    return d;
+  }
+}
+
+function hb(overrides: Partial<Heartbeat>): Partial<Heartbeat> {
+  return { agent: 'a', org: 'o', status: 'idle', current_task: '', mode: 'day', last_heartbeat: '2026-08-24T10:00:00Z', loop_interval: '', ...overrides };
+}
+
+let root: string;
+let mgr: FakeManager;
+let wd: RecoveryWatchdog;
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), 'recovery-wd-'));
+  mgr = new FakeManager(root);
+  wd = new RecoveryWatchdog(mgr, () => {});
+});
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// Discriminator
+// ---------------------------------------------------------------------------
+
+describe('classifyCodexLiveness (VETO-first)', () => {
+  it('alive-idle codex MUST NOT restart (socket up, pid alive, no turn) ⇒ ALIVE_IDLE', () => {
+    expect(classifyCodexLiveness({ socketAlive: true, pid: 123, pidAlive: true, turnInFlight: false })).toBe('ALIVE_IDLE');
+  });
+  it('wedged codex MUST restart (socket down) ⇒ WEDGED', () => {
+    expect(classifyCodexLiveness({ socketAlive: false, pid: 123, pidAlive: true, turnInFlight: false })).toBe('WEDGED');
+  });
+  it('codex child pid gone ⇒ WEDGED', () => {
+    expect(classifyCodexLiveness({ socketAlive: true, pid: null, pidAlive: false, turnInFlight: false })).toBe('WEDGED');
+  });
+  it('codex turn in flight ⇒ UNCERTAIN (actively working, veto)', () => {
+    expect(classifyCodexLiveness({ socketAlive: true, pid: 123, pidAlive: true, turnInFlight: true })).toBe('UNCERTAIN');
+  });
+});
+
+describe('classifyProcStateLiveness (fail-safe ps)', () => {
+  it('idle claude S MUST NOT restart ⇒ UNCERTAIN', () => {
+    expect(classifyProcStateLiveness({ pid: 5, pidAlive: true, procState: 'S' })).toBe('UNCERTAIN');
+  });
+  it('interruptible-sleep variants (S+, Ss, I, R, D, T) ⇒ UNCERTAIN', () => {
+    for (const st of ['S+', 'Ss', 'I', 'R', 'D', 'T']) {
+      expect(classifyProcStateLiveness({ pid: 5, pidAlive: true, procState: st })).toBe('UNCERTAIN');
+    }
+  });
+  it('zombie Z MUST restart ⇒ WEDGED', () => {
+    expect(classifyProcStateLiveness({ pid: 5, pidAlive: true, procState: 'Z' })).toBe('WEDGED');
+  });
+  it('confirmed-gone pid ⇒ WEDGED', () => {
+    expect(classifyProcStateLiveness({ pid: 5, pidAlive: false, procState: null })).toBe('WEDGED');
+  });
+  it('probe-error (ps missing / no pid) ⇒ UNCERTAIN (veto)', () => {
+    expect(classifyProcStateLiveness({ pid: 5, pidAlive: true, procState: null })).toBe('UNCERTAIN');
+    expect(classifyProcStateLiveness({ pid: null, pidAlive: false, procState: null })).toBe('UNCERTAIN');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// FrozenContentTrigger
+// ---------------------------------------------------------------------------
+
+describe('FrozenContentTrigger', () => {
+  const upt = BOOT_GRACE_MS + 60_000; // past boot grace
+
+  it('healthy-changing content MUST NOT flag (freeze resets each sweep)', () => {
+    const t = new FrozenContentTrigger(mgr);
+    mgr.snapshot = [{ name: 'a', enabled: true, uptimeMs: upt, heartbeat: hb({ current_task: 'task 1' }) }];
+    expect(t.evaluate({ nowMs: NOW })).toEqual([]);
+    mgr.snapshot = [{ name: 'a', enabled: true, uptimeMs: upt, heartbeat: hb({ current_task: 'task 2' }) }];
+    expect(t.evaluate({ nowMs: NOW + RECOVERY_FREEZE_MS + 1 })).toEqual([]);
+  });
+
+  it('frozen content past the window MUST flag as a force-fresh candidate', () => {
+    const t = new FrozenContentTrigger(mgr);
+    const frozen = hb({ status: 'working', current_task: 'stuck task' });
+    mgr.snapshot = [{ name: 'a', enabled: true, uptimeMs: upt, heartbeat: frozen }];
+    expect(t.evaluate({ nowMs: NOW })).toEqual([]); // first observation
+    const out = t.evaluate({ nowMs: NOW + RECOVERY_FREEZE_MS + 1 });
+    expect(out).toHaveLength(1);
+    expect(out[0]).toMatchObject({ agent: 'a', action: 'force-fresh-restart' });
+  });
+
+  it('boot-grace MUST NOT flag: an agent under boot grace is skipped', () => {
+    const t = new FrozenContentTrigger(mgr);
+    const frozen = hb({ status: 'working', current_task: 'stuck' });
+    mgr.snapshot = [{ name: 'a', enabled: true, uptimeMs: BOOT_GRACE_MS - 1, heartbeat: frozen }];
+    t.evaluate({ nowMs: NOW });
+    expect(t.evaluate({ nowMs: NOW + RECOVERY_FREEZE_MS + 1 })).toEqual([]);
+  });
+
+  it('a frozen idle-beat agent still flags (wedged agents show only daemon idle beats)', () => {
+    const t = new FrozenContentTrigger(mgr);
+    const idle = hb({ status: '[watchdog] a alive — idle session 2026-08-24T10:00:00Z' });
+    mgr.snapshot = [{ name: 'a', enabled: true, uptimeMs: upt, heartbeat: idle }];
+    expect(t.evaluate({ nowMs: NOW })).toEqual([]);
+    // A later idle beat (different timestamp) normalizes identically ⇒ frozen.
+    mgr.snapshot = [{ name: 'a', enabled: true, uptimeMs: upt, heartbeat: hb({ status: '[watchdog] a alive — idle session 2026-08-24T10:50:00Z' }) }];
+    expect(t.evaluate({ nowMs: NOW + RECOVERY_FREEZE_MS + 1 })).toHaveLength(1);
+  });
+
+  it('disabled agent MUST NOT flag', () => {
+    const t = new FrozenContentTrigger(mgr);
+    const frozen = hb({ status: 'working', current_task: 'stuck' });
+    mgr.snapshot = [{ name: 'a', enabled: false, uptimeMs: upt, heartbeat: frozen }];
+    t.evaluate({ nowMs: NOW });
+    expect(t.evaluate({ nowMs: NOW + RECOVERY_FREEZE_MS + 1 })).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// recover() chokepoint
+// ---------------------------------------------------------------------------
+
+const wedge = (agent = 'a'): RecoveryCandidate => ({ agent, action: 'force-fresh-restart', reason: 'wedge' });
+
+describe('recover() — discriminator VETO', () => {
+  it('alive-idle codex MUST NOT restart: a non-WEDGED verdict vetoes the action', async () => {
+    mgr.verdict = 'ALIVE_IDLE';
+    await wd.recover(wedge(), NOW, new Set());
+    expect(mgr.forceCalls).toEqual([]);
+  });
+  it('UNCERTAIN vetoes too', async () => {
+    mgr.verdict = 'UNCERTAIN';
+    await wd.recover(wedge(), NOW, new Set());
+    expect(mgr.forceCalls).toEqual([]);
+  });
+  it('WEDGED proceeds', async () => {
+    mgr.verdict = 'WEDGED';
+    await wd.recover(wedge(), NOW, new Set());
+    expect(mgr.forceCalls).toEqual(['a']);
+  });
+  it('start-absent skips the discriminator (absent agent has no process to probe)', async () => {
+    mgr.verdict = 'UNCERTAIN'; // would veto a force-fresh, but not a start-absent
+    await wd.recover({ agent: 'ghost', action: 'start-absent', reason: 'absent' }, NOW, new Set());
+    expect(mgr.startCalls).toEqual(['ghost']);
+  });
+});
+
+describe('recover() — single-sweep dedup', () => {
+  it('the same agent is actioned at most once per sweep', async () => {
+    mgr.verdict = 'WEDGED';
+    const seen = new Set<string>();
+    await wd.recover(wedge('a'), NOW, seen);
+    await wd.recover(wedge('a'), NOW, seen);
+    expect(mgr.forceCalls).toEqual(['a']);
+  });
+});
+
+describe('recover() — cross-watchdog cooldown', () => {
+  it('a .restart-planned within the cooldown window skips (do not fight another restarter)', async () => {
+    mgr.verdict = 'WEDGED';
+    const marker = join(mgr.stateDirFor('a'), '.restart-planned');
+    writeFileSync(marker, 'planned');
+    const recentSec = (NOW - 5 * 60_000) / 1000; // 5 min ago (< 15 min cooldown)
+    utimesSync(marker, recentSec, recentSec);
+    await wd.recover(wedge('a'), NOW, new Set());
+    expect(mgr.forceCalls).toEqual([]);
+  });
+
+  it('a .restart-planned older than the cooldown proceeds', async () => {
+    mgr.verdict = 'WEDGED';
+    const marker = join(mgr.stateDirFor('a'), '.restart-planned');
+    writeFileSync(marker, 'planned');
+    const oldSec = (NOW - RESTART_COOLDOWN_MS - 60_000) / 1000; // 16 min ago
+    utimesSync(marker, oldSec, oldSec);
+    await wd.recover(wedge('a'), NOW, new Set());
+    expect(mgr.forceCalls).toEqual(['a']);
+  });
+});
+
+describe('recover() — circuit breaker', () => {
+  it('2 recoveries proceed, the 3rd trips, and it resets after the pause', async () => {
+    mgr.verdict = 'WEDGED';
+    // Distinct sweeps (fresh Set each), spaced 1 min apart — all inside the 15-min window.
+    await wd.recover(wedge('a'), NOW, new Set());
+    await wd.recover(wedge('a'), NOW + 60_000, new Set());
+    expect(mgr.forceCalls).toHaveLength(CIRCUIT_MAX_RESTARTS); // 2 proceeded
+
+    await wd.recover(wedge('a'), NOW + 120_000, new Set());
+    expect(mgr.forceCalls).toHaveLength(CIRCUIT_MAX_RESTARTS); // 3rd tripped — no new call
+
+    // After the 30-min pause expires, recovery is allowed again.
+    await wd.recover(wedge('a'), NOW + CIRCUIT_PAUSE_MS + 130_000, new Set());
+    expect(mgr.forceCalls).toHaveLength(CIRCUIT_MAX_RESTARTS + 1);
+  });
+});

--- a/tests/unit/utils/heartbeat-content.test.ts
+++ b/tests/unit/utils/heartbeat-content.test.ts
@@ -1,0 +1,90 @@
+/**
+ * tests/unit/utils/heartbeat-content.test.ts
+ *
+ * Unit tests for the pure heartbeat-content gate: normalizeHeartbeatContent()
+ * and contentDiffers(). No I/O — plain injected heartbeat objects. Each
+ * behavior is paired with a discriminating control so a regressed normalizer or
+ * differ would flip an assertion.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeHeartbeatContent,
+  contentDiffers,
+  WATCHDOG_IDLE,
+} from '../../../src/utils/heartbeat-content';
+import type { Heartbeat } from '../../../src/types/index';
+
+function hb(overrides: Partial<Heartbeat>): Partial<Heartbeat> {
+  return {
+    agent: 'a',
+    org: 'o',
+    status: 'idle',
+    current_task: '',
+    mode: 'day',
+    last_heartbeat: '2026-08-24T10:00:00Z',
+    loop_interval: '',
+    ...overrides,
+  };
+}
+
+describe('normalizeHeartbeatContent', () => {
+  it('ignores last_heartbeat/mode/loop_interval — only status+current_task drive content', () => {
+    const a = normalizeHeartbeatContent(hb({ last_heartbeat: '2026-08-24T10:00:00Z', mode: 'day', loop_interval: '20m' }));
+    const b = normalizeHeartbeatContent(hb({ last_heartbeat: '2026-08-24T23:59:59Z', mode: 'night', loop_interval: '4h' }));
+    expect(a).toBe(b);
+  });
+
+  it('collapses ISO timestamps embedded in status/current_task to a constant token', () => {
+    const a = normalizeHeartbeatContent(hb({ current_task: 'sweeping at 2026-08-24T10:00:00Z' }));
+    const b = normalizeHeartbeatContent(hb({ current_task: 'sweeping at 2026-08-24T18:30:45Z' }));
+    expect(a).toBe(b);
+  });
+
+  it('a daemon idle-beat status collapses to WATCHDOG_IDLE', () => {
+    const norm = normalizeHeartbeatContent(hb({ status: '[watchdog] a alive — idle session 2026-08-24T10:00:00Z' }));
+    expect(norm).toBe(WATCHDOG_IDLE);
+  });
+
+  it('two different idle-beat heartbeats normalize to the SAME value (frozen, not changing)', () => {
+    const a = normalizeHeartbeatContent(hb({ status: '[watchdog] a alive — idle session 2026-08-24T10:00:00Z' }));
+    const b = normalizeHeartbeatContent(hb({ status: '[watchdog] a alive — idle session 2026-08-24T10:50:00Z' }));
+    expect(a).toBe(b);
+    expect(a).toBe(WATCHDOG_IDLE);
+  });
+
+  it('a real working status is NOT collapsed to WATCHDOG_IDLE', () => {
+    const norm = normalizeHeartbeatContent(hb({ status: 'working', current_task: 'building the recovery watchdog' }));
+    expect(norm).not.toBe(WATCHDOG_IDLE);
+    expect(norm).toContain('building the recovery watchdog');
+  });
+
+  it('null/empty heartbeat → empty string', () => {
+    expect(normalizeHeartbeatContent(null)).toBe('');
+    expect(normalizeHeartbeatContent(undefined)).toBe('');
+  });
+});
+
+describe('contentDiffers — the recovery-verification predicate', () => {
+  it('spawn-carry MUST NOT clear: identical normalized content ⇒ differs=false', () => {
+    // A restart that re-stamps the SAME status/current_task (only last_heartbeat
+    // moves) normalizes identically — recovery did not produce fresh content.
+    const captured = normalizeHeartbeatContent(hb({ status: 'working', current_task: 'task A', last_heartbeat: '2026-08-24T10:00:00Z' }));
+    const live = normalizeHeartbeatContent(hb({ status: 'working', current_task: 'task A', last_heartbeat: '2026-08-24T10:30:00Z' }));
+    expect(live).toBe(captured); // guard: spawn-carry really is byte-identical after normalization
+    expect(contentDiffers(live, captured)).toBe(false);
+  });
+
+  it('watchdog-idle MUST NOT clear: a live WATCHDOG_IDLE never counts as fresh content', () => {
+    const captured = normalizeHeartbeatContent(hb({ status: 'working', current_task: 'task A' }));
+    const live = normalizeHeartbeatContent(hb({ status: '[watchdog] a alive — idle session 2026-08-24T11:00:00Z' }));
+    expect(live).toBe(WATCHDOG_IDLE); // guard
+    expect(contentDiffers(live, captured)).toBe(false);
+  });
+
+  it('real-task change MUST clear: genuinely new content ⇒ differs=true', () => {
+    const captured = normalizeHeartbeatContent(hb({ status: 'working', current_task: 'task A' }));
+    const live = normalizeHeartbeatContent(hb({ status: 'working', current_task: 'task B' }));
+    expect(contentDiffers(live, captured)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a periodic **recovery watchdog** that restarts genuinely-wedged agents the
existing timestamp-based dormancy check cannot see.

The daemon writes an idle-beat heartbeat (`[watchdog] <agent> alive — idle
session <ts>`) every ~50min regardless of REPL state, so `last_heartbeat` stays
fresh even when an agent's brain is frozen. Timestamp staleness therefore cannot
detect a "mapped wedge". This watchdog detects staleness at the **detection
layer** via heartbeat **content-freshness** instead: a pure normalizer collapses
every self-moving field (embedded ISO timestamps, the idle-beat status) to a
canonical token, and a wedge is flagged when the semantic content
(`status` + `current_task`) is frozen across a window.

### Design invariants

- **Single restart authority**; one **circuit breaker** (`CIRCUIT_MAX_RESTARTS = 2`)
  prevents restart storms.
- **Secondary-liveness VETO-first discriminator**: an alive-but-idle agent with
  an empty queue is never restarted (fail-safe).
- Recovery is credited only when a restart produces genuinely fresh, non-idle
  content (`contentDiffers`).
- **`RecoveryTrigger` extension point** for future positive-signal triggers
  (e.g. PTY stuck-banner detection).
- Runs on a 5-minute sweep.

`src/utils/heartbeat-content.ts` is a pure, side-effect-free normalizer (mirrors
`dormancy.ts`) with full unit coverage.

## Test Plan

- `npx tsc --noEmit` — clean (EXIT 0).
- `npx vitest run tests/unit/daemon/recovery-watchdog.test.ts tests/unit/utils/heartbeat-content.test.ts`
  — **31/31 pass**, including revert-red controls on both the content-freshness
  and secondary-liveness discriminators.
- Full unit suite: adds **+31 passing, zero new failures** vs base
  (pre-existing base failures are unrelated to these files).
- Live-sandbox validation via cortext-designer (pending).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019UZqP5BH45mEQETLNuM5XS
