### PR TITLE
fix(hooks): drop inherited GIT_DIR before pre-push runs the suite

### DIFF
--- a/scripts/hooks/pre-push
+++ b/scripts/hooks/pre-push
@@ -10,6 +10,21 @@
 
 set -euo pipefail
 
+# Git exports GIT_DIR and friends into hooks, and everything this hook runs
+# inherits them. The test suite creates git fixtures; with GIT_DIR inherited,
+# those fixtures operate on THIS repository instead of their own temp dirs.
+# Observed on 2026-08-25, all three in one session: commits named "init" and
+# "fixture" landing on the branch being pushed, core.bare flipped to true (after
+# which every ordinary git command dies with "must be run in a work tree"), and
+# a filter.evil.clean entry left behind in the config by the malicious-filter
+# security test.
+#
+# This must come before the git call below: with GIT_DIR pointing at a repo
+# whose work tree git cannot infer, rev-parse --show-toplevel itself fails.
+unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_OBJECT_DIRECTORY \
+      GIT_ALTERNATE_OBJECT_DIRECTORIES GIT_PREFIX GIT_QUARANTINE_PATH \
+      GIT_COMMON_DIR GIT_NAMESPACE
+
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
 

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -254,7 +254,18 @@ export function isClaudeDirOperation(
   // thing left to vet.
   const canonAgentDir = canonicalizePath(resolve(base));
   const claudeRoot = join(canonAgentDir, '.claude');
-  const target = resolve(canonAgentDir, filePath);
+  const rawBase = resolve(base);
+  let target = resolve(canonAgentDir, filePath);
+
+  // The caller may hand us an absolute path built from the *uncanonical* agent
+  // dir, which is the normal case on macOS where /tmp and /var are themselves
+  // symlinks. Such a path is legitimate, but it would fail the containment check
+  // below against a canonicalized claudeRoot, and a genuine write into .claude
+  // would be refused. Rebase it onto the canonical dir first. This does not
+  // weaken anything: every component under .claude is still vetted for symlinks.
+  if (rawBase !== canonAgentDir && target.startsWith(rawBase + sep)) {
+    target = join(canonAgentDir, target.slice(rawBase.length + 1));
+  }
 
   // Lexical containment within the agent's own .claude/.
   if (target !== claudeRoot && !target.startsWith(claudeRoot + sep)) return false;


### PR DESCRIPTION
> Stacked on #968. That PR fixes the test this hook trips over; without it, this branch cannot be pushed from a macOS clone at all. Review #968 first, and this diff reduces to a single hunk in `scripts/hooks/pre-push` once it lands.

## The bug

Git exports `GIT_DIR` (and friends) into hooks, and everything the hook launches inherits them. `pre-push` launches the test suite. The suite builds git fixtures. With `GIT_DIR` inherited, those fixtures operate on **the repository being pushed from** instead of their own temp dirs.

## What it did

Three distinct corruptions, all observed in a single session on a real clone:

1. **Commits landed on the branch being pushed.** New tips named `init` and `fixture`, with `package.json` truncated to 4 lines. Recovering meant `git reset --hard` back to the intended commit, twice.
2. **`core.bare` was flipped to `true`** in the working clone. After that, every ordinary git command fails with `fatal: this operation must be run in a work tree` — including `git status` and, ironically, the `git rev-parse --show-toplevel` at the top of this very hook.
3. **A `filter.*` entry was left in the repo config** by the malicious-filter security test:
   `filter.evil.clean=/var/folders/.../cortext-lifecycle-fixture-XXXXXX/malicious-clean-filter`. The fixture is long gone from temp, but the config entry persists.

Symptom worth calling out, because it is confusing: pushing a branch that is checked out in another worktree fails with `fatal: this operation must be run in a work tree` from the hook itself, for the reason in (2).

## The fix

`unset` the git environment variables before the hook does anything else. The unset has to precede the `rev-parse`, or the hook cannot locate its own repo root in the poisoned case.

`scripts/hooks/pre-commit` needs no equivalent change: it launches no child processes.

## Why this matters beyond one machine

`SECURITY.md:28` tells every fresh clone to run `bash scripts/setup-hooks.sh`. Anyone following that gets a hook that can write to their repo config.

## Verification

A full push now runs build + suite and leaves `git config --local --list` byte-identical (diffed before and after), with no stray commits and a clean working tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)