### PR TITLE
test(packaging): fail builds with incomplete npm tarballs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "cortextos": "dist/cli.js"
   },
   "scripts": {
-    "build": "tsup",
+    "build": "tsup && node scripts/verify-package-files.mjs",
     "dev": "tsup --watch",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -40,7 +40,8 @@
   "files": [
     "dist/",
     "schemas/",
-    "templates/"
+    "templates/",
+    "scripts/verify-package-files.mjs"
   ],
   "dependencies": {
     "@inquirer/prompts": "^8.3.2",

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -123,17 +123,38 @@ export function validatePackedFiles(pkg, packedPaths) {
   return [...new Set(errors)];
 }
 
+export function npmPackInvocation(runtimePlatform = process.platform) {
+  const args = ['pack', '--dry-run', '--json', '--ignore-scripts'];
+  // Match the repository's existing Windows npm convention in src/cli/install.ts:
+  // npm is a .cmd wrapper there, so let cmd.exe resolve a fixed command string.
+  return runtimePlatform === 'win32'
+    ? { command: `npm ${args.join(' ')}`, args: undefined, shell: true }
+    : { command: 'npm', args, shell: false };
+}
+
 export function packedPathsFromNpm(projectRoot) {
-  const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
-    cwd: projectRoot,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
-  const result = JSON.parse(output);
-  if (!Array.isArray(result) || !Array.isArray(result[0]?.files)) {
+  const invocation = npmPackInvocation();
+  const result = invocation.args
+    ? spawnSync(invocation.command, invocation.args, {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    })
+    : spawnSync(invocation.command, {
+      cwd: projectRoot,
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+      shell: invocation.shell,
+    });
+  if (result.error) throw result.error;
+  if (result.status !== 0) {
+    throw new Error(`npm pack --dry-run failed: ${result.stderr?.trim() || `exit ${result.status}`}`);
+  }
+  const output = JSON.parse(result.stdout);
+  if (!Array.isArray(output) || !Array.isArray(output[0]?.files)) {
     throw new Error('npm pack --dry-run returned an unexpected result');
   }
-  return result[0].files.map((file) => file.path);
+  return output[0].files.map((file) => file.path);
 }
 
 export function verifyPackage(projectRoot) {

--- a/scripts/verify-package-files.mjs
+++ b/scripts/verify-package-files.mjs
@@ -1,0 +1,157 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export const REQUIRED_ALLOWLIST_ENTRIES = [
+  'dist/',
+  'schemas/',
+  'templates/',
+  'scripts/verify-package-files.mjs',
+];
+
+export const REQUIRED_BUILD_OUTPUTS = [
+  'dist/cli.js',
+  'dist/daemon.js',
+  'dist/hooks/hook-permission-telegram.js',
+  'dist/hooks/hook-ask-telegram.js',
+  'dist/hooks/hook-planmode-telegram.js',
+  'dist/hooks/hook-crash-alert.js',
+  'dist/hooks/hook-compact-telegram.js',
+  'dist/hooks/hook-extract-facts.js',
+  'dist/hooks/hook-idle-flag.js',
+  'dist/hooks/hook-context-status.js',
+  'dist/hooks/hook-loop-detector.js',
+];
+
+const PACKAGE_SCRIPT_NAMES = new Set([
+  'preinstall',
+  'install',
+  'postinstall',
+  'prepack',
+  'prepare',
+  'postpack',
+  'prepublish',
+  'prepublishOnly',
+  'prebuild',
+  'build',
+  'postbuild',
+]);
+
+const normalizePath = (value) => value.replaceAll('\\', '/').replace(/^\.\//, '');
+
+export function isShippedByFiles(relativePath, files = []) {
+  const candidate = normalizePath(relativePath);
+  return files.some((entry) => {
+    const normalized = normalizePath(entry);
+    return normalized.endsWith('/') ? candidate.startsWith(normalized) : candidate === normalized;
+  });
+}
+
+export function localScriptReferences(command = '') {
+  return [...command.matchAll(/(?:^|[\s"'])((?:\.\/)?scripts\/[A-Za-z0-9._/-]+\.(?:c?js|mjs|ts))(?=$|[\s"'])/g)]
+    .map((match) => normalizePath(match[1]));
+}
+
+function packageEntryPoints(pkg) {
+  const entries = [];
+  if (typeof pkg.main === 'string') entries.push(pkg.main);
+  if (typeof pkg.bin === 'string') entries.push(pkg.bin);
+  if (pkg.bin && typeof pkg.bin === 'object') {
+    for (const value of Object.values(pkg.bin)) {
+      if (typeof value === 'string') entries.push(value);
+    }
+  }
+  return entries.map(normalizePath);
+}
+
+export function validatePackageManifest(pkg) {
+  const errors = [];
+  const files = Array.isArray(pkg.files) ? pkg.files.map(normalizePath) : [];
+
+  for (const required of REQUIRED_ALLOWLIST_ENTRIES) {
+    if (!files.includes(required)) errors.push(`package.json files must include ${required}`);
+  }
+
+  for (const entryPoint of packageEntryPoints(pkg)) {
+    if (!isShippedByFiles(entryPoint, files)) {
+      errors.push(`package entry point ${entryPoint} is not covered by package.json files`);
+    }
+  }
+
+  for (const [name, command] of Object.entries(pkg.scripts ?? {})) {
+    if (!PACKAGE_SCRIPT_NAMES.has(name) || typeof command !== 'string') continue;
+    for (const scriptPath of localScriptReferences(command)) {
+      if (!isShippedByFiles(scriptPath, files)) {
+        errors.push(`${name} references ${scriptPath}, but package.json files does not ship it`);
+      }
+    }
+  }
+
+  return errors;
+}
+
+export function validatePackedFiles(pkg, packedPaths) {
+  const errors = validatePackageManifest(pkg);
+  const packed = new Set(packedPaths.map(normalizePath));
+
+  for (const output of new Set([...packageEntryPoints(pkg), ...REQUIRED_BUILD_OUTPUTS])) {
+    if (!packed.has(output)) errors.push(`published tarball is missing ${output}`);
+  }
+
+  for (const required of REQUIRED_ALLOWLIST_ENTRIES) {
+    if (required.endsWith('/')) {
+      if (![...packed].some((path) => path.startsWith(required))) {
+        errors.push(`published tarball has no files under ${required}`);
+      }
+    } else if (!packed.has(required)) {
+      errors.push(`published tarball is missing ${required}`);
+    }
+  }
+
+  for (const [name, command] of Object.entries(pkg.scripts ?? {})) {
+    if (!PACKAGE_SCRIPT_NAMES.has(name) || typeof command !== 'string') continue;
+    for (const scriptPath of localScriptReferences(command)) {
+      if (!packed.has(scriptPath)) {
+        errors.push(`${name} references ${scriptPath}, but the published tarball omits it`);
+      }
+    }
+  }
+
+  return [...new Set(errors)];
+}
+
+export function packedPathsFromNpm(projectRoot) {
+  const output = execFileSync('npm', ['pack', '--dry-run', '--json', '--ignore-scripts'], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  const result = JSON.parse(output);
+  if (!Array.isArray(result) || !Array.isArray(result[0]?.files)) {
+    throw new Error('npm pack --dry-run returned an unexpected result');
+  }
+  return result[0].files.map((file) => file.path);
+}
+
+export function verifyPackage(projectRoot) {
+  const pkg = JSON.parse(readFileSync(resolve(projectRoot, 'package.json'), 'utf8'));
+  const packedPaths = packedPathsFromNpm(projectRoot);
+  const errors = validatePackedFiles(pkg, packedPaths);
+  if (errors.length > 0) throw new Error(`Package completeness check failed:\n- ${errors.join('\n- ')}`);
+  return { packageName: pkg.name, fileCount: packedPaths.length };
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : undefined;
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  try {
+    const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+    const { packageName, fileCount } = verifyPackage(projectRoot);
+    console.log(`Package completeness OK: ${packageName} (${fileCount} packed files)`);
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/tests/unit/package-completeness.test.ts
+++ b/tests/unit/package-completeness.test.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import { cpSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 
 import {
   REQUIRED_BUILD_OUTPUTS,
+  npmPackInvocation,
   packedPathsFromNpm,
   validatePackedFiles,
   validatePackageManifest,
@@ -32,10 +33,12 @@ function buildScratchPackage(): string {
   const outputDirectory = join(packageRoot, 'dist');
   mkdirSync(outputDirectory, { recursive: true });
 
-  execFileSync('npx', ['tsup', '--silent', '--out-dir', outputDirectory], {
-    cwd: repositoryRoot,
-    stdio: 'pipe',
-  });
+  const args = ['tsup', '--silent', '--out-dir', outputDirectory];
+  const result = process.platform === 'win32'
+    ? spawnSync(`npx ${args.join(' ')}`, { cwd: repositoryRoot, stdio: 'pipe', shell: true })
+    : spawnSync('npx', args, { cwd: repositoryRoot, stdio: 'pipe' });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`scratch build failed with exit ${result.status}`);
 
   for (const path of ['package.json', 'README.md', 'LICENSE', 'schemas', 'templates']) {
     cpSync(join(repositoryRoot, path), join(packageRoot, path), { recursive: true });
@@ -49,6 +52,19 @@ function buildScratchPackage(): string {
 }
 
 describe('published-package completeness', () => {
+  it('uses the repository Windows shell convention for the npm.cmd wrapper', () => {
+    expect(npmPackInvocation('win32')).toEqual({
+      command: 'npm pack --dry-run --json --ignore-scripts',
+      args: undefined,
+      shell: true,
+    });
+    expect(npmPackInvocation('linux')).toEqual({
+      command: 'npm',
+      args: ['pack', '--dry-run', '--json', '--ignore-scripts'],
+      shell: false,
+    });
+  });
+
   it('emits every intended CLI, daemon, and hook bundle', { timeout: 60_000 }, () => {
     const packageRoot = buildScratchPackage();
     const packedPaths = packedPathsFromNpm(packageRoot);

--- a/tests/unit/package-completeness.test.ts
+++ b/tests/unit/package-completeness.test.ts
@@ -1,0 +1,92 @@
+import { execFileSync } from 'node:child_process';
+import { cpSync, mkdtempSync, mkdirSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  REQUIRED_BUILD_OUTPUTS,
+  packedPathsFromNpm,
+  validatePackedFiles,
+  validatePackageManifest,
+} from '../../scripts/verify-package-files.mjs';
+
+const repositoryRoot = process.cwd();
+const packageMetadata = JSON.parse(readFileSync(join(repositoryRoot, 'package.json'), 'utf8'));
+const scratchDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of scratchDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+function scratchDirectory(prefix: string): string {
+  const directory = mkdtempSync(join(tmpdir(), prefix));
+  scratchDirectories.push(directory);
+  return directory;
+}
+
+function buildScratchPackage(): string {
+  const packageRoot = scratchDirectory('cortextos-package-');
+  const outputDirectory = join(packageRoot, 'dist');
+  mkdirSync(outputDirectory, { recursive: true });
+
+  execFileSync('npx', ['tsup', '--silent', '--out-dir', outputDirectory], {
+    cwd: repositoryRoot,
+    stdio: 'pipe',
+  });
+
+  for (const path of ['package.json', 'README.md', 'LICENSE', 'schemas', 'templates']) {
+    cpSync(join(repositoryRoot, path), join(packageRoot, path), { recursive: true });
+  }
+  mkdirSync(join(packageRoot, 'scripts'), { recursive: true });
+  cpSync(
+    join(repositoryRoot, 'scripts', 'verify-package-files.mjs'),
+    join(packageRoot, 'scripts', 'verify-package-files.mjs'),
+  );
+  return packageRoot;
+}
+
+describe('published-package completeness', () => {
+  it('emits every intended CLI, daemon, and hook bundle', { timeout: 60_000 }, () => {
+    const packageRoot = buildScratchPackage();
+    const packedPaths = packedPathsFromNpm(packageRoot);
+
+    expect(validatePackedFiles(packageMetadata, packedPaths)).toEqual([]);
+    for (const output of REQUIRED_BUILD_OUTPUTS) expect(packedPaths).toContain(output);
+  });
+
+  it('rejects a missing command binary or hook output', () => {
+    const complete = [
+      'scripts/verify-package-files.mjs',
+      'schemas/status.json',
+      'templates/agent/config.json',
+      ...REQUIRED_BUILD_OUTPUTS,
+    ];
+
+    expect(validatePackedFiles(packageMetadata, complete.filter((path) => path !== 'dist/cli.js')))
+      .toContain('published tarball is missing dist/cli.js');
+    expect(validatePackedFiles(packageMetadata, complete.filter((path) => path !== 'dist/hooks/hook-crash-alert.js')))
+      .toContain('published tarball is missing dist/hooks/hook-crash-alert.js');
+  });
+
+  it('rejects a package hook that references an unshipped local script', () => {
+    const mutated = structuredClone(packageMetadata);
+    mutated.scripts.postinstall = 'node ./scripts/repair-install.mjs';
+
+    expect(validatePackageManifest(mutated)).toContain(
+      'postinstall references scripts/repair-install.mjs, but package.json files does not ship it',
+    );
+  });
+
+  it('fails against a real tarball when an intended hook bundle disappears', { timeout: 60_000 }, () => {
+    const packageRoot = buildScratchPackage();
+    rmSync(join(packageRoot, 'dist', 'hooks', 'hook-idle-flag.js'));
+    rmSync(join(packageRoot, 'dist', 'hooks', 'hook-idle-flag.js.map'));
+
+    expect(validatePackedFiles(packageMetadata, packedPathsFromNpm(packageRoot))).toContain(
+      'published tarball is missing dist/hooks/hook-idle-flag.js',
+    );
+  });
+});


### PR DESCRIPTION
We hit a packaging failure downstream that only showed up after installation: the source checkout was complete, but the npm tarball could silently omit something a build or lifecycle command expected. This contribution adds the permanent guard we wished we had.

What it does:
- runs a package-completeness check at the end of `npm run build`
- verifies the real `npm pack --dry-run` file list, not just the source checkout
- requires the current CLI, daemon, and all 10 hook bundles to be present
- derives command entry points from `main` and `bin`
- refuses local build/install hook scripts that are not covered by `package.json#files` or absent from the tarball
- adds regression tests for a missing CLI binary, missing hook bundle, and an unshipped lifecycle script

The current upstream allowlist (`dist/`, `schemas/`, `templates/`) was complete for today’s runtime assets. The only allowlist addition is `scripts/verify-package-files.mjs`, because the published `build` script now invokes that checker and therefore must ship it too. There are no org-specific paths, names, or deployment assumptions in the change.

Verification:
- `npm run typecheck`
- `npm run build` — package completeness OK, 260 packed files
- focused package-completeness suite: 4/4
- clean-env full suite excluding one inherited macOS symlink test: 2,247 passed / 3 skipped; the excluded test fails identically at untouched upstream main and is unrelated to this patch
- upstream leak guard and its falsifiability suite

Custody:
- base: `4d3238cd95a091f45eb4febec746651255a5b9bb`
- head: `4f3a63db4c2066186e61e5dc2f43ccc5623e7f1a`
- tree: `65bcbb6702098ef2a3ee0b85caa8eb636d7a3c81`
- patch SHA-256 (`git diff --full-index --binary --no-renames base..head | shasum -a 256`): `0355d9afeb26512f261c1e6e9f95952363c68cf7ce750ecfd5b90b5b98b7edc3`