### PR TITLE
fix(claude-to-codex-migration): remove inline (?i) flags that break convert.py import on Python 3.11+

### DIFF
--- a/community/skills/claude-to-codex-migration/scripts/convert.py
+++ b/community/skills/claude-to-codex-migration/scripts/convert.py
@@ -143,8 +143,8 @@ def orchestrator_route_re(orchestrator):
 # agent's identity files. Absent/ambiguous => param-only safe-degrade.
 _ORCH_IDENTITY_RE = re.compile(
     r"(?im)^\s*(?:#+\s*)?role\s*[:=]\s*orchestrator\b"
-    r"|(?i)\b(?:you are|i am)\s+(?:the\s+|an\s+)?orchestrator\b"
-    r"|(?i)\borchestrator\s+(?:agent|role)\s+for\s+(?:the\s+)?(?:org|fleet)\b")
+    r"|\b(?:you are|i am)\s+(?:the\s+|an\s+)?orchestrator\b"
+    r"|\borchestrator\s+(?:agent|role)\s+for\s+(?:the\s+)?(?:org|fleet)\b")
 
 
 def _agent_declares_orchestrator(agent_dir):


### PR DESCRIPTION
Fixes #976.

`community/skills/claude-to-codex-migration/scripts/convert.py` raises at import time on current CPython, so the skill cannot run at all — `detect.py` and `verify.py` are fine, but every path through the migration engine imports `convert.py` first, and `tests/test_migration_bakes.py` aborts on the traceback before a single test runs.

### Cause

`_ORCH_IDENTITY_RE` places global flag groups partway through the pattern. A `(?i)` group must be at the start of the expression; this was deprecated in CPython 3.6 and became a hard error in 3.11.

```
re.PatternError: global flags not at the start of the expression at position 48
```

### The change

The leading `(?im)` already applies to the whole pattern, including both later alternatives, so the two extra `(?i)` groups are redundant. Removing them is semantics-preserving — the same strings match, case-insensitively, as before. Two lines, one file, no behavior change intended.

### Testing

- Reproduced against `main` at 4d3238c: `python3 -c "import sys; sys.path.insert(0, 'community/skills/claude-to-codex-migration/scripts'); import convert"` raises `re.PatternError`.
- With this patch applied to that same tree, `convert.py` imports and `python3 tests/test_migration_bakes.py` reports **93 passed, 0 failed**.
- Verified on CPython 3.12.x and 3.14.5 (macOS, Homebrew). The bundled suite is the skill's own; no new tests were added, since the failure was at import and the existing suite now exercises the code it could not reach before.

### Agent Awareness checklist

No new bus command, CLI command, or API endpoint. No change to agent behavior or hooks. The skill's `SKILL.md` `description` is unchanged and still accurate. No template update needed.
