### PR TITLE
reliability: symlink-aware atomic writes + RMW locking for daemon state files

### DIFF
--- a/src/bus/cron-state.ts
+++ b/src/bus/cron-state.ts
@@ -15,9 +15,10 @@
  * Storage: state/<agent>/cron-state.json (same dir as pending-reminders.json).
  */
 
-import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
-import { ensureDir } from '../utils/atomic.js';
+import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+import { withFileLockSync } from '../utils/lock.js';
 
 export interface CronFireRecord {
   name: string;
@@ -59,21 +60,33 @@ export function updateCronFire(
   cronName: string,
   interval?: string,
 ): void {
+  // ensureDir runs BEFORE the lock: acquireLock creates its `.lock.d` inside
+  // stateDir, so the directory must already exist.
   ensureDir(stateDir);
-  const state = readCronState(stateDir);
-  const now = new Date().toISOString();
 
-  const idx = state.crons.findIndex(r => r.name === cronName);
-  const record: CronFireRecord = { name: cronName, last_fire: now, ...(interval ? { interval } : {}) };
+  // The read-modify-write runs under the per-agent stateDir lock so two
+  // concurrent callers can't lose each other's records, and the write itself
+  // goes through atomicWriteSync (tmp + rename) so a crash mid-write can never
+  // tear the file — a torn cron-state.json degrades to `{crons: []}` on read,
+  // dropping the last-fire references and risking duplicate catch-up fires.
+  withFileLockSync(stateDir, () => {
+    const state = readCronState(stateDir);
+    const now = new Date().toISOString();
 
-  if (idx === -1) {
-    state.crons.push(record);
-  } else {
-    state.crons[idx] = record;
-  }
+    const idx = state.crons.findIndex(r => r.name === cronName);
+    const record: CronFireRecord = { name: cronName, last_fire: now, ...(interval ? { interval } : {}) };
 
-  state.updated_at = now;
-  writeFileSync(cronStatePath(stateDir), JSON.stringify(state, null, 2) + '\n', 'utf-8');
+    if (idx === -1) {
+      state.crons.push(record);
+    } else {
+      state.crons[idx] = record;
+    }
+
+    state.updated_at = now;
+    // atomicWriteSync appends the trailing '\n' itself — on-disk bytes are
+    // identical to the previous plain writeFileSync format.
+    atomicWriteSync(cronStatePath(stateDir), JSON.stringify(state, null, 2));
+  });
 }
 
 /**

--- a/src/bus/event.ts
+++ b/src/bus/event.ts
@@ -2,6 +2,7 @@ import { appendFileSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import type { EventCategory, EventSeverity, BusPaths, Heartbeat } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+import { withFileLockSync } from '../utils/lock.js';
 import { randomString } from '../utils/random.js';
 import { validateEventCategory, validateEventSeverity, isValidJson } from '../utils/validate.js';
 
@@ -87,9 +88,19 @@ function refreshHeartbeatTimestamp(paths: BusPaths, timestamp: string): void {
   try {
     const hbPath = join(paths.stateDir, 'heartbeat.json');
     if (!existsSync(hbPath)) return;
-    const hb = JSON.parse(readFileSync(hbPath, 'utf-8')) as Heartbeat;
-    hb.last_heartbeat = timestamp;
-    atomicWriteSync(hbPath, JSON.stringify(hb));
+    // This read-modify-write is NOT atomic against a concurrent full overwrite
+    // in updateHeartbeat(): without a lock, this reader can load a stale
+    // heartbeat, an explicit update writes new status/mode/task fields, and then
+    // this write clobbers them back to stale (TOCTOU lost update). Take the same
+    // per-agent stateDir lock updateHeartbeat() takes so the read+write is
+    // serialized against it. withFileLockSync may throw on timeout; the
+    // surrounding try/catch keeps the refresh best-effort and never blocks the
+    // already-persisted event.
+    withFileLockSync(paths.stateDir, () => {
+      const hb = JSON.parse(readFileSync(hbPath, 'utf-8')) as Heartbeat;
+      hb.last_heartbeat = timestamp;
+      atomicWriteSync(hbPath, JSON.stringify(hb));
+    });
   } catch {
     // Best-effort — event already persisted, heartbeat refresh is secondary.
   }

--- a/src/bus/heartbeat.ts
+++ b/src/bus/heartbeat.ts
@@ -2,6 +2,7 @@ import { readdirSync, readFileSync, existsSync, unlinkSync, statSync } from 'fs'
 import { join } from 'path';
 import type { Heartbeat, BusPaths } from '../types/index.js';
 import { atomicWriteSync, ensureDir } from '../utils/atomic.js';
+import { withFileLockSync } from '../utils/lock.js';
 
 /**
  * SessionEnd-hook end-type markers (see src/hooks/hook-crash-alert.ts). A
@@ -85,10 +86,18 @@ export function updateHeartbeat(
     loop_interval: options?.loopInterval ?? '',
   };
 
-  atomicWriteSync(
-    join(paths.stateDir, 'heartbeat.json'),
-    JSON.stringify(heartbeat),
-  );
+  // Serialize this full overwrite against the read-modify-write heartbeat
+  // refresh in event.ts: both take the same per-agent stateDir lock, so a
+  // concurrent refresh cannot load a stale heartbeat and then clobber the
+  // status/mode/current_task fields set here back to stale (TOCTOU lost
+  // update). withFileLockSync may throw on lock timeout — that surfaces
+  // rather than silently losing the update.
+  withFileLockSync(paths.stateDir, () => {
+    atomicWriteSync(
+      join(paths.stateDir, 'heartbeat.json'),
+      JSON.stringify(heartbeat),
+    );
+  });
 
   // The agent is alive in its (post-restart) session — clear stale SessionEnd
   // markers so the crash-alert hook cannot misclassify a later genuine crash

--- a/src/utils/atomic.ts
+++ b/src/utils/atomic.ts
@@ -1,5 +1,5 @@
-import { writeFileSync, renameSync, mkdirSync, existsSync, copyFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { writeFileSync, renameSync, mkdirSync, existsSync, copyFileSync, lstatSync, realpathSync, readlinkSync } from 'fs';
+import { dirname, join, resolve } from 'path';
 import { randomBytes } from 'crypto';
 
 /**
@@ -11,15 +11,81 @@ import { randomBytes } from 'crypto';
  * `<filePath>.bak` before the rename.  This gives callers a single-step
  * rollback point without the cost of maintaining a full backup chain.
  * The `.bak` write is best-effort — if it fails the main write still proceeds.
+ *
+ * Symlink-aware: if `filePath` is a symlink (a common way to share one file
+ * across several locations), the write is routed THROUGH the link to its real
+ * target. A naive temp-file + rename onto the link path would replace the
+ * symlink with a regular file and detach it from the shared target. For
+ * non-symlinks the behavior is byte-identical to a plain atomic
+ * create/overwrite.
  */
 export function atomicWriteSync(filePath: string, data: string, keepBak = false): void {
-  const dir = dirname(filePath);
+  // Resolve the rename DESTINATION. For a symlink we must write through to the
+  // real target (and create the temp in the real target's dir so the rename
+  // stays same-filesystem/atomic). lstat ENOENT => the path does not exist yet,
+  // which is the plain atomic-create path and MUST NOT crash.
+  let destPath = filePath;
+  // Only the initial lstat is swallowed (path absent => plain atomic-create).
+  // Resolution errors below — notably the ELOOP cycle guard — must propagate,
+  // so they sit OUTSIDE this narrow try.
+  let isLink = false;
+  try {
+    isLink = lstatSync(filePath).isSymbolicLink();
+  } catch {
+    // lstat ENOENT (or other lstat failure): the path itself is absent — treat
+    // as a brand-new file at filePath. This is the plain atomic-create path and
+    // must not throw here.
+  }
+  if (isLink) {
+    // Resolve the link to its real target. For a DANGLING symlink (target
+    // does not exist), realpathSync FOLLOWS the link and throws ENOENT. In
+    // that case we must NOT fall back to filePath — that would replace the
+    // symlink with a regular file via rename and detach it. Instead walk the
+    // link chain hop by hop to its terminus and write THROUGH to create it,
+    // leaving every link intact. A single readlink is not enough: in a chain
+    // a -> b -> missing, one hop resolves only to b — itself a symlink — and
+    // renaming onto b would replace THAT link with a regular file.
+    try {
+      destPath = realpathSync(filePath);
+    } catch {
+      // Dangling chain: follow each link's declared target (readlinkSync
+      // returns it even when it does not exist; relative targets resolve
+      // against that link's own directory) until a non-symlink or a
+      // nonexistent path — the terminus where the write must land. The hop
+      // cap guards against symlink cycles, mirroring the kernel's ELOOP.
+      let current = filePath;
+      let hops = 0;
+      for (;;) {
+        if (hops++ >= 40) {
+          const err = new Error(`atomicWriteSync: symlink cycle or chain too deep at ${filePath}`) as NodeJS.ErrnoException;
+          err.code = 'ELOOP';
+          throw err;
+        }
+        let st2;
+        try {
+          st2 = lstatSync(current);
+        } catch {
+          break; // nonexistent — this is the terminus to create
+        }
+        if (!st2.isSymbolicLink()) break; // real file — write through onto it
+        current = resolve(dirname(current), readlinkSync(current));
+      }
+      destPath = current;
+    }
+  }
+
+  const dir = dirname(destPath);
   mkdirSync(dir, { recursive: true });
 
-  // Best-effort backup of the current file before overwriting.
-  if (keepBak && existsSync(filePath)) {
+  // Best-effort backup of the current file before overwriting. The backup
+  // SOURCE is destPath (the real current target — captures live content even
+  // through a symlink), but the backup lands at `filePath + '.bak'` (the given/
+  // link path) so a caller that recovers from `<given path>.bak` finds it
+  // whether or not the path was a symlink. (For a non-symlink filePath ===
+  // destPath, so this is byte-identical to a plain backup.)
+  if (keepBak && existsSync(destPath)) {
     try {
-      copyFileSync(filePath, filePath + '.bak');
+      copyFileSync(destPath, filePath + '.bak');
     } catch {
       // Ignore backup errors — do not block the main write.
     }
@@ -28,7 +94,7 @@ export function atomicWriteSync(filePath: string, data: string, keepBak = false)
   const tmpPath = join(dir, `.tmp.${randomBytes(6).toString('hex')}`);
   try {
     writeFileSync(tmpPath, data + '\n', { encoding: 'utf-8', mode: 0o600 });
-    renameSync(tmpPath, filePath);
+    renameSync(tmpPath, destPath);
   } catch (err) {
     // Clean up temp file on failure
     try {

--- a/tests/unit/bus/cron-state.test.ts
+++ b/tests/unit/bus/cron-state.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { updateCronFire, readCronState, parseDurationMs } from '../../../src/bus/cron-state';
+import * as lock from '../../../src/utils/lock';
 
 let tmpDir: string;
 
@@ -108,5 +109,40 @@ describe('updateCronFire', () => {
     expect(inbox?.interval).toBe('2h');
     expect(hb?.interval).toBe('4h');
     cleanup();
+  });
+});
+
+describe('updateCronFire — locked, atomic read-modify-write', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    cleanup();
+  });
+
+  it('runs the read-modify-write under the stateDir lock', () => {
+    const withLock = vi.spyOn(lock, 'withFileLockSync');
+    updateCronFire(tmpDir, 'heartbeat', '4h');
+    expect(withLock.mock.calls.some(([dir]) => dir === tmpDir)).toBe(true);
+  });
+
+  it('writes atomically — no leftover temp file, on-disk bytes end with a newline', () => {
+    updateCronFire(tmpDir, 'heartbeat', '4h');
+    // atomicWriteSync uses a `.tmp.<hex>` sidecar it renames away; none should remain
+    expect(readdirSync(tmpDir).some(f => f.startsWith('.tmp.'))).toBe(false);
+    const bytes = readFileSync(join(tmpDir, 'cron-state.json'), 'utf-8');
+    expect(bytes.endsWith('}\n')).toBe(true);
+    expect(() => JSON.parse(bytes)).not.toThrow();
+  });
+
+  it('a concurrent writer is refused while the stateDir lock is held (no lost update)', () => {
+    updateCronFire(tmpDir, 'first', '2h');
+    lock.withFileLockSync(tmpDir, () => {
+      // A holds the lock; a second writer's acquire must be refused, so it
+      // cannot race into A's read->write window and drop A's record.
+      expect(lock.acquireLock(tmpDir)).toBe(false);
+    });
+    // After release the second write lands serially; both records survive.
+    updateCronFire(tmpDir, 'second', '6h');
+    const names = readCronState(tmpDir).crons.map(r => r.name).sort();
+    expect(names).toEqual(['first', 'second']);
   });
 });

--- a/tests/unit/bus/heartbeat-lost-update.test.ts
+++ b/tests/unit/bus/heartbeat-lost-update.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Regression tests for a heartbeat TOCTOU lost-update.
+ *
+ * Two writers touch <stateDir>/heartbeat.json:
+ *   - updateHeartbeat() (heartbeat.ts) — an authoritative OVERWRITE that sets
+ *     status / mode / current_task / loop_interval.
+ *   - logEvent()'s heartbeat refresh (event.ts, opt-in) — a READ-MODIFY-WRITE
+ *     that bumps only last_heartbeat and preserves the rest.
+ *
+ * Without a shared lock, this interleave loses an update:
+ *   1. refresh reads heartbeat    (status="online")
+ *   2. updateHeartbeat overwrites  (status="busy")
+ *   3. refresh writes its stale copy back (status="online")  ← busy lost.
+ *
+ * The fix wraps BOTH writers in withFileLockSync(stateDir, ...) so the RMW is
+ * atomic against the overwrite. These tests prove (a) both writers take the
+ * SAME per-agent lock and (b) the interleave that used to clobber a field can
+ * no longer happen.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { updateHeartbeat } from '../../../src/bus/heartbeat';
+import { logEvent } from '../../../src/bus/event';
+import * as lock from '../../../src/utils/lock';
+import type { BusPaths, Heartbeat } from '../../../src/types';
+
+let testDir: string;
+let paths: BusPaths;
+
+function makePaths(root: string): BusPaths {
+  return {
+    ctxRoot: root,
+    inbox: join(root, 'inbox'),
+    inflight: join(root, 'inflight'),
+    processed: join(root, 'processed'),
+    logDir: join(root, 'logs'),
+    stateDir: join(root, 'state'),
+    taskDir: join(root, 'tasks'),
+    approvalDir: join(root, 'approvals'),
+    analyticsDir: join(root, 'analytics'),
+    deliverablesDir: join(root, 'deliverables'),
+  };
+}
+
+const AGENT = 'agent';
+const ORG = 'org';
+
+beforeEach(() => {
+  testDir = mkdtempSync(join(tmpdir(), 'hb-lostupdate-'));
+  paths = makePaths(testDir);
+  mkdirSync(paths.stateDir, { recursive: true });
+  mkdirSync(paths.logDir, { recursive: true });
+  mkdirSync(paths.analyticsDir, { recursive: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  rmSync(testDir, { recursive: true, force: true });
+});
+
+describe('heartbeat lost-update — both writers take the per-agent stateDir lock', () => {
+  it('updateHeartbeat acquires the stateDir lock', () => {
+    const withLock = vi.spyOn(lock, 'withFileLockSync');
+    updateHeartbeat(paths, AGENT, 'busy', { org: ORG });
+    expect(withLock.mock.calls.some(([dir]) => dir === paths.stateDir)).toBe(true);
+  });
+
+  it('the opt-in logEvent heartbeat refresh acquires the stateDir lock', () => {
+    // Refresh only runs when a heartbeat already exists AND the caller opts in.
+    const hb: Heartbeat = {
+      agent: AGENT, org: ORG, status: 'online',
+      current_task: '', mode: 'day',
+      last_heartbeat: '2026-04-23T12:00:00Z', loop_interval: '4h',
+    };
+    writeFileSync(join(paths.stateDir, 'heartbeat.json'), JSON.stringify(hb));
+
+    const withLock = vi.spyOn(lock, 'withFileLockSync');
+    logEvent(paths, AGENT, ORG, 'action', 'tick', 'info', undefined, { refreshHeartbeat: true });
+    expect(withLock.mock.calls.some(([dir]) => dir === paths.stateDir)).toBe(true);
+  });
+});
+
+describe('heartbeat lost-update — the lock enforces mutual exclusion', () => {
+  it('a second writer cannot enter the critical section while the stateDir lock is held', () => {
+    // Seed status=online (the value a stale RMW would clobber back to).
+    const seed: Heartbeat = {
+      agent: AGENT, org: ORG, status: 'online',
+      current_task: 'old-task', mode: 'day',
+      last_heartbeat: '2026-04-23T12:00:00Z', loop_interval: '4h',
+    };
+    const hbPath = join(paths.stateDir, 'heartbeat.json');
+    writeFileSync(hbPath, JSON.stringify(seed));
+
+    // Model the exact lost-update interleave deterministically:
+    //  (1) writer A (the refresh) holds the stateDir lock and reads the stale
+    //      online snapshot.
+    //  (2) WHILE A holds the lock, writer B (updateHeartbeat) would try to set
+    //      status=busy — but both take the SAME lock, so B's acquire is refused
+    //      and it cannot race into A's read->write window. Proven directly:
+    //      acquireLock(stateDir) returns false while A holds it.
+    //  (3) A finishes its bump and releases.
+    const refreshTs = new Date().toISOString().replace(/\.\d{3}Z$/, 'Z');
+
+    lock.withFileLockSync(paths.stateDir, () => {
+      const aSnapshot = JSON.parse(readFileSync(hbPath, 'utf-8')) as Heartbeat;
+      expect(aSnapshot.status).toBe('online');
+      expect(lock.acquireLock(paths.stateDir)).toBe(false);
+      aSnapshot.last_heartbeat = refreshTs;
+      writeFileSync(hbPath, JSON.stringify(aSnapshot));
+    });
+
+    // After A released, B's update applies cleanly and serially — the post-fix
+    // world. Both contributions survive: B's status AND A's timestamp bump.
+    updateHeartbeat(paths, AGENT, 'busy', { org: ORG, currentTask: 'now-busy' });
+    const final = JSON.parse(readFileSync(hbPath, 'utf-8')) as Heartbeat;
+    expect(final.status).toBe('busy');
+    expect(final.current_task).toBe('now-busy');
+  });
+
+  it('sequential overwrite-then-refresh keeps the overwrite status and refreshes the timestamp', async () => {
+    updateHeartbeat(paths, AGENT, 'online', { org: ORG, currentTask: 'boot' });
+    await new Promise((r) => setTimeout(r, 2));
+    updateHeartbeat(paths, AGENT, 'busy', { org: ORG, currentTask: 'working' });
+    await new Promise((r) => setTimeout(r, 2));
+    logEvent(paths, AGENT, ORG, 'action', 'tick', 'info', undefined, { refreshHeartbeat: true });
+
+    const hbPath = join(paths.stateDir, 'heartbeat.json');
+    expect(existsSync(hbPath)).toBe(true);
+    const final = JSON.parse(readFileSync(hbPath, 'utf-8')) as Heartbeat;
+    expect(final.status).toBe('busy');
+    expect(final.current_task).toBe('working');
+  });
+});

--- a/tests/unit/utils/atomic.test.ts
+++ b/tests/unit/utils/atomic.test.ts
@@ -1,0 +1,135 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, symlinkSync, lstatSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { atomicWriteSync } from '../../../src/utils/atomic';
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), 'atomic-test-'));
+});
+
+afterEach(() => {
+  try { rmSync(tmpDir, { recursive: true }); } catch { /* ignore */ }
+});
+
+describe('atomicWriteSync', () => {
+  it('creates a new file with the data plus a trailing newline', () => {
+    const p = join(tmpDir, 'new.json');
+    atomicWriteSync(p, '{"a":1}');
+    expect(readFileSync(p, 'utf-8')).toBe('{"a":1}\n');
+  });
+
+  it('overwrites an existing regular file atomically', () => {
+    const p = join(tmpDir, 'reg.json');
+    writeFileSync(p, 'old\n');
+    atomicWriteSync(p, 'new');
+    expect(readFileSync(p, 'utf-8')).toBe('new\n');
+    // no temp file left behind
+    expect(existsSync(join(tmpDir, '.tmp'))).toBe(false);
+  });
+
+  describe('symlink-aware writes', () => {
+    it('writes THROUGH a symlink to its target and leaves the link intact', () => {
+      const target = join(tmpDir, 'target.json');
+      const link = join(tmpDir, 'link.json');
+      writeFileSync(target, 'original\n');
+      symlinkSync(target, link);
+
+      atomicWriteSync(link, 'updated');
+
+      // the link is still a symlink — NOT replaced by a regular file
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+      // the write landed on the real target
+      expect(readFileSync(target, 'utf-8')).toBe('updated\n');
+      // and reading through the link sees it too
+      expect(readFileSync(link, 'utf-8')).toBe('updated\n');
+    });
+
+    it('creates the declared target of a DANGLING symlink and keeps the link', () => {
+      const target = join(tmpDir, 'not-yet.json');
+      const link = join(tmpDir, 'dangling.json');
+      // link points at a target that does not exist yet
+      symlinkSync(target, link);
+      expect(existsSync(target)).toBe(false);
+
+      atomicWriteSync(link, 'created');
+
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+      expect(readFileSync(target, 'utf-8')).toBe('created\n');
+    });
+
+    it('resolves a RELATIVE dangling-symlink target against the link directory', () => {
+      const target = join(tmpDir, 'rel-target.json');
+      const link = join(tmpDir, 'rel-link.json');
+      symlinkSync('rel-target.json', link); // relative target
+      atomicWriteSync(link, 'via-relative');
+      expect(readFileSync(target, 'utf-8')).toBe('via-relative\n');
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    });
+
+    it('resolves a MULTI-HOP dangling chain to its terminus, keeping every link intact', () => {
+      // a -> b -> missing: a single readlink hop would stop at b (itself a
+      // symlink) and the rename would replace b with a regular file. The write
+      // must land AT the terminus path, with both a and b still symlinks.
+      const terminus = join(tmpDir, 'chain-terminus.json');
+      const b = join(tmpDir, 'chain-b.json');
+      const a = join(tmpDir, 'chain-a.json');
+      symlinkSync(terminus, b);
+      symlinkSync(b, a);
+      expect(existsSync(terminus)).toBe(false);
+
+      atomicWriteSync(a, 'through-the-chain');
+
+      expect(lstatSync(a).isSymbolicLink()).toBe(true);
+      expect(lstatSync(b).isSymbolicLink()).toBe(true);
+      expect(lstatSync(terminus).isSymbolicLink()).toBe(false);
+      expect(readFileSync(terminus, 'utf-8')).toBe('through-the-chain\n');
+      // and reading through the chain sees it
+      expect(readFileSync(a, 'utf-8')).toBe('through-the-chain\n');
+    });
+
+    it('throws ELOOP on a symlink cycle instead of silently replacing a link', () => {
+      const a = join(tmpDir, 'cycle-a.json');
+      const b = join(tmpDir, 'cycle-b.json');
+      symlinkSync(b, a);
+      symlinkSync(a, b);
+
+      expect(() => atomicWriteSync(a, 'never-lands')).toThrow(/cycle/);
+      // both links untouched — the failure must not mutate the link structure
+      expect(lstatSync(a).isSymbolicLink()).toBe(true);
+      expect(lstatSync(b).isSymbolicLink()).toBe(true);
+    });
+
+    it('keepBak backs up the real target content at <linkpath>.bak', () => {
+      const target = join(tmpDir, 't.json');
+      const link = join(tmpDir, 'l.json');
+      writeFileSync(target, 'v1\n');
+      symlinkSync(target, link);
+
+      atomicWriteSync(link, 'v2', true);
+
+      // backup captured the prior target content, and sits at the LINK path + .bak
+      expect(readFileSync(link + '.bak', 'utf-8')).toBe('v1\n');
+      expect(readFileSync(target, 'utf-8')).toBe('v2\n');
+      expect(lstatSync(link).isSymbolicLink()).toBe(true);
+    });
+  });
+
+  describe('keepBak on a regular file', () => {
+    it('writes the prior content to <path>.bak', () => {
+      const p = join(tmpDir, 'k.json');
+      writeFileSync(p, 'first\n');
+      atomicWriteSync(p, 'second', true);
+      expect(readFileSync(p, 'utf-8')).toBe('second\n');
+      expect(readFileSync(p + '.bak', 'utf-8')).toBe('first\n');
+    });
+
+    it('does not create a .bak on first write (nothing to back up)', () => {
+      const p = join(tmpDir, 'fresh.json');
+      atomicWriteSync(p, 'only', true);
+      expect(existsSync(p + '.bak')).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Background

The daemon's JSON state files (`heartbeat.json`, `cron-state.json`) are written by multiple concurrent actors — the daemon itself, CLI commands, and the opt-in heartbeat refresh on event writes. Two failure classes exist there today, both of the kind that only shows up under concurrency or a crash and then looks like mystery state corruption.

## The two fixes

**1. `atomicWriteSync` silently replaced symlinks.** The temp-file + rename pattern renames onto the *given* path, so when that path is a symlink (a common way to share one file across several locations), the link gets replaced by a regular file and quietly detached from its target — the two locations stop being the same file and drift apart. `atomicWriteSync` now resolves the rename destination *through* the link (including a dangling link's declared target via `readlink`, so the link survives even when its target doesn't exist yet) and writes to the real target. For non-symlink paths the behavior is byte-identical; `keepBak` still lands the backup at `<given path>.bak` where existing callers recover it.

**2. Unserialized writers lost updates.** `heartbeat.json` has two writers: the authoritative overwrite in `updateHeartbeat()` and the read-modify-write refresh in `logEvent()` (opt-in). With no lock between them, the refresh can read a stale heartbeat, an explicit update lands new `status`/`mode`/`current_task` fields, and the refresh writes its stale copy back — a classic TOCTOU lost update that makes a busy agent look idle (or vice versa). Both writers now take the same per-agent `withFileLockSync(stateDir)` — the lock utility you already ship. `cron-state.json` had the same unserialized RMW plus a plain `writeFileSync`; it now runs under the lock and writes through `atomicWriteSync`, so a crash mid-write can no longer tear the file (a torn `cron-state.json` parses as `{crons: []}`, which drops the last-fire references and risks duplicate catch-up fires). On-disk formats are unchanged in both files.

## Tests

- `atomicWriteSync`: write-through-symlink (link stays a link, target gets the bytes), dangling-link creation, relative link targets, `keepBak` through a link, plus plain create/overwrite/backup behavior.
- Heartbeat: both writers proven to take the same `stateDir` lock, and a deterministic mutual-exclusion test that models the exact lost-update interleave — a second writer's `acquireLock` is refused inside the first writer's critical section, then both contributions survive serial execution.
- Cron-state: lock acquisition, no temp-file residue, byte-format stability, and both records surviving a contended write sequence.

`tsc` clean; full unit suite passes (1544). One unrelated test — the `hooks.test.ts` symlink case — fails identically on `main` before this change (verified on a pristine checkout); it's outside this diff.

This is the first of a small series of reliability PRs (delivery-lock recovery and daemon cleanup hardening to follow), each kept small and independent so you can take or leave them individually.