### PR TITLE
fix(hooks): rebase target on the canonical agent dir before containment

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -254,7 +254,18 @@ export function isClaudeDirOperation(
   // thing left to vet.
   const canonAgentDir = canonicalizePath(resolve(base));
   const claudeRoot = join(canonAgentDir, '.claude');
-  const target = resolve(canonAgentDir, filePath);
+  const rawBase = resolve(base);
+  let target = resolve(canonAgentDir, filePath);
+
+  // The caller may hand us an absolute path built from the *uncanonical* agent
+  // dir, which is the normal case on macOS where /tmp and /var are themselves
+  // symlinks. Such a path is legitimate, but it would fail the containment check
+  // below against a canonicalized claudeRoot, and a genuine write into .claude
+  // would be refused. Rebase it onto the canonical dir first. This does not
+  // weaken anything: every component under .claude is still vetted for symlinks.
+  if (rawBase !== canonAgentDir && target.startsWith(rawBase + sep)) {
+    target = join(canonAgentDir, target.slice(rawBase.length + 1));
+  }
 
   // Lexical containment within the agent's own .claude/.
   if (target !== claudeRoot && !target.startsWith(claudeRoot + sep)) return false;


### PR DESCRIPTION
## The bug

`isClaudeDirOperation` canonicalizes the agent dir, then compares it against a `file_path` that is left uncanonical. Whenever the install path itself goes through a symlink, the containment check fails and a legitimate write into the agent's own `.claude` is refused.

On macOS this is the normal case, not an edge case: `/tmp` and `/var` are symlinks to `/private/*`.

## How it shows up

`tests/unit/hooks/hooks.test.ts` currently **fails on `main`** on macOS:

```
FAIL  tests/unit/hooks/hooks.test.ts > isClaudeDirOperation (permission-gate hardening)
      > refuses a write that escapes via a symlink inside .claude (#18, codex)
AssertionError: expected false to be true
```

It is the sanity assertion at the end of that test, not the symlink-escape assertion. The test builds its fixture under `mkdtempSync(tmpdir())`, so the agent dir sits behind `/var -> /private/var`, `claudeRoot` gets canonicalized, the absolute `file_path` does not, and `target.startsWith(claudeRoot)` is false.

Because `pre-push` runs the suite, this also means the hook blocks every push from a macOS clone.

## The fix

Rebase the target onto the canonical agent dir before the lexical containment check.

Nothing is weakened. Every component below `.claude` is still vetted by `hasSymlinkComponent`, so the planted-symlink escape the test guards against is still refused. The first assertion in that test keeps passing.

## Impact

The failure is fail-safe: it refuses instead of wrongly approving. That is why it goes unnoticed on installs that sit on a symlink-free path.

## Verification

- `tests/unit/hooks/hooks.test.ts`: 42/42 pass (was 41/42)
- full suite green, `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)