### PR TITLE
fix(ecosystem): use daemon roster authority

### DIFF
--- a/src/cli/ecosystem.ts
+++ b/src/cli/ecosystem.ts
@@ -1,8 +1,9 @@
 import { Command } from 'commander';
-import { existsSync, readFileSync, readdirSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { homedir } from 'os';
 import { fileURLToPath } from 'url';
+import { discoverSourceAgentCandidates } from '../daemon/agent-discovery.js';
 
 export const ecosystemCommand = new Command('ecosystem')
   .option('--instance <id>', 'Instance ID', 'default')
@@ -23,22 +24,9 @@ export const ecosystemCommand = new Command('ecosystem')
       projectRoot = existsSync(join(canonical, 'orgs')) ? canonical : process.cwd();
     }
 
-    // Find all agents
-    const agents: Array<{ name: string; dir: string; org?: string }> = [];
-
-    // Scan orgs/*/agents/*
-    const orgsDir = join(projectRoot, 'orgs');
-    if (existsSync(orgsDir)) {
-      for (const org of readdirSync(orgsDir, { withFileTypes: true })) {
-        if (!org.isDirectory()) continue;
-        const agentsDir = join(orgsDir, org.name, 'agents');
-        if (!existsSync(agentsDir)) continue;
-        for (const agent of readdirSync(agentsDir, { withFileTypes: true })) {
-          if (!agent.isDirectory()) continue;
-          agents.push({ name: agent.name, dir: join(agentsDir, agent.name), org: org.name });
-        }
-      }
-    }
+    // Use the daemon's own roster authority. A second directory walk had
+    // drifted and counted shared/hidden infrastructure as runnable agents.
+    const agents = discoverSourceAgentCandidates(projectRoot);
 
     if (agents.length === 0) {
       console.log('No agents found. Add agents first: cortextos add-agent <name>');

--- a/src/daemon/agent-discovery.ts
+++ b/src/daemon/agent-discovery.ts
@@ -1,0 +1,42 @@
+import { existsSync, readdirSync } from 'fs';
+import { join } from 'path';
+
+export interface SourceAgentCandidate {
+  name: string;
+  dir: string;
+  org: string;
+}
+
+/**
+ * Discover the source-side agent directories the daemon considers at boot.
+ * Shared and hidden directories are infrastructure, not runnable agents.
+ */
+export function discoverSourceAgentCandidates(frameworkRoot: string): SourceAgentCandidate[] {
+  const candidates: SourceAgentCandidate[] = [];
+  const orgsBase = join(frameworkRoot, 'orgs');
+  if (!existsSync(orgsBase)) return candidates;
+
+  let orgNames: string[];
+  try {
+    orgNames = readdirSync(orgsBase, { withFileTypes: true })
+      .filter(entry => entry.isDirectory())
+      .map(entry => entry.name);
+  } catch {
+    return candidates;
+  }
+
+  for (const org of orgNames) {
+    const agentsBase = join(orgsBase, org, 'agents');
+    if (!existsSync(agentsBase)) continue;
+    try {
+      for (const entry of readdirSync(agentsBase, { withFileTypes: true })) {
+        if (!entry.isDirectory() || entry.name.startsWith('_') || entry.name.startsWith('.')) continue;
+        candidates.push({ name: entry.name, dir: join(agentsBase, entry.name), org });
+      }
+    } catch {
+      // One unreadable organization must not hide agents in the others.
+    }
+  }
+
+  return candidates;
+}

--- a/src/daemon/agent-manager.ts
+++ b/src/daemon/agent-manager.ts
@@ -22,6 +22,7 @@ import { stripBom } from '../utils/strip-bom.js';
 import { BuzzRelayClient, BuzzDispatcher, loadBuzzConfig, type NostrEvent } from '../buzz/index.js';
 import { computeDormancy, parseHeartbeatIntervalMs } from '../utils/dormancy.js';
 import { CRONS_DIRECTORY, CRONS_FILENAME } from '../bus/crons-schema.js';
+import { discoverSourceAgentCandidates } from './agent-discovery.js';
 
 type LogFn = (msg: string) => void;
 
@@ -1982,40 +1983,10 @@ export class AgentManager {
    * lookups via `resolveAgentOrg()`.
    */
   private discoverAgents(): Array<{ name: string; dir: string; org: string; config: AgentConfig }> {
-    const agents: Array<{ name: string; dir: string; org: string; config: AgentConfig }> = [];
-
-    const orgsBase = join(this.frameworkRoot, 'orgs');
-    if (!existsSync(orgsBase)) return agents;
-
-    let orgNames: string[] = [];
-    try {
-      orgNames = readdirSync(orgsBase, { withFileTypes: true })
-        .filter(d => d.isDirectory())
-        .map(d => d.name);
-    } catch {
-      return agents; // unreadable orgs dir — treat as empty
-    }
-
-    for (const org of orgNames) {
-      const agentsBase = join(orgsBase, org, 'agents');
-      if (!existsSync(agentsBase)) continue;
-
-      try {
-        const dirs = readdirSync(agentsBase, { withFileTypes: true })
-          .filter(d => d.isDirectory())
-          .map(d => d.name);
-
-        for (const name of dirs) {
-          const dir = join(agentsBase, name);
-          const config = this.loadAgentConfig(dir);
-          agents.push({ name, dir, org, config });
-        }
-      } catch {
-        // Ignore read errors for this org — continue scanning others
-      }
-    }
-
-    return agents;
+    return discoverSourceAgentCandidates(this.frameworkRoot).map(candidate => ({
+      ...candidate,
+      config: this.loadAgentConfig(candidate.dir),
+    }));
   }
 
   /**

--- a/tests/unit/cli/ecosystem-roster-authority.test.ts
+++ b/tests/unit/cli/ecosystem-roster-authority.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { ecosystemCommand } from '../../../src/cli/ecosystem';
+import { discoverSourceAgentCandidates } from '../../../src/daemon/agent-discovery';
+
+describe('ecosystem roster uses the daemon discovery authority', () => {
+  const originalFrameworkRoot = process.env.CTX_FRAMEWORK_ROOT;
+  const roots: string[] = [];
+
+  afterEach(() => {
+    if (originalFrameworkRoot === undefined) delete process.env.CTX_FRAMEWORK_ROOT;
+    else process.env.CTX_FRAMEWORK_ROOT = originalFrameworkRoot;
+    for (const root of roots.splice(0)) rmSync(root, { recursive: true, force: true });
+    vi.restoreAllMocks();
+  });
+
+  function makeRoot(agentCount: number): string {
+    const root = mkdtempSync(join(tmpdir(), 'ecosystem-roster-'));
+    roots.push(root);
+    const agentsBase = join(root, 'orgs', 'acme', 'agents');
+    for (let index = 0; index < agentCount; index++) {
+      const dir = join(agentsBase, `agent${index}`);
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'config.json'), JSON.stringify({ enabled: true }), 'utf8');
+    }
+    mkdirSync(join(agentsBase, '_shared', 'scripts'), { recursive: true });
+    mkdirSync(join(agentsBase, '.cache'), { recursive: true });
+    return root;
+  }
+
+  it('known-positive: daemon discovery excludes shared and hidden directories', () => {
+    const discovered = discoverSourceAgentCandidates(makeRoot(3));
+    expect(discovered.map(candidate => candidate.name).sort()).toEqual(['agent0', 'agent1', 'agent2']);
+  });
+
+  it('production ecosystem command reports the daemon roster, not every directory', async () => {
+    const root = makeRoot(3);
+    process.env.CTX_FRAMEWORK_ROOT = root;
+    const messages: string[] = [];
+    vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      messages.push(args.map(String).join(' '));
+    });
+
+    await ecosystemCommand.parseAsync([
+      'node', 'cortextos', '--org', 'acme', '--output', join(root, 'ecosystem.config.cjs'),
+    ]);
+
+    const generated = messages.find(message => message.includes('manages'));
+    expect(generated).toContain('manages 3 agents');
+    expect(generated).not.toContain('manages 5 agents');
+  });
+
+  it('specificity: adding a real agent changes the production count', async () => {
+    const counts: string[] = [];
+    for (const count of [2, 4]) {
+      const root = makeRoot(count);
+      process.env.CTX_FRAMEWORK_ROOT = root;
+      vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+        const message = args.map(String).join(' ');
+        if (message.includes('manages')) counts.push(message);
+      });
+      await ecosystemCommand.parseAsync([
+        'node', 'cortextos', '--org', 'acme', '--output', join(root, 'ecosystem.config.cjs'),
+      ]);
+      vi.restoreAllMocks();
+    }
+    expect(counts[0]).toContain('manages 2 agents');
+    expect(counts[1]).toContain('manages 4 agents');
+  });
+
+  it('the CLI and daemon query one shared discovery function', () => {
+    const ecosystemSource = readFileSync('src/cli/ecosystem.ts', 'utf8');
+    const managerSource = readFileSync('src/daemon/agent-manager.ts', 'utf8');
+    expect(ecosystemSource).toContain('discoverSourceAgentCandidates(projectRoot)');
+    expect(managerSource).toContain('discoverSourceAgentCandidates(this.frameworkRoot)');
+    expect(ecosystemSource).not.toContain('readdirSync');
+  });
+});


### PR DESCRIPTION
## Summary

- make the daemon's source-agent discovery the single roster authority
- have `cortextos ecosystem` query that authority instead of maintaining a second directory walk
- exclude hidden and underscore-prefixed infrastructure directories consistently
- keep daemon config loading behavior unchanged while sharing the population discovery

## Why

The ecosystem generator counted every directory under `orgs/*/agents/*`, while the runnable daemon roster excludes shared and hidden infrastructure such as `_shared`. That made the generated `manages N agents` report disagree with the population the daemon can actually start and stop.

This is the public-framework port of [ascendops-live PR338](https://github.com/noogalabs/ascendops-live/pull/338), merged there as `dcde0654defa00dc2730d597206c030088b7781d`. No organization-specific data is included.

## Verification

- `npm test -- --run tests/unit/cli/ecosystem-roster-authority.test.ts` — 4 passed
- `npm run build` — passed
- production-entry casualties cover `_shared`/hidden exclusion, the reported roster count, a real-agent specificity change, and shared-authority wiring in both CLI and daemon

The repository-wide local test command also ran 2,107 tests successfully, with unrelated environment/baseline failures from unavailable dashboard packages and inherited live `CTX_*` variables. The focused suite and build are green; pull-request CI is authoritative for the clean environment.
