### PR TITLE
reliability: orphaned-lock recovery, honest inbox failures, transport re-queue

### DIFF
--- a/src/bus/message.ts
+++ b/src/bus/message.ts
@@ -88,6 +88,20 @@ export function sendMessage(
 }
 
 /**
+ * Distinguishes an unreadable inbox from a successfully-read empty inbox.
+ * Production callers must surface this state and retry; they must never emit
+ * the successful empty representation (`[]`).
+ */
+export class InboxLockUnavailableError extends Error {
+  readonly code = 'INBOX_LOCK_UNAVAILABLE';
+
+  constructor(readonly inbox: string) {
+    super(`Inbox lock unavailable: ${inbox}`);
+    this.name = 'InboxLockUnavailableError';
+  }
+}
+
+/**
  * Check inbox for pending messages.
  * Reads inbox directory, moves messages to inflight, returns sorted array.
  * Recovers stale inflight messages (>5 minutes old).
@@ -98,9 +112,12 @@ export function checkInbox(paths: BusPaths): InboxMessage[] {
   ensureDir(inbox);
   ensureDir(inflight);
 
-  // Acquire lock
-  if (!acquireLock(inbox)) {
-    return [];
+  // Acquire lock. A refused lock throws rather than returning [] — a permanently
+  // orphaned lock must look like a failure to the caller, never like a
+  // successfully-read empty inbox (which silently black-holes every message).
+  const lockHandle = acquireLock(inbox);
+  if (!lockHandle) {
+    throw new InboxLockUnavailableError(inbox);
   }
 
   try {
@@ -159,7 +176,10 @@ export function checkInbox(paths: BusPaths): InboxMessage[] {
 
     return messages;
   } finally {
-    releaseLock(inbox);
+    // Release is bound to the acquired generation handle: if another process
+    // legitimately stole this lock as stale mid-operation, this release is a
+    // no-op instead of destroying the new holder's lock.
+    releaseLock(lockHandle);
   }
 }
 

--- a/src/cli/bus.ts
+++ b/src/cli/bus.ts
@@ -127,8 +127,15 @@ busCommand
   .action(() => {
     const env = resolveEnv();
     const paths = resolvePaths(env.agentName, env.instanceId, env.org);
-    const messages = checkInbox(paths);
-    console.log(JSON.stringify(messages));
+    // An unavailable inbox lock must exit nonzero with an error — printing []
+    // would be indistinguishable from a successfully-read empty inbox.
+    try {
+      const messages = checkInbox(paths);
+      console.log(JSON.stringify(messages));
+    } catch (err) {
+      console.error(`check-inbox failed: ${err instanceof Error ? err.message : String(err)}`);
+      process.exitCode = 1;
+    }
   });
 
 busCommand

--- a/src/daemon/fast-checker.ts
+++ b/src/daemon/fast-checker.ts
@@ -232,31 +232,49 @@ export class FastChecker {
     let messageBlock = '';
     const ackIds: string[] = [];
 
-    // Process queued Telegram messages
-    let hasTelegramMessage = false;
+    // Process queued transport messages. Drain into local buffers rather than
+    // discarding outright — if injection fails (agent mid-restart, or deduped)
+    // we must re-queue, since these in-memory queues are the ONLY backing store
+    // for Telegram/Buzz/Slack (no inbox-style ACK/redelivery). Mirrors the
+    // inbox ACK-after-inject recovery model below.
+    const drainedTelegram: typeof this.telegramMessages = [];
     while (this.telegramMessages.length > 0) {
       const msg = this.telegramMessages.shift()!;
       messageBlock += msg.formatted;
-      hasTelegramMessage = true;
+      drainedTelegram.push(msg);
     }
+    const hasTelegramMessage = drainedTelegram.length > 0;
 
     // Process queued Buzz messages
+    const drainedBuzz: typeof this.buzzMessages = [];
     while (this.buzzMessages.length > 0) {
       const msg = this.buzzMessages.shift()!;
       messageBlock += msg.formatted;
+      drainedBuzz.push(msg);
     }
 
     // Process queued Slack messages. Deliberately does NOT set
     // hasTelegramMessage / lastMessageInjectedAt — see slackMessages'
     // declaration for why the typing-indicator timer must stay
     // Telegram-only.
+    const drainedSlack: typeof this.slackMessages = [];
     while (this.slackMessages.length > 0) {
-      messageBlock += this.slackMessages.shift()!;
+      const msg = this.slackMessages.shift()!;
+      messageBlock += msg;
+      drainedSlack.push(msg);
     }
 
 
-    // Check agent inbox
-    const inboxMessages = checkInbox(this.paths);
+    // Check agent inbox. A refused inbox lock throws InboxLockUnavailableError;
+    // keep independent transport delivery moving, but make the failure explicit
+    // in the daemon log — the next poll retries instead of claiming a
+    // successful empty inbox.
+    let inboxMessages: InboxMessage[] = [];
+    try {
+      inboxMessages = checkInbox(this.paths);
+    } catch (err) {
+      this.log(`Inbox check failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
     for (const msg of inboxMessages) {
       messageBlock += this.formatInboxMessage(msg);
       ackIds.push(msg.id);
@@ -264,8 +282,12 @@ export class FastChecker {
 
     // Inject if there's anything
     if (messageBlock) {
-      const injected = this.agent.injectMessage(messageBlock);
-      if (injected) {
+      // The detailed result matters here: a bare boolean conflates NOT_RUNNING
+      // with DEDUPED, and re-queueing a DEDUPED batch would park it in the
+      // queue forever (every retry dedups again) or replay it later alongside
+      // new traffic. Only NOT_RUNNING is retriable.
+      const injected = this.agent.injectMessageDetailed(messageBlock);
+      if (injected.ok) {
         // ACK inbox messages
         for (const id of ackIds) {
           ackInbox(this.paths, id);
@@ -279,6 +301,25 @@ export class FastChecker {
         }
         // Cooldown after injection
         await sleep(5000);
+      } else if (
+        injected.code === 'NOT_RUNNING' &&
+        (drainedTelegram.length > 0 || drainedBuzz.length > 0 || drainedSlack.length > 0)
+      ) {
+        // Agent not running (mid-restart). Re-queue the drained transport
+        // messages at the FRONT so they are retried next cycle in original
+        // order. Inbox messages need no action — they were never ACK'd, so
+        // checkInbox redelivers them. Without this, inbound transport traffic
+        // during a restart is silently and permanently lost.
+        this.telegramMessages.unshift(...drainedTelegram);
+        this.buzzMessages.unshift(...drainedBuzz);
+        this.slackMessages.unshift(...drainedSlack);
+        const requeued = drainedTelegram.length + drainedBuzz.length + drainedSlack.length;
+        this.log(`Inject failed (${injected.code}); re-queued ${requeued} transport message(s)`);
+      } else if (!injected.ok) {
+        // DEDUPED: an identical block was already injected — treat as
+        // delivered and drop the drained copies. Re-queueing would never
+        // succeed (each retry dedups again) and could replay the batch later.
+        this.log(`Inject skipped (${injected.code}); dropped duplicate transport batch`);
       }
     }
 

--- a/src/utils/lock.ts
+++ b/src/utils/lock.ts
@@ -1,21 +1,294 @@
-import { mkdirSync, rmdirSync, writeFileSync, readFileSync, rmSync } from 'fs';
+import { mkdirSync, writeFileSync, readFileSync, renameSync, rmSync, statSync } from 'fs';
 import { join } from 'path';
+
+/**
+ * A lock directory without a readable PID can only be a process still inside
+ * the tiny mkdir -> PID publication window, or an abandoned partial acquire.
+ * Preserve the live window, but make the abandoned state recoverable.
+ */
+export const PARTIAL_LOCK_STALE_MS = 5_000;
+
+interface LockSnapshot {
+  readonly dev: number;
+  readonly ino: number;
+  readonly mtimeMs: number;
+}
+
+interface OwnedLockGeneration {
+  readonly snapshot: LockSnapshot;
+  readonly ownerFile: string;
+  readonly ownerToken: string;
+}
+
+class GenerationLockHandle {
+  readonly #lockHandleBrand = true;
+}
+
+interface LockHandleState {
+  readonly lockDir: string;
+  readonly generation: OwnedLockGeneration;
+}
+
+const LOCK_HANDLE_STATE = new WeakMap<GenerationLockHandle, LockHandleState>();
+
+function createLockHandle(
+  lockDir: string,
+  generation: OwnedLockGeneration,
+): GenerationLockHandle {
+  // Copy at the materialization door so even an internal alias to the
+  // acquisition-time object cannot rewrite the identity retained for release.
+  const snapshot = Object.freeze({ ...generation.snapshot });
+  const immutableGeneration = Object.freeze({
+    snapshot,
+    ownerFile: generation.ownerFile,
+    ownerToken: generation.ownerToken,
+  });
+  const handle = new GenerationLockHandle();
+  Object.freeze(handle);
+
+  LOCK_HANDLE_STATE.set(handle, Object.freeze({
+    lockDir,
+    generation: immutableGeneration,
+  }));
+  return handle;
+}
+
+export type LockHandle = GenerationLockHandle;
+
+function ownsLockGeneration(lockDir: string, generation: OwnedLockGeneration): boolean {
+  const current = snapshotLock(lockDir);
+  if (!current || !sameLock(current, generation.snapshot)) return false;
+
+  try {
+    return readFileSync(generation.ownerFile, 'utf-8') === generation.ownerToken;
+  } catch {
+    // A missing or unreadable owner token is ambiguous. Never publish into or
+    // remove a path unless both its inode and token still identify our claim.
+    return false;
+  }
+}
+
+function createLock(lockDir: string, pidFile: string): LockHandle | false {
+  let createdLockDir = false;
+  let acquired = false;
+  let generation: OwnedLockGeneration | null = null;
+  const ownerToken = `${process.pid}-${process.hrtime.bigint()}`;
+  const ownerFile = join(lockDir, '.owner');
+  const pendingPidFile = join(lockDir, `pid.${ownerToken}.pending`);
+
+  try {
+    mkdirSync(lockDir);
+    createdLockDir = true;
+
+    // The fixed-name token is the ownership publication point. If a delayed
+    // creator resumes after its directory was quarantined and replaced, wx
+    // observes the successor's token and refuses to claim the rebound path.
+    try {
+      writeFileSync(ownerFile, ownerToken, { flag: 'wx' });
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
+      throw err;
+    }
+
+    const createdSnapshot = snapshotLock(lockDir);
+    if (!createdSnapshot) return false;
+    generation = { snapshot: createdSnapshot, ownerFile, ownerToken };
+    if (!ownsLockGeneration(lockDir, generation)) return false;
+
+    try {
+      writeFileSync(pendingPidFile, String(process.pid));
+    } catch (err) {
+      if (!ownsLockGeneration(lockDir, generation)) return false;
+      throw err;
+    }
+    if (!ownsLockGeneration(lockDir, generation)) return false;
+
+    try {
+      renameSync(pendingPidFile, pidFile);
+    } catch (err) {
+      if (!ownsLockGeneration(lockDir, generation)) return false;
+      throw err;
+    }
+    if (!ownsLockGeneration(lockDir, generation)) return false;
+    acquired = true;
+    return createLockHandle(lockDir, generation);
+  } finally {
+    // writeFileSync/renameSync can fail after mkdirSync succeeds (ENOSPC was
+    // observed in production). Never leave that local partial acquire behind.
+    // A hard crash cannot run finally; the mtime reap below covers that case.
+    if (
+      createdLockDir
+      && !acquired
+      && generation
+      && ownsLockGeneration(lockDir, generation)
+    ) {
+      try {
+        removeOwnedLockGeneration(lockDir, generation);
+      } catch {
+        // Preserve the original acquire error. The partial directory remains
+        // time-reapable by a later caller.
+      }
+    }
+  }
+}
+
+function snapshotLock(lockDir: string): LockSnapshot | null {
+  try {
+    const stat = statSync(lockDir);
+    return { dev: stat.dev, ino: stat.ino, mtimeMs: stat.mtimeMs };
+  } catch {
+    return null;
+  }
+}
+
+function sameLock(left: LockSnapshot, right: LockSnapshot): boolean {
+  return left.dev === right.dev && left.ino === right.ino;
+}
+
+function removeOwnedTakeoverMarker(markerFile: string, markerToken: string): void {
+  try {
+    if (readFileSync(markerFile, 'utf-8') === markerToken) {
+      rmSync(markerFile, { force: true });
+    }
+  } catch {
+    // The generation was concurrently released or replaced. Never remove an
+    // unverified marker from the new generation.
+  }
+}
+
+function staleMarkerCanBeRecovered(
+  lockDir: string,
+  markerFile: string,
+  expected: LockSnapshot,
+): boolean {
+  const marked = snapshotLock(lockDir);
+  if (!marked || !sameLock(marked, expected)) return false;
+  if (Date.now() - marked.mtimeMs < PARTIAL_LOCK_STALE_MS) return false;
+
+  let markerRaw: string;
+  try {
+    markerRaw = readFileSync(markerFile, 'utf-8').trim();
+  } catch {
+    // A transient read failure cannot prove the marker owner is gone.
+    return false;
+  }
+
+  const match = /^([1-9]\d*):\d+$/.exec(markerRaw);
+  if (!match) {
+    // An old partial marker has no credible live owner. The caller still has
+    // to claim the exact directory generation through atomic quarantine.
+    return true;
+  }
+
+  const markerPid = Number(match[1]);
+  if (!Number.isSafeInteger(markerPid)) return true;
+
+  try {
+    process.kill(markerPid, 0);
+    // A live synchronous release/reclaim operation may have been descheduled
+    // beyond the age ceiling. Never steal its operation marker by time alone.
+    return false;
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === 'ESRCH';
+  }
+}
+
+function removeOwnedLockGeneration(
+  lockDir: string,
+  generation: OwnedLockGeneration,
+): boolean {
+  const markerFile = join(lockDir, '.takeover');
+  const markerToken = `${process.pid}:${process.hrtime.bigint()}`;
+
+  try {
+    writeFileSync(markerFile, markerToken, { flag: 'wx' });
+  } catch {
+    return false;
+  }
+
+  if (!ownsLockGeneration(lockDir, generation)) {
+    removeOwnedTakeoverMarker(markerFile, markerToken);
+    return false;
+  }
+
+  try {
+    rmSync(lockDir, { recursive: true, force: true });
+    return true;
+  } catch {
+    removeOwnedTakeoverMarker(markerFile, markerToken);
+    return false;
+  }
+}
+
+function replaceStaleLock(
+  lockDir: string,
+  pidFile: string,
+  expected: LockSnapshot,
+): LockHandle | false {
+  const markerFile = join(lockDir, '.takeover');
+  const markerToken = `${process.pid}:${process.hrtime.bigint()}`;
+  let createdMarker = false;
+
+  try {
+    writeFileSync(markerFile, markerToken, { flag: 'wx' });
+    createdMarker = true;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT') return false;
+    if (code !== 'EEXIST') throw err;
+
+    if (!staleMarkerCanBeRecovered(lockDir, markerFile, expected)) return false;
+  }
+
+  const claimed = snapshotLock(lockDir);
+  if (!claimed || !sameLock(claimed, expected)) {
+    if (createdMarker) removeOwnedTakeoverMarker(markerFile, markerToken);
+    return false;
+  }
+
+  // Keep the claimed generation as a non-empty tombstone. A delayed reclaimer
+  // that observed this same inode cannot rename a newly-acquired `.lock.d`
+  // over the tombstone, so it must lose rather than report a second success.
+  const quarantineDir = `${lockDir}.orphan-${expected.dev}-${expected.ino}`;
+  try {
+    renameSync(lockDir, quarantineDir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === 'ENOENT' || code === 'EEXIST' || code === 'ENOTEMPTY') return false;
+    throw err;
+  }
+
+  try {
+    return createLock(lockDir, pidFile);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw err;
+  }
+}
+
+function recoverPartialLock(
+  lockDir: string,
+  pidFile: string,
+  observed: LockSnapshot,
+): LockHandle | false {
+  if (Date.now() - observed.mtimeMs < PARTIAL_LOCK_STALE_MS) return false;
+  return replaceStaleLock(lockDir, pidFile, observed);
+}
 
 /**
  * Acquire a mutex lock using mkdir (atomic on all filesystems).
  * Matches the bash pattern: mkdir .lock.d with PID tracking.
  *
- * Returns true if lock acquired, false if another process holds it.
+ * Returns an opaque generation handle if acquired, false if another process
+ * holds it. The exact handle is required for generation-safe release.
  * Automatically recovers stale locks (dead process).
  */
-export function acquireLock(dir: string): boolean {
+export function acquireLock(dir: string): LockHandle | false {
   const lockDir = join(dir, '.lock.d');
   const pidFile = join(lockDir, 'pid');
 
   try {
-    mkdirSync(lockDir);
-    writeFileSync(pidFile, String(process.pid));
-    return true;
+    return createLock(lockDir, pidFile);
   } catch (err) {
     // Only EEXIST means contention. EACCES / ENOSPC / EROFS / etc. are real
     // filesystem failures — propagate so the caller (withFileLockSync) does
@@ -25,26 +298,27 @@ export function acquireLock(dir: string): boolean {
       throw err;
     }
     // mkdirSync failed with EEXIST — another process holds (or is mid-acquire
-    // of) the lock.  We must NOT treat the gap between mkdirSync and
-    // writeFileSync as "stale" — doing so allows two acquirers to interleave
-    // and BOTH believe they hold the lock (the actual race that broke iter
-    // 12).  When the PID file is missing, the holder is mid-acquire; the
-    // caller should retry.
+    // of) the lock. A recent partial lock is protected from theft; an old one
+    // is an abandoned acquire and can be replaced.
+    const observedLock = snapshotLock(lockDir);
+    if (!observedLock) return false;
+
     let storedPidRaw: string;
     try {
       storedPidRaw = readFileSync(pidFile, 'utf-8').trim();
-    } catch {
-      // PID file not yet written.  Holder is between mkdir and writeFileSync.
-      // Refuse the lock — the caller's retry loop will try again.
-      return false;
+    } catch (readErr) {
+      // Only a genuinely absent PID is a partial acquire. EACCES/EIO/EMFILE
+      // and every other ambiguous read failure must preserve mutual exclusion.
+      if ((readErr as NodeJS.ErrnoException).code !== 'ENOENT') return false;
+      return recoverPartialLock(lockDir, pidFile, observedLock);
     }
 
-    const storedPid = parseInt(storedPidRaw, 10);
-    if (isNaN(storedPid) || storedPidRaw === '') {
-      // Corrupt PID file.  Don't steal — let caller retry; if it persists
-      // the holder is broken and a future stale-detection pass (process.kill
-      // check below, after the PID is written cleanly) will recover.
-      return false;
+    if (!/^[1-9]\d*$/.test(storedPidRaw)) {
+      return recoverPartialLock(lockDir, pidFile, observedLock);
+    }
+    const storedPid = Number(storedPidRaw);
+    if (!Number.isSafeInteger(storedPid)) {
+      return recoverPartialLock(lockDir, pidFile, observedLock);
     }
 
     // Check if process is still alive
@@ -52,31 +326,24 @@ export function acquireLock(dir: string): boolean {
       process.kill(storedPid, 0);
       // Process is alive - lock is held
       return false;
-    } catch {
+    } catch (killErr) {
+      // EPERM and other ambiguous errors mean the process may still be alive.
+      // Only ESRCH proves the recorded owner no longer exists.
+      if ((killErr as NodeJS.ErrnoException).code !== 'ESRCH') return false;
       // Process is dead - stale lock, remove and re-acquire atomically.
-      try {
-        rmSync(lockDir, { recursive: true, force: true });
-        mkdirSync(lockDir);
-        writeFileSync(pidFile, String(process.pid));
-        return true;
-      } catch {
-        // Another process beat us to the steal — let caller retry.
-        return false;
-      }
+      return replaceStaleLock(lockDir, pidFile, observedLock);
     }
   }
 }
 
 /**
- * Release a mutex lock.
+ * Release exactly the mutex generation represented by `handle`.
  */
-export function releaseLock(dir: string): void {
-  const lockDir = join(dir, '.lock.d');
-  try {
-    rmSync(lockDir, { recursive: true, force: true });
-  } catch {
-    // Ignore errors on release
-  }
+export function releaseLock(handle: LockHandle): boolean {
+  if (!(handle instanceof GenerationLockHandle)) return false;
+  const state = LOCK_HANDLE_STATE.get(handle);
+  if (!state) return false;
+  return removeOwnedLockGeneration(state.lockDir, state.generation);
 }
 
 /**
@@ -126,7 +393,8 @@ export function withFileLockSync<T>(
   const timeoutNs = BigInt(timeoutMs) * 1_000_000n;
   let backoff = initBackoff;
 
-  while (!acquireLock(dir)) {
+  let handle: LockHandle | false;
+  while (!(handle = acquireLock(dir))) {
     if (process.hrtime.bigint() - start > timeoutNs) {
       throw new Error(
         `withFileLockSync: failed to acquire lock on "${dir}" within ${timeoutMs}ms`,
@@ -139,6 +407,6 @@ export function withFileLockSync<T>(
   try {
     return fn();
   } finally {
-    releaseLock(dir);
+    releaseLock(handle);
   }
 }

--- a/tests/fixtures/lock-handle-opacity-consumer.ts
+++ b/tests/fixtures/lock-handle-opacity-consumer.ts
@@ -1,0 +1,11 @@
+import type { LockHandle } from '../../src/utils/lock';
+
+declare const staleHandle: LockHandle;
+
+// These are the exact identity members a caller used to rewrite a stale
+// handle into a live successor. The opacity test compiles this fixture and
+// requires every access to remain a property-not-found diagnostic.
+staleHandle.lockDir;
+staleHandle.generation.snapshot.dev = 1;
+staleHandle.generation.snapshot.ino = 1;
+staleHandle.generation.ownerToken = 'successor-owner-token';

--- a/tests/unit/bus/message.test.ts
+++ b/tests/unit/bus/message.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, readdirSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { sendMessage, checkInbox, ackInbox } from '../../../src/bus/message';
+import { sendMessage, checkInbox, ackInbox, InboxLockUnavailableError } from '../../../src/bus/message';
+import { acquireLock, releaseLock } from '../../../src/utils/lock';
 import { resolvePaths } from '../../../src/utils/paths';
 import type { BusPaths } from '../../../src/types';
 
@@ -122,6 +123,26 @@ describe('Message Bus', () => {
 
       expect(inboxFiles.length).toBe(0);
       expect(inflightFiles.length).toBe(1);
+    });
+
+    it('throws InboxLockUnavailableError when the inbox lock is held — never a fake empty read', () => {
+      // A held (or permanently orphaned) lock must surface as a failure the
+      // caller can retry — returning [] here is indistinguishable from a
+      // successfully-read empty inbox and silently black-holes every message.
+      sendMessage(senderPaths, 'sender', 'receiver', 'normal', 'must not vanish');
+      const held = acquireLock(receiverPaths.inbox);
+      expect(held).not.toBe(false);
+      try {
+        expect(() => checkInbox(receiverPaths)).toThrow(InboxLockUnavailableError);
+        expect(() => checkInbox(receiverPaths)).toThrow(/Inbox lock unavailable/);
+      } finally {
+        if (held) releaseLock(held);
+      }
+      // Once the lock is free the message is still there and delivers — nothing
+      // was consumed or lost during the locked window.
+      const messages = checkInbox(receiverPaths);
+      expect(messages.length).toBe(1);
+      expect(messages[0].text).toBe('must not vanish');
     });
   });
 

--- a/tests/unit/daemon/fast-checker-buzz.test.ts
+++ b/tests/unit/daemon/fast-checker-buzz.test.ts
@@ -12,6 +12,7 @@ function createMockAgent(name = 'test-agent') {
     name,
     isBootstrapped: vi.fn().mockReturnValue(true),
     injectMessage: vi.fn().mockReturnValue(true),
+    injectMessageDetailed: vi.fn().mockReturnValue({ ok: true }),
     write: vi.fn(),
   } as any;
 }
@@ -92,6 +93,7 @@ describe('FastChecker — Buzz (Nostr/NIP-29) additions', () => {
 
       const injectedCalls = [
         ...agent.injectMessage.mock.calls.map((c: unknown[]) => String(c[0])),
+        ...agent.injectMessageDetailed.mock.calls.map((c: unknown[]) => String(c[0])),
         ...agent.write.mock.calls.map((c: unknown[]) => String(c[0])),
       ];
       const sawBuzzMessage = injectedCalls.some((text) => text.includes('queued message'));

--- a/tests/unit/daemon/fast-checker.test.ts
+++ b/tests/unit/daemon/fast-checker.test.ts
@@ -5,6 +5,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, readdirSync, mkdirSyn
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { FastChecker } from '../../../src/daemon/fast-checker';
+import { acquireLock, releaseLock } from '../../../src/utils/lock';
 import type { BusPaths, TelegramCallbackQuery } from '../../../src/types';
 
 // Minimal mock for AgentProcess
@@ -13,6 +14,7 @@ function createMockAgent(name = 'test-agent') {
     name,
     isBootstrapped: vi.fn().mockReturnValue(true),
     injectMessage: vi.fn().mockReturnValue(true),
+    injectMessageDetailed: vi.fn().mockReturnValue({ ok: true }),
     write: vi.fn(),
   } as any;
 }
@@ -1222,6 +1224,129 @@ describe('FastChecker', () => {
       expect(injected(agent).some(m => m.includes('CONTEXT HANDOFF REQUIRED'))).toBe(true);
       expect((checker as any).ctxHandoffFiredAt).toBeGreaterThan(0);
       expect(orchestratorMessages().length).toBe(0);
+    });
+  });
+
+  describe('inbox lock failure visibility', () => {
+    it('logs the failure instead of treating the inbox as empty', async () => {
+      const log = vi.fn();
+      const checker = new FastChecker(createMockAgent(), paths, '/tmp/framework', { log }) as any;
+      // Hold the inbox lock from "another process" so checkInbox's acquire is refused.
+      const lockHandle = acquireLock(paths.inbox);
+      expect(lockHandle).not.toBe(false);
+
+      try {
+        await checker.pollCycle();
+      } finally {
+        if (lockHandle) releaseLock(lockHandle);
+      }
+
+      expect(log).toHaveBeenCalledWith(expect.stringContaining('Inbox check failed'));
+      expect(log).toHaveBeenCalledWith(expect.stringContaining(paths.inbox));
+    });
+  });
+
+  describe('transport re-queue on inject failure', () => {
+    it('NOT_RUNNING: re-queues drained telegram/buzz/slack in order, then delivers once on recovery', async () => {
+      vi.useFakeTimers();
+      try {
+        const agent = createMockAgent();
+        agent.injectMessageDetailed.mockReturnValue({ ok: false, code: 'NOT_RUNNING', message: 'mid-restart' });
+        const log = vi.fn();
+        const checker = new FastChecker(agent, paths, '/tmp/framework', { log }) as any;
+
+        checker.queueTelegramMessage('tg-1');
+        checker.queueTelegramMessage('tg-2');
+        checker.queueBuzzMessage('bz-1');
+        checker.queueSlackMessage('sl-1');
+
+        await checker.pollCycle();
+
+        // The in-memory queues are the only backing store — a NOT_RUNNING inject
+        // must put every drained message back, at the front, in original order.
+        expect(checker.telegramMessages.map((m: { formatted: string }) => m.formatted)).toEqual(['tg-1', 'tg-2']);
+        expect(checker.buzzMessages.map((m: { formatted: string }) => m.formatted)).toEqual(['bz-1']);
+        expect(checker.slackMessages).toEqual(['sl-1']);
+        expect(log).toHaveBeenCalledWith(expect.stringContaining('re-queued 4 transport message(s)'));
+
+        // Recovery: the agent comes back, the next cycle delivers the SAME batch
+        // exactly once and the queues drain.
+        agent.injectMessageDetailed.mockReturnValue({ ok: true });
+        const cycle = checker.pollCycle();
+        await vi.advanceTimersByTimeAsync(5000); // post-inject cooldown sleep
+        await cycle;
+        const delivered = agent.injectMessageDetailed.mock.calls.at(-1)![0] as string;
+        expect(delivered).toContain('tg-1');
+        expect(delivered).toContain('tg-2');
+        expect(delivered).toContain('bz-1');
+        expect(delivered).toContain('sl-1');
+        expect(checker.telegramMessages).toEqual([]);
+        expect(checker.buzzMessages).toEqual([]);
+        expect(checker.slackMessages).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('DEDUPED: does NOT re-queue — treated as delivered, and no replay beside new traffic', async () => {
+      vi.useFakeTimers();
+      try {
+        const agent = createMockAgent();
+        agent.injectMessageDetailed.mockReturnValue({ ok: false, code: 'DEDUPED', message: 'duplicate' });
+        const log = vi.fn();
+        const checker = new FastChecker(agent, paths, '/tmp/framework', { log }) as any;
+
+        checker.queueTelegramMessage('dup-1');
+        checker.queueBuzzMessage('dup-2');
+        checker.queueSlackMessage('dup-3');
+
+        await checker.pollCycle();
+
+        // A deduped batch was already injected once — re-queueing it would park
+        // it forever (every retry dedups again) or replay it later. Dropped.
+        expect(checker.telegramMessages).toEqual([]);
+        expect(checker.buzzMessages).toEqual([]);
+        expect(checker.slackMessages).toEqual([]);
+        expect(log).toHaveBeenCalledWith(expect.stringContaining('DEDUPED'));
+
+        // New traffic arrives: the next inject carries ONLY the new message —
+        // no replay of the deduped batch.
+        agent.injectMessageDetailed.mockReturnValue({ ok: true });
+        checker.queueTelegramMessage('new-1');
+        const cycle = checker.pollCycle();
+        await vi.advanceTimersByTimeAsync(5000);
+        await cycle;
+        const delivered = agent.injectMessageDetailed.mock.calls.at(-1)![0] as string;
+        expect(delivered).toContain('new-1');
+        expect(delivered).not.toContain('dup-1');
+        expect(delivered).not.toContain('dup-2');
+        expect(delivered).not.toContain('dup-3');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('drains the queues (no re-queue) when inject succeeds', async () => {
+      vi.useFakeTimers();
+      try {
+        const agent = createMockAgent(); // injectMessageDetailed -> { ok: true }
+        const checker = new FastChecker(agent, paths, '/tmp/framework', { log: vi.fn() }) as any;
+
+        checker.queueTelegramMessage('tg-ok');
+        checker.queueBuzzMessage('bz-ok');
+        checker.queueSlackMessage('sl-ok');
+
+        const cycle = checker.pollCycle();
+        await vi.advanceTimersByTimeAsync(5000); // post-inject cooldown sleep
+        await cycle;
+
+        expect(agent.injectMessageDetailed).toHaveBeenCalledTimes(1);
+        expect(checker.telegramMessages).toEqual([]);
+        expect(checker.buzzMessages).toEqual([]);
+        expect(checker.slackMessages).toEqual([]);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/tests/unit/utils/lock-acquire-failure.test.ts
+++ b/tests/unit/utils/lock-acquire-failure.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const fsMock = vi.hoisted(() => ({
+  writeFileSync: vi.fn(),
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  fsMock.writeFileSync.mockImplementation(actual.writeFileSync);
+  return {
+    ...actual,
+    writeFileSync: fsMock.writeFileSync,
+  };
+});
+
+import { acquireLock, releaseLock } from '../../../src/utils/lock';
+
+describe('lock acquisition failure cleanup', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-lock-enospc-'));
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('removes the partial lock directory when writing the pid fails with ENOSPC', () => {
+    const enospc = Object.assign(new Error('disk full'), { code: 'ENOSPC' });
+    const actualWriteFileSync = fsMock.writeFileSync.getMockImplementation()!;
+    let failed = false;
+    fsMock.writeFileSync.mockImplementation(((target, ...rest) => {
+      if (!failed && String(target).endsWith('.pending')) {
+        failed = true;
+        throw enospc;
+      }
+      return actualWriteFileSync(target, ...rest);
+    }) as typeof import('fs').writeFileSync);
+
+    expect(() => acquireLock(testDir)).toThrow(enospc);
+    expect(existsSync(join(testDir, '.lock.d'))).toBe(false);
+
+    const handle = acquireLock(testDir);
+    expect(handle).not.toBe(false);
+    if (!handle) throw new Error('expected lock handle');
+    expect(releaseLock(handle)).toBe(true);
+  });
+});

--- a/tests/unit/utils/lock-handle-opacity.test.ts
+++ b/tests/unit/utils/lock-handle-opacity.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { join } from 'node:path';
+import ts from 'typescript';
+
+describe('LockHandle compile-time opacity', () => {
+  it('does not expose filesystem generation identity to importing callers', () => {
+    const root = process.cwd();
+    const fixture = join(root, 'tests/fixtures/lock-handle-opacity-consumer.ts');
+    const configPath = join(root, 'tsconfig.json');
+    const loaded = ts.readConfigFile(configPath, ts.sys.readFile);
+    expect(loaded.error).toBeUndefined();
+
+    const parsed = ts.parseJsonConfigFileContent(loaded.config, ts.sys, root, {
+      noEmit: true,
+      rootDir: undefined,
+    }, configPath);
+    const program = ts.createProgram([fixture], parsed.options);
+    const diagnostics = ts.getPreEmitDiagnostics(program)
+      .filter(diagnostic => diagnostic.file?.fileName === fixture);
+
+    expect(diagnostics.map(diagnostic => diagnostic.code)).toEqual([
+      2339,
+      2339,
+      2339,
+      2339,
+    ]);
+    expect(diagnostics.map(diagnostic => ts.flattenDiagnosticMessageText(
+      diagnostic.messageText,
+      '\n',
+    ))).toEqual([
+      expect.stringContaining("Property 'lockDir' does not exist on type 'GenerationLockHandle'"),
+      expect.stringContaining("Property 'generation' does not exist on type 'GenerationLockHandle'"),
+      expect.stringContaining("Property 'generation' does not exist on type 'GenerationLockHandle'"),
+      expect.stringContaining("Property 'generation' does not exist on type 'GenerationLockHandle'"),
+    ]);
+  });
+});

--- a/tests/unit/utils/lock-recovery-concurrency.test.ts
+++ b/tests/unit/utils/lock-recovery-concurrency.test.ts
@@ -1,0 +1,289 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const fsMock = vi.hoisted(() => ({
+  readFileSync: vi.fn(),
+  renameSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  actualReadFileSync: undefined as typeof import('fs').readFileSync | undefined,
+  actualRenameSync: undefined as typeof import('fs').renameSync | undefined,
+  actualRmSync: undefined as typeof import('fs').rmSync | undefined,
+  actualWriteFileSync: undefined as typeof import('fs').writeFileSync | undefined,
+}));
+
+vi.mock('fs', async () => {
+  const actual = await vi.importActual<typeof import('fs')>('fs');
+  fsMock.actualReadFileSync = actual.readFileSync;
+  fsMock.actualRenameSync = actual.renameSync;
+  fsMock.actualRmSync = actual.rmSync;
+  fsMock.actualWriteFileSync = actual.writeFileSync;
+  fsMock.readFileSync.mockImplementation(actual.readFileSync);
+  fsMock.rmSync.mockImplementation(actual.rmSync);
+  fsMock.writeFileSync.mockImplementation(actual.writeFileSync);
+  return {
+    ...actual,
+    readFileSync: fsMock.readFileSync,
+    renameSync: fsMock.renameSync,
+    rmSync: fsMock.rmSync,
+    writeFileSync: fsMock.writeFileSync,
+  };
+});
+
+import { acquireLock, releaseLock, type LockHandle } from '../../../src/utils/lock';
+
+function releaseWinner(...candidates: Array<LockHandle | false | undefined>): void {
+  const winner = candidates.find(candidate => candidate !== false && candidate !== undefined);
+  expect(winner).toBeDefined();
+  expect(releaseLock(winner as LockHandle)).toBe(true);
+}
+
+describe('lock recovery concurrency and ambiguity', () => {
+  let testDir: string;
+
+  beforeEach(() => {
+    testDir = mkdtempSync(join(tmpdir(), 'cortextos-lock-recovery-'));
+    fsMock.readFileSync.mockImplementation(fsMock.actualReadFileSync!);
+    fsMock.renameSync.mockImplementation(fsMock.actualRenameSync!);
+    fsMock.rmSync.mockImplementation(fsMock.actualRmSync!);
+    fsMock.writeFileSync.mockImplementation(fsMock.actualWriteFileSync!);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  it('allows exactly one winner when a delayed stale reclaimer resumes after another wins', () => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'pid'), '99999999');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    const actualKill = process.kill.bind(process);
+    const killSpy = vi.spyOn(process, 'kill');
+    let firstWinner: LockHandle | false | undefined;
+    killSpy.mockImplementationOnce(((..._args: Parameters<typeof process.kill>) => {
+      killSpy.mockImplementation(actualKill);
+      firstWinner = acquireLock(testDir);
+      throw Object.assign(new Error('process gone'), { code: 'ESRCH' });
+    }) as typeof process.kill);
+
+    const delayedReclaimer = acquireLock(testDir);
+
+    expect([firstWinner, delayedReclaimer].filter(Boolean)).toHaveLength(1);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(firstWinner, delayedReclaimer);
+    const next = acquireLock(testDir);
+    expect(next).not.toBe(false);
+    releaseWinner(next);
+  });
+
+  it.each(['absent', 'empty'])('allows one winner when two reclaimers race on a stale %s pid', shape => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+    if (shape === 'empty') writeFileSync(join(lockDir, 'pid'), '');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    let interleaved = false;
+    let firstWinner: LockHandle | false | undefined;
+    fsMock.rmSync.mockImplementation(((target, options) => {
+      if (!interleaved && target === lockDir) {
+        interleaved = true;
+        firstWinner = acquireLock(testDir);
+      }
+      return fsMock.actualRmSync!(target, options);
+    }) as typeof rmSync);
+    fsMock.writeFileSync.mockImplementation(((target, ...rest) => {
+      if (!interleaved && target === join(lockDir, '.takeover')) {
+        interleaved = true;
+        firstWinner = acquireLock(testDir);
+      }
+      return fsMock.actualWriteFileSync!(target, ...rest);
+    }) as typeof writeFileSync);
+
+    const delayedReclaimer = acquireLock(testDir);
+
+    expect(interleaved).toBe(true);
+    expect([firstWinner, delayedReclaimer].filter(Boolean)).toHaveLength(1);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(firstWinner, delayedReclaimer);
+  });
+
+  it('allows one winner when two stale reclaimers interleave at generation quarantine', () => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    let interleaved = false;
+    let secondWinner: LockHandle | false | undefined;
+    vi.spyOn(process, 'kill').mockImplementation(() => {
+      // Model a first reclaimer that died after publishing its marker. The
+      // second then reaches the atomic quarantine boundary before the delayed
+      // first call resumes, proving the rename remains the single-winner gate.
+      throw Object.assign(new Error('marker owner exited'), { code: 'ESRCH' });
+    });
+    fsMock.renameSync.mockImplementation(((source, destination) => {
+      if (!interleaved && source === lockDir) {
+        interleaved = true;
+        // The first reclaimer's marker refreshed the directory mtime. Age it
+        // again so the second reaches the correctness-bearing rename boundary.
+        utimesSync(lockDir, stale, stale);
+        secondWinner = acquireLock(testDir);
+      }
+      return fsMock.actualRenameSync!(source, destination);
+    }) as typeof renameSync);
+
+    const firstWinner = acquireLock(testDir);
+
+    expect(interleaved).toBe(true);
+    expect([firstWinner, secondWinner].filter(Boolean)).toHaveLength(1);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(firstWinner, secondWinner);
+  });
+
+  it('does not age-steal a takeover marker owned by a live operation', () => {
+    const handle = acquireLock(testDir);
+    expect(handle).not.toBe(false);
+    const lockDir = join(testDir, '.lock.d');
+    writeFileSync(join(lockDir, 'pid'), '');
+    writeFileSync(join(lockDir, '.takeover'), `${process.pid}:1`);
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    expect(acquireLock(testDir)).toBe(false);
+    rmSync(join(lockDir, '.takeover'), { force: true });
+    releaseWinner(handle);
+  });
+
+  it('recovers an old partial takeover marker without a credible owner', () => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, '.takeover'), '');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    const handle = acquireLock(testDir);
+
+    expect(handle).not.toBe(false);
+    releaseWinner(handle);
+  });
+
+  it.each(['EACCES', 'EIO', 'EMFILE'])('does not reap a valid live lock when pid reading fails with %s', code => {
+    const handle = acquireLock(testDir);
+    expect(handle).not.toBe(false);
+    const lockDir = join(testDir, '.lock.d');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+    fsMock.readFileSync.mockImplementationOnce(() => {
+      throw Object.assign(new Error(`transient ${code}`), { code });
+    });
+
+    expect(acquireLock(testDir)).toBe(false);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(handle);
+  });
+
+  it('does not reap when owner liveness is ambiguous rather than ESRCH', () => {
+    const handle = acquireLock(testDir);
+    expect(handle).not.toBe(false);
+    const lockDir = join(testDir, '.lock.d');
+    vi.spyOn(process, 'kill').mockImplementationOnce(() => {
+      throw Object.assign(new Error('operation not permitted'), { code: 'EPERM' });
+    });
+
+    expect(acquireLock(testDir)).toBe(false);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(handle);
+  });
+
+  it('treats a numeric-prefix pid as corrupt rather than a live holder', () => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'pid'), `${process.pid}garbage`);
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    const handle = acquireLock(testDir);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    expect(handle).not.toBe(false);
+    releaseWinner(handle);
+  });
+
+  it('allows exactly one winner when a second acquirer arrives mid-publication', () => {
+    let contender: LockHandle | false | undefined;
+    let paused = false;
+    fsMock.writeFileSync.mockImplementation(((target, ...rest) => {
+      if (!paused && String(target).endsWith('.pending')) {
+        paused = true;
+        contender = acquireLock(testDir);
+      }
+      return fsMock.actualWriteFileSync!(target, ...rest);
+    }) as typeof writeFileSync);
+
+    const owner = acquireLock(testDir);
+
+    expect([owner, contender].filter(Boolean)).toHaveLength(1);
+    expect(existsSync(join(testDir, '.lock.d'))).toBe(true);
+    expect(readFileSync(join(testDir, '.lock.d', 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(owner, contender);
+  });
+
+  it('revokes a delayed original publisher after its partial generation is reclaimed', () => {
+    const lockDir = join(testDir, '.lock.d');
+    const stale = new Date(Date.now() - 60_000);
+    let contender: LockHandle | false | undefined;
+    let paused = false;
+    fsMock.writeFileSync.mockImplementation(((target, ...rest) => {
+      if (!paused && String(target).endsWith('.pending')) {
+        paused = true;
+        utimesSync(join(String(target), '..'), stale, stale);
+        contender = acquireLock(testDir);
+      }
+      return fsMock.actualWriteFileSync!(target, ...rest);
+    }) as typeof writeFileSync);
+
+    const originalPublisher = acquireLock(testDir);
+
+    expect([originalPublisher, contender].filter(Boolean)).toHaveLength(1);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(originalPublisher, contender);
+  });
+
+  it('does not delete a successor when a revoked publisher fails during publication', () => {
+    const lockDir = join(testDir, '.lock.d');
+    const stale = new Date(Date.now() - 60_000);
+    const publicationFailure = Object.assign(new Error('publication failed'), { code: 'EIO' });
+    let contender: LockHandle | false | undefined;
+    let publicationInterrupted = false;
+    fsMock.renameSync.mockImplementation(((source, destination) => {
+      if (!publicationInterrupted && String(source).endsWith('.pending')) {
+        publicationInterrupted = true;
+        utimesSync(lockDir, stale, stale);
+        contender = acquireLock(testDir);
+        throw publicationFailure;
+      }
+      return fsMock.actualRenameSync!(source, destination);
+    }) as typeof renameSync);
+
+    expect(acquireLock(testDir)).toBe(false);
+    expect(contender).not.toBe(false);
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(join(lockDir, 'pid'), 'utf-8')).toBe(String(process.pid));
+    releaseWinner(contender);
+  });
+});

--- a/tests/unit/utils/lock-release-callers.test.ts
+++ b/tests/unit/utils/lock-release-callers.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import ts from 'typescript';
+
+function sourceFiles(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...sourceFiles(path));
+    if (entry.isFile() && entry.name.endsWith('.ts')) files.push(path);
+  }
+  return files;
+}
+
+describe('generation-bound release caller roster', () => {
+  it('keeps every production release call bound to its acquired handle', () => {
+    const root = process.cwd();
+    const calls: string[] = [];
+
+    for (const path of sourceFiles(join(root, 'src'))) {
+      const source = ts.createSourceFile(
+        path,
+        readFileSync(path, 'utf-8'),
+        ts.ScriptTarget.Latest,
+        true,
+        ts.ScriptKind.TS,
+      );
+
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isCallExpression(node)
+          && ts.isIdentifier(node.expression)
+          && node.expression.text === 'releaseLock'
+        ) {
+          calls.push(`${relative(root, path)}:${node.arguments.map(arg => arg.getText(source)).join(',')}`);
+        }
+        ts.forEachChild(node, visit);
+      };
+      visit(source);
+    }
+
+    expect(calls.sort()).toEqual([
+      'src/bus/message.ts:lockHandle',
+      'src/utils/lock.ts:handle',
+    ]);
+  });
+});

--- a/tests/unit/utils/lock.test.ts
+++ b/tests/unit/utils/lock.test.ts
@@ -1,8 +1,28 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { mkdtempSync, rmSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  utimesSync,
+  writeFileSync,
+} from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import { acquireLock, releaseLock } from '../../../src/utils/lock';
+import {
+  acquireLock,
+  releaseLock,
+  withFileLockSync,
+  type LockHandle,
+} from '../../../src/utils/lock';
+
+function acquire(testDir: string): LockHandle {
+  const handle = acquireLock(testDir);
+  expect(handle).not.toBe(false);
+  return handle as LockHandle;
+}
 
 describe('mkdir-based locking', () => {
   let testDir: string;
@@ -16,24 +36,145 @@ describe('mkdir-based locking', () => {
   });
 
   it('acquires lock on empty directory', () => {
-    expect(acquireLock(testDir)).toBe(true);
-    releaseLock(testDir);
+    const handle = acquire(testDir);
+    expect(readFileSync(join(testDir, '.lock.d', 'pid'), 'utf-8')).toBe(String(process.pid));
+    expect(releaseLock(handle)).toBe(true);
   });
 
   it('prevents double acquire', () => {
-    expect(acquireLock(testDir)).toBe(true);
+    const handle = acquire(testDir);
     // Same process, same PID - should fail since lock.d already exists
     // (but our PID check will see it's our own process and succeed)
     // Actually, mkdir will fail because it already exists, then we check PID
     // Since it's our own PID, it sees process alive and returns false
     expect(acquireLock(testDir)).toBe(false);
-    releaseLock(testDir);
+    expect(releaseLock(handle)).toBe(true);
   });
 
   it('releases lock correctly', () => {
-    expect(acquireLock(testDir)).toBe(true);
-    releaseLock(testDir);
-    expect(acquireLock(testDir)).toBe(true);
-    releaseLock(testDir);
+    const first = acquire(testDir);
+    expect(releaseLock(first)).toBe(true);
+    const second = acquire(testDir);
+    expect(releaseLock(second)).toBe(true);
+  });
+
+  it('reaps a stale partial lock whose pid file is absent', () => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    const handle = acquire(testDir);
+    expect(releaseLock(handle)).toBe(true);
+  });
+
+  it('reaps a stale partial lock whose pid file is empty', () => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+    writeFileSync(join(lockDir, 'pid'), '');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    const handle = acquire(testDir);
+    expect(releaseLock(handle)).toBe(true);
+  });
+
+  it('does not steal a recent partial lock while its owner may be mid-acquire', () => {
+    const lockDir = join(testDir, '.lock.d');
+    mkdirSync(lockDir);
+
+    expect(acquireLock(testDir)).toBe(false);
+    expect(existsSync(lockDir)).toBe(true);
+  });
+
+  it('preserves a successor when a revoked live owner releases late', () => {
+    const lockDir = join(testDir, '.lock.d');
+    const originalHandle = acquire(testDir);
+    const originalOwner = readFileSync(join(lockDir, '.owner'), 'utf-8');
+
+    writeFileSync(join(lockDir, 'pid'), '');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    const successorHandle = acquire(testDir);
+    const successorOwner = readFileSync(join(lockDir, '.owner'), 'utf-8');
+    expect(successorOwner).not.toBe(originalOwner);
+
+    expect(releaseLock(originalHandle)).toBe(false);
+
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(join(lockDir, '.owner'), 'utf-8')).toBe(successorOwner);
+    expect(releaseLock(successorHandle)).toBe(true);
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  it('keeps generation identity opaque from a revoked external holder', () => {
+    const lockDir = join(testDir, '.lock.d');
+    const staleHandle = acquire(testDir);
+
+    writeFileSync(join(lockDir, 'pid'), '');
+    const stale = new Date(Date.now() - 60_000);
+    utimesSync(lockDir, stale, stale);
+
+    const successorHandle = acquire(testDir);
+    const successorStat = statSync(lockDir);
+    const successorOwner = readFileSync(join(lockDir, '.owner'), 'utf-8');
+
+    let rewriteRejected = false;
+    try {
+      Object.assign(staleHandle, {
+        lockDir,
+        generation: {
+          snapshot: {
+            dev: successorStat.dev,
+            ino: successorStat.ino,
+            mtimeMs: successorStat.mtimeMs,
+          },
+          ownerFile: join(lockDir, '.owner'),
+          ownerToken: successorOwner,
+        },
+      });
+    } catch (err) {
+      expect(err).toBeInstanceOf(TypeError);
+      rewriteRejected = true;
+    }
+
+    expect(releaseLock(staleHandle)).toBe(false);
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(join(lockDir, '.owner'), 'utf-8')).toBe(successorOwner);
+    expect(rewriteRejected).toBe(true);
+    expect(Object.isFrozen(staleHandle)).toBe(true);
+    expect(Reflect.ownKeys(staleHandle)).toEqual([]);
+    expect(JSON.stringify(staleHandle)).toBe('{}');
+    expect(() => Object.setPrototypeOf(staleHandle, {})).toThrow(TypeError);
+
+    // Copying the genuine prototype still cannot forge module-private state.
+    const forgedHandle = Object.create(Object.getPrototypeOf(staleHandle));
+    expect(releaseLock(forgedHandle)).toBe(false);
+
+    expect(releaseLock(successorHandle)).toBe(true);
+    expect(existsSync(lockDir)).toBe(false);
+  });
+
+  it('withFileLockSync preserves a successor acquired after its handle is revoked', () => {
+    const lockDir = join(testDir, '.lock.d');
+    let successorHandle: LockHandle | false = false;
+    let successorOwner = '';
+
+    const result = withFileLockSync(testDir, () => {
+      writeFileSync(join(lockDir, 'pid'), '');
+      const stale = new Date(Date.now() - 60_000);
+      utimesSync(lockDir, stale, stale);
+      successorHandle = acquireLock(testDir);
+      expect(successorHandle).not.toBe(false);
+      successorOwner = readFileSync(join(lockDir, '.owner'), 'utf-8');
+      return 'complete';
+    });
+
+    expect(result).toBe('complete');
+    expect(existsSync(lockDir)).toBe(true);
+    expect(readFileSync(join(lockDir, '.owner'), 'utf-8')).toBe(successorOwner);
+    expect(successorHandle).not.toBe(false);
+    expect(releaseLock(successorHandle as LockHandle)).toBe(true);
   });
 });


### PR DESCRIPTION
Second PR in the reliability series (after #983 — each is independent; take or leave individually). This one is about message delivery: three ways a message could silently vanish.

## 1. An unavailable inbox lock black-holed messages

`checkInbox()` returned `[]` when `acquireLock` failed — indistinguishable from a successfully-read empty inbox. So a permanently orphaned lock (holder crashed between `mkdir` and the pid write, or a corrupt pid file) didn't look like a failure at all: every future poll reported an empty inbox while messages piled up unseen. `checkInbox` now throws `InboxLockUnavailableError`; the CLI command exits nonzero with the error text, and the fast-checker logs the failure and retries next poll (independent transport delivery keeps moving). An unreadable inbox and an empty inbox are now different observable states.

## 2. Lock stealing raced

Stale-lock takeover was unserialized: two processes could both judge a lock stale, both steal it, and both believe they held it — and a slow original holder's later `releaseLock(dir)` would destroy the *new* holder's lock. `acquireLock` now returns an opaque generation-bound handle (dev/ino/birth identity plus an owner token); takeover of a stale or mid-acquire-abandoned lock is serialized through an atomic marker rename so exactly one stealer wins; and `releaseLock` takes the handle and releases only the generation it acquired — a late release of a stolen lock is a no-op instead of a foreign-lock deletion. The handle is compile-time opaque (a fixture test asserts its identity members remain inaccessible to importers), so a caller can't rewrite a stale handle into a live one. `withFileLockSync` keeps its signature — existing callers are untouched.

## 3. Failed injection dropped transport messages

The in-memory Telegram, Buzz, and Slack queues are the *only* backing store for those transports — there's no inbox-style ACK/redelivery behind them. The poll cycle drained all three into the outgoing block before knowing whether PTY injection would succeed, so an inject failure (agent mid-restart, or deduped) silently and permanently lost the drained messages. They're now re-queued at the front, in original order, when injection fails. (Inbox messages were already safe — un-ACK'd messages redeliver.)

## Tests

- Lock: generation lifecycle, serialized-takeover concurrency (only one stealer wins), release-generation binding, acquire-failure propagation, and the compile-time opacity fixture.
- Inbox: lock-held ⇒ throws, and the message **survives and delivers after release** — never consumed, never faked empty.
- Fast-checker: inbox-failure visibility in the daemon log, plus both re-queue polarities — inject failure restores all three queues in order; inject success drains them.
- Every new behavior test was run against the pre-change code first and fails there.

`tsc` clean; full unit suite passes (1556). The one unrelated `hooks.test.ts` symlink failure exists identically on `main` (same pre-existing case noted on #983).