### PR TITLE
Buzz relay adapter: fix reconnect hang and gate WebSocket on unsupported Node

### DIFF
--- a/src/buzz/relay-client.ts
+++ b/src/buzz/relay-client.ts
@@ -62,7 +62,7 @@ export class BuzzRelayClient {
   private eoseSeen = new Set<string>();
 
   private pendingOks = new Map<string, PendingOk>();
-  private pendingAuthChallenge: { resolve: (challenge: string) => void; timer: ReturnType<typeof setTimeout> } | null = null;
+  private pendingAuthChallenge: { resolve: (challenge: string) => void; reject: (reason: string) => void; timer: ReturnType<typeof setTimeout> } | null = null;
 
   /** Why the client last stopped. Read by daemon supervision to decide whether to restart. */
   lastExitReason: string = '';
@@ -102,6 +102,15 @@ export class BuzzRelayClient {
    * orchestrator boot.
    */
   async start(): Promise<void> {
+    // Fail loud, not retry-forever-silent: native WebSocket is unavailable on
+    // older Node, so `new WebSocket` inside the loop would throw ReferenceError
+    // on every attempt and reconnect forever with Buzz silently offline. Gate
+    // here before the loop (native WebSocket is default-on from Node 22).
+    if (typeof WebSocket === 'undefined') {
+      this.log('WARN: native WebSocket not available — Buzz requires Node 22+; adapter inactive.');
+      this.lastExitReason = 'websocket-unavailable';
+      return;
+    }
     this.running = true;
     this.lastExitReason = '';
     while (this.running) {
@@ -233,6 +242,10 @@ export class BuzzRelayClient {
           clearTimeout(timer);
           resolve(challenge);
         },
+        reject: (reason: string) => {
+          clearTimeout(timer);
+          reject(new Error(reason));
+        },
         timer,
       };
     });
@@ -333,7 +346,10 @@ export class BuzzRelayClient {
     }
     this.pendingOks.clear();
     if (this.pendingAuthChallenge) {
-      clearTimeout(this.pendingAuthChallenge.timer);
+      // Settle the waiter — clearing only the timer would leave
+      // waitForAuthChallenge()'s promise suspended forever, so connectAndRun()
+      // never returns and the reconnect loop dies on a socket-close-before-AUTH.
+      this.pendingAuthChallenge.reject(reason);
       this.pendingAuthChallenge = null;
     }
   }

--- a/src/cli/buzz.ts
+++ b/src/cli/buzz.ts
@@ -49,6 +49,11 @@ function resolveBuzzCredentials(): { relayUrl: string; secretKey: string; pubkey
  * open+authenticated socket. Callers are responsible for closing it.
  */
 async function connectAndAuthenticate(relayUrl: string, secretKey: string): Promise<WebSocket> {
+  // Fail loud with a clear runtime requirement rather than a bare
+  // ReferenceError: native WebSocket is unavailable on older Node.
+  if (typeof WebSocket === 'undefined') {
+    throw new Error('native WebSocket not available — Buzz requires Node 22+. Upgrade Node to use Buzz.');
+  }
   const ws = new WebSocket(relayUrl);
 
   await new Promise<void>((resolve, reject) => {

--- a/tests/unit/buzz/relay-client.test.ts
+++ b/tests/unit/buzz/relay-client.test.ts
@@ -94,6 +94,43 @@ describe('BuzzRelayClient', () => {
     client.stop();
   });
 
+  it('a socket close BEFORE the AUTH challenge rejects the waiter and RECONNECTS (was a suspended-promise hang)', async () => {
+    // rejectAllPending() used to clear the auth-wait timer without settling
+    // waitForAuthChallenge()'s promise, so connectAndRun() hung forever and the
+    // reconnect loop died. A close before any AUTH challenge must produce a
+    // SECOND connection attempt, not suspend.
+    vi.useFakeTimers();
+    const client = new BuzzRelayClient('wss://relay.test', secretKey);
+    const startPromise = client.start();
+    await Promise.resolve();
+    await Promise.resolve();
+    const ws1 = FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+    ws1.triggerOpen();
+    await Promise.resolve();
+    ws1.close(); // close before AUTH — the waiter must reject, not hang
+    await Promise.resolve();
+    await Promise.resolve();
+    await vi.advanceTimersByTimeAsync(1_100); // past INITIAL_BACKOFF_MS (1000ms)
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(FakeWebSocket.instances.length).toBeGreaterThanOrEqual(2);
+    client.stop();
+    void startPromise;
+    vi.useRealTimers();
+  });
+
+  it('gates loudly and does NOT enter the reconnect loop when native WebSocket is unavailable', async () => {
+    const saved = (globalThis as any).WebSocket;
+    delete (globalThis as any).WebSocket;
+    try {
+      const client = new BuzzRelayClient('wss://relay.test', secretKey);
+      await client.start(); // must RETURN promptly rather than throw-and-retry-forever
+      expect(FakeWebSocket.instances.length).toBe(0);
+    } finally {
+      (globalThis as any).WebSocket = saved;
+    }
+  });
+
   it('issues a REQ subscription for each subscribed channel after authentication', async () => {
     const client = new BuzzRelayClient('wss://relay.test', secretKey);
     client.subscribeChannels(['chan-1', 'chan-2']);


### PR DESCRIPTION
Two fixes to the existing Buzz (NIP-29 / Nostr) relay adapter, found while running it in production.

### 1. Reconnect hang when the socket closes before AUTH
If the relay or network drops the connection *before* sending the NIP-42 AUTH challenge, `rejectAllPending()` cleared the auth-wait timer but never settled the promise returned by `waitForAuthChallenge()`. `connectAndRun()` then stayed suspended forever, so the reconnect loop never ran again and Buzz inbound went silently offline until the daemon was restarted. The pending auth-wait now carries a reject callback that fires on close. New test: close the socket before the challenge and assert a second connection attempt happens.

### 2. Unguarded `WebSocket` on older Node
Native `WebSocket` is only available by default from Node 22, but the adapter called `new WebSocket()` unguarded. On older Node it threw `ReferenceError` inside the reconnect loop and retried forever while Buzz stayed offline. `start()` now checks for `WebSocket` up front and logs a clear "requires Node 22+" message instead of looping; the CLI throws the same clear error. New test covers the gated path.

All existing Buzz tests still pass, plus the two new ones. Scoped to the adapter — no changes to the transport's design or public surface. Thanks for the adapter; these are just the rough edges we hit putting it under load.
